### PR TITLE
feat: add tooltip component, use for tutorial-card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@reach/popover": "^0.16.2",
         "@reach/portal": "^0.16.2",
         "@reach/tabs": "^0.16.4",
+        "@reach/tooltip": "^0.17.0",
         "@reach/visually-hidden": "^0.16.0",
         "@react-aria/ssr": "^3.1.0",
         "@react-aria/utils": "^3.11.0",
@@ -3710,6 +3711,30 @@
         "react": ">=16.x"
       }
     },
+    "node_modules/@hashicorp/react-tabs/node_modules/@reach/tooltip": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
+      "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
+      "dependencies": {
+        "@reach/auto-id": "0.16.0",
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
+        "@reach/visually-hidden": "0.16.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/react-tabs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/@hashicorp/react-text-input": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hashicorp/react-text-input/-/react-text-input-5.0.1.tgz",
@@ -5526,17 +5551,86 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/tooltip": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
-      "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.17.0.tgz",
+      "integrity": "sha512-HP8Blordzqb/Cxg+jnhGmWQfKgypamcYLBPlcx6jconyV5iLJ5m93qipr1giK7MqKT2wlsKWy44ZcOrJ+Wrf8w==",
       "dependencies": {
-        "@reach/auto-id": "0.16.0",
-        "@reach/portal": "0.16.2",
-        "@reach/rect": "0.16.0",
-        "@reach/utils": "0.16.0",
-        "@reach/visually-hidden": "0.16.0",
+        "@reach/auto-id": "0.17.0",
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "@reach/visually-hidden": "0.17.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/tooltip/node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/tooltip/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/tooltip/node_modules/@reach/rect": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/tooltip/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/tooltip/node_modules/@reach/visually-hidden": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -36274,6 +36368,28 @@
         "@reach/portal": "^0.16.2",
         "@reach/tooltip": "^0.16.2",
         "classnames": "^2.3.1"
+      },
+      "dependencies": {
+        "@reach/tooltip": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
+          "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
+          "requires": {
+            "@reach/auto-id": "0.16.0",
+            "@reach/portal": "0.16.2",
+            "@reach/rect": "0.16.0",
+            "@reach/utils": "0.16.0",
+            "@reach/visually-hidden": "0.16.0",
+            "prop-types": "^15.7.2",
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "@hashicorp/react-text-input": {
@@ -37656,20 +37772,69 @@
       }
     },
     "@reach/tooltip": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
-      "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.17.0.tgz",
+      "integrity": "sha512-HP8Blordzqb/Cxg+jnhGmWQfKgypamcYLBPlcx6jconyV5iLJ5m93qipr1giK7MqKT2wlsKWy44ZcOrJ+Wrf8w==",
       "requires": {
-        "@reach/auto-id": "0.16.0",
-        "@reach/portal": "0.16.2",
-        "@reach/rect": "0.16.0",
-        "@reach/utils": "0.16.0",
-        "@reach/visually-hidden": "0.16.0",
+        "@reach/auto-id": "0.17.0",
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "@reach/visually-hidden": "0.17.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "@reach/auto-id": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+          "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+          "requires": {
+            "@reach/utils": "0.17.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/portal": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+          "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+          "requires": {
+            "@reach/utils": "0.17.0",
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/rect": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+          "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+          "requires": {
+            "@reach/observe-rect": "1.2.0",
+            "@reach/utils": "0.17.0",
+            "prop-types": "^15.7.2",
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/utils": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+          "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+          "requires": {
+            "tiny-warning": "^1.0.3",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@reach/visually-hidden": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+          "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+          "requires": {
+            "prop-types": "^15.7.2",
+            "tslib": "^2.3.0"
+          }
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@reach/popover": "^0.16.2",
     "@reach/portal": "^0.16.2",
     "@reach/tabs": "^0.16.4",
+    "@reach/tooltip": "^0.17.0",
     "@reach/visually-hidden": "^0.16.0",
     "@react-aria/ssr": "^3.1.0",
     "@react-aria/utils": "^3.11.0",

--- a/src/components/tooltip/docs.mdx
+++ b/src/components/tooltip/docs.mdx
@@ -17,23 +17,45 @@ non-interactive popup is displayed near it.
 
 Note that **touch events are not supported**. This is a somewhat intentional limitation of the underlying dependency, `@reach/tooltip`. See [Reach UI's `<Tooltip />` docs](https://reach.tech/tooltip/) for details.
 
+## Playground
+
+<LiveComponent>{`
+<Tooltip
+  theme="light"
+  label="Hi there! I'm a tooltip, and this is some long plain text, which should wrap nicely based on some collision calculations we're doing behind the scenes."
+>
+  <button>I'm a React node with a tooltip.</button>
+</Tooltip>
+`}</LiveComponent>
+
 ## Examples
 
 ### `label="Plain text"`
 
-<Tooltip label="Hi there! I'm a tooltip, and this is some long plain text, which should wrap nicely based on some collision calculations we're doing behind the scenes.">
-  <button
-    style={{
-      border: '1px solid magenta',
-      padding: '0.25rem 0.5rem',
-      borderRadius: '5px',
-    }}
-  >
-    I'm a React node with a tooltip.
+<Tooltip
+  theme="light"
+  label="Hi there! I'm a tooltip, and this is some long plain text, which should wrap nicely based on some collision calculations we're doing behind the scenes."
+>
+  <button>I'm a React node with a tooltip.</button>
+</Tooltip>
+
+### `theme="light" vs theme="dark"`
+
+<Tooltip label="Light theme tooltip contents." theme="light">
+  <button style={{ marginRight: '8px' }}>
+    <code>theme="light"</code>
+  </button>
+</Tooltip>
+
+<Tooltip label="Dark theme tooltip contents." theme="dark">
+  <button>
+    <code>theme="dark"</code>
   </button>
 </Tooltip>
 
 ### `label={<Slot />}`
+
+Note: with the guidelines for tooltips in mind, the React element support of the `label` prop should be used only after very careful consideration.
 
 <Tooltip
   theme="light"
@@ -43,7 +65,6 @@ Note that **touch events are not supported**. This is a somewhat intentional lim
       style={{
         display: 'inline-block',
         border: '1px solid magenta',
-        padding: '0.25rem 0.5rem',
         borderRadius: '4px',
       }}
     >
@@ -51,41 +72,8 @@ Note that **touch events are not supported**. This is a somewhat intentional lim
     </div>
   }
 >
-  <button
-    style={{
-      border: '1px solid magenta',
-      padding: '0.25rem 0.5rem',
-      borderRadius: '5px',
-    }}
-  >
+  <button>
     This tooltip wraps a text node, and renders a React node as the tooltip
     contents.
-  </button>
-</Tooltip>
-
-### `theme="light" vs theme="dark"`
-
-<Tooltip label="Light theme tooltip contents." theme="dark">
-  <button
-    style={{
-      border: '1px solid magenta',
-      padding: '0.25rem 0.5rem',
-      borderRadius: '5px',
-      marginRight: '8px',
-    }}
-  >
-    <code>theme="light"</code>
-  </button>
-</Tooltip>
-
-<Tooltip label="Dark theme tooltip contents." theme="dark">
-  <button
-    style={{
-      border: '1px solid magenta',
-      padding: '0.25rem 0.5rem',
-      borderRadius: '5px',
-    }}
-  >
-    <code>theme="dark"</code>
   </button>
 </Tooltip>

--- a/src/components/tooltip/docs.mdx
+++ b/src/components/tooltip/docs.mdx
@@ -22,16 +22,15 @@ Note that **touch events are not supported**. This is a somewhat intentional lim
 ### `label="Plain text"`
 
 <Tooltip label="Hi there! I'm a tooltip, and this is some long plain text, which should wrap nicely based on some collision calculations we're doing behind the scenes.">
-  <div
+  <button
     style={{
-      display: 'inline-block',
       border: '1px solid magenta',
       padding: '0.25rem 0.5rem',
       borderRadius: '5px',
     }}
   >
     I'm a React node with a tooltip.
-  </div>
+  </button>
 </Tooltip>
 
 ### `label={<Slot />}`
@@ -52,9 +51,8 @@ Note that **touch events are not supported**. This is a somewhat intentional lim
     </div>
   }
 >
-  <div
+  <button
     style={{
-      display: 'inline-block',
       border: '1px solid magenta',
       padding: '0.25rem 0.5rem',
       borderRadius: '5px',
@@ -62,7 +60,32 @@ Note that **touch events are not supported**. This is a somewhat intentional lim
   >
     This tooltip wraps a text node, and renders a React node as the tooltip
     contents.
-  </div>
+  </button>
 </Tooltip>
 
 ### `theme="light" vs theme="dark"`
+
+<Tooltip label="Light theme tooltip contents." theme="dark">
+  <button
+    style={{
+      border: '1px solid magenta',
+      padding: '0.25rem 0.5rem',
+      borderRadius: '5px',
+      marginRight: '8px',
+    }}
+  >
+    <code>theme="light"</code>
+  </button>
+</Tooltip>
+
+<Tooltip label="Dark theme tooltip contents." theme="dark">
+  <button
+    style={{
+      border: '1px solid magenta',
+      padding: '0.25rem 0.5rem',
+      borderRadius: '5px',
+    }}
+  >
+    <code>theme="dark"</code>
+  </button>
+</Tooltip>

--- a/src/components/tooltip/docs.mdx
+++ b/src/components/tooltip/docs.mdx
@@ -1,0 +1,68 @@
+---
+componentName: 'Tooltip'
+---
+
+The tooltip component is used to display supplementary, non-critical information. When the user's mouse or focus rests on an element, a
+non-interactive popup is displayed near it.
+
+## Rough guidelines for `Tooltip` use
+
+- Do not use tooltips for information vital to task completion
+- Tooltips may be useful in providing extra information or hints
+- The element a tooltip is attached to should usually make sense on its own
+- Keep tooltip content minimal. Longer form content likely belongs in a modal, or perhaps even in a separate page.
+
+- New users may benefit from tooltips
+- Experienced users should rarely have to reference tooltips. The need for an experienced user to access a tooltip may indicate that the content within is somewhat vital to task completion, or that the element to which the tooltip is attached does not make enough sense on its own.
+
+Note that **touch events are not supported**. This is a somewhat intentional limitation of the underlying dependency, `@reach/tooltip`. See [Reach UI's `<Tooltip />` docs](https://reach.tech/tooltip/) for details.
+
+## Examples
+
+### `label="Plain text"`
+
+<Tooltip label="Hi there! I'm a tooltip, and this is some long plain text, which should wrap nicely based on some collision calculations we're doing behind the scenes.">
+  <div
+    style={{
+      display: 'inline-block',
+      border: '1px solid magenta',
+      padding: '0.25rem 0.5rem',
+      borderRadius: '5px',
+    }}
+  >
+    I'm a React node with a tooltip.
+  </div>
+</Tooltip>
+
+### `label={<Slot />}`
+
+<Tooltip
+  theme="light"
+  forceVisible
+  label={
+    <div
+      style={{
+        display: 'inline-block',
+        border: '1px solid magenta',
+        padding: '0.25rem 0.5rem',
+        borderRadius: '4px',
+      }}
+    >
+      Hi there! This is a React node rendered within a tooltip.
+    </div>
+  }
+>
+  <div
+    style={{
+      display: 'inline-block',
+      border: '1px solid magenta',
+      padding: '0.25rem 0.5rem',
+      borderRadius: '5px',
+    }}
+  >
+    This tooltip wraps a text node, and renders a React node as the tooltip
+    contents.
+  </div>
+</Tooltip>
+
+### `theme="light" vs theme="dark"`

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,23 +1,9 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import Portal from '@reach/portal'
 import { useTooltip, TooltipPopup } from '@reach/tooltip'
 import classNames from 'classnames'
+import { TooltipArrowProps, TooltipProps, PRect } from './types'
 import s from './style.module.css'
-
-interface TooltipProps {
-  /** Element that, when hovered, will display the tooltip. */
-  children: React.ReactElement
-  /** Plain text for the tooltip to render */
-  label: React.ReactNode
-  /** What the screen reader announces  */
-  'aria-label'?: string
-  /** Minimum spacing from viewport edge */
-  collisionBuffer?: number
-  /** Theme for light or dark mode */
-  theme: 'light' | 'dark'
-  /** Optional CSS override for background color. Foreground color can be overridden by passing a styled React node to the label prop.  */
-  themeBackground?: string
-}
 
 function Tooltip({
   children,
@@ -25,40 +11,33 @@ function Tooltip({
   collisionBuffer = 8,
   'aria-label': ariaLabel,
   theme = 'light',
-  themeBackground,
-}: TooltipProps): React.ReactElement {
+}: TooltipProps): ReactElement {
   const [trigger, tooltip] = useTooltip()
   const { isVisible, triggerRect } = tooltip
 
   const themeClass = s[`theme-${theme}`]
-  const themeProps = {}
-  if (themeBackground) {
-    themeProps['--theme-background'] = themeBackground
-  }
 
   return (
     <>
       {typeof children == 'string'
         ? React.createElement('span', trigger, children)
         : React.cloneElement(children, trigger)}
-      {isVisible && (
+      {isVisible ? (
         <Portal>
-          <Arrow
+          <TooltipArrow
             triggerRect={triggerRect}
             collisionBuffer={collisionBuffer}
             themeClass={themeClass}
-            themeProps={themeProps}
           />
         </Portal>
-      )}
+      ) : null}
       <TooltipPopup
         {...tooltip}
         isVisible={isVisible}
-        style={themeProps as React.CSSProperties}
-        className={classNames(s.box, themeClass)}
+        className={classNames(s.tooltip, themeClass)}
         label={label}
         aria-label={ariaLabel}
-        position={(triggerRect, tooltipRect) =>
+        position={(triggerRect: PRect, tooltipRect: PRect) =>
           centeringFunction(triggerRect, tooltipRect, collisionBuffer)
         }
       />
@@ -79,7 +58,11 @@ function Tooltip({
  * doesn't appear at the very edge of the
  * viewport.
  */
-function centeringFunction(triggerRect, tooltipRect, collisionBuffer) {
+function centeringFunction(
+  triggerRect: PRect,
+  tooltipRect: PRect,
+  collisionBuffer: number
+) {
   const triggerCenter = triggerRect.left + triggerRect.width / 2
   const left = triggerCenter - tooltipRect.width / 2
   const maxLeft = window.innerWidth - tooltipRect.width - collisionBuffer
@@ -102,7 +85,11 @@ function centeringFunction(triggerRect, tooltipRect, collisionBuffer) {
  * than have it perfectly centered but
  * disconnected from the popup.
  */
-function Arrow({ triggerRect, collisionBuffer, themeClass, themeProps }) {
+function TooltipArrow({
+  triggerRect,
+  collisionBuffer,
+  themeClass,
+}: TooltipArrowProps) {
   const arrowThickness = 10
   const arrowLeft = triggerRect
     ? `${Math.min(
@@ -125,7 +112,6 @@ function Arrow({ triggerRect, collisionBuffer, themeClass, themeProps }) {
         {
           '--left': arrowLeft,
           '--top': arrowTop,
-          ...themeProps,
         } as React.CSSProperties
       }
     />

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -39,9 +39,8 @@ function Tooltip({
 
   return (
     <>
-      {typeof children == 'string'
-        ? React.createElement('span', trigger, children)
-        : React.cloneElement(children, trigger)}
+      {/* Wrapper span acts as trigger */}
+      {React.createElement('span', trigger, children)}
       {isVisible ? (
         <Portal>
           <TooltipArrow

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import Portal from '@reach/portal'
+import { useTooltip, TooltipPopup } from '@reach/tooltip'
+import classNames from 'classnames'
+import s from './style.module.css'
+
+interface TooltipProps {
+  /** Element that, when hovered, will display the tooltip. */
+  children: React.ReactElement
+  /** Plain text for the tooltip to render */
+  label: React.ReactNode
+  /** What the screen reader announces  */
+  'aria-label'?: string
+  /** Minimum spacing from viewport edge */
+  collisionBuffer?: number
+  /** Theme for light or dark mode */
+  theme: 'light' | 'dark'
+  /** Optional CSS override for background color. Foreground color can be overridden by passing a styled React node to the label prop.  */
+  themeBackground?: string
+}
+
+function Tooltip({
+  children,
+  label,
+  collisionBuffer = 8,
+  'aria-label': ariaLabel,
+  theme = 'light',
+  themeBackground,
+}: TooltipProps): React.ReactElement {
+  const [trigger, tooltip] = useTooltip()
+  const { isVisible, triggerRect } = tooltip
+
+  const themeClass = s[`theme-${theme}`]
+  const themeProps = {}
+  if (themeBackground) {
+    themeProps['--theme-background'] = themeBackground
+  }
+
+  return (
+    <>
+      {typeof children == 'string'
+        ? React.createElement('span', trigger, children)
+        : React.cloneElement(children, trigger)}
+      {isVisible && (
+        <Portal>
+          <Arrow
+            triggerRect={triggerRect}
+            collisionBuffer={collisionBuffer}
+            themeClass={themeClass}
+            themeProps={themeProps}
+          />
+        </Portal>
+      )}
+      <TooltipPopup
+        {...tooltip}
+        isVisible={isVisible}
+        style={themeProps as React.CSSProperties}
+        className={classNames(s.box, themeClass)}
+        label={label}
+        aria-label={ariaLabel}
+        position={(triggerRect, tooltipRect) =>
+          centeringFunction(triggerRect, tooltipRect, collisionBuffer)
+        }
+      />
+    </>
+  )
+}
+
+/**
+ * Given the bounding rectangle for both
+ * the tooltip trigger and tooltip popup,
+ * render the tooltip centered and below
+ * the trigger.
+ *
+ * Allow viewport collisions to override
+ * the centered position where needed,
+ * using the collisionBuffer argument
+ * to inset the collision area so the tooltip
+ * doesn't appear at the very edge of the
+ * viewport.
+ */
+function centeringFunction(triggerRect, tooltipRect, collisionBuffer) {
+  const triggerCenter = triggerRect.left + triggerRect.width / 2
+  const left = triggerCenter - tooltipRect.width / 2
+  const maxLeft = window.innerWidth - tooltipRect.width - collisionBuffer
+  return {
+    left: Math.min(Math.max(collisionBuffer, left), maxLeft) + window.scrollX,
+    top: triggerRect.bottom + collisionBuffer + window.scrollY,
+  }
+}
+
+/**
+ * Given the bounding rectangle for
+ * the tooltip trigger, render a small
+ * triangular arrow.
+ *
+ * This arrow is centered relative to
+ * the trigger, but accounts for possible
+ * viewport collisions, as we would prefer
+ * to have the arrow connected to the popup
+ * (which is bound by the viewport) rather
+ * than have it perfectly centered but
+ * disconnected from the popup.
+ */
+function Arrow({ triggerRect, collisionBuffer, themeClass, themeProps }) {
+  const arrowThickness = 10
+  const arrowLeft = triggerRect
+    ? `${Math.min(
+        // Centered position, covers most use cases
+        triggerRect.left - arrowThickness + triggerRect.width / 2,
+        // Ensure the arrow is not rendered even partially offscreen,
+        // as it will look disconnected from our tooltip body,
+        // which must be rendered within the viewport
+        window.innerWidth - arrowThickness * 2 - collisionBuffer
+      )}px`
+    : 'auto'
+  const arrowTop = triggerRect
+    ? `${triggerRect.bottom + window.scrollY}px`
+    : 'auto'
+
+  return (
+    <div
+      className={classNames(s.arrow, themeClass)}
+      style={
+        {
+          '--left': arrowLeft,
+          '--top': arrowTop,
+          ...themeProps,
+        } as React.CSSProperties
+      }
+    />
+  )
+}
+
+export default Tooltip

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -30,7 +30,7 @@ function Tooltip({
   children,
   label,
   ariaLabel,
-  theme = 'light',
+  theme = 'dark',
 }: TooltipProps): ReactElement {
   const [trigger, tooltip] = useTooltip()
   const { isVisible, triggerRect } = tooltip

--- a/src/components/tooltip/style.module.css
+++ b/src/components/tooltip/style.module.css
@@ -32,7 +32,7 @@ theme.module.css class at the component root.
   border-bottom: 10px solid var(--background);
 }
 
-.box {
+.tooltip {
   composes: g-type-body-small from global;
   font-size: 0.875rem;
   background: var(--background);

--- a/src/components/tooltip/style.module.css
+++ b/src/components/tooltip/style.module.css
@@ -39,7 +39,7 @@ theme.module.css class at the component root.
   height: var(--size);
   left: var(--left);
   position: absolute;
-  transform: translateY(-50%);
+  transform: translateY(-48%); /* not 50% avoids off-by-a-bit rounding issues */
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/tooltip/style.module.css
+++ b/src/components/tooltip/style.module.css
@@ -1,11 +1,8 @@
 /*
-Additional composition is helpful here.
-Note that .arrow and .root can't use CSS custom properties
-nicely since .arrow is rendered into a Portal.
-
-This also means that, unlike in other /partials,
-we can't reliably pull CSS custom properties from a
-theme.module.css class at the component root.
+Duplicative composing of `.theme-light` & `.theme-dark` in JSX may seem odd,
+compared to propogating the CSS custom properties from a single parent element,
+but note that .arrowContainer and .tooltip don't have a common parent element,
+as .arrowContainer is rendered into a Portal.
 */
 
 .theme-light {

--- a/src/components/tooltip/style.module.css
+++ b/src/components/tooltip/style.module.css
@@ -1,0 +1,48 @@
+/*
+Additional composition is helpful here.
+Note that .arrow and .root can't use CSS custom properties
+nicely since .arrow is rendered into a Portal.
+
+This also means that, unlike in other /partials,
+we can't reliably pull CSS custom properties from a
+theme.module.css class at the component root.
+*/
+
+.theme-light {
+  --background: var(--theme-background, var(--gray-2));
+  --foreground: var(--white);
+}
+
+.theme-dark {
+  --background: var(--theme-background, var(--gray-1));
+  --foreground: var(--white);
+}
+
+.arrow {
+  position: absolute;
+
+  /* --top and --left are set in JS, to allow
+    for dynamic, collision-free positioning. */
+  top: var(--top);
+  left: var(--left);
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid var(--background);
+}
+
+.box {
+  composes: g-type-body-small from global;
+  font-size: 0.875rem;
+  background: var(--background);
+  box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1);
+  color: var(--foreground);
+  padding: 0.5em 1em;
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+  border-radius: 3px;
+  max-width: 75vw;
+  max-width: min(75vw, 20em);
+}

--- a/src/components/tooltip/style.module.css
+++ b/src/components/tooltip/style.module.css
@@ -9,40 +9,88 @@ theme.module.css class at the component root.
 */
 
 .theme-light {
-  --background: var(--theme-background, var(--gray-2));
-  --foreground: var(--white);
+  --background: var(--token-color-surface-primary);
+  --foreground: var(--token-color-foreground-strong);
 }
 
 .theme-dark {
-  --background: var(--theme-background, var(--gray-1));
-  --foreground: var(--white);
+  --background: var(--token-color-foreground-strong);
+  --foreground: var(--token-color-surface-primary);
+}
+
+.arrowContainer {
+  /**
+   * Note: --top, --left, --offset, & --size are set in JS,
+   * to allow for dynamic, collision-free positioning.
+   *
+   * --top & --left position this element center-top aligned
+   * with the tooltip container.
+   * - We use translateY(-50%) to make half this element
+   *   protrude above the tooltip.
+   * - The .arrow element provides the visible tooltip arrow element,
+   *   which includes a box shadow that we need to clip, as otherwise it
+   *   would overlap on the tooltip
+   * - The clip-path clips the .arrow element to prevent it from
+   *   casting a box-shadow on the tooltip below. It also contains a -2px
+   *   clip inset at the top, to ensure we don't clip off the top corner
+   *   of the .arrow element, which protrudes a bit.
+   */
+  clip-path: inset(-2px 0 50% 0);
+  height: var(--size);
+  left: var(--left);
+  position: absolute;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: var(--top);
+  width: var(--size);
+  z-index: 2;
 }
 
 .arrow {
-  position: absolute;
+  /**
+   * We want to set the width of this .arrow relative to the parent width,
+   * such that when .arrow is rotated 45˚, its diagonal will fully
+   * span the parent container's width.
+   *
+   * Consider a diagonal cut through the inner box, this yields a right-angled
+   * triangle, with the adjacent and opposite sides "a" & "b" equal in length,
+   * corresponding to the inner box's size, & the hypotenuse "c" corresponding
+   * to the width of the parent container.
+   *
+   * a^2 + b^2 = c^2
+   * 2*(a^2) = c^2
+   * a^2 = (c^2 / 2)
+   * a = sqrt(c^2 / 2)
+   *
+   * We can use relative widths here, and the width of "c" is 100%.
+   * We can then calculate our desired width for "a":
+   *
+   * a = sqrt(100^2 / 2)
+   * a = sqrt(5000)
+   * a ~= 70.71
+   */
+  --square-size: 70.71%;
 
-  /* --top and --left are set in JS, to allow
-    for dynamic, collision-free positioning. */
-  top: var(--top);
-  left: var(--left);
-  width: 0;
-  height: 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 10px solid var(--background);
+  background: var(--background);
+  border-top-left-radius: 2px;
+  width: var(--square-size);
+  height: var(--square-size);
+  transform: rotate(45deg);
+  box-shadow: var(--token-surface-higher-box-shadow);
 }
 
 .tooltip {
-  composes: g-type-body-small from global;
-  font-size: 0.875rem;
   background: var(--background);
-  box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1);
+  border-radius: 5px;
+  box-shadow: var(--token-surface-higher-box-shadow);
   color: var(--foreground);
-  padding: 0.5em 1em;
+  composes: hds-typography-body-200 from global;
+  font-size: 0.875rem;
+  max-width: min(75vw, 20em);
+  padding: 8px 12px;
   pointer-events: none;
   position: absolute;
   z-index: 1;
-  border-radius: 3px;
-  max-width: 75vw;
-  max-width: min(75vw, 20em);
 }

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -19,7 +19,7 @@ export interface TooltipProps {
   ariaLabel?: string
 
   /**
-   * Theme for light or dark mode
+   * Optionally specify the appearance of the component. Defaults to "dark".
    */
   theme?: 'light' | 'dark'
 }

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -1,0 +1,26 @@
+import { Position } from '@reach/tooltip'
+import { ReactElement, ReactNode } from 'react'
+
+export type PRect = Parameters<Position>[0]
+
+export interface TooltipProps {
+  /** Element that, when hovered, will display the tooltip. */
+  children: ReactElement
+  /** Plain text, or render slot, to render in the tooltip */
+  label: ReactNode
+  /** Optional alternate content for screen readers.
+   * Useful if the label prop is not suitable for screen reader announcement. */
+  'aria-label'?: string
+  /** Minimum spacing from viewport edge */
+  collisionBuffer?: number
+  /** Theme for light or dark mode */
+  theme: 'light' | 'dark'
+  /** Optional CSS override for background color. Foreground color can be overridden by passing a styled React node to the label prop.  */
+  themeBackground?: string
+}
+
+export interface TooltipArrowProps {
+  triggerRect: PRect
+  collisionBuffer: number
+  themeClass: string
+}

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -1,27 +1,58 @@
 import { Position } from '@reach/tooltip'
 import { ReactElement, ReactNode } from 'react'
-
-export type PRect = Parameters<Position>[0]
-
 export interface TooltipProps {
-  /** Element that, when hovered, will display the tooltip. */
+  /**
+   * Element that, when hovered, will display the tooltip.
+   */
   children: ReactElement
-  /** Plain text, or render slot, to render in the tooltip */
+
+  /**
+   * Plain text, or `<ReactElement />`, to render in the tooltip.
+   */
   label: ReactNode
-  /** Optional alternate content for screen readers.
-   * Useful if the label prop is not suitable for screen reader announcement. */
+
+  /**
+   * Optional alternate content for screen readers.
+   * Useful if the label prop is not suitable for screen reader announcement,
+   * for example for icon-only tooltips.
+   */
   ariaLabel?: string
-  /** Minimum spacing from viewport edge */
-  collisionBuffer?: number
-  /** Theme for light or dark mode */
+
+  /**
+   * Theme for light or dark mode
+   */
   theme?: 'light' | 'dark'
-  /** Optional CSS override for background color. Foreground color can be overridden by passing a styled React node to the label prop.  */
-  themeBackground?: string
 }
 
+/**
+ * A partial DOMRect, describe further within @reach/tooltip
+ */
+export type PRect = Parameters<Position>[0]
+
 export interface TooltipArrowProps {
+  /**
+   * A partial DOMRect which describes the position of the tooltip trigger.
+   * Used to position the tooltip arrow.
+   * For use within <Tooltip /> only.
+   */
   triggerRect: PRect
+
+  /**
+   * The minimum pixel distance to maintain
+   * between the tooltip edge and the viewport edge.
+   * For use within <Tooltip /> only.
+   */
   collisionBuffer: number
+
+  /**
+   * A class shared within the component to alter appearance.
+   * For use within <Tooltip /> only.
+   */
   themeClass: string
+
+  /**
+   * The desired width of the tooltip arrow.
+   * For use within <Tooltip /> only.
+   */
   arrowWidth: number
 }

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -10,7 +10,7 @@ export interface TooltipProps {
   label: ReactNode
   /** Optional alternate content for screen readers.
    * Useful if the label prop is not suitable for screen reader announcement. */
-  'aria-label'?: string
+  ariaLabel?: string
   /** Minimum spacing from viewport edge */
   collisionBuffer?: number
   /** Theme for light or dark mode */
@@ -23,4 +23,5 @@ export interface TooltipArrowProps {
   triggerRect: PRect
   collisionBuffer: number
   themeClass: string
+  arrowWidth: number
 }

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -14,7 +14,7 @@ export interface TooltipProps {
   /** Minimum spacing from viewport edge */
   collisionBuffer?: number
   /** Theme for light or dark mode */
-  theme: 'light' | 'dark'
+  theme?: 'light' | 'dark'
   /** Optional CSS override for background color. Foreground color can be overridden by passing a styled React node to the label prop.  */
   themeBackground?: string
 }

--- a/src/components/tutorial-card/helpers/build-aria-label.ts
+++ b/src/components/tutorial-card/helpers/build-aria-label.ts
@@ -1,0 +1,42 @@
+import { ProductOption } from 'lib/learn-client/types'
+import { TutorialCardProps } from '../types'
+
+const PRODUCT_LABEL_MAP: Record<ProductOption, string> = {
+  boundary: 'Boundary',
+  consul: 'Consul',
+  nomad: 'Nomad',
+  packer: 'Packer',
+  terraform: 'Terraform',
+  vault: 'Vault',
+  vagrant: 'Vagrant',
+  waypoint: 'Waypoint',
+}
+
+export function buildAriaLabel({
+  heading,
+  duration,
+  productsUsed,
+  hasVideo,
+  hasInteractiveLab,
+}: Pick<
+  TutorialCardProps,
+  'heading' | 'duration' | 'productsUsed' | 'hasVideo' | 'hasInteractiveLab'
+>): string {
+  let ariaLabel = ''
+  const speakableDuration = duration
+    .replace('hr', ' hour')
+    .replace('min', ' minute')
+  ariaLabel += `${heading}. ${speakableDuration} tutorial.`
+  if (productsUsed.length > 0) {
+    ariaLabel += ` Uses the following products: ${productsUsed
+      .map((p: ProductOption) => PRODUCT_LABEL_MAP[p])
+      .join(', ')}.`
+  }
+  if (hasVideo) {
+    ariaLabel += ` Tutorial has video.`
+  }
+  if (hasInteractiveLab) {
+    ariaLabel += ` Tutorial has interactive lab.`
+  }
+  return ariaLabel
+}

--- a/src/components/tutorial-card/helpers/build-aria-label.ts
+++ b/src/components/tutorial-card/helpers/build-aria-label.ts
@@ -32,11 +32,11 @@ export function buildAriaLabel({
       .map((p: ProductOption) => PRODUCT_LABEL_MAP[p])
       .join(', ')}.`
   }
-  if (hasVideo) {
-    ariaLabel += ` Tutorial has video.`
-  }
   if (hasInteractiveLab) {
     ariaLabel += ` Tutorial has interactive lab.`
+  }
+  if (hasVideo) {
+    ariaLabel += ` Tutorial has video.`
   }
   return ariaLabel
 }

--- a/src/components/tutorial-card/helpers/format-tutorial-card.ts
+++ b/src/components/tutorial-card/helpers/format-tutorial-card.ts
@@ -4,7 +4,7 @@ import {
   ProductUsed,
   TutorialLite as ClientTutorialLite,
 } from 'lib/learn-client/types'
-import { TutorialCardPropsWithId } from './types'
+import { TutorialCardPropsWithId } from '../types'
 
 export function formatTutorialCard(
   tutorial: ClientTutorialLite,

--- a/src/components/tutorial-card/helpers/index.ts
+++ b/src/components/tutorial-card/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './build-aria-label'
+export * from './format-tutorial-card'

--- a/src/components/tutorial-card/index.tsx
+++ b/src/components/tutorial-card/index.tsx
@@ -8,6 +8,7 @@ import {
   CardBadgeOption,
 } from 'components/tutorial-collection-cards'
 import s from './tutorial-card.module.css'
+import { buildAriaLabel } from './helpers'
 
 /**
  * Render a card that links to a tutorial.
@@ -33,8 +34,16 @@ function TutorialCard({
     badges.push('video')
   }
 
+  const ariaLabel = buildAriaLabel({
+    heading,
+    duration,
+    productsUsed,
+    hasVideo,
+    hasInteractiveLab,
+  })
+
   return (
-    <CardLink href={url} className={s.root}>
+    <CardLink href={url} className={s.root} ariaLabel={ariaLabel}>
       <CardEyebrow text={duration} />
       <CardHeading level={3} text={heading} />
       <CardBody text={description} />

--- a/src/components/tutorial-card/types.ts
+++ b/src/components/tutorial-card/types.ts
@@ -8,7 +8,6 @@ export interface TutorialCardProps {
 
   /**
    * A string representation the duration of the tutorial, such as "10mins".
-   * TODO: change this to be a number, and do formatting in in this component
    */
   duration: string
 

--- a/src/components/tutorial-collection-cards/components/card-badges/index.tsx
+++ b/src/components/tutorial-collection-cards/components/card-badges/index.tsx
@@ -58,13 +58,11 @@ function CardBadges({ badges }: CardBadgesProps) {
         return (
           <li key={badge}>
             <Tooltip label={CARD_BADGE_LABEL_MAP[badge]}>
-              <div role="button">
-                <Badge
-                  ariaLabel={CARD_BADGE_LABEL_MAP[badge]}
-                  icon={CARD_BADGE_ICON_MAP[badge]}
-                  className={s.badge}
-                />
-              </div>
+              <Badge
+                ariaLabel={CARD_BADGE_LABEL_MAP[badge]}
+                icon={CARD_BADGE_ICON_MAP[badge]}
+                className={s.badge}
+              />
             </Tooltip>
           </li>
         )

--- a/src/components/tutorial-collection-cards/components/card-badges/index.tsx
+++ b/src/components/tutorial-collection-cards/components/card-badges/index.tsx
@@ -6,7 +6,6 @@ import ProductIcon from 'components/product-icon'
 import { CardBadgesProps, CardBadgeOption } from './types'
 import s from './card-badges.module.css'
 import Tooltip from 'components/tooltip'
-import { useId } from '@react-aria/utils'
 
 /**
  * Map product badge options to icons

--- a/src/components/tutorial-collection-cards/components/card-badges/index.tsx
+++ b/src/components/tutorial-collection-cards/components/card-badges/index.tsx
@@ -5,7 +5,12 @@ import Badge from 'components/badge'
 import ProductIcon from 'components/product-icon'
 import { CardBadgesProps, CardBadgeOption } from './types'
 import s from './card-badges.module.css'
+import Tooltip from 'components/tooltip'
+import { useId } from '@react-aria/utils'
 
+/**
+ * Map product badge options to icons
+ */
 const PRODUCT_ICON_MAP: Record<ProductOption, JSX.Element> = {
   boundary: <ProductIcon productSlug="boundary" />,
   consul: <ProductIcon productSlug="consul" />,
@@ -16,10 +21,35 @@ const PRODUCT_ICON_MAP: Record<ProductOption, JSX.Element> = {
   vagrant: <ProductIcon productSlug="vagrant" />,
   waypoint: <ProductIcon productSlug="waypoint" />,
 }
-const CARD_BADGE_MAP: Record<CardBadgeOption, JSX.Element> = {
+/**
+ * Map all card badge options to icons
+ */
+const CARD_BADGE_ICON_MAP: Record<CardBadgeOption, JSX.Element> = {
   ...PRODUCT_ICON_MAP,
   video: <IconPlay16 />,
   interactive: <IconTerminalScreen16 />,
+}
+
+/**
+ * Map product badge options to badge labels
+ */
+const PRODUCT_LABEL_MAP: Record<ProductOption, string> = {
+  boundary: 'Boundary',
+  consul: 'Consul',
+  nomad: 'Nomad',
+  packer: 'Packer',
+  terraform: 'Terraform',
+  vault: 'Vault',
+  vagrant: 'Vagrant',
+  waypoint: 'Waypoint',
+}
+/**
+ * Map all card badge options to badge labels
+ */
+const CARD_BADGE_LABEL_MAP: Record<CardBadgeOption, string> = {
+  ...PRODUCT_LABEL_MAP,
+  video: 'Video',
+  interactive: 'Interactive',
 }
 
 function CardBadges({ badges }: CardBadgesProps) {
@@ -28,11 +58,15 @@ function CardBadges({ badges }: CardBadgesProps) {
       {badges.map((badge: CardBadgeOption) => {
         return (
           <li key={badge}>
-            <Badge
-              ariaLabel={badge}
-              icon={CARD_BADGE_MAP[badge]}
-              className={s.badge}
-            />
+            <Tooltip label={CARD_BADGE_LABEL_MAP[badge]}>
+              <div role="button">
+                <Badge
+                  ariaLabel={CARD_BADGE_LABEL_MAP[badge]}
+                  icon={CARD_BADGE_ICON_MAP[badge]}
+                  className={s.badge}
+                />
+              </div>
+            </Tooltip>
           </li>
         )
       })}


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][swingset] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Builds a `Tooltip` component, uses it for `TutorialCard` via `CardBadges`, and provides an accessible equivalent by implementing a custom `aria-label` for `TutorialCard` links.

## 🤷 

To make `TutorialCard`'s product & "content type" icons more accessible to all visitors who might not be familiar with them already.

## 🛠️ How

- Implements `components/tooltip`
- Uses `Tooltip` in `CardBadges`
- For `TutorialCard`, currently each badge in `CardBadges` is not focus-able (as there is no action to be taken on activating a non-interactive badge). With this in mind, rather than try to make the tooltips on `CardBadges` accessible to screen readers, we've implemented a descriptive `aria-label` for `TutorialCard` links, which includes the information conveyed through `CardBadges`.

## 📸 Design Screenshots

<details>
<summary>Design spec</summary>

![CleanShot 2022-04-25 at 19 50 09@2x](https://user-images.githubusercontent.com/4624598/165193537-a4b6f5ec-cfe0-4dd5-9d1f-560c0e127dc6.png)

</details>

<details>
<summary>Implementation - aria-label for screen reader communication</summary>

<img width="838" alt="CleanShot 2022-04-25 at 19 59 15@2x" src="https://user-images.githubusercontent.com/4624598/165193459-9800a6cb-9516-459c-9c5b-55a4ff002ed4.png">

<img width="954" alt="CleanShot 2022-04-25 at 19 59 28@2x" src="https://user-images.githubusercontent.com/4624598/165193474-d5d7d6a9-25be-4d91-8a0d-9e180046497e.png">

</details>

<details>
<summary>Implementation - Tooltips for visual communication</summary>

![CleanShot 2022-04-25 at 20 00 08](https://user-images.githubusercontent.com/4624598/165193432-a327ce50-59d7-42a3-9b04-2bb404c57d2f.gif)

</details>

## 🧪 Testing

- [ ] Visit [the Swingset page][swingset], and ensure the component works as expected
- [ ] Visit a collection page, such as [`/vault/tutorials/secrets-management`][collection-page], and ensure:
    - [ ] Each `TutorialCard` has both the expected `Tooltip` behaviour in the bottom `CardBadge` section
    - [ ] Each `TutorialCard` has an `aria-label` which provides a screen-reader-friendly description of the tutorial being linked to. This description should include the details conveyed visually in the `CardBadges` section.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202001387788447/1202170815898210/f
[swingset]: https://dev-portal-git-zsadd-tooltip-hashicorp.vercel.app/swingset/components/tooltip
[collection-page]: https://dev-portal-git-zsadd-tooltip-hashicorp.vercel.app/vault/tutorials/secrets-management
