### PR TITLE
chore: bump to latest docs-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@hashicorp/react-checkbox-input": "^5.0.1",
         "@hashicorp/react-code-block": "^4.4.0",
         "@hashicorp/react-consent-manager": "^7.1.0",
-        "@hashicorp/react-docs-page": "^14.14.0",
+        "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-error-view": "^0.0.1",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
@@ -2452,11 +2452,11 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "dependencies": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1.tgz",
-      "integrity": "sha512-tOUmacAxN+VWzS9wIn9ePXnWv140b1eUHMvNgSjn8Q7bZYKFZLTYZpLN1P0rIPgwK9MU2psD1vBwisWHLUk2ZQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -2709,11 +2709,11 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1.tgz",
-      "integrity": "sha512-No+Smuw5XGLLXtQMa8vmQ0ODLPa/IsovcB95qpBlppiTuHcy32GdweXm1yg2+XFfVf7xqamJ9k1GVF4hg4JLjg==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",
@@ -32121,11 +32121,11 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "requires": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -32292,9 +32292,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1.tgz",
-      "integrity": "sha512-tOUmacAxN+VWzS9wIn9ePXnWv140b1eUHMvNgSjn8Q7bZYKFZLTYZpLN1P0rIPgwK9MU2psD1vBwisWHLUk2ZQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -32322,11 +32322,11 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1.tgz",
-      "integrity": "sha512-No+Smuw5XGLLXtQMa8vmQ0ODLPa/IsovcB95qpBlppiTuHcy32GdweXm1yg2+XFfVf7xqamJ9k1GVF4hg4JLjg==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@hashicorp/react-checkbox-input": "^5.0.1",
     "@hashicorp/react-code-block": "^4.4.0",
     "@hashicorp/react-consent-manager": "^7.1.0",
-    "@hashicorp/react-docs-page": "^14.14.0",
+    "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-error-view": "^0.0.1",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][preview] 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1200794405240290/f) 🎟️

## What

This PR bumps `@hashicorp/react-docs-page` to the latest stable version.

## Why

To bring in a Firefox-specific fix for manual copying of `code-block` contents, as detailed in hashicorp/react-components#503

## How

Bumps `npm` dependency.

## Testing

When using [Firefox](https://www.mozilla.org/en-US/firefox/new/):

- [ ] On [the live site][live], manually selecting code block contents, copying, and pasting into a plain text editor should result in missing newlines.
- [ ] On [the preview][preview], in `Vault` mode, manually selecting code block contents, copying, and pasting into a plain text editor should result in the expected content, with newlines intact.
    - Note that you'll need to select `Vault` from the dropdown for the specific preview links shown. The underlying fix should apply to any product's code-blocks on any docs page.

## Anything else?

Nope!

[preview]: https://dev-portal-git-zsbump-docs-page-hashicorp.vercel.app
[live]: https://www.vaultproject.io/docs/configuration