### PR TITLE
Fix product switcher non-clickable edges

### DIFF
--- a/src/components/product-switcher/index.tsx
+++ b/src/components/product-switcher/index.tsx
@@ -80,11 +80,15 @@ const ProductSwitcher: React.FC = () => {
   }, [isOpen])
 
   /**
-   * It would be more optimal to set onKeyDown for the containing element, but that is not allowed
-   * on a <div> with no role. We do not want to use a menu role (see https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html)
-   * so there is no role currently set on the containing <div>. If we find an appropriate role, then we can
-   * change the approach. For now, it's most appropriate to set onKeyDown on the <button> and <ul>,
-   * hence the `KeyboardEventHandler<HTMLButtonElement | HTMLUListElement>` definition.
+   * It would be more optimal to set onKeyDown for the containing element, but
+   * that is not allowed on a <div> with no role. We do not want to use a menu
+   * role (see Adrian Roselli link below) so there is no role currently set on
+   * the containing <div>. If we find an appropriate role, then we can change
+   * the approach. For now, it's most appropriate to set onKeyDown on the
+   * <button> and <ul>, hence this defintion:
+   * `KeyboardEventHandler<HTMLButtonElement | HTMLUListElement>`.
+   *
+   * https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html
    */
   const handleKeyDown: KeyboardEventHandler<
     HTMLButtonElement | HTMLUListElement
@@ -94,13 +98,13 @@ const ProductSwitcher: React.FC = () => {
     const isSpaceKey = e.key === ' '
 
     /**
-     * The reason we can't focus the first anchor here is because we have the anchor element
-     * is not rendered until after `setIsOpen(true)` is called by the <button>'s onClick (default
-     * behavior of <button> elements).
+     * The reason we can't focus the first anchor here is because we have the
+     * anchor element is not rendered until after `setIsOpen(true)` is called by
+     * the <button>'s onClick (default behavior of <button> elements).
      *
-     * Might be possible to do e.preventDefault and then do the focus() call here? Not sure we
-     * need to do that though unless we are very against this approach. I'd rather not prevent
-     * default behavior if we don't have to.
+     * Might be possible to do e.preventDefault and then do the focus() call
+     * here? Not sure we need to do that though unless we are very against this
+     * approach. I'd rather not prevent default behavior if we don't have to.
      */
     if (!isOpen && (isEnterKey || isSpaceKey)) {
       shouldFocusFirstAnchor.current = true
@@ -204,8 +208,8 @@ const ProductSwitcher: React.FC = () => {
   }
 
   /**
-   * I _think_ we want the containing element to be a nav, currently clashes with other
-   * styles so not using that element just yet
+   * I _think_ we want the containing element to be a nav, currently clashes
+   * with other styles so not using that element just yet
    */
   return (
     <div className={s.productSwitcher} ref={productChooserRef}>

--- a/src/components/product-switcher/index.tsx
+++ b/src/components/product-switcher/index.tsx
@@ -181,11 +181,13 @@ const ProductSwitcher: React.FC = () => {
           onKeyDown={handleAnchorKeyDown}
           ref={refToPass}
         >
-          <ProductIcon
-            className={productIconClassName}
-            product={product.slug}
-          />
-          <span>{product.name}</span>
+          <span className={s.focusContainer}>
+            <ProductIcon
+              className={productIconClassName}
+              product={product.slug}
+            />
+            <span>{product.name}</span>
+          </span>
         </a>
       </li>
     )

--- a/src/components/product-switcher/style.module.css
+++ b/src/components/product-switcher/style.module.css
@@ -59,7 +59,6 @@
 }
 
 .switcherOption {
-  padding: 4px;
   margin: 2px 0;
 
   &:hover {
@@ -77,14 +76,32 @@ Two items to note:
   - both paddings are set to adjust for transparent border
 */
 .switcherOptionAnchor {
-  composes: focus-border-and-box-shadow-dark from global;
+  align-items: center;
+  color: #f1f2f3;
+  display: flex;
+  padding: 3px;
+  position: relative;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    & .focusContainer {
+      border: 1px solid #107dff;
+      box-shadow: 0 0 0 3px #5fbcff;
+      outline: none;
+    }
+  }
+}
+
+.focusContainer {
   align-items: center;
   border: 1px solid transparent;
   border-radius: 5px;
-  color: #f1f2f3;
   display: flex;
-  padding: 3px 7px;
-  position: relative;
+  padding: 4px 8px;
+  width: 100%;
 }
 
 .switcherOptionContainer {


### PR DESCRIPTION
🔎 [Preview link](https://dev-portal-git-ambfix-product-switcher-hover-hashicorp.vercel.app/)
🎟️ [Asana ticket](https://app.asana.com/0/1201010428539925/1201602267333025/f)

## What

This PR fixes an issue where it was possible to hover over a `ProductSwitcher` option around its edges but not be able to click on it. This was because of the padding within the `<li>` elements containing the clickable `<a>` elements.

## How

I removed the padding within the `<li>` elements, increased the padding of the `<a>` elements to achieve the desired height, added a `<span>` directly within the `<a>` element for each switcher option, and then when the `<a>` receives focus that `<span>` gets the custom focus outline applied to match the "inset" style that's been specified in the designs.

## Testing

- [ ] Nothing should have changed visually about the default, hover, or focus states of switcher options
- [ ] Each switcher option should be entirely clickable now