### PR TITLE
Add install view DownloadsSection

### DIFF
--- a/src/components/download-standalone-link/docs.mdx
+++ b/src/components/download-standalone-link/docs.mdx
@@ -4,10 +4,11 @@ componentName: DownloadStandaloneLink
 
 ## Props
 
-| Prop name | Description                                                                | Required? | Default value | Type   |
-| --------- | -------------------------------------------------------------------------- | --------- | ------------- | ------ |
-| ariaLabel | A non-visual accessible and descriptive label for what's being downloaded. | Yes       | N/A           | string |
-| href      | The location of the file to download.                                      | Yes       | N/A           | string |
+| Prop name | Description                                                                                                   | Required? | Default value | Type                            |
+| --------- | ------------------------------------------------------------------------------------------------------------- | --------- | ------------- | ------------------------------- |
+| ariaLabel | A non-visual accessible and descriptive label for what's being downloaded.                                    | Yes       | N/A           | string                          |
+| href      | The location of the file to download. Passedd directly to the internally rendered `StandaloneLink`.           | Yes       | N/A           | string                          |
+| textSize  | Same as the `StandaloneLink` `textSize` prop and passed directly to the internally rendered `StandaloneLink`. | No        | 200           | StandaloneLinkProps['textSize'] |
 
 ## Playground
 

