### PR TITLE
enhance(waypoint): Add Demandbase tag

### DIFF
--- a/src/layouts/_proxied-dot-io/waypoint/index.tsx
+++ b/src/layouts/_proxied-dot-io/waypoint/index.tsx
@@ -6,6 +6,7 @@ import Min100Layout from '@hashicorp/react-min-100-layout'
 import useProductMeta, { Products } from '@hashicorp/platform-product-meta'
 import usePageviewAnalytics from '@hashicorp/platform-analytics'
 import createConsentManager from '@hashicorp/react-consent-manager/loader'
+import localConsentManagerServices from 'lib/consent-manager-services/waypoint'
 // product-specific layout elements
 import Footer from 'components/_proxied-dot-io/waypoint/footer-with-props'
 import ProductSubnav from 'components/_proxied-dot-io/waypoint/subnav'
@@ -14,6 +15,7 @@ import productData from 'data/waypoint.json'
 const { ConsentManager, openConsentManager } = createConsentManager({
   segmentWriteKey: productData.analyticsConfig.segmentWriteKey,
   preset: 'oss',
+  otherServices: [...localConsentManagerServices],
 })
 
 function WaypointIoLayout({

--- a/src/lib/consent-manager-services/waypoint.ts
+++ b/src/lib/consent-manager-services/waypoint.ts
@@ -1,0 +1,14 @@
+import { ConsentManagerService } from '@hashicorp/react-consent-manager/types'
+
+const localConsentManagerServices: ConsentManagerService[] = [
+  {
+    name: 'Demandbase Tag',
+    description:
+      'The Demandbase tag is a tracking service to identify website visitors and measure interest on our website.',
+    category: 'Analytics',
+    url: 'https://tag.demandbase.com/960ab0a0f20fb102.min.js',
+    async: true,
+  },
+]
+
+export default localConsentManagerServices


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-nq-add-demandbase-tag-waypoint-hashicorp.vercel.app/_proxied-dot-io/waypoint) 🔎
- [Asana task](https://app.asana.com/0/346384260719996/1201528651665558/f) 🎟️

## What

This PR adds a Demandbase tag to the local consent manger services for `waypointproject.io`.

## Testing

- [ ] Temporarily disable your adblocker(s).
- [ ] Open our consent manager preferences by clicking "Manage Preferences" in the banner at the bottom of the screen.
- [ ] In the preferences window, find the option for "Demandbase Tag" under the Analytics category, and turn it on.
- [ ] Open the Inspector in the browser: right-click > Inspect or `Ctrl/Cmd + Shift + i`.
- [ ] Check near the closing `</body>` tag for two `<img>` tags. They will have the IDs `db_bw_pixel_ad` and `db_lr_pixel_ad`, respectively.
- [ ] Still in the inspector, go to the Network tab. Type `company-target` into the `Filter` box in the top-left. Five (5) results should remain.