### PR TITLE
fix(io switcher): adjust z-index

### DIFF
--- a/src/components/_proxied-dot-io/common/preview-product-select/index.tsx
+++ b/src/components/_proxied-dot-io/common/preview-product-select/index.tsx
@@ -292,10 +292,7 @@ const ProductSwitcher: React.FC = () => {
         </span>
         <IconCaret16 className={s.switcherCaret} />
       </button>
-      <Popover
-        targetRef={buttonRef}
-        style={{ display: 'block', zIndex: '999' }}
-      >
+      <Popover targetRef={buttonRef} style={{ display: 'block', zIndex: 999 }}>
         <ul
           className={s.switcherOptionList}
           id={OPTION_LIST_ID}

--- a/src/components/_proxied-dot-io/common/preview-product-select/index.tsx
+++ b/src/components/_proxied-dot-io/common/preview-product-select/index.tsx
@@ -14,7 +14,6 @@ import { IconVagrantColor16 } from '@hashicorp/flight-icons/svg-react/vagrant-co
 import { IconVaultColor16 } from '@hashicorp/flight-icons/svg-react/vault-color-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import {
-  Fragment,
   KeyboardEventHandler,
   ReactElement,
   useEffect,
@@ -23,7 +22,7 @@ import {
 } from 'react'
 import classNames from 'classnames'
 import { IconCaret16 } from '@hashicorp/flight-icons/svg-react/caret-16'
-import { Product, ProductGroup, ProductSlug } from 'types/products'
+import { Product, ProductSlug } from 'types/products'
 import { products as productGroups } from '../../../../../config/products'
 import s from './style.module.css'
 
@@ -293,7 +292,10 @@ const ProductSwitcher: React.FC = () => {
         </span>
         <IconCaret16 className={s.switcherCaret} />
       </button>
-      <Popover targetRef={buttonRef} style={{ display: 'block' }}>
+      <Popover
+        targetRef={buttonRef}
+        style={{ display: 'block', zIndex: '999' }}
+      >
         <ul
           className={s.switcherOptionList}
           id={OPTION_LIST_ID}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

- [Preview link](url) 🔎
- [Asana task](url) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->
Adjust z-index on the product switcher popover element

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
Some elements were showing up on top of the switcher, when in reality it should be above everythin

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
More z-index!

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
- [ ] Visit the preview deployment
- [ ] Open the product switcher in the bottom left
- [ ] Validate that no elements show up above it

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
