### PR TITLE
Use .nvmrc and latest npm in bundle analysis

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -19,9 +19,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version-file: '.nvmrc'
+
+      - name: Install latest npm
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

- [Preview link](url) 🔎
- [Asana task](url) 🎟️

## What

This PR updates the Next.js Bundle Analysis workflow to source the node version from `.nvmrc` and install the latest version of npm.

## Why

Next.js v12 uses features of npm v7 and up, but GitHub's runners only come with npm v6.
