### PR TITLE
feat: Add DocsAnchor to fix internal links

### DIFF
--- a/src/components/docs-anchor/__tests__/docs-anchor.test.tsx
+++ b/src/components/docs-anchor/__tests__/docs-anchor.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import makeDocsAnchor from '..'
+
+describe('DocsAnchor', () => {
+  test('rewrites internal links based on props to the factory function', async () => {
+    const DocsAnchor = makeDocsAnchor('waypoint', ['docs'])
+
+    render(<DocsAnchor href="/docs/some/page">This is a link</DocsAnchor>)
+
+    const result = screen.queryByText('This is a link')
+
+    expect(result).toHaveAttribute('href', '/waypoint/docs/some/page')
+  })
+})

--- a/src/components/docs-anchor/index.tsx
+++ b/src/components/docs-anchor/index.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable jsx-a11y/anchor-has-content -- We're just passing through props here, so the links should be well formatted */
+import { ProductSlug } from 'types/products'
+import Link from 'next/link'
+
+export default function makeDocsAnchor(
+  product: ProductSlug,
+  basePaths: string[]
+) {
+  const DocsAnchor: React.FC<JSX.IntrinsicElements['a']> = ({
+    href,
+    ...rest
+  }) => {
+    if (!href) return <a {...rest} />
+
+    let adjustedHref = href
+    // TODO: infer this condition dynamically
+    if (basePaths.some((basePath) => href.startsWith(`/${basePath}`))) {
+      // TODO: infer the product dynamically
+      adjustedHref = `/${product}${href}`
+    }
+
+    // Render a next/link to avoid a full reload if we know for sure the link is an internal docs link.
+    // TODO: This heuristic can likely be tweaked to be more inclusive of other internal links
+    if (adjustedHref !== href) {
+      return (
+        <Link href={adjustedHref}>
+          <a {...rest} />
+        </Link>
+      )
+    }
+
+    return <a href={adjustedHref} {...rest} />
+  }
+
+  return DocsAnchor
+}

--- a/src/components/docs-anchor/index.tsx
+++ b/src/components/docs-anchor/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-has-content -- We're just passing through props here, so the links should be well formatted */
 import { ProductSlug } from 'types/products'
 import Link from 'next/link'
 
@@ -8,9 +7,10 @@ export default function makeDocsAnchor(
 ) {
   const DocsAnchor: React.FC<JSX.IntrinsicElements['a']> = ({
     href,
+    children,
     ...rest
   }) => {
-    if (!href) return <a {...rest} />
+    if (!href) return <a {...rest}>{children}</a>
 
     let adjustedHref = href
     // TODO: infer this condition dynamically
@@ -24,12 +24,16 @@ export default function makeDocsAnchor(
     if (adjustedHref !== href) {
       return (
         <Link href={adjustedHref}>
-          <a {...rest} />
+          <a {...rest}>{children}</a>
         </Link>
       )
     }
 
-    return <a href={adjustedHref} {...rest} />
+    return (
+      <a href={adjustedHref} {...rest}>
+        {children}
+      </a>
+    )
   }
 
   return DocsAnchor

--- a/src/pages/waypoint/commands/[[...page]].tsx
+++ b/src/pages/waypoint/commands/[[...page]].tsx
@@ -6,6 +6,7 @@ import { anchorLinks } from '@hashicorp/remark-plugins'
 import waypointConfig from '../../../../config/waypoint.json'
 import Placement from 'components/author-primitives/shared/placement-table'
 import NestedNode from 'components/author-primitives/waypoint/nested-node'
+import makeDocsAnchor from 'components/docs-anchor'
 import DocsLayout from 'layouts/docs'
 import { MDXRemote } from 'next-mdx-remote'
 // import WaypointIoLayout from 'layouts/proxied-io-sites/waypoint'
@@ -18,7 +19,11 @@ const temporary_noop = 'im just for show'
 const productName = waypointConfig.name
 const productSlug = waypointConfig.slug
 const basePath = 'commands'
-const additionalComponents = { Placement, NestedNode }
+const additionalComponents = {
+  Placement,
+  NestedNode,
+  a: makeDocsAnchor('waypoint', ['docs', 'plugins', 'commands']),
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function WaypointCommandsPage(props) {

--- a/src/pages/waypoint/docs/[[...page]].tsx
+++ b/src/pages/waypoint/docs/[[...page]].tsx
@@ -8,6 +8,7 @@ import { MDXRemote } from 'next-mdx-remote'
 import waypointConfig from '../../../../config/waypoint.json'
 import Placement from 'components/author-primitives/shared/placement-table'
 import NestedNode from 'components/author-primitives/waypoint/nested-node'
+import makeDocsAnchor from 'components/docs-anchor'
 import DocsLayout from 'layouts/docs'
 
 // because some of the util functions still require param arity, but we ignore
@@ -18,7 +19,11 @@ const temporary_noop = 'im just for show'
 const productName = waypointConfig.name
 const productSlug = waypointConfig.slug
 const basePath = 'docs'
-const additionalComponents = { Placement, NestedNode }
+const additionalComponents = {
+  Placement,
+  NestedNode,
+  a: makeDocsAnchor('waypoint', ['docs', 'plugins', 'commands']),
+}
 
 // TODO: inline styles will be removed in a follow-up layout task (ref: https://app.asana.com/0/0/1201217826547576/f)
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/src/pages/waypoint/plugins/[[...page]].tsx
+++ b/src/pages/waypoint/plugins/[[...page]].tsx
@@ -6,6 +6,7 @@ import { anchorLinks } from '@hashicorp/remark-plugins'
 import waypointConfig from '../../../../config/waypoint.json'
 import Placement from 'components/author-primitives/shared/placement-table'
 import NestedNode from 'components/author-primitives/waypoint/nested-node'
+import makeDocsAnchor from 'components/docs-anchor'
 import DocsLayout from 'layouts/docs'
 import { MDXRemote } from 'next-mdx-remote'
 
@@ -17,7 +18,11 @@ const temporary_noop = 'im just for show'
 const productName = waypointConfig.name
 const productSlug = waypointConfig.slug
 const basePath = 'plugins'
-const additionalComponents = { Placement, NestedNode }
+const additionalComponents = {
+  Placement,
+  NestedNode,
+  a: makeDocsAnchor('waypoint', ['docs', 'plugins', 'commands']),
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function WaypointPluginsPage(props) {


### PR DESCRIPTION
👀 [Preview](https://dev-portal-git-brkfeat-docs-anchor-hashicorp.vercel.app/waypoint/docs/intro)

Adding `DocsAnchor` to rewrite internal links so that they have the right product path segment. In the future it'd be ideal if we had some sort of `NavigationContext` which contained the current product and relevant base paths so that we didn't have to pass them in.

Usage:
```ts
import makeDocsAnchor from 'components/docs-anchor'

const components = {
  a: makeDocsAnchor('waypoint', ['docs', 'commands', 'plugins'])
}
```