### PR TITLE
fix noindex regex to include homepage

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const withSwingset = require('swingset')
 
 // temporary: set all paths as noindex, until we're serving from this project
 const temporary_hideDocsPaths = {
-  source: '/:path*',
+  source: '/:path*{/}?',
   headers: [
     {
       key: 'X-Robots-Tag',


### PR DESCRIPTION
this should allow us to remove the pw protection and operate under security through obscurity

to test:
- load https://developer.hashi-mktg.com and view the response headers. notice `x-robots-tag` is not present
- load https://developer.hashi-mktg.com/waypoint and view the response headers. notice `x-robots-tag` is properly set
- load https://dev-portal-ebuuwrs0f-hashicorp.vercel.app/ and see `x-robots-tag` is now properly set on the homepage 
- load https://dev-portal-ebuuwrs0f-hashicorp.vercel.app/waypoint and see `x-robots-tag` is still properly set on sub paths
