### PR TITLE
fix: patch code render in breadcrumbs

### DIFF
--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -44,9 +44,10 @@ function BreadcrumbBar({
                 className={s.breadcrumbText}
                 href={url}
                 aria-current={isCurrentPage ? 'page' : undefined}
-              >
-                {title}
-              </Elem>
+                // Note: HTML setting is necessary here, as some titles
+                // are formatted as "<code>Some title</code>"
+                dangerouslySetInnerHTML={{ __html: title }}
+              />
             </li>
           )
         })}
@@ -55,10 +56,12 @@ function BreadcrumbBar({
   )
 }
 
-function InternalLink({ href, children, ...rest }) {
+function InternalLink({ href, ...rest }) {
   return (
     <Link href={href}>
-      <a {...rest}>{children}</a>
+      {/* Link content may be set by "children" or by setting HTML */}
+      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
+      <a {...rest} />
     </Link>
   )
 }

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -37,17 +37,17 @@ function BreadcrumbBar({
     <nav aria-label="Breadcrumb" className={s.root}>
       <ol className={s.listRoot}>
         {links.map(({ title, url, isCurrentPage }) => {
+          const cleanTitle = title.replace(/<[^>]+>/g, '')
           const Elem = url ? InternalLink : 'span'
           return (
-            <li key={`${title}_${url}`} className={s.listItem}>
+            <li key={`${cleanTitle}_${url}`} className={s.listItem}>
               <Elem
                 className={s.breadcrumbText}
                 href={url}
                 aria-current={isCurrentPage ? 'page' : undefined}
-                // Note: HTML setting is necessary here, as some titles
-                // are formatted as "<code>Some title</code>"
-                dangerouslySetInnerHTML={{ __html: title }}
-              />
+              >
+                {cleanTitle}
+              </Elem>
             </li>
           )
         })}
@@ -56,12 +56,10 @@ function BreadcrumbBar({
   )
 }
 
-function InternalLink({ href, ...rest }) {
+function InternalLink({ href, children, ...rest }) {
   return (
     <Link href={href}>
-      {/* Link content may be set by "children" or by setting HTML */}
-      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-      <a {...rest} />
+      <a {...rest}>{children}</a>
     </Link>
   )
 }


### PR DESCRIPTION
👀 [Preview](https://dev-portal-git-zspatch-breadcrumb-html-issue-hashicorp.vercel.app/waypoint/docs/waypoint-hcl/build)

This PR fixes an issue with `<code>` element rendering in the `<BreadcrumbBar />` component.

## Before

<img width="1144" alt="CleanShot 2022-01-05 at 11 22 10@2x" src="https://user-images.githubusercontent.com/4624598/148252045-ca9ef2d7-7723-49f3-966a-82f1491f53f6.png">

## After

<img width="1144" alt="CleanShot 2022-01-05 at 11 30 07@2x" src="https://user-images.githubusercontent.com/4624598/148253390-abb9fdc3-7c82-4b81-8fbb-7873bf645c2b.png">

<details>
<summary>Alternate treatment</summary>

This treatment renders the `<code>` element rather than stripping it out. It felt like more of a departure from the appearance of the rest of the breadcrumb bar, so was dropped in favour of stripping out HTML tags from titles when rendering them in the breadcrumb bar.

<img width="1148" alt="CleanShot 2022-01-05 at 11 23 06@2x" src="https://user-images.githubusercontent.com/4624598/148252243-2375cbaa-4440-4e31-aa9d-96f6bec7f936.png">

</details>

