### PR TITLE
Add Waypoint downloads header

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -64,4 +64,5 @@ const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
   </BaseLayout>
 )
 
+export type { SidebarSidecarLayoutProps }
 export default SidebarSidecarLayout

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -1,0 +1,53 @@
+import { Product } from 'types/products'
+import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
+import { BreadcrumbLink } from 'components/breadcrumb-bar'
+import { MenuItem } from 'components/sidebar'
+
+export const initializeBackToLink = (
+  currentProduct: Product
+): SidebarSidecarLayoutProps['backToLink'] => {
+  return {
+    text: `Back to ${currentProduct.name}`,
+    url: `/${currentProduct.slug}`,
+  }
+}
+
+export const initializeBreadcrumbLinks = (
+  currentProduct: Product,
+  selectedVersion: string
+): BreadcrumbLink[] => {
+  return [
+    {
+      title: 'Developer',
+      url: '/',
+    },
+    {
+      title: currentProduct.name,
+      url: `/${currentProduct.slug}`,
+    },
+    {
+      isCurrentPage: true,
+      title: `Install v${selectedVersion}`,
+      url: `/${currentProduct.slug}/downloads/${currentProduct.slug}`,
+    },
+  ]
+}
+
+export const initializeNavData = (currentProduct: Product): MenuItem[] => {
+  return [
+    ...currentProduct.sidebar.landingPageNavData,
+    { divider: true },
+    ...currentProduct.sidebar.resourcesNavData,
+  ]
+}
+
+export const getPageSubtitle = (
+  currentProduct: Product,
+  selectedVersion: string,
+  isLatestVersion: boolean
+): string => {
+  const versionText = `v${selectedVersion}${
+    isLatestVersion ? ' (latest version)' : ''
+  }`
+  return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
+}

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -2,20 +2,15 @@ import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
 import { Product } from 'types/products'
 import { useCurrentProduct } from 'contexts'
-import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
-import Text from 'components/text'
-import s from './product-downloads-view.module.css'
 import { MenuItem } from 'components/sidebar'