--- a/src/components/download-standalone-link/index.tsx
+++ b/src/components/download-standalone-link/index.tsx
@@ -6,6 +6,7 @@ import { DownloadStandaloneLinkProps } from './types'
 const DownloadStandaloneLink = ({
   ariaLabel,
   href,
+  textSize = 200,
 }: DownloadStandaloneLinkProps): ReactElement => (
   <StandaloneLink
     ariaLabel={ariaLabel}
@@ -14,6 +15,7 @@ const DownloadStandaloneLink = ({
     icon={<IconDownload16 />}
     iconPosition="trailing"
     text="Download"
+    textSize={textSize}
   />
 )
 

--- a/src/components/download-standalone-link/types.ts
+++ b/src/components/download-standalone-link/types.ts
@@ -1,3 +1,5 @@
+import { StandaloneLinkProps } from 'components/standalone-link'
+
 export interface DownloadStandaloneLinkProps {
   /**
    * A non-visual accessible and descriptive label for what's being downloaded.
@@ -5,7 +7,14 @@ export interface DownloadStandaloneLinkProps {
   ariaLabel: string
 
   /**
-   * The location of the file to download.
+   * The location of the file to download. Passedd directly to the internally
+   * rendered `StandaloneLink`.
    */
-  href: string
+  href: StandaloneLinkProps['href']
+
+  /**
+   * Same as the `StandaloneLink` `textSize` prop and passed directly to the
+   * internally rendered `StandaloneLink`.
+   */
+  textSize?: StandaloneLinkProps['textSize']
 }

--- a/src/components/standalone-link/docs.mdx
+++ b/src/components/standalone-link/docs.mdx
@@ -16,17 +16,18 @@ Internally, this component uses two other components:
 - If `textSize` is being set to 100 or 200, then size 16 icons are recommended
 - If `textSize` is being set to 300, then size 24 icons are recommended
 
-| Prop name      | Description                                                                                                             | Required? | Default value | Type                                   |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------- | --------- | ------------- | -------------------------------------- |
-| `ariaLabel`    | A non-visible label presented by screen readers. Passed directly to the internal link element as the `aria-label` prop. | No        | undefined     | string                                 |
-| `className`    | A string of one or more class names. Applied last to the rendered `<a>` element.                                        | No        | undefined     | string                                 |
-| `color`        | Determines the set of colors to use for various states of the component.                                                | No        | 'primary'     | Either: 'primary' or 'secondary'       |
-| `download`     | Same as the `<a>` element's download prop. Passed directly to the internal link element.                                | No        | undefined     | Either as boolean or with string value |
-| `href`         | The destination of the link.                                                                                            | Yes       | N/A           | string                                 |
-| `icon`         | An icon from `@hashicorp/flight-icons` to render.                                                                       | Yes       | N/A           | ReactElement                           |
-| `iconPosition` | Where the icon should be rendered within the link. See examples below.                                                  | Yes       | N/A           | Either: 'leading' or 'trailing'        |
-| `text`         | The text rendered within the `<a>` element.                                                                             | Yes       | N/A           | string                                 |
-| `textSize`     | The `size` passed to the inner `Text` component.                                                                        | No        | undefined     | TextProps[`size`]                      |
+| Prop name      | Description                                                                                                                             | Required? | Default value | Type                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------- | -------------------------------------- |
+| `ariaLabel`    | A non-visible label presented by screen readers. Passed directly to the internal link element as the `aria-label` prop.                 | No        | undefined     | string                                 |
+| `className`    | A string of one or more class names. Applied last to the rendered `<a>` element.                                                        | No        | undefined     | string                                 |
+| `color`        | Determines the set of colors to use for various states of the component.                                                                | No        | 'primary'     | Either: 'primary' or 'secondary'       |
+| `download`     | Same as the `<a>` element's download prop. Passed directly to the internal link element.                                                | No        | undefined     | Either as boolean or with string value |
+| `href`         | The destination of the link.                                                                                                            | Yes       | N/A           | string                                 |
+| `icon`         | An icon from `@hashicorp/flight-icons` to render.                                                                                       | Yes       | N/A           | ReactElement                           |
+| `iconPosition` | Where the icon should be rendered within the link. See examples below.                                                                  | Yes       | N/A           | Either: 'leading' or 'trailing'        |
+| `openInNewTab` | Whether or not the link should open in a new tab. Affects the `target` and `rel` props passed to the internally rendered `<a>` element. | No        | false         | boolean                                |
+| `text`         | The text rendered within the `<a>` element.                                                                                             | Yes       | N/A           | string                                 |
+| `textSize`     | The `size` passed to the inner `Text` component.                                                                                        | No        | undefined     | TextProps[`size`]                      |
 
 ## Examples
 

--- a/src/components/standalone-link/index.tsx
+++ b/src/components/standalone-link/index.tsx
@@ -13,6 +13,7 @@ const StandaloneLink = ({
   href,
   icon,
   iconPosition,
+  openInNewTab = false,
   text,
   textSize,
 }: StandaloneLinkProps): ReactElement => {
@@ -24,6 +25,8 @@ const StandaloneLink = ({
       className={classes}
       download={download}
       href={href}
+      target={openInNewTab ? '_blank' : '_self'}
+      rel={openInNewTab ? 'noreferrer noopener' : undefined}
     >
       {iconPosition === 'leading' && icon}
       <Text asElement="span" className={s.text} size={textSize} weight="medium">

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -62,6 +62,12 @@ export interface StandaloneLinkProps {
   iconPosition: 'leading' | 'trailing'
 
   /**
+   * Whether or not the link should open in a new tab. Affects the `target` and
+   * `rel` props passed to the internally rendered `<a>` element.
+   */
+  openInNewTab?: boolean
+
+  /**
    * The text rendered within the `<a>` element.
    */
   text: string

--- a/src/data/waypoint-install.json
+++ b/src/data/waypoint-install.json
@@ -1,0 +1,48 @@
+{
+  "packageManagers": [
+    {
+      "label": "Homebrew",
+      "commands": [
+        "brew tap hashicorp/tap",
+        "brew install hashicorp/tap/waypoint"
+      ],
+      "os": "darwin"
+    },
+    {
+      "label": "Ubuntu/Debian",
+      "commands": [
+        "curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
+        "sudo apt-add-repository 'deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main'",
+        "sudo apt-get update && sudo apt-get install waypoint"
+      ],
+      "os": "linux"
+    },
+    {
+      "label": "CentOS/RHEL",
+      "commands": [
+        "sudo yum install -y yum-utils",
+        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo",
+        "sudo yum -y install waypoint"
+      ],
+      "os": "linux"
+    },
+    {
+      "label": "Fedora",
+      "commands": [
+        "sudo dnf install -y dnf-plugins-core",
+        "sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
+        "sudo dnf -y install waypoint"
+      ],
+      "os": "linux"
+    },
+    {
+      "label": "Amazon Linux",
+      "commands": [
+        "sudo yum install -y yum-utils",
+        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo",
+        "sudo yum -y install waypoint"
+      ],
+      "os": "linux"
+    }
+  ]
+}

--- a/src/data/waypoint-install.json
+++ b/src/data/waypoint-install.json
@@ -12,7 +12,7 @@
       "label": "Ubuntu/Debian",
       "commands": [
         "curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
-        "sudo apt-add-repository 'deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main'",
+        "sudo apt-add-repository \"deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main\"",
         "sudo apt-get update && sudo apt-get install waypoint"
       ],
       "os": "linux"

--- a/src/data/waypoint.json
+++ b/src/data/waypoint.json
@@ -70,51 +70,5 @@
       "label": "Install",
       "path": "/waypoint/downloads"
     }
-  ],
-  "packageManagers": [
-    {
-      "label": "Homebrew",
-      "commands": [
-        "brew tap hashicorp/tap",
-        "brew install hashicorp/tap/waypoint"
-      ],
-      "os": "darwin"
-    },
-    {
-      "label": "Ubuntu/Debian",
-      "commands": [
-        "curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
-        "sudo apt-add-repository 'deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main'",
-        "sudo apt-get update && sudo apt-get install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "CentOS/RHEL",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo",
-        "sudo yum -y install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Fedora",
-      "commands": [
-        "sudo dnf install -y dnf-plugins-core",
-        "sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
-        "sudo dnf -y install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Amazon Linux",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo",
-        "sudo yum -y install waypoint"
-      ],
-      "os": "linux"
-    }
   ]
 }

--- a/src/pages/waypoint/downloads/index.tsx
+++ b/src/pages/waypoint/downloads/index.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react'
 import { GetStaticProps } from 'next'
 import waypointData from 'data/waypoint.json'
+import installData from 'data/waypoint-install.json'
 import { Product } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
 import EmptyLayout from 'layouts/empty'
@@ -11,7 +12,11 @@ const WaypointDownloadsPage = (props: GeneratedProps): ReactElement => {
   if (__config.flags.enable_new_downloads_view) {
     const { latestVersion, releases } = props
     return (
-      <ProductDownloadsView latestVersion={latestVersion} releases={releases} />
+      <ProductDownloadsView
+        latestVersion={latestVersion}
+        pageContent={installData}
+        releases={releases}
+      />
     )
   } else {
     return <PlaceholderDownloadsView />

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -13,6 +13,10 @@
   margin-top: 24px;
 }
 
+.codeTabsCodeBlock {
+  margin-top: 4px;
+}
+
 .downloadCard {
   align-items: center;
   display: flex;

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -17,7 +17,7 @@
   margin-top: 4px;
 }
 
-.downloadCard {
+.textAndLinkCard {
   align-items: center;
   display: flex;
   justify-content: space-between;
@@ -27,15 +27,15 @@
   }
 }
 
-.downloadCardText {
+.textAndLinkCardTextContainer {
   margin-right: 16px;
 }
 
-.archNameLabel {
+.textAndLinkCardLabel {
   color: var(--token-color-neutral-foreground-primary);
   margin-bottom: 4px;
 }
 
-.archVersionLabel {
+.textAndLinkCardVersionLabel {
   color: var(--token-color-neutral-foreground-faint);
 }

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -13,6 +13,10 @@
   margin-top: 24px;
 }
 
+.specialSubHeading {
+  margin-bottom: 8px;
+}
+
 .codeTabsCodeBlock {
   margin-top: 4px;
 }

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -1,0 +1,37 @@
+.operatingSystemTitle {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 12px;
+}
+
+.tabContent {
+  margin-top: 16px;
+}
+
+.subHeading {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 16px;
+  margin-top: 24px;
+}
+
+.downloadCard {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+
+  &:not(:last-child) {
+    margin-bottom: 16px;
+  }
+}
+
+.downloadCardText {
+  margin-right: 16px;
+}
+
+.archNameLabel {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 4px;
+}
+
+.archVersionLabel {
+  color: var(--token-color-neutral-foreground-faint);
+}

--- a/src/views/product-downloads-view/components/downloads-section/helpers.ts
+++ b/src/views/product-downloads-view/components/downloads-section/helpers.ts
@@ -1,0 +1,28 @@
+import { ReleaseVersion } from 'lib/fetch-release-data'
+import { PackageManager } from 'views/product-downloads-view/types'
+import { sortPlatforms } from 'views/product-downloads-view/helpers'
+
+export const generateCodePropFromCommands = (
+  commands: PackageManager['commands']
+): string => {
+  return commands.map((command: string) => `$ ${command}`).join('\n')
+}
+
+export const groupDownloadsByOS = (selectedRelease: ReleaseVersion) => {
+  return sortPlatforms(selectedRelease)
+}
+
+export const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
+  const result = {}
+
+  packageManagers.forEach((packageManager) => {
+    const { os } = packageManager
+    if (result[os]) {
+      result[os].push(packageManager)
+    } else {
+      result[os] = [packageManager]
+    }
+  })
+
+  return result
+}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,19 +1,13 @@
 import { ReactElement, useMemo } from 'react'
 import CodeBlock from '@hashicorp/react-code-block'
-import { ReleaseVersion } from 'lib/fetch-release-data'
 import Card from 'components/card'
 import Heading from 'components/heading'
-import { PackageManager } from 'views/product-downloads-view/types'
 import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import s from './downloads-section.module.css'
 import DownloadStandaloneLink from 'components/download-standalone-link'
-
-interface DownloadsSectionProps {
-  packageManagers: PackageManager[]
-  selectedRelease: ReleaseVersion
-}
+import { DownloadsSectionProps } from './types'
 
 const DownloadsSection = ({
   packageManagers,

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useMemo } from 'react'
+import classNames from 'classnames'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
 import { PackageManager } from 'views/product-downloads-view/types'
@@ -159,8 +160,11 @@ const NotesSection = ({ selectedRelease }) => {
     <>
       <Heading
         {...SHARED_HEADING_LEVEL_3_PROPS}
+        className={classNames(
+          SHARED_HEADING_LEVEL_3_PROPS.className,
+          s.specialSubHeading
+        )}
         slug="notes"
-        style={{ marginBottom: 8 }}
       >
         Notes
       </Heading>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -8,6 +8,7 @@ import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
 import Card from 'components/card'
 import DownloadStandaloneLink from 'components/download-standalone-link'
 import Heading from 'components/heading'
+import InlineLink from 'components/inline-link'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import StandaloneLink from 'components/standalone-link'
@@ -95,7 +96,6 @@ const DownloadsSection = ({
                       tabs={packageManagers.map(({ label }) => label)}
                     >
                       {packageManagers.map((packageManager) => {
-                        console.log(packageManager)
                         return (
                           <CodeBlock
                             key={packageManager.label}
@@ -181,6 +181,37 @@ const DownloadsSection = ({
                       textSize={200}
                     />
                   </Card>
+                  <Heading
+                    className={s.subHeading}
+                    level={3}
+                    size={200}
+                    slug="notes"
+                    style={{ marginBottom: 8 }}
+                    weight="semibold"
+                  >
+                    Notes
+                  </Heading>
+                  <Text size={200}>
+                    You can find the{' '}
+                    <InlineLink
+                      href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums}`}
+                      text={`SHA256 checksums for Waypoint ${selectedRelease.version}`}
+                      textSize={200}
+                    />{' '}
+                    online and you can{' '}
+                    <InlineLink
+                      href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums_signature}`}
+                      text="verify the checksums signature file"
+                      textSize={200}
+                    />{' '}
+                    which has been signed using{' '}
+                    <InlineLink
+                      href="https://www.hashicorp.com/security"
+                      text="HashiCorp's GPG key"
+                      textSize={200}
+                    />
+                    .
+                  </Text>
                 </div>
               </Tab>
             )

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -43,7 +43,6 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
       >
         Package manager for {prettyOSName}
       </Heading>
-
       {hasOnePackageManager && (
         <CodeBlock
           code={generateCodePropFromCommands(packageManagers[0].commands)}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -33,6 +33,10 @@ const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
   return result
 }
 
+const generateCodePropFromCommands = (commands: PackageManager['commands']) => {
+  return commands.map((command: string) => `$ ${command}`).join('\n')
+}
+
 const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
   const hasOnePackageManager = packageManagers?.length === 1
   const hasManyPackageManagers = packageManagers?.length > 1
@@ -53,9 +57,7 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
       )}
       {hasOnePackageManager && (
         <CodeBlock
-          code={packageManagers[0].commands
-            .map((command: string) => `$ ${command}`)
-            .join('\n')}
+          code={generateCodePropFromCommands(packageManagers[0].commands)}
           language="shell-session"
           options={{ showClipboard: true }}
         />
@@ -73,9 +75,7 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
               <Tab heading={label} key={label}>
                 <CodeBlock
                   className={s.codeTabsCodeBlock}
-                  code={commands
-                    .map((command: string) => `$ ${command}`)
-                    .join('\n')}
+                  code={generateCodePropFromCommands(commands)}
                   language="shell-session"
                   options={{ showClipboard: true }}
                 />

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useMemo } from 'react'
+import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
 import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
 import { PackageManager } from 'views/product-downloads-view/types'
@@ -9,6 +10,7 @@ import DownloadStandaloneLink from 'components/download-standalone-link'
 import Heading from 'components/heading'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
+import StandaloneLink from 'components/standalone-link'
 import s from './downloads-section.module.css'
 import { DownloadsSectionProps } from './types'
 
@@ -144,6 +146,41 @@ const DownloadsSection = ({
                       />
                     </Card>
                   ))}
+                  <Heading
+                    className={s.subHeading}
+                    level={3}
+                    size={200}
+                    slug="release-information"
+                    weight="semibold"
+                  >
+                    Release information
+                  </Heading>
+                  <Card className={s.downloadCard} elevation="base">
+                    <div className={s.downloadCardText}>
+                      <Text
+                        className={s.archNameLabel}
+                        size={200}
+                        weight="semibold"
+                      >
+                        Changelog
+                      </Text>
+                      <Text
+                        className={s.archVersionLabel}
+                        size={200}
+                        weight="regular"
+                      >
+                        Version: {selectedRelease.version}
+                      </Text>
+                    </div>
+                    <StandaloneLink
+                      ariaLabel="TODO"
+                      href={`https://github.com/hashicorp/waypoint/blob/v${selectedRelease.version}/CHANGELOG.md`}
+                      icon={<IconExternalLink16 />}
+                      iconPosition="trailing"
+                      text="GitHub"
+                      textSize={200}
+                    />
+                  </Card>
                 </div>
               </Tab>
             )

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,19 +1,21 @@
 import { ReactElement, useMemo } from 'react'
 import CodeBlock from '@hashicorp/react-code-block'
-import Card from 'components/card'
-import Heading from 'components/heading'
+import { PackageManager } from 'views/product-downloads-view/types'
+import { ReleaseVersion } from 'lib/fetch-release-data'
 import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
+import Card from 'components/card'
+import DownloadStandaloneLink from 'components/download-standalone-link'
+import Heading from 'components/heading'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import s from './downloads-section.module.css'
-import DownloadStandaloneLink from 'components/download-standalone-link'
 import { DownloadsSectionProps } from './types'
 
-const groupDownloadsByOS = (selectedRelease) => {
+const groupDownloadsByOS = (selectedRelease: ReleaseVersion) => {
   return sortPlatforms(selectedRelease)
 }
 
-const groupPackageManagersByOS = (packageManagers) => {
+const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
   const result = {}
 
   packageManagers.forEach((packageManager) => {

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -2,39 +2,27 @@ import { ReactElement, useMemo } from 'react'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
 import { PackageManager } from 'views/product-downloads-view/types'
-import { ReleaseVersion } from 'lib/fetch-release-data'
-import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
+import { prettyOs } from 'views/product-downloads-view/helpers'
 import Card from 'components/card'
 import DownloadStandaloneLink from 'components/download-standalone-link'
-import Heading from 'components/heading'
+import Heading, { HeadingProps } from 'components/heading'
 import InlineLink from 'components/inline-link'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import StandaloneLink from 'components/standalone-link'
-import s from './downloads-section.module.css'
 import { DownloadsSectionProps } from './types'
+import {
+  generateCodePropFromCommands,
+  groupDownloadsByOS,
+  groupPackageManagersByOS,
+} from './helpers'
+import s from './downloads-section.module.css'
 
-const groupDownloadsByOS = (selectedRelease: ReleaseVersion) => {
-  return sortPlatforms(selectedRelease)
-}
-
-const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
-  const result = {}
-
-  packageManagers.forEach((packageManager) => {
-    const { os } = packageManager
-    if (result[os]) {
-      result[os].push(packageManager)
-    } else {
-      result[os] = [packageManager]
-    }
-  })
-
-  return result
-}
-
-const generateCodePropFromCommands = (commands: PackageManager['commands']) => {
-  return commands.map((command: string) => `$ ${command}`).join('\n')
+const SHARED_HEADING_LEVEL_3_PROPS = {
+  className: s.subHeading,
+  level: 3 as HeadingProps['level'],
+  size: 200 as HeadingProps['size'],
+  weight: 'semibold' as HeadingProps['weight'],
 }
 
 const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
@@ -46,11 +34,8 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
     <>
       {hasPackageManagers && (
         <Heading
-          className={s.subHeading}
-          level={3}
-          size={200}
+          {...SHARED_HEADING_LEVEL_3_PROPS}
           slug={`package-manager-for-${prettyOSName}`}
-          weight="semibold"
         >
           Package manager for {prettyOSName}
         </Heading>
@@ -98,11 +83,8 @@ const BinaryDownloadsSection = ({
   return (
     <>
       <Heading
-        className={s.subHeading}
-        level={3}
-        size={200}
+        {...SHARED_HEADING_LEVEL_3_PROPS}
         slug={`binary-download-for-${prettyOSName}`}
-        weight="semibold"
       >
         Binary download for {prettyOSName}
       </Heading>
@@ -130,13 +112,7 @@ const ChangelogSection = ({ selectedRelease }) => {
   const { version } = selectedRelease
   return (
     <>
-      <Heading
-        className={s.subHeading}
-        level={3}
-        size={200}
-        slug="release-information"
-        weight="semibold"
-      >
+      <Heading {...SHARED_HEADING_LEVEL_3_PROPS} slug="release-information">
         Release information
       </Heading>
       <Card className={s.downloadCard} elevation="base">
@@ -167,12 +143,9 @@ const NotesSection = ({ selectedRelease }) => {
   return (
     <>
       <Heading
-        className={s.subHeading}
-        level={3}
-        size={200}
+        {...SHARED_HEADING_LEVEL_3_PROPS}
         slug="notes"
         style={{ marginBottom: 8 }}
-        weight="semibold"
       >
         Notes
       </Heading>
@@ -230,6 +203,12 @@ const DownloadsSection = ({
             const packageManagers: PackageManager[] = packageManagersByOS[os]
             const prettyOSName = prettyOs(os)
 
+            /**
+             * TODO: it might be nice to introduce a local Context here with all
+             * the information needed so that these helper components don't have
+             * APIs that could potentially require changes with every visual
+             * change.
+             */
             return (
               <Tab heading={prettyOSName} key={os}>
                 <div className={s.tabContent}>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useMemo } from 'react'
 import CodeBlock from '@hashicorp/react-code-block'
+import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
 import { PackageManager } from 'views/product-downloads-view/types'
 import { ReleaseVersion } from 'lib/fetch-release-data'
 import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
@@ -59,32 +60,52 @@ const DownloadsSection = ({
             const packageManagers = packageManagersByOS[os]
             const hasOnePackageManager = packageManagers?.length === 1
             const hasManyPackageManagers = packageManagers?.length > 1
+            const hasPackageManagers =
+              hasOnePackageManager || hasManyPackageManagers
 
             const prettyOSName = prettyOs(os)
             return (
               <Tab heading={prettyOSName} key={os}>
                 <div className={s.tabContent}>
+                  {hasPackageManagers && (
+                    <Heading
+                      className={s.subHeading}
+                      level={3}
+                      size={200}
+                      slug={`package-manager-for-${prettyOSName}`}
+                      weight="semibold"
+                    >
+                      Package manager for {prettyOSName}
+                    </Heading>
+                  )}
                   {hasOnePackageManager && (
-                    <>
-                      <Heading
-                        className={s.subHeading}
-                        level={3}
-                        size={200}
-                        slug={`package-manager-for-${prettyOSName}`}
-                        weight="semibold"
-                      >
-                        Package manager for {prettyOSName}
-                      </Heading>
-                      <CodeBlock
-                        code={packageManagers[0].commands
-                          .map((command) => `$ ${command}`)
-                          .join('\n')}
-                        options={{ showClipboard: true }}
-                      />
-                    </>
+                    <CodeBlock
+                      code={packageManagers[0].commands
+                        .map((command: string) => `$ ${command}`)
+                        .join('\n')}
+                      language="shell-session"
+                      options={{ showClipboard: true }}
+                    />
                   )}
                   {hasManyPackageManagers && (
-                    <>TODO: show tabs component for many package managers</>
+                    <CodeTabs
+                      className={s.codeTabs}
+                      tabs={packageManagers.map(({ label }) => label)}
+                    >
+                      {packageManagers.map((packageManager) => {
+                        console.log(packageManager)
+                        return (
+                          <CodeBlock
+                            key={packageManager.label}
+                            code={packageManager.commands
+                              .map((command: string) => `$ ${command}`)
+                              .join('\n')}
+                            language="shell-session"
+                            options={{ showClipboard: true }}
+                          />
+                        )
+                      })}
+                    </CodeTabs>
                   )}
                   <Heading
                     className={s.subHeading}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, useMemo } from 'react'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
-import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
 import { PackageManager } from 'views/product-downloads-view/types'
 import { ReleaseVersion } from 'lib/fetch-release-data'
 import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
@@ -60,7 +59,7 @@ const DownloadsSection = ({
         </Heading>
         <Tabs showAnchorLine>
           {Object.keys(downloadsByOS).map((os) => {
-            const packageManagers = packageManagersByOS[os]
+            const packageManagers: PackageManager[] = packageManagersByOS[os]
             const hasOnePackageManager = packageManagers?.length === 1
             const hasManyPackageManagers = packageManagers?.length > 1
             const hasPackageManagers =
@@ -91,23 +90,31 @@ const DownloadsSection = ({
                     />
                   )}
                   {hasManyPackageManagers && (
-                    <CodeTabs
-                      className={s.codeTabs}
-                      tabs={packageManagers.map(({ label }) => label)}
-                    >
+                    /**
+                     * TODO: this will eventually be <CodeTabs> once a bug has
+                     * been fixed.
+                     *
+                     * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
+                     */
+                    <Tabs showAnchorLine={false}>
                       {packageManagers.map((packageManager) => {
                         return (
-                          <CodeBlock
+                          <Tab
+                            heading={packageManager.label}
                             key={packageManager.label}
-                            code={packageManager.commands
-                              .map((command: string) => `$ ${command}`)
-                              .join('\n')}
-                            language="shell-session"
-                            options={{ showClipboard: true }}
-                          />
+                          >
+                            <CodeBlock
+                              className={s.codeTabsCodeBlock}
+                              code={packageManager.commands
+                                .map((command: string) => `$ ${command}`)
+                                .join('\n')}
+                              language="shell-session"
+                              options={{ showClipboard: true }}
+                            />
+                          </Tab>
                         )
                       })}
-                    </CodeTabs>
+                    </Tabs>
                   )}
                   <Heading
                     className={s.subHeading}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -109,7 +109,7 @@ const BinaryDownloadsSection = ({
 }
 
 const ChangelogSection = ({ selectedRelease }) => {
-  const { version } = selectedRelease
+  const { name, version } = selectedRelease
   return (
     <>
       <Heading {...SHARED_HEADING_LEVEL_3_PROPS} slug="release-information">
@@ -125,7 +125,7 @@ const ChangelogSection = ({ selectedRelease }) => {
           </Text>
         </div>
         <StandaloneLink
-          ariaLabel="TODO"
+          ariaLabel={`${name} version ${version} changelog`}
           href={`https://github.com/hashicorp/waypoint/blob/v${version}/CHANGELOG.md`}
           icon={<IconExternalLink16 />}
           iconPosition="trailing"

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -30,16 +30,19 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
   const hasManyPackageManagers = packageManagers?.length > 1
   const hasPackageManagers = hasOnePackageManager || hasManyPackageManagers
 
+  if (!hasPackageManagers) {
+    return null
+  }
+
   return (
     <>
-      {hasPackageManagers && (
-        <Heading
-          {...SHARED_HEADING_LEVEL_3_PROPS}
-          slug={`package-manager-for-${prettyOSName}`}
-        >
-          Package manager for {prettyOSName}
-        </Heading>
-      )}
+      <Heading
+        {...SHARED_HEADING_LEVEL_3_PROPS}
+        slug={`package-manager-for-${prettyOSName}`}
+      >
+        Package manager for {prettyOSName}
+      </Heading>
+
       {hasOnePackageManager && (
         <CodeBlock
           code={generateCodePropFromCommands(packageManagers[0].commands)}
@@ -187,6 +190,7 @@ const NotesSection = ({ selectedRelease }) => {
 }
 
 const DownloadsSection = ({
+  latestVersionIsSelected,
   packageManagers,
   selectedRelease,
 }: DownloadsSectionProps): ReactElement => {
@@ -224,10 +228,12 @@ const DownloadsSection = ({
             return (
               <Tab heading={prettyOSName} key={os}>
                 <div className={s.tabContent}>
-                  <PackageManagerSection
-                    packageManagers={packageManagers}
-                    prettyOSName={prettyOSName}
-                  />
+                  {latestVersionIsSelected && (
+                    <PackageManagerSection
+                      packageManagers={packageManagers}
+                      prettyOSName={prettyOSName}
+                    />
+                  )}
                   <BinaryDownloadsSection
                     downloadsByOS={downloadsByOS}
                     os={os}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -177,6 +177,7 @@ const DownloadsSection = ({
                       href={`https://github.com/hashicorp/waypoint/blob/v${selectedRelease.version}/CHANGELOG.md`}
                       icon={<IconExternalLink16 />}
                       iconPosition="trailing"
+                      openInNewTab
                       text="GitHub"
                       textSize={200}
                     />

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useMemo } from 'react'
 import classNames from 'classnames'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
+import { useCurrentProduct } from 'contexts'
 import { PackageManager } from 'views/product-downloads-view/types'
 import { prettyOs } from 'views/product-downloads-view/helpers'
 import Card from 'components/card'
@@ -141,7 +142,7 @@ const ChangelogSection = ({ selectedRelease }) => {
         </div>
         <StandaloneLink
           ariaLabel={`${name} version ${version} changelog`}
-          href={`https://github.com/hashicorp/waypoint/blob/v${version}/CHANGELOG.md`}
+          href={`https://github.com/hashicorp/${name}/blob/v${version}/CHANGELOG.md`}
           icon={<IconExternalLink16 />}
           iconPosition="trailing"
           openInNewTab
@@ -154,7 +155,9 @@ const ChangelogSection = ({ selectedRelease }) => {
 }
 
 const NotesSection = ({ selectedRelease }) => {
+  const currentProduct = useCurrentProduct()
   const { name, shasums, shasums_signature, version } = selectedRelease
+
   return (
     <>
       <Heading
@@ -171,7 +174,7 @@ const NotesSection = ({ selectedRelease }) => {
         You can find the{' '}
         <InlineLink
           href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
-          text={`SHA256 checksums for Waypoint ${version}`}
+          text={`SHA256 checksums for ${currentProduct.name} ${version}`}
           textSize={200}
         />{' '}
         online and you can{' '}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,0 +1,131 @@
+import { ReactElement, useMemo } from 'react'
+import CodeBlock from '@hashicorp/react-code-block'
+import { ReleaseVersion } from 'lib/fetch-release-data'
+import Card from 'components/card'
+import Heading from 'components/heading'
+import { PackageManager } from 'views/product-downloads-view/types'
+import { sortPlatforms, prettyOs } from 'views/product-downloads-view/helpers'
+import Tabs, { Tab } from 'components/tabs'
+import Text from 'components/text'
+import s from './downloads-section.module.css'
+import DownloadStandaloneLink from 'components/download-standalone-link'
+
+interface DownloadsSectionProps {
+  packageManagers: PackageManager[]
+  selectedRelease: ReleaseVersion
+}
+
+const DownloadsSection = ({
+  packageManagers,
+  selectedRelease,
+}: DownloadsSectionProps): ReactElement => {
+  const downloadsByOS = useMemo(() => sortPlatforms(selectedRelease), [
+    selectedRelease,
+  ])
+  const packageManagersByOS = useMemo(() => {
+    const result = {}
+
+    packageManagers.forEach((packageManager) => {
+      const { os } = packageManager
+      if (result[os]) {
+        result[os].push(packageManager)
+      } else {
+        result[os] = [packageManager]
+      }
+    })
+
+    return result
+  }, [packageManagers])
+
+  return (
+    <section>
+      <Card elevation="base">
+        <Heading
+          className={s.operatingSystemTitle}
+          level={2}
+          size={300}
+          slug="operating-system"
+          weight="bold"
+        >
+          Operating System
+        </Heading>
+        <Tabs showAnchorLine>
+          {Object.keys(downloadsByOS).map((os) => {
+            const packageManagers = packageManagersByOS[os]
+            const hasOnePackageManager = packageManagers?.length === 1
+            const hasManyPackageManagers = packageManagers?.length > 1
+
+            const prettyOSName = prettyOs(os)
+            return (
+              <Tab heading={prettyOSName} key={os}>
+                <div className={s.tabContent}>
+                  {hasOnePackageManager && (
+                    <>
+                      <Heading
+                        className={s.subHeading}
+                        level={3}
+                        size={200}
+                        slug={`package-manager-for-${prettyOSName}`}
+                        weight="semibold"
+                      >
+                        Package manager for {prettyOSName}
+                      </Heading>
+                      <CodeBlock
+                        code={packageManagers[0].commands
+                          .map((command) => `$ ${command}`)
+                          .join('\n')}
+                        options={{ showClipboard: true }}
+                      />
+                    </>
+                  )}
+                  {hasManyPackageManagers && (
+                    <>TODO: show tabs component for many package managers</>
+                  )}
+                  <Heading
+                    className={s.subHeading}
+                    level={3}
+                    size={200}
+                    slug={`binary-download-for-${prettyOSName}`}
+                    weight="semibold"
+                  >
+                    Binary download for {prettyOSName}
+                  </Heading>
+                  {Object.keys(downloadsByOS[os]).map((arch) => (
+                    <Card
+                      className={s.downloadCard}
+                      elevation="base"
+                      key={arch}
+                    >
+                      <div className={s.downloadCardText}>
+                        <Text
+                          className={s.archNameLabel}
+                          size={200}
+                          weight="semibold"
+                        >
+                          {arch.toUpperCase()}
+                        </Text>
+                        <Text
+                          className={s.archVersionLabel}
+                          size={200}
+                          weight="regular"
+                        >
+                          Version: {selectedRelease.version}
+                        </Text>
+                      </div>
+                      <DownloadStandaloneLink
+                        ariaLabel="TODO"
+                        href={downloadsByOS[os][arch]}
+                      />
+                    </Card>
+                  ))}
+                </div>
+              </Tab>
+            )
+          })}
+        </Tabs>
+      </Card>
+    </section>
+  )
+}
+
+export default DownloadsSection

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -89,12 +89,20 @@ const BinaryDownloadsSection = ({
         Binary download for {prettyOSName}
       </Heading>
       {Object.keys(downloadsByOS[os]).map((arch) => (
-        <Card className={s.downloadCard} elevation="base" key={arch}>
-          <div className={s.downloadCardText}>
-            <Text className={s.archNameLabel} size={200} weight="semibold">
+        <Card className={s.textAndLinkCard} elevation="base" key={arch}>
+          <div className={s.textAndLinkCardTextContainer}>
+            <Text
+              className={s.textAndLinkCardLabel}
+              size={200}
+              weight="semibold"
+            >
               {arch.toUpperCase()}
             </Text>
-            <Text className={s.archVersionLabel} size={200} weight="regular">
+            <Text
+              className={s.textAndLinkCardVersionLabel}
+              size={200}
+              weight="regular"
+            >
               Version: {version}
             </Text>
           </div>
@@ -115,12 +123,16 @@ const ChangelogSection = ({ selectedRelease }) => {
       <Heading {...SHARED_HEADING_LEVEL_3_PROPS} slug="release-information">
         Release information
       </Heading>
-      <Card className={s.downloadCard} elevation="base">
-        <div className={s.downloadCardText}>
-          <Text className={s.archNameLabel} size={200} weight="semibold">
+      <Card className={s.textAndLinkCard} elevation="base">
+        <div className={s.textAndLinkCardTextContainer}>
+          <Text className={s.textAndLinkCardLabel} size={200} weight="semibold">
             Changelog
           </Text>
-          <Text className={s.archVersionLabel} size={200} weight="regular">
+          <Text
+            className={s.textAndLinkCardVersionLabel}
+            size={200}
+            weight="regular"
+          >
             Version: {version}
           </Text>
         </div>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -9,27 +9,36 @@ import s from './downloads-section.module.css'
 import DownloadStandaloneLink from 'components/download-standalone-link'
 import { DownloadsSectionProps } from './types'
 
+const groupDownloadsByOS = (selectedRelease) => {
+  return sortPlatforms(selectedRelease)
+}
+
+const groupPackageManagersByOS = (packageManagers) => {
+  const result = {}
+
+  packageManagers.forEach((packageManager) => {
+    const { os } = packageManager
+    if (result[os]) {
+      result[os].push(packageManager)
+    } else {
+      result[os] = [packageManager]
+    }
+  })
+
+  return result
+}
+
 const DownloadsSection = ({
   packageManagers,
   selectedRelease,
 }: DownloadsSectionProps): ReactElement => {
-  const downloadsByOS = useMemo(() => sortPlatforms(selectedRelease), [
+  const downloadsByOS = useMemo(() => groupDownloadsByOS(selectedRelease), [
     selectedRelease,
   ])
-  const packageManagersByOS = useMemo(() => {
-    const result = {}
-
-    packageManagers.forEach((packageManager) => {
-      const { os } = packageManager
-      if (result[os]) {
-        result[os].push(packageManager)
-      } else {
-        result[os] = [packageManager]
-      }
-    })
-
-    return result
-  }, [packageManagers])
+  const packageManagersByOS = useMemo(
+    () => groupPackageManagersByOS(packageManagers),
+    [packageManagers]
+  )
 
   return (
     <section>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -79,7 +79,7 @@ const BinaryDownloadsSection = ({
   prettyOSName,
   selectedRelease,
 }) => {
-  const { version } = selectedRelease
+  const { name, version } = selectedRelease
   return (
     <>
       <Heading
@@ -99,7 +99,7 @@ const BinaryDownloadsSection = ({
             </Text>
           </div>
           <DownloadStandaloneLink
-            ariaLabel="TODO"
+            ariaLabel={`download ${name} version ${version} for ${prettyOSName}, architecture ${arch}`}
             href={downloadsByOS[os][arch]}
           />
         </Card>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -68,12 +68,12 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
          * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
          */
         <Tabs showAnchorLine={false}>
-          {packageManagers.map((packageManager) => {
+          {packageManagers.map(({ label, commands }) => {
             return (
-              <Tab heading={packageManager.label} key={packageManager.label}>
+              <Tab heading={label} key={label}>
                 <CodeBlock
                   className={s.codeTabsCodeBlock}
-                  code={packageManager.commands
+                  code={commands
                     .map((command: string) => `$ ${command}`)
                     .join('\n')}
                   language="shell-session"
@@ -94,6 +94,7 @@ const BinaryDownloadsSection = ({
   prettyOSName,
   selectedRelease,
 }) => {
+  const { version } = selectedRelease
   return (
     <>
       <Heading
@@ -112,7 +113,7 @@ const BinaryDownloadsSection = ({
               {arch.toUpperCase()}
             </Text>
             <Text className={s.archVersionLabel} size={200} weight="regular">
-              Version: {selectedRelease.version}
+              Version: {version}
             </Text>
           </div>
           <DownloadStandaloneLink
@@ -126,6 +127,7 @@ const BinaryDownloadsSection = ({
 }
 
 const ChangelogSection = ({ selectedRelease }) => {
+  const { version } = selectedRelease
   return (
     <>
       <Heading
@@ -143,12 +145,12 @@ const ChangelogSection = ({ selectedRelease }) => {
             Changelog
           </Text>
           <Text className={s.archVersionLabel} size={200} weight="regular">
-            Version: {selectedRelease.version}
+            Version: {version}
           </Text>
         </div>
         <StandaloneLink
           ariaLabel="TODO"
-          href={`https://github.com/hashicorp/waypoint/blob/v${selectedRelease.version}/CHANGELOG.md`}
+          href={`https://github.com/hashicorp/waypoint/blob/v${version}/CHANGELOG.md`}
           icon={<IconExternalLink16 />}
           iconPosition="trailing"
           openInNewTab
@@ -161,6 +163,7 @@ const ChangelogSection = ({ selectedRelease }) => {
 }
 
 const NotesSection = ({ selectedRelease }) => {
+  const { name, shasums, shasums_signature, version } = selectedRelease
   return (
     <>
       <Heading
@@ -176,13 +179,13 @@ const NotesSection = ({ selectedRelease }) => {
       <Text size={200}>
         You can find the{' '}
         <InlineLink
-          href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums}`}
-          text={`SHA256 checksums for Waypoint ${selectedRelease.version}`}
+          href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
+          text={`SHA256 checksums for Waypoint ${version}`}
           textSize={200}
         />{' '}
         online and you can{' '}
         <InlineLink
-          href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums_signature}`}
+          href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
           text="verify the checksums signature file"
           textSize={200}
         />{' '}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -33,6 +33,171 @@ const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
   return result
 }
 
+const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
+  const hasOnePackageManager = packageManagers?.length === 1
+  const hasManyPackageManagers = packageManagers?.length > 1
+  const hasPackageManagers = hasOnePackageManager || hasManyPackageManagers
+
+  return (
+    <>
+      {hasPackageManagers && (
+        <Heading
+          className={s.subHeading}
+          level={3}
+          size={200}
+          slug={`package-manager-for-${prettyOSName}`}
+          weight="semibold"
+        >
+          Package manager for {prettyOSName}
+        </Heading>
+      )}
+      {hasOnePackageManager && (
+        <CodeBlock
+          code={packageManagers[0].commands
+            .map((command: string) => `$ ${command}`)
+            .join('\n')}
+          language="shell-session"
+          options={{ showClipboard: true }}
+        />
+      )}
+      {hasManyPackageManagers && (
+        /**
+         * TODO: this will eventually be <CodeTabs> once a bug has
+         * been fixed.
+         *
+         * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
+         */
+        <Tabs showAnchorLine={false}>
+          {packageManagers.map((packageManager) => {
+            return (
+              <Tab heading={packageManager.label} key={packageManager.label}>
+                <CodeBlock
+                  className={s.codeTabsCodeBlock}
+                  code={packageManager.commands
+                    .map((command: string) => `$ ${command}`)
+                    .join('\n')}
+                  language="shell-session"
+                  options={{ showClipboard: true }}
+                />
+              </Tab>
+            )
+          })}
+        </Tabs>
+      )}
+    </>
+  )
+}
+
+const BinaryDownloadsSection = ({
+  downloadsByOS,
+  os,
+  prettyOSName,
+  selectedRelease,
+}) => {
+  return (
+    <>
+      <Heading
+        className={s.subHeading}
+        level={3}
+        size={200}
+        slug={`binary-download-for-${prettyOSName}`}
+        weight="semibold"
+      >
+        Binary download for {prettyOSName}
+      </Heading>
+      {Object.keys(downloadsByOS[os]).map((arch) => (
+        <Card className={s.downloadCard} elevation="base" key={arch}>
+          <div className={s.downloadCardText}>
+            <Text className={s.archNameLabel} size={200} weight="semibold">
+              {arch.toUpperCase()}
+            </Text>
+            <Text className={s.archVersionLabel} size={200} weight="regular">
+              Version: {selectedRelease.version}
+            </Text>
+          </div>
+          <DownloadStandaloneLink
+            ariaLabel="TODO"
+            href={downloadsByOS[os][arch]}
+          />
+        </Card>
+      ))}
+    </>
+  )
+}
+
+const ChangelogSection = ({ selectedRelease }) => {
+  return (
+    <>
+      <Heading
+        className={s.subHeading}
+        level={3}
+        size={200}
+        slug="release-information"
+        weight="semibold"
+      >
+        Release information
+      </Heading>
+      <Card className={s.downloadCard} elevation="base">
+        <div className={s.downloadCardText}>
+          <Text className={s.archNameLabel} size={200} weight="semibold">
+            Changelog
+          </Text>
+          <Text className={s.archVersionLabel} size={200} weight="regular">
+            Version: {selectedRelease.version}
+          </Text>
+        </div>
+        <StandaloneLink
+          ariaLabel="TODO"
+          href={`https://github.com/hashicorp/waypoint/blob/v${selectedRelease.version}/CHANGELOG.md`}
+          icon={<IconExternalLink16 />}
+          iconPosition="trailing"
+          openInNewTab
+          text="GitHub"
+          textSize={200}
+        />
+      </Card>
+    </>
+  )
+}
+
+const NotesSection = ({ selectedRelease }) => {
+  return (
+    <>
+      <Heading
+        className={s.subHeading}
+        level={3}
+        size={200}
+        slug="notes"
+        style={{ marginBottom: 8 }}
+        weight="semibold"
+      >
+        Notes
+      </Heading>
+      <Text size={200}>
+        You can find the{' '}
+        <InlineLink
+          href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums}`}
+          text={`SHA256 checksums for Waypoint ${selectedRelease.version}`}
+          textSize={200}
+        />{' '}
+        online and you can{' '}
+        <InlineLink
+          href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums_signature}`}
+          text="verify the checksums signature file"
+          textSize={200}
+        />{' '}
+        which has been signed using{' '}
+        <InlineLink
+          href="https://www.hashicorp.com/security"
+          text="HashiCorp's GPG key"
+          textSize={200}
+        />
+        .
+      </Text>
+    </>
+  )
+}
+
 const DownloadsSection = ({
   packageManagers,
   selectedRelease,
@@ -46,7 +211,7 @@ const DownloadsSection = ({
   )
 
   return (
-    <section>
+    <article>
       <Card elevation="base">
         <Heading
           className={s.operatingSystemTitle}
@@ -60,173 +225,30 @@ const DownloadsSection = ({
         <Tabs showAnchorLine>
           {Object.keys(downloadsByOS).map((os) => {
             const packageManagers: PackageManager[] = packageManagersByOS[os]
-            const hasOnePackageManager = packageManagers?.length === 1
-            const hasManyPackageManagers = packageManagers?.length > 1
-            const hasPackageManagers =
-              hasOnePackageManager || hasManyPackageManagers
-
             const prettyOSName = prettyOs(os)
+
             return (
               <Tab heading={prettyOSName} key={os}>
                 <div className={s.tabContent}>
-                  {hasPackageManagers && (
-                    <Heading
-                      className={s.subHeading}
-                      level={3}
-                      size={200}
-                      slug={`package-manager-for-${prettyOSName}`}
-                      weight="semibold"
-                    >
-                      Package manager for {prettyOSName}
-                    </Heading>
-                  )}
-                  {hasOnePackageManager && (
-                    <CodeBlock
-                      code={packageManagers[0].commands
-                        .map((command: string) => `$ ${command}`)
-                        .join('\n')}
-                      language="shell-session"
-                      options={{ showClipboard: true }}
-                    />
-                  )}
-                  {hasManyPackageManagers && (
-                    /**
-                     * TODO: this will eventually be <CodeTabs> once a bug has
-                     * been fixed.
-                     *
-                     * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
-                     */
-                    <Tabs showAnchorLine={false}>
-                      {packageManagers.map((packageManager) => {
-                        return (
-                          <Tab
-                            heading={packageManager.label}
-                            key={packageManager.label}
-                          >
-                            <CodeBlock
-                              className={s.codeTabsCodeBlock}
-                              code={packageManager.commands
-                                .map((command: string) => `$ ${command}`)
-                                .join('\n')}
-                              language="shell-session"
-                              options={{ showClipboard: true }}
-                            />
-                          </Tab>
-                        )
-                      })}
-                    </Tabs>
-                  )}
-                  <Heading
-                    className={s.subHeading}
-                    level={3}
-                    size={200}
-                    slug={`binary-download-for-${prettyOSName}`}
-                    weight="semibold"
-                  >
-                    Binary download for {prettyOSName}
-                  </Heading>
-                  {Object.keys(downloadsByOS[os]).map((arch) => (
-                    <Card
-                      className={s.downloadCard}
-                      elevation="base"
-                      key={arch}
-                    >
-                      <div className={s.downloadCardText}>
-                        <Text
-                          className={s.archNameLabel}
-                          size={200}
-                          weight="semibold"
-                        >
-                          {arch.toUpperCase()}
-                        </Text>
-                        <Text
-                          className={s.archVersionLabel}
-                          size={200}
-                          weight="regular"
-                        >
-                          Version: {selectedRelease.version}
-                        </Text>
-                      </div>
-                      <DownloadStandaloneLink
-                        ariaLabel="TODO"
-                        href={downloadsByOS[os][arch]}
-                      />
-                    </Card>
-                  ))}
-                  <Heading
-                    className={s.subHeading}
-                    level={3}
-                    size={200}
-                    slug="release-information"
-                    weight="semibold"
-                  >
-                    Release information
-                  </Heading>
-                  <Card className={s.downloadCard} elevation="base">
-                    <div className={s.downloadCardText}>
-                      <Text
-                        className={s.archNameLabel}
-                        size={200}
-                        weight="semibold"
-                      >
-                        Changelog
-                      </Text>
-                      <Text
-                        className={s.archVersionLabel}
-                        size={200}
-                        weight="regular"
-                      >
-                        Version: {selectedRelease.version}
-                      </Text>
-                    </div>
-                    <StandaloneLink
-                      ariaLabel="TODO"
-                      href={`https://github.com/hashicorp/waypoint/blob/v${selectedRelease.version}/CHANGELOG.md`}
-                      icon={<IconExternalLink16 />}
-                      iconPosition="trailing"
-                      openInNewTab
-                      text="GitHub"
-                      textSize={200}
-                    />
-                  </Card>
-                  <Heading
-                    className={s.subHeading}
-                    level={3}
-                    size={200}
-                    slug="notes"
-                    style={{ marginBottom: 8 }}
-                    weight="semibold"
-                  >
-                    Notes
-                  </Heading>
-                  <Text size={200}>
-                    You can find the{' '}
-                    <InlineLink
-                      href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums}`}
-                      text={`SHA256 checksums for Waypoint ${selectedRelease.version}`}
-                      textSize={200}
-                    />{' '}
-                    online and you can{' '}
-                    <InlineLink
-                      href={`https://releases.hashicorp.com/${selectedRelease.name}/${selectedRelease.version}/${selectedRelease.shasums_signature}`}
-                      text="verify the checksums signature file"
-                      textSize={200}
-                    />{' '}
-                    which has been signed using{' '}
-                    <InlineLink
-                      href="https://www.hashicorp.com/security"
-                      text="HashiCorp's GPG key"
-                      textSize={200}
-                    />
-                    .
-                  </Text>
+                  <PackageManagerSection
+                    packageManagers={packageManagers}
+                    prettyOSName={prettyOSName}
+                  />
+                  <BinaryDownloadsSection
+                    downloadsByOS={downloadsByOS}
+                    os={os}
+                    prettyOSName={prettyOSName}
+                    selectedRelease={selectedRelease}
+                  />
+                  <ChangelogSection selectedRelease={selectedRelease} />
+                  <NotesSection selectedRelease={selectedRelease} />
                 </div>
               </Tab>
             )
           })}
         </Tabs>
       </Card>
-    </section>
+    </article>
   )
 }
 

--- a/src/views/product-downloads-view/components/downloads-section/types.ts
+++ b/src/views/product-downloads-view/components/downloads-section/types.ts
@@ -2,6 +2,7 @@ import { ReleaseVersion } from 'lib/fetch-release-data'
 import { PackageManager } from 'views/product-downloads-view/types'
 
 export interface DownloadsSectionProps {
+  latestVersionIsSelected: boolean
   packageManagers: PackageManager[]
   selectedRelease: ReleaseVersion
 }

--- a/src/views/product-downloads-view/components/downloads-section/types.ts
+++ b/src/views/product-downloads-view/components/downloads-section/types.ts
@@ -1,0 +1,7 @@
+import { ReleaseVersion } from 'lib/fetch-release-data'
+import { PackageManager } from 'views/product-downloads-view/types'
+
+export interface DownloadsSectionProps {
+  packageManagers: PackageManager[]
+  selectedRelease: ReleaseVersion
+}

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
@@ -26,6 +26,7 @@ const SidecarMarketingCard = ({
       href={learnMoreLink}
       icon={<IconExternalLink16 />}
       iconPosition="trailing"
+      openInNewTab
       textSize={200}
       text="Learn more"
     />

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -1,7 +1,20 @@
 import { Product } from 'types/products'
+import { ReleaseVersion } from 'lib/fetch-release-data'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { MenuItem } from 'components/sidebar'
+
+const PLATFORM_MAP = {
+  Mac: 'darwin',
+  Win: 'windows',
+  Linux: 'linux',
+}
+
+export interface SortedReleases {
+  [os: string]: {
+    [arch: string]: string
+  }
+}
 
 export const initializeBackToLink = (
   currentProduct: Product
@@ -50,4 +63,60 @@ export const getPageSubtitle = (
     isLatestVersion ? ' (latest version)' : ''
   }`
   return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
+}
+
+export const sortPlatforms = (releaseData: ReleaseVersion): SortedReleases => {
+  // first we pull the platforms out of the release data object and format it the way we want
+  const platforms = releaseData.builds.reduce((acc, build) => {
+    if (!acc[build.os]) acc[build.os] = {}
+    acc[build.os][build.arch] = build.url
+    return acc
+  }, {})
+
+  const platformKeys = Object.keys(platforms)
+
+  // create array of sorted values to base the order on
+  const sortedValues = Object.keys(PLATFORM_MAP)
+    .map((e) => PLATFORM_MAP[e])
+    // join the lists together to make sure
+    // all items are accounted for when sorting
+    .concat(platformKeys)
+    // filter our any duplicates and unneeded items
+    .filter((elem, pos, arr) => {
+      return arr.indexOf(elem) == pos && platformKeys.indexOf(elem) > -1
+    })
+
+  return (
+    platformKeys
+      // sort items based on PLATFORM_MAP order
+      .sort((a, b) => {
+        return sortedValues.indexOf(a) - sortedValues.indexOf(b)
+      })
+      // create new sorted object to return
+      .reduce((result, key) => {
+        result[key] = platforms[key]
+        return result
+      }, {})
+  )
+}
+
+export function prettyOs(os: string): string {
+  switch (os) {
+    case 'darwin':
+      return 'macOS'
+    case 'freebsd':
+      return 'FreeBSD'
+    case 'openbsd':
+      return 'OpenBSD'
+    case 'netbsd':
+      return 'NetBSD'
+    case 'archlinux':
+      return 'Arch Linux'
+    case 'linux':
+      return 'Linux'
+    case 'windows':
+      return 'Windows'
+    default:
+      return os.charAt(0).toUpperCase() + os.slice(1)
+  }
 }

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -1,22 +1,28 @@
 import { ReactElement, useMemo, useState } from 'react'
+import CodeBlock from '@hashicorp/react-code-block'
 import semverRSort from 'semver/functions/rsort'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import Card from 'components/card'
 import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
+import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import {
   getPageSubtitle,
   initializeBackToLink,
   initializeBreadcrumbLinks,
   initializeNavData,
+  sortPlatforms,
+  prettyOs,
 } from './helpers'
 import { ProductDownloadsViewProps } from './types'
 import s from './product-downloads-view.module.css'
 
 const ProductDownloadsView = ({
   latestVersion,
+  pageContent,
   releases,
 }: ProductDownloadsViewProps): ReactElement => {
   const versionSwitcherOptions = useMemo(() => {
@@ -42,6 +48,25 @@ const ProductDownloadsView = ({
   const navData = useMemo(() => initializeNavData(currentProduct), [
     currentProduct,
   ])
+
+  const downloadsByOS = useMemo(
+    () => sortPlatforms(releases.versions[selectedVersion]),
+    [releases.versions, selectedVersion]
+  )
+  const packageManagersByOS = useMemo(() => {
+    const result = {}
+
+    pageContent.packageManagers.forEach((packageManager) => {
+      const { os } = packageManager
+      if (result[os]) {
+        result[os].push(packageManager)
+      } else {
+        result[os] = [packageManager]
+      }
+    })
+
+    return result
+  }, [pageContent.packageManagers])
 
   const pageTitle = `Install ${currentProduct.name}`
   const pageSubtitle = getPageSubtitle(
@@ -79,25 +104,68 @@ const ProductDownloadsView = ({
           </Text>
         </div>
       </div>
-      {
-        <>
-          <label style={{ display: 'block' }}>Version (temp switcher)</label>
-          <select
-            onChange={(e) => setSelectedVersion(e.target.value)}
-            value={selectedVersion}
-          >
-            {versionSwitcherOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </>
-      }
-      <p>
-        This content should only show when the{' '}
-        <code>enable_new_downloads_view</code> flag is on
-      </p>
+      <div style={{ marginBottom: 48 }}>
+        {
+          <>
+            <label style={{ display: 'block' }}>Version (temp switcher)</label>
+            <select
+              onChange={(e) => setSelectedVersion(e.target.value)}
+              value={selectedVersion}
+            >
+              {versionSwitcherOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </>
+        }
+      </div>
+      <Card elevation="base">
+        <Heading
+          className={s.operatingSystemTitle}
+          level={2}
+          size={300}
+          slug="operating-system"
+          weight="bold"
+        >
+          Operating System
+        </Heading>
+        <Tabs showAnchorLine>
+          {Object.keys(downloadsByOS).map((os) => {
+            const packageManagers = packageManagersByOS[os]
+            const hasOnePackageManager = packageManagers?.length === 1
+            const hasManyPackageManagers = packageManagers?.length > 1
+
+            const prettyOSName = prettyOs(os)
+            return (
+              <Tab heading={prettyOSName} key={os}>
+                <div className={s.tabContent}>
+                  {hasOnePackageManager && (
+                    <>
+                      <Heading
+                        level={3}
+                        size={200}
+                        slug={`package-manager-for-${prettyOSName}`}
+                        weight="semibold"
+                      >
+                        Package manager for {prettyOSName}
+                      </Heading>
+                      <CodeBlock
+                        code={packageManagers[0].commands
+                          .map((command) => `$ ${command}`)
+                          .join('\n')}
+                        options={{ showClipboard: true }}
+                      />
+                    </>
+                  )}
+                  {hasManyPackageManagers && <>{/* TODO: Tabs */}</>}
+                </div>
+              </Tab>
+            )
+          })}
+        </Tabs>
+      </Card>
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -34,6 +34,7 @@ const ProductDownloadsView = ({
   const [selectedVersion, setSelectedVersion] = useState<string>(
     versionSwitcherOptions[0].value
   )
+  const latestVersionIsSelected = selectedVersion === latestVersion
   const currentProduct = useCurrentProduct()
   const backToLink = useMemo(() => initializeBackToLink(currentProduct), [
     currentProduct,
@@ -50,7 +51,7 @@ const ProductDownloadsView = ({
   const pageSubtitle = getPageSubtitle(
     currentProduct,
     selectedVersion,
-    selectedVersion === latestVersion
+    latestVersionIsSelected
   )
   return (
     <SidebarSidecarLayout
@@ -98,6 +99,7 @@ const ProductDownloadsView = ({
         </select>
       </div>
       <DownloadsSection
+        latestVersionIsSelected={latestVersionIsSelected}
         packageManagers={pageContent.packageManagers}
         selectedRelease={releases.versions[selectedVersion]}
       />

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -1,23 +1,19 @@
 import { ReactElement, useMemo, useState } from 'react'
-import CodeBlock from '@hashicorp/react-code-block'
 import semverRSort from 'semver/functions/rsort'
 import { useCurrentProduct } from 'contexts'
 import EmptyLayout from 'layouts/empty'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import Card from 'components/card'
 import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
-import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import {
   getPageSubtitle,
   initializeBackToLink,
   initializeBreadcrumbLinks,
   initializeNavData,
-  sortPlatforms,
-  prettyOs,
 } from './helpers'
 import { ProductDownloadsViewProps } from './types'
+import DownloadsSection from './components/downloads-section'
 import s from './product-downloads-view.module.css'
 
 const ProductDownloadsView = ({
@@ -48,25 +44,6 @@ const ProductDownloadsView = ({
   const navData = useMemo(() => initializeNavData(currentProduct), [
     currentProduct,
   ])
-
-  const downloadsByOS = useMemo(
-    () => sortPlatforms(releases.versions[selectedVersion]),
-    [releases.versions, selectedVersion]
-  )
-  const packageManagersByOS = useMemo(() => {
-    const result = {}
-
-    pageContent.packageManagers.forEach((packageManager) => {
-      const { os } = packageManager
-      if (result[os]) {
-        result[os].push(packageManager)
-      } else {
-        result[os] = [packageManager]
-      }
-    })
-
-    return result
-  }, [pageContent.packageManagers])
 
   const pageTitle = `Install ${currentProduct.name}`
   const pageSubtitle = getPageSubtitle(
@@ -121,51 +98,10 @@ const ProductDownloadsView = ({
           </>
         }
       </div>
-      <Card elevation="base">
-        <Heading
-          className={s.operatingSystemTitle}
-          level={2}
-          size={300}
-          slug="operating-system"
-          weight="bold"
-        >
-          Operating System
-        </Heading>
-        <Tabs showAnchorLine>
-          {Object.keys(downloadsByOS).map((os) => {
-            const packageManagers = packageManagersByOS[os]
-            const hasOnePackageManager = packageManagers?.length === 1
-            const hasManyPackageManagers = packageManagers?.length > 1
-
-            const prettyOSName = prettyOs(os)
-            return (
-              <Tab heading={prettyOSName} key={os}>
-                <div className={s.tabContent}>
-                  {hasOnePackageManager && (
-                    <>
-                      <Heading
-                        level={3}
-                        size={200}
-                        slug={`package-manager-for-${prettyOSName}`}
-                        weight="semibold"
-                      >
-                        Package manager for {prettyOSName}
-                      </Heading>
-                      <CodeBlock
-                        code={packageManagers[0].commands
-                          .map((command) => `$ ${command}`)
-                          .join('\n')}
-                        options={{ showClipboard: true }}
-                      />
-                    </>
-                  )}
-                  {hasManyPackageManagers && <>{/* TODO: Tabs */}</>}
-                </div>
-              </Tab>
-            )
-          })}
-        </Tabs>
-      </Card>
+      <DownloadsSection
+        packageManagers={pageContent.packageManagers}
+        selectedRelease={releases.versions[selectedVersion]}
+      />
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -85,21 +85,17 @@ const ProductDownloadsView = ({
         </div>
       </div>
       <div style={{ marginBottom: 48 }}>
-        {
-          <>
-            <label style={{ display: 'block' }}>Version (temp switcher)</label>
-            <select
-              onChange={(e) => setSelectedVersion(e.target.value)}
-              value={selectedVersion}
-            >
-              {versionSwitcherOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </>
-        }
+        <label style={{ display: 'block' }}>Version (temp switcher)</label>
+        <select
+          onChange={(e) => setSelectedVersion(e.target.value)}
+          value={selectedVersion}
+        >
+          {versionSwitcherOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
       </div>
       <DownloadsSection
         packageManagers={pageContent.packageManagers}

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -21,7 +21,6 @@ const ProductDownloadsView = ({
   latestVersion,
   pageContent,
   releases,
-  pageContent,
 }: ProductDownloadsViewProps): ReactElement => {
   const versionSwitcherOptions = useMemo(() => {
     return semverRSort(Object.keys(releases.versions)).map((version) => {

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -9,17 +9,10 @@
 }
 
 .pageHeaderTitle {
+  color: var(--token-color-neutral-foreground-primary);
   margin-bottom: 12px;
 }
 
 .pageHeaderSubtitle {
   color: var(--token-color-neutral-foreground-secondary);
-}
-
-.operatingSystemTitle {
-  margin-bottom: 12px;
-}
-
-.tabContent {
-  margin-top: 16px;
 }

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -15,3 +15,11 @@
 .pageHeaderSubtitle {
   color: var(--token-color-neutral-foreground-secondary);
 }
+
+.operatingSystemTitle {
+  margin-bottom: 12px;
+}
+
+.tabContent {
+  margin-top: 16px;
+}

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -11,9 +11,7 @@ export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
     packageManagers: PackageManager[]
-  }
-  releases: ReleasesAPIResponse
-  pageContent: {
     sidecarMarketingCard: SidecarMarketingCardProps
   }
+  releases: ReleasesAPIResponse
 }

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -1,13 +1,15 @@
 import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 
+export interface PackageManager {
+  label: string
+  commands: string[]
+  os: string
+}
+
 export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
-    packageManagers: {
-      label: string
-      commands: string[]
-      os: string
-    }[]
+    packageManagers: PackageManager[]
   }
   releases: ReleasesAPIResponse
 }

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -2,5 +2,12 @@ import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 
 export interface ProductDownloadsViewProps {
   latestVersion: string
+  pageContent: {
+    packageManagers: {
+      label: string
+      commands: string[]
+      os: string
+    }[]
+  }
   releases: ReleasesAPIResponse
 }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-waypoint-downloads-tabbed-card-hashicorp.vercel.app/waypoint/downloads) 🔎

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds new `DownloadsSection` portion of the page that handles the whole downloads card where links and information can be changed based on the version selected from the switcher.
- Adds `textSize` prop to `DownloadStandaloneLink` with a default value of `200`. Can undo these changes if we feel it's unneeded, but since the component is in the main `components` directory (readily available for reuse), I figured it would be a helpful prop for future-proofing.
- Adds `openInNewTab` prop to `StandaloneLink`. There are a few instances of pairing an external link icon with a `StandaloneLink` in the new install view, so this seemed like a useful addition in those cases.
- Moved `packageManagers` property from `src/data/waypoint.json` to `src/data/waypoint-install.json` since the latter file is new and intended to house data that's only used in the new install view. This property also has the latest data according to 0.7.2 at the time of writing: https://github.com/hashicorp/waypoint/blob/v0.7.2/website/data/version.js.
- Adds `sortPlatforms` and `prettyOs` helpers to `src/views/product-downloads-view/helpers.ts`

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

A few things, such as helpers, are directly copied from `react-components/product-download-page`. Otherwise, this work was accomplished by using some foundational components worked on over the past several weeks. I also tried to split things up into separate files to prevent:

- a single, overwhelmingly long file
- long and difficult to parse markup

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads on the preview link](https://dev-portal-git-ambadd-waypoint-downloads-tabbed-card-hashicorp.vercel.app/waypoint/downloads)
- [ ] The downloads section will look something like this with the macOS tab highlighted and "Package manager for macOS", "Binary download for macOS", "Release information", and "Notes" sections within:
  ![image](https://user-images.githubusercontent.com/43934258/155618283-66634890-0677-4159-9c45-b697635aa046.png)
- [ ] Ensure all version labels and links have the same version as selected in the version switcher
- [ ] Pick a different version in the switcher
- [ ] Ensure all version labels and links update to the correct version
- [ ] Ensure the package manager section never shows if the version selected is not the latest
- [ ] Select the latest version from the version switcher
- [ ] Select the Windows tab
- [ ] Ensure the information displayed is correct
- [ ] Select the Linux tab
- [ ] Interact with the package manager tabs
- [ ] Ensure information displayed is correct


## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

We want to use `CodeTabs` where there are multiple package managers for an OS, but there is a bug that is preventing it. For now, we're using the regular `Tabs` component and have a `TODO` in the code noting the technical debt and the Asana task for the bug we've identififed.

The version switcher belongs inside of this card, but that's a more complex change to make so that the page subtitle under "Install Waypoint" reflects the correct version. I want to spend a little more time thinking on this and whether or not it's worth adding something like a local context for any area of the page to have access to the currently selected version. Happy to hear more thoughts on this idea in comments!