### PR TITLE
Add Waypoint downloads sidecar content

### DIFF
--- a/src/data/waypoint-install.json
+++ b/src/data/waypoint-install.json
@@ -1,0 +1,25 @@
+{
+  "sidecarMarketingCard": {
+    "title": "About Waypoint",
+    "subtitle": "Use Waypoint to deliver a PaaS-like experience for Kubernetes, ECS, and other platforms.",
+    "learnMoreLink": "https://www.waypointproject.io/",
+    "featuredDocsLinks": [
+      {
+        "href": "/waypoint/docs/projects",
+        "text": "Projects"
+      },
+      {
+        "href": "/waypoint/docs/plugins",
+        "text": "Plugins"
+      },
+      {
+        "href": "/waypoint/docs/lifecycle/build",
+        "text": "Build"
+      },
+      {
+        "href": "/waypoint/docs/lifecycle/deploy",
+        "text": "Deploy"
+      }
+    ]
+  }
+}

--- a/src/lib/fetch-release-data.ts
+++ b/src/lib/fetch-release-data.ts
@@ -3,7 +3,6 @@ import semverSort from 'semver/functions/rsort'
 import { Products as HashiCorpProduct } from '@hashicorp/platform-product-meta'
 import { Product } from 'types/products'
 import { makeFetchWithRetry } from './fetch-with-retry'
-import { products } from '../../config/products'
 
 export type OperatingSystem =
   | 'darwin'
