### PR TITLE
Upgrading flight-icons and Vault icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dev-portal",
       "dependencies": {
         "@hashicorp/design-system-tokens": "^0.4.7",
-        "@hashicorp/flight-icons": "^2.0.1",
+        "@hashicorp/flight-icons": "^2.1.0",
         "@hashicorp/mktg-global-styles": "^4.0.0",
         "@hashicorp/mktg-logos": "^1.2.0",
         "@hashicorp/platform-code-highlighting": "^0.1.2",
@@ -1002,9 +1002,9 @@
       "integrity": "sha512-n1q+hPA57k4fUQ7PcNMvn37O4uSSx3paPU/bn5phcvdv63vJ+SYgjojt7RdTzMwT5qYeXvboMPHhELr2KNIBCQ=="
     },
     "node_modules/@hashicorp/flight-icons": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.0.1.tgz",
-      "integrity": "sha512-445WEmL0ysOeVQDe2khCqGbmNm+/Rv5B35Q8FXvc+RuE+r9mNWL0ufe2cVa8Sqqt/VRg0lyTEhArNX9gYCX1Yg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.1.0.tgz",
+      "integrity": "sha512-4HWwty+LNhMD7O30sBinn7OQo2KTSUEk1qm65hqFitfp2m8sEl8F+7gY4NcTJV9Y1eEe3C7bED5OOnsPVc60ww=="
     },
     "node_modules/@hashicorp/js-utils": {
       "version": "1.0.10",
@@ -24064,9 +24064,9 @@
       "integrity": "sha512-n1q+hPA57k4fUQ7PcNMvn37O4uSSx3paPU/bn5phcvdv63vJ+SYgjojt7RdTzMwT5qYeXvboMPHhELr2KNIBCQ=="
     },
     "@hashicorp/flight-icons": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.0.1.tgz",
-      "integrity": "sha512-445WEmL0ysOeVQDe2khCqGbmNm+/Rv5B35Q8FXvc+RuE+r9mNWL0ufe2cVa8Sqqt/VRg0lyTEhArNX9gYCX1Yg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.1.0.tgz",
+      "integrity": "sha512-4HWwty+LNhMD7O30sBinn7OQo2KTSUEk1qm65hqFitfp2m8sEl8F+7gY4NcTJV9Y1eEe3C7bED5OOnsPVc60ww=="
     },
     "@hashicorp/js-utils": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@hashicorp/design-system-tokens": "^0.4.7",
-    "@hashicorp/flight-icons": "^2.0.1",
+    "@hashicorp/flight-icons": "^2.1.0",
     "@hashicorp/mktg-global-styles": "^4.0.0",
     "@hashicorp/mktg-logos": "^1.2.0",
     "@hashicorp/platform-code-highlighting": "^0.1.2",

--- a/src/components/product-switcher/style.module.css
+++ b/src/components/product-switcher/style.module.css
@@ -120,17 +120,6 @@ Two items to note:
 }
 
 /*
-TODO: this is temporary for the Vault icon since:
-  - we do not have a yellow version of the icon available from flight-icons yet
-  - the icon is currently on a dark background and appears "invisible"
-*/
-.vaultProductIcon {
-  & path {
-    fill: white;
-  }
-}
-
-/*
 The HCP icon is dark by default, and would not show up on the dark
 ProductSwitcher background. So, we adjust it to be light.
 


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambupdate-vault-icon-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201829867097121/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `flight-icons` to the latest, `2.1.0`
- Removes the CSS that sets the color of the Vault icon to white in `ProductSwitcher`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The Vault icon color was updated to yellow a little while ago so it's been time to update. This has been the first chance to get to it. 😊 

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Upgraded a package, deleted some code. 🤩

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [the main home page](https://dev-portal-git-ambupdate-vault-icon-hashicorp.vercel.app/)
- [ ] The Vault icon in the Vault card should now be yellow
- [ ] Open the `ProductSwitcher`
- [ ] The Vault icon in the dropdown should now be yellow
- [ ] Select the Vault option from the dropdown
- [ ] The Vault icon in the closed `ProductSwitcher` should now be yellow
- [ ] The Vault icon in `IconTileLogo` should now be yellow
- [ ] The Vault icon in learn tutorial cards at the bottom of the page should now be yellow

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!
