### PR TITLE
Adding PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## "Ready for Review" checklist
+
+- [ ] The Vercel preview link has been added to this PR's description
+- [ ] The Asana task has been added to this PR's description
+- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
+- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
+
+---
+
+## Relevant links
+
+- [Preview link](url) 🔎
+- [Asana task](url) 🎟️
+
+## What
+
+_Briefly list out the changes proposed in this PR._
+
+## Why
+
+_Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc._
+
+## How
+
+_Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc._
+
+## Testing
+
+_Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first._
+
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+- [ ] ...
+
+## Anything else?
+
+_If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
 ## "Ready for Review" checklist
 
+<!--
+Check these items off in the GitHub PR UI as you complete them.
+-->
+
 - [ ] The Vercel preview link has been added to this PR's description
 - [ ] The Asana task has been added to this PR's description
 - [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
@@ -15,25 +19,35 @@
 
 ## What
 
-_Briefly list out the changes proposed in this PR._
+<!--
+Briefly list out the changes proposed in this PR.
+-->
 
 ## Why
 
-_Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc._
+<!--
+Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
+-->
 
 ## How
 
-_Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc._
+<!--
+Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
+-->
 
 ## Testing
 
-_Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first._
+<!--
+Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.
 
 - [ ] Step 1
 - [ ] Step 2
 - [ ] Step 3
 - [ ] ...
+-->
 
 ## Anything else?
 
-_If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them._
+<!--
+If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 - [ ] The Asana task has been added to this PR's description
 - [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
 - [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
+- [ ] The description template has been filled in below
 
 ---
 


### PR DESCRIPTION
## Relevant links

- A preview link is not needed for this PR, there are no changes to the project code
- There is no Asana task for this work

## What

- Adds a template for PRs 😊 

## Why

- In my experience I've found that automating PR content is a large time and effort saver by preventing everyone from having to remember all the details we'd like to see in PRs.
- The goal of the `"Ready for Review" checklist` section is to ensure we're giving updates across communication channels for folks outside of the engineering team.
- @BRKalow and @zchsh have both complimented the `Testing` section I've included in recent PRs ([this one](https://github.com/hashicorp/dev-portal/pull/64) and [this one](https://github.com/hashicorp/dev-portal/pull/65)) so it seems like a suitable time to add a template. 😊

## How

This template is based off of one I wrote in my previous role, which was based off research of templates and guides publicly posted by other engineering organizations and teams. I personally found it useful for writing PRs and I also received positive feedback from others that used it for writing PRs and/or reviewed my PRs written in this format. There weren't many people involved (small company & team) and of course all people are different, so I'm excited to hear feedback on this. 😊

## Testing

Nothing to test!

## Anything else?

Nope