### PR TITLE
Add global WIP banner

### DIFF
--- a/src/components/alert-banner/index.tsx
+++ b/src/components/alert-banner/index.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames'
+import s from './style.module.css'
+
+interface AlertBannerProps {
+  type: 'action' | 'danger' | 'highlight' | 'success' | 'warning'
+}
+
+/**
+ * This is currently built to accept children (instead of several props like react-components/alert-banner)
+ * because we have designs for future uses of this component that will accept things like inline code blocks,
+ * bold text, and inline links.
+ *
+ * This is currently not dismissible because its only use is as a global banner noting that the site is a WIP
+ * and accepting feedback.
+ */
+const AlertBanner: React.FC<AlertBannerProps> = ({ children, type }) => {
+  const className = classNames(s.alertBanner, {
+    [s[`${type}AlertBanner`]]: !!type,
+  })
+  return <div className={className}>{children}</div>
+}
+
+export default AlertBanner

--- a/src/components/alert-banner/style.module.css
+++ b/src/components/alert-banner/style.module.css
@@ -1,0 +1,37 @@
+.actionAlertBanner {
+  background-color: #f2f8ff;
+}
+
+.dangerAlertBanner {
+  background-color: #fff5f5;
+}
+
+.hightlightAlertBanner {
+  background-color: #f9f2ff;
+}
+
+.successAlertBanner {
+  background-color: #f2fbf6;
+}
+
+.warningAlertBanner {
+  background-color: #fff9e8;
+}
+
+.alertBanner {
+  color: var(--token-color-palette-neutral-600);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  padding: 24px;
+  text-align: center;
+
+  & > * {
+    margin: 0;
+  }
+
+  & a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}

--- a/src/components/alert-banner/style.module.css
+++ b/src/components/alert-banner/style.module.css
@@ -6,7 +6,7 @@
   background-color: #fff5f5;
 }
 
-.hightlightAlertBanner {
+.highlightAlertBanner {
   background-color: #f9f2ff;
 }
 

--- a/src/components/product-switcher/style.module.css
+++ b/src/components/product-switcher/style.module.css
@@ -63,7 +63,7 @@
   margin: 2px 0;
 
   &:hover {
-    background-color: #3b3d45;
+    background-color: var(--token-color-palette-neutral-600);
   }
 }
 

--- a/src/layouts/docs/docs-layout.module.css
+++ b/src/layouts/docs/docs-layout.module.css
@@ -1,12 +1,4 @@
-/* Overwriting these two variables here keeps the changes isolated to the new UI */
 .container {
-  --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol';
-  --font-display: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol';
-
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,7 +18,11 @@ export default function App({ Component, pageProps }) {
           <p>
             You are viewing an internal preview and work in progress version of
             this site.{' '}
-            <a href="https://airtable.com/shrU3eYHIOXO60o23">
+            <a
+              href="https://airtable.com/shrU3eYHIOXO60o23"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               We'd love to hear your feedback
             </a>
             !

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import '@hashicorp/platform-util/nprogress/style.css'
 import { ErrorBoundary } from '@hashicorp/platform-runtime-error-monitoring'
 import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analytics'
 import { DeviceSizeProvider } from 'contexts'
+import AlertBanner from 'components/alert-banner'
 import BaseLayout from 'layouts/base'
 import './style.css'
 
@@ -13,6 +14,16 @@ export default function App({ Component, pageProps }) {
   return (
     <ErrorBoundary FallbackComponent={Error}>
       <DeviceSizeProvider>
+        <AlertBanner type="highlight">
+          <p>
+            You are viewing an internal preview and work in progress version of
+            this site.{' '}
+            <a href="https://airtable.com/shrU3eYHIOXO60o23">
+              We'd love to hear your feedback
+            </a>
+            !
+          </p>
+        </AlertBanner>
         <Layout {...pageProps?.layoutProps}>
           <Component {...pageProps} />
         </Layout>

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -39,6 +39,12 @@
 :root {
   --mobile-width-breakpoint: 728px;
   --tablet-width-breakpoint: 1000px;
+  --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+  --font-display: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
 }
 
 @custom-media --mobile only screen and (max-width: 728px);


### PR DESCRIPTION
🔎  [Preview link](https://dev-portal-git-ambadd-wip-banner-hashicorp.vercel.app/waypoint/docs)
🎟️  Asana tickets
- [Create AlertBanner component](https://app.asana.com/0/0/1201490161340315/f)
- [Add work in progress banner](https://app.asana.com/0/0/1201530235872969/f)

---

This PR adds a very basic `AlertBanner` component and renders one globally at the top of every page with a link to a feedback form. Questions about that form should be directed to @jescalan.

The colors introduced in the new component come from these `AlertBox` designs: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=1498%3A43240. The color for the globally rendered banner is a new one that isn't in those designs but was specifically requested in Slack. At the time of writing, it's called Highlight/Background/Faint in Figma.