### PR TITLE
Improve sidecar scrolling

### DIFF
--- a/src/components/sidecar/index.tsx
+++ b/src/components/sidecar/index.tsx
@@ -1,9 +1,10 @@
+import { useMemo } from 'react'
 import classNames from 'classnames'
+import { SidecarHeading } from './types'
 import { useDeviceSize } from 'contexts'
 import { useActiveSection } from './use-active-section'
-import { SidecarHeading } from './types'
-import s from './style.module.css'
 import getTruncatedTitle from './utils/get-truncated-title'
+import s from './style.module.css'
 
 interface SidecarProps {
   headings: SidecarHeading[]
@@ -12,14 +13,14 @@ interface SidecarProps {
 const SIDECAR_LABEL_ELEMENT_ID = 'sidecar-label'
 
 const Sidecar: React.FC<SidecarProps> = ({ headings }) => {
+  const level1And2Headings = useMemo(
+    () => headings.filter((heading) => heading.level <= 2),
+    [headings]
+  )
   const { isDesktop } = useDeviceSize()
-  const activeSection = useActiveSection(headings, isDesktop)
+  const activeSection = useActiveSection(level1And2Headings, isDesktop)
 
-  const renderListItem = ({ level, slug, title }) => {
-    if (level > 2) {
-      return null
-    }
-
+  const renderListItem = ({ slug, title }) => {
     const isActive = slug === activeSection
     const className = classNames(s.sidecarListItem, {
       [s.activeSidecarListItem]: isActive,
@@ -41,7 +42,9 @@ const Sidecar: React.FC<SidecarProps> = ({ headings }) => {
       <p className={s.sidecarLabel} id={SIDECAR_LABEL_ELEMENT_ID}>
         On this page
       </p>
-      <ol className={s.sidecarList}>{headings.map(renderListItem)}</ol>
+      <ol className={s.sidecarList}>
+        {level1And2Headings.map(renderListItem)}
+      </ol>
     </nav>
   )
 }

--- a/src/components/sidecar/use-active-section.ts
+++ b/src/components/sidecar/use-active-section.ts
@@ -80,7 +80,7 @@ export function useActiveSection(
           previousY.current = currentY
         }
       },
-      { rootMargin: '0% 0% -75% 0%' }
+      { rootMargin: '0% 0% -65% 0%', threshold: 1 }
     )
 
     headings.forEach((section) => {

--- a/src/components/sidecar/use-active-section.ts
+++ b/src/components/sidecar/use-active-section.ts
@@ -67,8 +67,8 @@ export function useActiveSection(
           ? findMatchingSectionIndex(entries[0].target.id)
           : -1
 
-        // Find the heading closest to the top
         if (visibleHeadings.current.size > 0) {
+          // Find the heading closest to the top of the viewport
           let shortestDistance
           let closestHeading
           visibleHeadings.current.forEach((headingId) => {
@@ -80,34 +80,32 @@ export function useActiveSection(
             }
           })
           setActiveSection(closestHeading)
-        } else if (previousY.current) {
+        } else if (previousY.current && scrollTrend === 'up') {
           // If we detect that we're scrolling up, and there are no visible
           // headers, optimistically set the previous header as visible to make
           // the active section match the visible content
-          if (visibleHeadings.current.size === 0 && scrollTrend === 'up') {
-            setActiveSection((current) => {
-              const curActiveIndex = findMatchingSectionIndex(current)
+          setActiveSection((current) => {
+            const curActiveIndex = findMatchingSectionIndex(current)
 
-              // Handle an ege case where we get an intersection event for a
-              // heading further down the page leaving intersection, otherwise
-              // this would cause the active heading to incorrectly get bumped
-              // up
-              if (
-                isSingleEntryLeaving &&
-                singleEntryLeavingIndex > curActiveIndex
-              ) {
-                return current
-              }
+            // Handle an ege case where we get an intersection event for a
+            // heading further down the page leaving intersection, otherwise
+            // this would cause the active heading to incorrectly get bumped
+            // up
+            if (
+              isSingleEntryLeaving &&
+              singleEntryLeavingIndex > curActiveIndex
+            ) {
+              return current
+            }
 
-              const newIndex = curActiveIndex - 1
+            const newIndex = curActiveIndex - 1
 
-              if (newIndex < 0) {
-                return current
-              }
+            if (newIndex < 0) {
+              return current
+            }
 
-              return headings[newIndex].slug
-            })
-          }
+            return headings[newIndex].slug
+          })
         }
 
         if (currentY) {

--- a/src/components/sidecar/use-active-section.ts
+++ b/src/components/sidecar/use-active-section.ts
@@ -31,7 +31,7 @@ export function useActiveSection(
   headings: SidecarHeading[],
   isEnabled = true
 ): string {
-  const visibleHeadings = useRef<Record<string, any>>({})
+  const visibleHeadings = useRef<Set<string>>(new Set())
   const [activeSection, setActiveSection] = useState<SidecarHeading['slug']>()
   const previousY = useRef<number>()
 

--- a/src/components/sidecar/use-active-section.ts
+++ b/src/components/sidecar/use-active-section.ts
@@ -36,6 +36,9 @@ export function useActiveSection(
   const previousY = useRef<number>()
 
   useEffect(() => {
+    // Need to clear this when all headings change
+    visibleHeadings.current = new Set()
+
     if (!isEnabled) {
       return
     }
@@ -118,7 +121,7 @@ export function useActiveSection(
     headings.forEach((section) => {
       const el = document
         .getElementById('main')
-        .querySelector(`#${section.slug}`)
+        ?.querySelector(`#${section.slug}`)
       if (el) observer.observe(el)
     })
 
@@ -126,7 +129,7 @@ export function useActiveSection(
       headings.forEach((section) => {
         const el = document
           .getElementById('main')
-          .querySelector(`#${section.slug}`)
+          ?.querySelector(`#${section.slug}`)
         if (el) observer.unobserve(el)
       })
     }

--- a/src/components/sidecar/use-active-section.ts
+++ b/src/components/sidecar/use-active-section.ts
@@ -50,14 +50,14 @@ export function useActiveSection(
         let scrollTrend: 'down' | 'up'
 
         entries.forEach((entry) => {
-          const entryId = entry.target.id
           currentY = window.scrollY
           scrollTrend = previousY.current < currentY ? 'down' : 'up'
 
+          const entryId = entry.target.id
           if (entry.isIntersecting) {
-            visibleHeadings.current[entryId] = entry.target
+            visibleHeadings.current.add(entryId)
           } else {
-            delete visibleHeadings.current[entryId]
+            visibleHeadings.current.delete(entryId)
           }
         })
 
@@ -68,13 +68,12 @@ export function useActiveSection(
           : -1
 
         // Find the heading closest to the top
-        const visibleHeadingIds = Object.keys(visibleHeadings.current)
-        if (visibleHeadingIds.length > 0) {
+        if (visibleHeadings.current.size > 0) {
           let shortestDistance
           let closestHeading
-          visibleHeadingIds.forEach((headingId) => {
-            const headingEntry = visibleHeadings.current[headingId]
-            const distance = headingEntry.getBoundingClientRect().bottom
+          visibleHeadings.current.forEach((headingId) => {
+            const targetElement = document.getElementById(headingId)
+            const distance = targetElement.getBoundingClientRect().bottom
             if (!closestHeading || distance < shortestDistance) {
               closestHeading = headingId
               shortestDistance = distance
@@ -85,7 +84,7 @@ export function useActiveSection(
           // If we detect that we're scrolling up, and there are no visible
           // headers, optimistically set the previous header as visible to make
           // the active section match the visible content
-          if (visibleHeadingIds.length === 0 && scrollTrend === 'up') {
+          if (visibleHeadings.current.size === 0 && scrollTrend === 'up') {
             setActiveSection((current) => {
               const curActiveIndex = findMatchingSectionIndex(current)
 
@@ -115,7 +114,7 @@ export function useActiveSection(
           previousY.current = currentY
         }
       },
-      { rootMargin: `-${getFullNavHeaderHeight()}px 0% -50% 0%`, threshold: 1 }
+      { rootMargin: `-${getFullNavHeaderHeight()}px 0% -60% 0%`, threshold: 1 }
     )
 
     headings.forEach((section) => {

--- a/src/contexts/device-size.tsx
+++ b/src/contexts/device-size.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+import getCSSVariableFromDocument from 'lib/get-css-variable-from-document'
 
 const DEFAULT_MOBILE_WIDTH = 728
 const DEFAULT_TABLET_WIDTH = 1000
@@ -7,22 +8,6 @@ interface DeviceSize {
   isDesktop?: boolean
   isMobile?: boolean
   isTablet?: boolean
-}
-
-// TODO: does this seem useful as a helper/util?
-const getCSSVariableFromDocument = (
-  variableName: string,
-  options: { asNumber?: boolean } = {}
-): string | number => {
-  const value = getComputedStyle(document.documentElement).getPropertyValue(
-    variableName
-  )
-
-  if (options.asNumber) {
-    return parseInt(value, 10)
-  }
-
-  return value
 }
 
 const DeviceSizeContext = createContext<DeviceSize>(undefined)

--- a/src/layouts/docs/docs-layout.module.css
+++ b/src/layouts/docs/docs-layout.module.css
@@ -61,12 +61,18 @@
     */
     & a:global(.__target-h)::before,
     &::before {
+      --permalink-scroll-offset: 24px;
+      --full-header-height: calc(
+        var(--navigation-header-height) + var(--alert-bar-height)
+      );
+      --height: calc(
+        var(--full-header-height) + var(--permalink-scroll-offset)
+      );
+
       display: block;
       content: '\200B';
-      height: calc(var(--navigation-header-height) + var(--alert-bar-height));
-      margin-top: calc(
-        -1 * calc(var(--navigation-header-height) + var(--alert-bar-height))
-      );
+      height: var(--height);
+      margin-top: calc(-1 * var(--height));
       visibility: hidden;
     }
   }

--- a/src/lib/get-css-variable-from-document.ts
+++ b/src/lib/get-css-variable-from-document.ts
@@ -1,0 +1,14 @@
+export default function getCSSVariableFromDocument(
+  variableName: string,
+  options: { asNumber?: boolean } = {}
+): string | number {
+  const value = getComputedStyle(document.documentElement).getPropertyValue(
+    variableName
+  )
+
+  if (options.asNumber) {
+    return parseInt(value, 10)
+  }
+
+  return value
+}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201508675437098/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `Sidecar` to completely ignore headings with level 3 or greater
- Tweaks the `rootMargin` and `threshold` values in `IntersectionObserver` in `use-active-section`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Ignoring headings with level 3 or greater is something we only did halfway at the time it was added. We stopped rendering the headings in `Sidecar` but we didn't have `use-active-section` ignoring them. It was setting headings that weren't visible in the `Sidecar` as active, making it look like there was no active heading in some pages while scrolling.
- The `rootMargin` and `threshold` tweaks are hopefully refining the accuracy of detecting active sections. 🤞🏻

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Used `Array.filter` on the `headings` passed into `Sidecar` to get only the headings we're interested in seeing: `h1` and `h2`, and used `useMemo` to create that filtered list so it's only calculated when the `headings` array changes.
- The `rootMargin` and `threshold` values are just some values I decided to try that appear to be working.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

It's tedious, but we need to step through _many_ pages under the following sections of the app to make sure we're covering as many cases as possible with these changes:

- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/waypoint
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/waypoint/docs
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/waypoint/commands
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/waypoint/plugins
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/vault
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/vault/docs
- [ ] https://dev-portal-git-ambimprove-sidecar-scrolling-hashicorp.vercel.app/vault/api-docs

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Some helpful resources:

- [Now You See Me: How To Defer, Lazy-Load And Act With IntersectionObserver](https://www.smashingmagazine.com/2018/01/deferring-lazy-loading-intersection-observer-api/)
- [The Intersection Observer API - Medium Article](https://blog.arnellebalane.com/the-intersection-observer-api-d441be0b088d)