### PR TITLE
Set up enable_new_downloads_view flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -3,5 +3,7 @@
     "max_static_paths": 0,
     "revalidate": 360
   },
-  "flags": {}
+  "flags": {
+    "enable_new_downloads_view": true
+  }
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -3,5 +3,7 @@
     "max_static_paths": 10,
     "revalidate": 360
   },
-  "flags": {}
+  "flags": {
+    "enable_new_downloads_view": true
+  }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -3,5 +3,7 @@
     "max_static_paths": 9999,
     "revalidate": 360
   },
-  "flags": {}
+  "flags": {
+    "enable_new_downloads_view": true
+  }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -4,6 +4,6 @@
     "revalidate": 360
   },
   "flags": {
-    "enable_new_downloads_view": true
+    "enable_new_downloads_view": false
   }
 }

--- a/src/lib/fetch-release-data.ts
+++ b/src/lib/fetch-release-data.ts
@@ -35,6 +35,12 @@ export interface ReleasesAPIResponse {
   }
 }
 
+export interface GeneratedProps {
+  latestVersion: string
+  product: Product | string
+  releases: ReleasesAPIResponse
+}
+
 /**
  * There is a bit of a race condition with product releases and the metadata for the latest release
  * propagating to releases.hashicorp.com. Often all it takes is a re-deploy of the website for it to work,
@@ -65,7 +71,7 @@ function getLatestVersionFromVersions(versions: string[]): string {
  */
 export function generateStaticProps(
   product: Product | string
-): Promise<GetStaticPropsResult<{ releases: ReleasesAPIResponse }>> {
+): Promise<GetStaticPropsResult<GeneratedProps>> {
   let productSlug: string
   if (typeof product === 'string') {
     productSlug = product

--- a/src/pages/waypoint/downloads/index.tsx
+++ b/src/pages/waypoint/downloads/index.tsx
@@ -1,8 +1,22 @@
+import { ReactElement } from 'react'
 import { GetStaticProps } from 'next'
 import waypointData from 'data/waypoint.json'
 import { Product } from 'types/products'
+import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import EmptyLayout from 'layouts/empty'
 import ProductDownloadsView from 'views/product-downloads-view'
-import { generateStaticProps } from 'lib/fetch-release-data'
+import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
+
+const WaypointDownloadsPage = (props: GeneratedProps): ReactElement => {
+  if (__config.flags.enable_new_downloads_view) {
+    const { latestVersion, releases } = props
+    return (
+      <ProductDownloadsView latestVersion={latestVersion} releases={releases} />
+    )
+  } else {
+    return <PlaceholderDownloadsView />
+  }
+}
 
 export const getStaticProps: GetStaticProps = async () => {
   const product = waypointData as Product
@@ -10,4 +24,6 @@ export const getStaticProps: GetStaticProps = async () => {
   return generateStaticProps(product)
 }
 
-export default ProductDownloadsView
+WaypointDownloadsPage.layout = EmptyLayout
+
+export default WaypointDownloadsPage

--- a/src/views/placeholder-product-downloads-view/index.tsx
+++ b/src/views/placeholder-product-downloads-view/index.tsx
@@ -1,0 +1,48 @@
+import { ReactElement } from 'react'
+import { useCurrentProduct } from 'contexts'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import Card from 'components/card'
+import Text from 'components/text'
+import s from './placeholder-product-downloads-view.module.css'
+
+const LOREM_IPSUM =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vitae leo id nunc convallis euismod et vel erat. Fusce vel velit turpis. Vivamus fringilla consequat metus, vitae euismod sem eleifend in. Morbi in ullamcorper dui. Quisque rutrum auctor tristique. Vivamus ac turpis non arcu fringilla interdum. Aliquam feugiat lectus ipsum, eu tincidunt mi tristique id. Aliquam sodales eros semper pharetra molestie. Mauris porta, nunc in tempor eleifend, metus massa sagittis nisi, non maximus quam mauris a erat. Duis nec risus diam. Aenean auctor accumsan ipsum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce et sagittis nunc. Cras vel eros id purus sollicitudin lobortis. Vivamus hendrerit volutpat nulla.'
+const LOREM_IPSUM_SHORT =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vitae leo id nunc convallis euismod et vel erat.'
+
+const PlaceholderSidecarContent = () => {
+  return (
+    <>
+      <Card elevation="base">
+        <Text className={s.sidecarCardLabel} size={200} weight="semibold">
+          Lorem ipsum
+        </Text>
+        <Text className={s.sidecarCardText} size={200}>
+          {LOREM_IPSUM_SHORT}
+        </Text>
+      </Card>
+    </>
+  )
+}
+
+const PlaceholderDownloadsView = (): ReactElement => {
+  const currentProduct = useCurrentProduct()
+  const navData = [
+    ...currentProduct.sidebar.landingPageNavData,
+    { divider: true },
+    ...currentProduct.sidebar.resourcesNavData,
+  ]
+
+  return (
+    <SidebarSidecarLayout
+      navData={navData}
+      productName={currentProduct.name}
+      sidecarChildren={<PlaceholderSidecarContent />}
+    >
+      <h1>Install {currentProduct.name}</h1>
+      <p>{LOREM_IPSUM}</p>
+    </SidebarSidecarLayout>
+  )
+}
+
+export default PlaceholderDownloadsView

--- a/src/views/placeholder-product-downloads-view/placeholder-product-downloads-view.module.css
+++ b/src/views/placeholder-product-downloads-view/placeholder-product-downloads-view.module.css
@@ -1,0 +1,7 @@
+.sidecarCardLabel {
+  margin-bottom: 4px;
+}
+
+.sidecarCardText {
+  color: var(--token-color-neutral-foreground-faint);
+}

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -2,30 +2,8 @@ import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
-import Card from 'components/card'
-import Text from 'components/text'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { ReleasesAPIResponse } from 'lib/fetch-release-data'
-import s from './product-downloads-view.module.css'
-
-const LOREM_IPSUM =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vitae leo id nunc convallis euismod et vel erat. Fusce vel velit turpis. Vivamus fringilla consequat metus, vitae euismod sem eleifend in. Morbi in ullamcorper dui. Quisque rutrum auctor tristique. Vivamus ac turpis non arcu fringilla interdum. Aliquam feugiat lectus ipsum, eu tincidunt mi tristique id. Aliquam sodales eros semper pharetra molestie. Mauris porta, nunc in tempor eleifend, metus massa sagittis nisi, non maximus quam mauris a erat. Duis nec risus diam. Aenean auctor accumsan ipsum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce et sagittis nunc. Cras vel eros id purus sollicitudin lobortis. Vivamus hendrerit volutpat nulla.'
-
-const WaypointDownloadsSidecarContent = () => {
-  return (
-    <>
-      <Card elevation="base">
-        <Text className={s.sidecarCardLabel} size={200} weight="semibold">
-          Lorem ipsum
-        </Text>
-        <Text className={s.sidecarCardText} size={200}>
-          This is a test to show that the Sidecar component can now render
-          custom content by page.
-        </Text>
-      </Card>
-    </>
-  )
-}
 
 interface ProductDownloadsViewProps {
   latestVersion: string
@@ -66,7 +44,7 @@ const ProductDownloadsView = ({
       navData={navData}
       productName="Waypoint"
       showFilterInput={false}
-      sidecarChildren={<WaypointDownloadsSidecarContent />}
+      sidecarChildren={<></>}
     >
       <h1>Install Waypoint v{selectedVersion}</h1>
       {
@@ -85,12 +63,10 @@ const ProductDownloadsView = ({
           </select>
         </>
       }
-      {Array(12)
-        .fill(null, 0)
-        .map((_, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <p key={index}>{LOREM_IPSUM}</p>
-        ))}
+      <p>
+        This content should only show when the{' '}
+        <code>enable_new_downloads_view</code> flag is on
+      </p>
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -1,7 +1,3 @@
-.sidecarCardLabel {
-  margin-bottom: 4px;
-}
-
-.sidecarCardText {
-  color: var(--token-color-neutral-foreground-faint);
-}
+/*
+TODO: this is temporarily empty
+*/


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambset-up-downloads-view-flag-hashicorp.vercel.app/waypoint/downloads) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds the `enable_new_downloads_view` flag to the `development`, `preview`, and `production` JSON files under `/config`
- Adds a `GeneratedProps` interface in `lib/fetch-release-data.js` that can be used where the props it generates can be consumed (used in `src/pages/waypoint/downloads/index.tsx` in this PR)
- Updates `WaypointDownloadsPage` to conditionally render content based on the new `enable_new_downloads_view` flag
- Adds a `PlaceholderDownloadsView` component that renders placeholder content for a downloads page and without any props sent to it
- Removes placeholder content from `ProductDownloadsViewProps`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

This is a test of feature flags for creating new views, which will allow us to quietly work on new views across multiple PRs without having to use an assembly branch for them and without affecting the existing view that will eventually be replaced.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Nothing in particular to add here. Moved a lot of existing code around. 😊

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads](https://dev-portal-git-ambset-up-downloads-view-flag-hashicorp.vercel.app/waypoint/downloads)
- [ ] You should see the temp version switcher and a message that says "This content should only show when the `enable_new_downloads_view` flag is on"
- [ ] After this branch is merged, [this page](https://dev-portal-git-assembly-ui-v1-hashicorp.vercel.app/waypoint/downloads) should show Lorem ipsum placeholder content and **no temp version switcher** on the assembly branch

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!