### PR TITLE
docs: add color page to swingset

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,10 @@ const temporary_hideDocsPaths = {
   ],
 }
 
-module.exports = withSwingset({ componentsRoot: 'src/components/*' })(
+module.exports = withSwingset({
+  componentsRoot: 'src/components/*',
+  docsRoot: 'src/swingset-docs/*',
+})(
   withHashicorp({
     nextOptimizedImages: true,
     transpileModules: ['swingset', '@hashicorp/flight-icons'],

--- a/src/components/swingset-color-token/docs.mdx
+++ b/src/components/swingset-color-token/docs.mdx
@@ -1,0 +1,9 @@
+---
+componentName: 'SwingsetColorToken'
+---
+
+**🚧 PLACEHOLDER 🚧**
+
+`SwingsetColorToken` is meant only for use in swingset pages, specifically the swingset `color` docs page. However, swingset does not currently expose `components` as configured in `[[...swingset]].tsx` to `docs` pages. This page is a temporary workaround, that allows the component to be included as a `peerComponent`.
+
+To resolve this issue, we likely want to expose `swingsetOptions` to docs page contexts in some way. See [this line of code in Swingset](https://github.com/hashicorp/swingset/blob/5fbae60a2d13283e5850fae0333bfa6f9f057231/page.jsx#L93) for where we'd likely want to pass `swingsetOptions` (which includes the `components` property).

--- a/src/components/swingset-color-token/index.tsx
+++ b/src/components/swingset-color-token/index.tsx
@@ -1,0 +1,28 @@
+function SwingsetColorToken({ token }: { token: string }): React.ReactElement {
+  return (
+    <div
+      style={{
+        width: '100%',
+        background: `var(--${token})`,
+        height: '50px',
+        boxShadow: 'inset 0px 0px 1px rgba(0,0,0,0.5)',
+        position: 'relative',
+      }}
+    >
+      <code
+        style={{
+          position: 'absolute',
+          top: '5px',
+          right: '5px',
+          background: 'rgba(240, 240, 240, 0.85)',
+          padding: '0.25rem 0.5rem',
+          fontSize: '0.75rem',
+        }}
+      >
+        var(--{`${token}`})
+      </code>
+    </div>
+  )
+}
+
+export default SwingsetColorToken

--- a/src/swingset-docs/color.mdx
+++ b/src/swingset-docs/color.mdx
@@ -18,7 +18,7 @@ These tokens are necessary to include in this project in order for our shared `@
 
 ## Placeholders for Design System Color Tokens
 
-We have additional color tokens set up, which are acting as a temporary placeholder for tokens expected to be sourced from the design systems team. These temporary tokens are outlined below.
+We have additional color tokens set up, which are acting as a temporary placeholder for tokens expected to be sourced from the design systems team, from [`hashicorp/design-system-tokens`](https://github.com/hashicorp/design-system-tokens). These temporary tokens are outlined below.
 
 ## Neutral Palette
 

--- a/src/swingset-docs/color.mdx
+++ b/src/swingset-docs/color.mdx
@@ -1,0 +1,47 @@
+---
+name: 'Color'
+peerComponents:
+  - 'SwingsetColorToken'
+---
+
+<!-- workaround to drop swingset's styling of first h1 -->
+
+<h1 />
+
+Color tokens in this project are currently coming from mixed sources.
+
+## Marketing Color Tokens
+
+At the global marketing level, we have [color tokens set up in `@hashicorp/mktg-global-styles`](https://github.com/hashicorp/mktg-global-styles/blob/main/custom-properties/color.css) which are available for use. These can be viewed in [our `react-components` playground](https://react-components.vercel.app/docs/color).
+
+These tokens are necessary to include in this project in order for our shared `@hashicorp/react-*` component packages to render correctly.
+
+## Placeholders for Design System Color Tokens
+
+We have additional color tokens set up, which are acting as a temporary placeholder for tokens expected to be sourced from the design systems team. These temporary tokens are outlined below.
+
+## Neutral Palette
+
+<>
+  {[
+    'token-color-palette-neutral-700',
+    'token-color-palette-neutral-600',
+    'token-color-palette-neutral-500',
+    'token-color-palette-neutral-400',
+    'token-color-palette-neutral-300',
+    'token-color-palette-neutral-200',
+    'token-color-palette-neutral-100',
+    'token-color-palette-neutral-50',
+    'token-color-palette-neutral-0',
+  ].map((n) => (
+    <SwingsetColorToken key={n} token={n} />
+  ))}
+</>
+
+## Blue Palette
+
+<>
+  {['blue-vibrant'].map((n) => (
+    <SwingsetColorToken key={n} token={n} />
+  ))}
+</>


### PR DESCRIPTION
👀 [Preview](https://dev-portal-git-zsadd-color-docs-hashicorp.vercel.app/swingset/docs/color)

This PR adds a rough docs page on color tokens to `/swingset`.

Preview:

<img width="1430" alt="CleanShot 2021-12-20 at 13 24 14@2x" src="https://user-images.githubusercontent.com/4624598/146814834-244529ea-4356-4330-a9eb-724c5e2914db.png">

> Note: Rendering this page in Swingset required a bit of an inconvenient workaround, using `peerComponents` in the `docs` page as Swingset does not yet support the `{ components }` option for docs pages. Intent here with this workaround was to avoid starting a yak-shaving session by trying to fix the underlying issue in `swingset`.

