### PR TITLE
fix: restore VERCEL_ENV to fix local dev experience

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,9 @@
 ENABLE_VERSIONED_DOCS=true
+# TODO: docs-page/server code requires VERCEL_ENV="production" to be set
+# TODO: in order to load remote content. We may want to update the server
+# TODO: code to rely only on the ENABLE_VERSIONED_DOCS env var instead,
+# TODO: as setting this manually for local dev feels inaccurate.
+VERCEL_ENV="production"
 
 NEXT_PUBLIC_ALGOLIA_APP_ID=YY0FFNI7MF
 # Temporary: for the purposes of this initial port, we'll default all search to waypoint


### PR DESCRIPTION
This PR restores `VERCEL_ENV="production"`. Without this, devs working locally would have to manually set this variable in order for Waypoint's remote content to work as expected.