@@ -70,8 +69,7 @@ function getLatestVersionFromVersions(versions: string[]): string {
  * either will make merging the `assembly-ui-v1` branch into `main` easier.
  */
 export function generateStaticProps(
-  product: Product | string,
-  additionalProps?: Record<string, any>
+  product: Product | string
 ): Promise<GetStaticPropsResult<GeneratedProps>> {
   let productSlug: string
   if (typeof product === 'string') {
@@ -98,7 +96,6 @@ export function generateStaticProps(
         // 5 minutes
         revalidate: 300,
         props: {
-          ...additionalProps,
           releases: result,
           product,
           latestVersion,

--- a/src/lib/fetch-release-data.ts
+++ b/src/lib/fetch-release-data.ts
@@ -70,7 +70,8 @@ function getLatestVersionFromVersions(versions: string[]): string {
  * either will make merging the `assembly-ui-v1` branch into `main` easier.
  */
 export function generateStaticProps(
-  product: Product | string
+  product: Product | string,
+  additionalProps?: Record<string, any>
 ): Promise<GetStaticPropsResult<GeneratedProps>> {
   let productSlug: string
   if (typeof product === 'string') {
@@ -97,6 +98,7 @@ export function generateStaticProps(
         // 5 minutes
         revalidate: 300,
         props: {
+          ...additionalProps,
           releases: result,
           product,
           latestVersion,

--- a/src/pages/waypoint/downloads/index.tsx
+++ b/src/pages/waypoint/downloads/index.tsx
@@ -1,17 +1,24 @@
 import { ReactElement } from 'react'
 import { GetStaticProps } from 'next'
 import waypointData from 'data/waypoint.json'
+import installData from 'data/waypoint-install.json'
 import { Product } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
 import EmptyLayout from 'layouts/empty'
 import ProductDownloadsView from 'views/product-downloads-view'
 import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
 
-const WaypointDownloadsPage = (props: GeneratedProps): ReactElement => {
+const WaypointDownloadsPage = (
+  props: GeneratedProps & { pageContent: any }
+): ReactElement => {
   if (__config.flags.enable_new_downloads_view) {
-    const { latestVersion, releases } = props
+    const { latestVersion, pageContent, releases } = props
     return (
-      <ProductDownloadsView latestVersion={latestVersion} releases={releases} />
+      <ProductDownloadsView
+        pageContent={pageContent}
+        latestVersion={latestVersion}
+        releases={releases}
+      />
     )
   } else {
     return <PlaceholderDownloadsView />
@@ -20,8 +27,9 @@ const WaypointDownloadsPage = (props: GeneratedProps): ReactElement => {
 
 export const getStaticProps: GetStaticProps = async () => {
   const product = waypointData as Product
+  const pageContent = installData
 
-  return generateStaticProps(product)
+  return generateStaticProps(product, { pageContent })
 }
 
 WaypointDownloadsPage.layout = EmptyLayout

--- a/src/pages/waypoint/downloads/index.tsx
+++ b/src/pages/waypoint/downloads/index.tsx
@@ -8,14 +8,12 @@ import EmptyLayout from 'layouts/empty'
 import ProductDownloadsView from 'views/product-downloads-view'
 import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
 
-const WaypointDownloadsPage = (
-  props: GeneratedProps & { pageContent: any }
-): ReactElement => {
+const WaypointDownloadsPage = (props: GeneratedProps): ReactElement => {
   if (__config.flags.enable_new_downloads_view) {
-    const { latestVersion, pageContent, releases } = props
+    const { latestVersion, releases } = props
     return (
       <ProductDownloadsView
-        pageContent={pageContent}
+        pageContent={installData}
         latestVersion={latestVersion}
         releases={releases}
       />
@@ -27,9 +25,8 @@ const WaypointDownloadsPage = (
 
 export const getStaticProps: GetStaticProps = async () => {
   const product = waypointData as Product
-  const pageContent = installData
 
-  return generateStaticProps(product, { pageContent })
+  return generateStaticProps(product)
 }
 
 WaypointDownloadsPage.layout = EmptyLayout

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
@@ -1,0 +1,45 @@
+import { ReactElement } from 'react'
+import slugify from 'slugify'
+import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
+import Card from 'components/card'
+import Text from 'components/text'
+import StandaloneLink from 'components/standalone-link'
+import MaybeInternalLink from 'components/maybe-internal-link'
+import { SidecarMarketingCardProps } from './types'
+
+const SidecarMarketingCard = ({
+  title,
+  subtitle,
+  learnMoreLink,
+  featuredDocsLinks,
+}: SidecarMarketingCardProps): ReactElement => (
+  <Card elevation="base">
+    <Text size={200} weight="semibold">
+      {title}
+    </Text>
+    <Text size={200} weight="regular">
+      {subtitle}
+    </Text>
+    <StandaloneLink
+      color="secondary"
+      href={learnMoreLink}
+      icon={<IconExternalLink16 />}
+      iconPosition="trailing"
+      textSize={200}
+      text="Learn more"
+    />
+    <Text size={200} weight="semibold">
+      Featured docs
+    </Text>
+    <ul>
+      {featuredDocsLinks.map(({ href, text }) => (
+        <Text asElement="li" key={slugify(text)} size={200} weight="regular">
+          <MaybeInternalLink href={href}>{text}</MaybeInternalLink>
+        </Text>
+      ))}
+    </ul>
+  </Card>
+)
+
+export type { SidecarMarketingCardProps }
+export default SidecarMarketingCard

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
@@ -6,6 +6,7 @@ import Text from 'components/text'
 import StandaloneLink from 'components/standalone-link'
 import MaybeInternalLink from 'components/maybe-internal-link'
 import { SidecarMarketingCardProps } from './types'
+import s from './sidecar-marketing-card.module.css'
 
 const SidecarMarketingCard = ({
   title,
@@ -14,10 +15,10 @@ const SidecarMarketingCard = ({
   featuredDocsLinks,
 }: SidecarMarketingCardProps): ReactElement => (
   <Card elevation="base">
-    <Text size={200} weight="semibold">
+    <Text className={s.cardTitle} size={200} weight="semibold">
       {title}
     </Text>
-    <Text size={200} weight="regular">
+    <Text className={s.cardSubtitle} size={200} weight="regular">
       {subtitle}
     </Text>
     <StandaloneLink
@@ -28,13 +29,21 @@ const SidecarMarketingCard = ({
       textSize={200}
       text="Learn more"
     />
-    <Text size={200} weight="semibold">
+    <Text className={s.featuredDocsLabel} size={200} weight="semibold">
       Featured docs
     </Text>
-    <ul>
+    <ul className={s.featuredDocsLinksList}>
       {featuredDocsLinks.map(({ href, text }) => (
-        <Text asElement="li" key={slugify(text)} size={200} weight="regular">
-          <MaybeInternalLink href={href}>{text}</MaybeInternalLink>
+        <Text
+          className={s.featuredDocsListItem}
+          asElement="li"
+          key={slugify(text)}
+          size={200}
+          weight="regular"
+        >
+          <MaybeInternalLink className={s.featuredDocsLink} href={href}>
+            {text}
+          </MaybeInternalLink>
         </Text>
       ))}
     </ul>

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/sidecar-marketing-card.module.css
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/sidecar-marketing-card.module.css
@@ -1,0 +1,38 @@
+.cardTitle {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 4px;
+}
+
+.cardSubtitle {
+  color: var(--token-color-neutral-foreground-faint);
+  margin-bottom: 8px;
+}
+
+.featuredDocsLabel {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 8px;
+  margin-top: 24px;
+}
+
+.featuredDocsLinksList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.featuredDocsListItem {
+  &:not(:last-child) {
+    margin-bottom: 2px;
+  }
+}
+
+.featuredDocsLink {
+  color: var(--token-color-neutral-foreground-faint);
+  display: block;
+  padding: 8px 0;
+  width: fit-content;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/types.ts
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/types.ts
@@ -1,0 +1,6 @@
+export interface SidecarMarketingCardProps {
+  title: string
+  subtitle: string
+  learnMoreLink: string
+  featuredDocsLinks: { href: string; text: string }[]
+}

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -1,18 +1,25 @@
 import { ReactElement, useMemo, useState } from 'react'
 import semverRSort from 'semver/functions/rsort'
+import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import { ReleasesAPIResponse } from 'lib/fetch-release-data'
+import SidecarMarketingCard, {
+  SidecarMarketingCardProps,
+} from './components/sidecar-marketing-card'
 
 interface ProductDownloadsViewProps {
   latestVersion: string
   releases: ReleasesAPIResponse
+  pageContent: {
+    sidecarMarketingCard: SidecarMarketingCardProps
+  }
 }
 
 const ProductDownloadsView = ({
   latestVersion,
   releases,
+  pageContent,
 }: ProductDownloadsViewProps): ReactElement => {
   const versionSwitcherOptions = useMemo(() => {
     return semverRSort(Object.keys(releases.versions)).map((version) => {
@@ -44,7 +51,9 @@ const ProductDownloadsView = ({
       navData={navData}
       productName="Waypoint"
       showFilterInput={false}
-      sidecarChildren={<></>}
+      sidecarChildren={
+        <SidecarMarketingCard {...pageContent.sidecarMarketingCard} />
+      }
     >
       <h1>Install Waypoint v{selectedVersion}</h1>
       {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-waypoint-downloads-sidec-c83119-hashicorp.vercel.app/waypoint/downloads) 🔎

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `src/data/waypoint-install.json` file for housing the customizable data shown in the new view
  - `sidecarMarketingCard` name is up for debate!
- Adds `pageContent` prop to `ProductDownloadsView`. My intention is to keep this as a single prop so the `ProductDownloadsView` interface doesn't have to be updated every time we want to add more customized data to the view.
- Adds new `SidecarMarketingCard` component local to `ProductDownloadsView`. I think we can move it to the main components folder if it's needed. For now I'm trying to keep that folder as small as possible.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads on the preview url](https://dev-portal-git-ambadd-waypoint-downloads-sidec-c83119-hashicorp.vercel.app/waypoint/downloads)
- [ ] It should look like the following screenshot:

![image](https://user-images.githubusercontent.com/43934258/155412778-65394b1c-8648-479a-a3ae-c38f3017fb3a.png)

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!