### PR TITLE
feat: exclude waypointproject from the noindex header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const redirectsConfig = require('./config/redirects')
 const rewritesConfig = require('./config/rewrites')
 
 // temporary: set all paths as noindex, until we're serving from this project
+// Update the excluded domains to ensure we are indexing content as the io sites get migrated
 const temporary_hideDocsPaths = {
   source: '/:path*',
   headers: [
@@ -12,6 +13,7 @@ const temporary_hideDocsPaths = {
       value: 'noindex',
     },
   ],
+  has: [{ type: 'host', value: '(^(?!.*(waypointproject)).*$)' }],
 }
 
 module.exports = withSwingset({ componentsRoot: 'src/components/*' })(


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

- [Preview link](url) 🔎
- [Asana task](url) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->
Updates our regex to ensure that waypointproject.io will **NOT** get the `noindex` header.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
With the migration, we definitely want the site to be indexed.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
Some good ol' regex magic.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

A bit cumbersome to validate, here's how I did it locally.

- [ ] Start up the app with `npm run start:waypoint`
- [ ] Validate that the noindex header DOES exist
- [ ] Update the regex to `(^(?!.*(waypointproject|localhost)).*$)`
- [ ] Restart the app with the command from step 1
- [ ] Validate that the noindex header DOES NOT exist (implying the regex works)

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