-
-interface ProductDownloadsViewProps {
-  latestVersion: string
-  releases: ReleasesAPIResponse
-}
+import Text from 'components/text'
+import { ProductDownloadsViewProps } from './types'
+import s from './product-downloads-view.module.css'
 
 const initializeBackToLink = (currentProduct: Product) => {
   return {

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -5,10 +5,12 @@ import { useCurrentProduct } from 'contexts'
 import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
 import Text from 'components/text'
 import s from './product-downloads-view.module.css'
+import { MenuItem } from 'components/sidebar'
 
 interface ProductDownloadsViewProps {
   latestVersion: string
@@ -25,7 +27,7 @@ const initializeBackToLink = (currentProduct: Product) => {
 const initializeBreadcrumbLinks = (
   currentProduct: Product,
   selectedVersion: string
-) => {
+): BreadcrumbLink[] => {
   return [
     {
       title: 'Developer',
@@ -36,15 +38,14 @@ const initializeBreadcrumbLinks = (
       url: `/${currentProduct.slug}`,
     },
     {
-      title: 'Install',
-    },
-    {
-      title: selectedVersion,
+      isCurrentPage: true,
+      title: `Install v${selectedVersion}`,
+      url: `/${currentProduct.slug}/downloads/${currentProduct.slug}`,
     },
   ]
 }
 
-const initializeNavData = (currentProduct: Product) => {
+const initializeNavData = (currentProduct: Product): MenuItem[] => {
   return [
     ...currentProduct.sidebar.landingPageNavData,
     { divider: true },
@@ -52,7 +53,11 @@ const initializeNavData = (currentProduct: Product) => {
   ]
 }
 
-const getPageSubtitle = (currentProduct, selectedVersion, isLatestVersion) => {
+const getPageSubtitle = (
+  currentProduct: Product,
+  selectedVersion: string,
+  isLatestVersion: boolean
+): string => {
   const versionText = `v${selectedVersion}${
     isLatestVersion ? ' (latest version)' : ''
   }`

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -1,63 +1,19 @@
 import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
-import { Product } from 'types/products'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
-import { MenuItem } from 'components/sidebar'
 import Text from 'components/text'
+import {
+  getPageSubtitle,
+  initializeBackToLink,
+  initializeBreadcrumbLinks,
+  initializeNavData,
+} from './helpers'
 import { ProductDownloadsViewProps } from './types'
 import s from './product-downloads-view.module.css'
-
-const initializeBackToLink = (currentProduct: Product) => {
-  return {
-    text: `Back to ${currentProduct.name}`,
-    url: `/${currentProduct.slug}`,
-  }
-}
-
-const initializeBreadcrumbLinks = (
-  currentProduct: Product,
-  selectedVersion: string
-): BreadcrumbLink[] => {
-  return [
-    {
-      title: 'Developer',
-      url: '/',
-    },
-    {
-      title: currentProduct.name,
-      url: `/${currentProduct.slug}`,
-    },
-    {
-      isCurrentPage: true,
-      title: `Install v${selectedVersion}`,
-      url: `/${currentProduct.slug}/downloads/${currentProduct.slug}`,
-    },
-  ]
-}
-
-const initializeNavData = (currentProduct: Product): MenuItem[] => {
-  return [
-    ...currentProduct.sidebar.landingPageNavData,
-    { divider: true },
-    ...currentProduct.sidebar.resourcesNavData,
-  ]
-}
-
-const getPageSubtitle = (
-  currentProduct: Product,
-  selectedVersion: string,
-  isLatestVersion: boolean
-): string => {
-  const versionText = `v${selectedVersion}${
-    isLatestVersion ? ' (latest version)' : ''
-  }`
-  return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
-}
 
 const ProductDownloadsView = ({
   latestVersion,

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
+import { Product } from 'types/products'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
 import Card from 'components/card'
@@ -32,6 +33,21 @@ interface ProductDownloadsViewProps {
   releases: ReleasesAPIResponse
 }
 
+const initializeBackToLink = (currentProduct: Product) => {
+  return {
+    text: `Back to ${currentProduct.name}`,
+    url: `/${currentProduct.slug}`,
+  }
+}
+
+const initializeNavData = (currentProduct: Product) => {
+  return [
+    ...currentProduct.sidebar.landingPageNavData,
+    { divider: true },
+    ...currentProduct.sidebar.resourcesNavData,
+  ]
+}
+
 const ProductDownloadsView = ({
   latestVersion,
   releases,
@@ -45,19 +61,16 @@ const ProductDownloadsView = ({
       }
     })
   }, [latestVersion, releases.versions])
-  const currentProduct = useCurrentProduct()
   const [selectedVersion, setSelectedVersion] = useState<string>(
     versionSwitcherOptions[0].value
   )
-  const backToLink = {
-    text: 'Back to Waypoint',
-    url: '/waypoint',
-  }
-  const navData = [
-    ...currentProduct.sidebar.landingPageNavData,
-    { divider: true },
-    ...currentProduct.sidebar.resourcesNavData,
-  ]
+  const currentProduct = useCurrentProduct()
+  const backToLink = useMemo(() => initializeBackToLink(currentProduct), [
+    currentProduct,
+  ])
+  const navData = useMemo(() => initializeNavData(currentProduct), [
+    currentProduct,
+  ])
 
   // TODO: currently shows placeholder content for testing purposes
   return (
@@ -68,7 +81,7 @@ const ProductDownloadsView = ({
       showFilterInput={false}
       sidecarChildren={<WaypointDownloadsSidecarContent />}
     >
-      <h1>Install Waypoint v{selectedVersion}</h1>
+      <h1>Install {currentProduct.name}</h1>
       {
         <>
           <label style={{ display: 'block' }}>Version (temp switcher)</label>

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -2,9 +2,13 @@ import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
 import { Product } from 'types/products'
 import { useCurrentProduct } from 'contexts'
+import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import { ReleasesAPIResponse } from 'lib/fetch-release-data'
+import Heading from 'components/heading'
+import IconTileLogo from 'components/icon-tile-logo'
+import Text from 'components/text'
+import s from './product-downloads-view.module.css'
 
 interface ProductDownloadsViewProps {
   latestVersion: string
@@ -48,6 +52,13 @@ const initializeNavData = (currentProduct: Product) => {
   ]
 }
 
+const getPageSubtitle = (currentProduct, selectedVersion, isLatestVersion) => {
+  const versionText = `v${selectedVersion}${
+    isLatestVersion ? ' (latest version)' : ''
+  }`
+  return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
+}
+
 const ProductDownloadsView = ({
   latestVersion,
   releases,
@@ -76,7 +87,12 @@ const ProductDownloadsView = ({
     currentProduct,
   ])
 
-  // TODO: currently shows placeholder content for testing purposes
+  const pageTitle = `Install ${currentProduct.name}`
+  const pageSubtitle = getPageSubtitle(
+    currentProduct,
+    selectedVersion,
+    selectedVersion === latestVersion
+  )
   return (
     <SidebarSidecarLayout
       backToLink={backToLink}
@@ -86,7 +102,27 @@ const ProductDownloadsView = ({
       showFilterInput={false}
       sidecarChildren={<></>}
     >
-      <h1>Install {currentProduct.name}</h1>
+      <div className={s.pageHeader}>
+        <IconTileLogo
+          product={
+            currentProduct.slug === 'sentinel' ? 'hcp' : currentProduct.slug
+          }
+        />
+        <div className={s.pageHeaderText}>
+          <Heading
+            className={s.pageHeaderTitle}
+            level={1}
+            size={500}
+            slug={`install-${currentProduct.slug}`}
+            weight="bold"
+          >
+            {pageTitle}
+          </Heading>
+          <Text className={s.pageHeaderSubtitle} size={300} weight="regular">
+            {pageSubtitle}
+          </Text>
+        </div>
+      </div>
       {
         <>
           <label style={{ display: 'block' }}>Version (temp switcher)</label>

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -18,6 +18,28 @@ const initializeBackToLink = (currentProduct: Product) => {
   }
 }
 
+const initializeBreadcrumbLinks = (
+  currentProduct: Product,
+  selectedVersion: string
+) => {
+  return [
+    {
+      title: 'Developer',
+      url: '/',
+    },
+    {
+      title: currentProduct.name,
+      url: `/${currentProduct.slug}`,
+    },
+    {
+      title: 'Install',
+    },
+    {
+      title: selectedVersion,
+    },
+  ]
+}
+
 const initializeNavData = (currentProduct: Product) => {
   return [
     ...currentProduct.sidebar.landingPageNavData,
@@ -46,6 +68,10 @@ const ProductDownloadsView = ({
   const backToLink = useMemo(() => initializeBackToLink(currentProduct), [
     currentProduct,
   ])
+  const breadcrumbLinks = useMemo(
+    () => initializeBreadcrumbLinks(currentProduct, selectedVersion),
+    [currentProduct, selectedVersion]
+  )
   const navData = useMemo(() => initializeNavData(currentProduct), [
     currentProduct,
   ])
@@ -54,6 +80,7 @@ const ProductDownloadsView = ({
   return (
     <SidebarSidecarLayout
       backToLink={backToLink}
+      breadcrumbLinks={breadcrumbLinks}
       navData={navData}
       productName="Waypoint"
       showFilterInput={false}
@@ -63,13 +90,12 @@ const ProductDownloadsView = ({
       {
         <>
           <label style={{ display: 'block' }}>Version (temp switcher)</label>
-          <select onChange={(e) => setSelectedVersion(e.target.value)}>
+          <select
+            onChange={(e) => setSelectedVersion(e.target.value)}
+            value={selectedVersion}
+          >
             {versionSwitcherOptions.map((option) => (
-              <option
-                key={option.value}
-                selected={option.value === selectedVersion}
-                value={option.value}
-              >
+              <option key={option.value} value={option.value}>
                 {option.label}
               </option>
             ))}

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -1,3 +1,17 @@
-/*
-TODO: this is temporarily empty
-*/
+.pageHeader {
+  align-items: center;
+  display: flex;
+  margin-bottom: 48px;
+}
+
+.pageHeaderText {
+  margin-left: 16px;
+}
+
+.pageHeaderTitle {
+  margin-bottom: 12px;
+}
+
+.pageHeaderSubtitle {
+  color: var(--token-color-neutral-foreground-secondary);
+}

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -1,0 +1,6 @@
+import { ReleasesAPIResponse } from 'lib/fetch-release-data'
+
+export interface ProductDownloadsViewProps {
+  latestVersion: string
+  releases: ReleasesAPIResponse
+}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-waypoint-downloads-header-hashicorp.vercel.app/waypoint/downloads) 🔎

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds the Breadcrumb, IconTileLogo, page title, and page subtitle of the new Waypoint downloads page
- Updates `SidebarSidecarLayout` to export `SidebarSidecarLayoutProps`. Useful in `src/views/product-downloads-view/helpers.ts`.
- Adds `src/views/product-downloads-view/helpers.ts` to house the helper functions that generate some sidebar items and some of the page text. Added to keep the main component file clean. I'm sure there will be more helpers added to this file!
- Updates `ProductDownloadsView` to use `useMemo` for some generated items based on `currentProduct`. This seems like a valuable optimization so that initializer helpers aren't called multiple times when `selectedVersion` updates and the view component gets re-rendered.
- Adds styles under `src/views/product-downloads-view/product-downloads-view.module.css`.
- Adds `src/views/product-downloads-view/types.ts`.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads on this PR's preview](https://dev-portal-git-ambadd-waypoint-downloads-header-hashicorp.vercel.app/waypoint/downloads)
- [ ] The breadcrumb should have three items:
  - [ ] Developer
  - [ ] Waypoint
  - [ ] Install v0.7.1
- [ ] The page title should say "Install Waypoint"
- [ ] The page subtitle should say "Install or update to v0.7.1 (latest version) of Waypoint to get started."
- [ ] The temp version switcher should say "0.7.1 (latest)"
- [ ] Change the version switcher to "0.6.3"
- [ ] The third breadcrumb item should update to "Install v0.6.3"
- [ ] The page subtitle should update to "Install or update to v0.6.3 of Waypoint to get started."
- [ ] Refresh the page
- [ ] The version should change back to `0.7.1`
- [ ] The breadcrumb and page subtitle should reflect the correct version

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!