### PR TITLE
feat: add segment write key for ConsentManager

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -38,6 +38,7 @@ module.exports = withSwingset({
       HASHI_ENV: process.env.HASHI_ENV || 'development',
       BUGSNAG_CLIENT_KEY: '06718db5e1d75829801baa0b4ca2fb7b',
       BUGSNAG_SERVER_KEY: 'b32b4487b5dc72b32f51c8fe33641a43',
+      SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
     },
     svgo: {
       plugins: [


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsadd-segment-write-key-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201630385846486/f) 🎟️

## What

This PR adds `SEGMENT_WRITE_KEY` to `next.config`, which allows us to configure this variable [for ConsentManager](https://github.com/hashicorp/react-components/blob/f802a62bc4bdeabd2c7fbff004896da5c1a07426/packages/consent-manager/loader/index.tsx#L17) through our environment variable settings.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Allows data to be written to Segment, once consent is given.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Takes a similar approach as we do on other sites, but relies on [ConsentManager's internal production vs development switching](https://github.com/hashicorp/react-components/blob/f802a62bc4bdeabd2c7fbff004896da5c1a07426/packages/consent-manager/loader/index.tsx#L45).

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

I don't think we can fully test setting the write key on the `assembly-ui-v1` branch, as it is not marked as our production branch and will therefore have `HASHI_ENV=preview`.

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

As mentioned in #70, we have [an Asana task](https://app.asana.com/0/1100423001970639/1201646681395160/f) to ensure ConsentManager use works when merging with upstream `.io` work on `main`. At that time I think we'll be in a better place to test that this change works as expected.
