### PR TITLE
chore: checkout PR template from main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+## "Ready for Review" checklist
+
+<!--
+Check these items off in the GitHub PR UI as you complete them.
+-->
+
+- [ ] The Vercel preview link has been added to this PR's description
+- [ ] The Asana task has been added to this PR's description
+- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
+- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
+- [ ] The description template has been filled in below
+
+---
+
+## Relevant links
+
+- [Preview link](url) 🔎
+- [Asana task](url) 🎟️
+
+## What
+
+<!--
+Briefly list out the changes proposed in this PR.
+-->
+
+## Why
+
+<!--
+Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
+-->
+
+## How
+
+<!--
+Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
+-->
+
+## Testing
+
+<!--
+Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.
+
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+- [ ] ...
+-->
+
+## Anything else?
+
+<!--
+If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
+-->


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
    - Not applicable, just adding PR template
- [x] The Asana task has been added to this PR's description
    - Not applicable, no Asana task associated
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
    - Not applicable, no Asana task associated
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
    - Not applicable, just adding PR template
- [x] The description template has been filled in below

---

## Relevant links

- Preview link 🔎 - Not applicable
- Asana task - Not applicable

## What

This PR checks out our wonderful PR template from `main`.

## Why

So that PRs onto `assembly-ui-v1` benefit from the template as well.

## How

`git checkout main .github/PULL_REQUEST_TEMPLATE.md`

## Testing

Not sure that testing is required, but we could open a new PR onto this PR as a base, I guess?

## Anything else?

Nope.
