### PR TITLE
feat: add consul docs routes

### DIFF
--- a/src/data/consul-landing.json
+++ b/src/data/consul-landing.json
@@ -15,7 +15,7 @@
       "text": "In this guide we cover what Consul is, what problems it can solve, how it compares to existing software, and how you can get started using it.",
       "link": {
         "text": "Learn More",
-        "url": "https://www.consul.io/docs/intro"
+        "url": "/consul/docs/intro"
       }
     },
     {
@@ -26,25 +26,25 @@
           "icon": "IconDocs",
           "heading": "Consul Reference Documentation",
           "text": "The documentation is reference material for all available features and options of Consul",
-          "url": "https://www.consul.io/docs"
+          "url": "/consul/docs"
         },
         {
           "icon": "IconTerminal",
           "heading": "Consul CLI",
           "text": "Consul is controlled via a very easy to use command-line interface (CLI).",
-          "url": "https://www.consul.io/commands"
+          "url": "/consul/commands"
         },
         {
           "icon": "IconServer",
           "heading": "Consul API",
           "text": "The main interface to Consul is a RESTful HTTP API. The API can perform basic CRUD operations on nodes, services, checks, configuration, and more.",
-          "url": "https://www.consul.io/api-docs"
+          "url": "/consul/api-docs"
         },
         {
           "icon": "IconDownload",
           "heading": "Consul Install",
           "text": "Please download the proper package for your operating system and architecture.",
-          "url": "https://www.consul.io/downloads"
+          "url": "/consul/downloads"
         }
       ]
     },
@@ -61,17 +61,17 @@
         {
           "heading": "Connect",
           "text": "Consul Connect provides service-to-service connection authorization and encryption...",
-          "url": "https://www.consul.io/docs/connect"
+          "url": "/consul/docs/connect"
         },
         {
           "heading": "Services",
           "text": "One of the main goals of service discovery is to provide a catalog of available services. ",
-          "url": "https://www.consul.io/docs/discovery/services"
+          "url": "/consul/docs/discovery/services"
         },
         {
           "heading": "Configuration",
           "text": "The agent has various configuration options that can be specified via the...",
-          "url": "https://www.consul.io/docs/agent/options"
+          "url": "/consul/docs/agent/options"
         }
       ]
     },
@@ -88,17 +88,17 @@
         {
           "heading": "Etiam quis in ac non quam.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ultricies nisi interdum vitae id.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         },
         {
           "heading": "Aliquet eu risus dis sed.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sit neque mattis phasellus quam.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         },
         {
           "heading": "Ornare faucibus blandit id.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Urna donec gravida viverra.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         }
       ]
     },
@@ -115,17 +115,17 @@
         {
           "heading": "Interdum sollicitudin.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed elementum lectus posuere.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         },
         {
           "heading": "Ornare nibh semper.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo facilisis diam.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         },
         {
           "heading": "Fames nibh gravida.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-          "url": "https://www.consul.io"
+          "url": "/consul/docs"
         }
       ]
     },

--- a/src/data/consul.json
+++ b/src/data/consul.json
@@ -1,6 +1,7 @@
 {
   "name": "Consul",
   "slug": "consul",
+  "basePaths": ["docs", "api-docs", "commands"],
   "sidebar": {
     "landingPageNavData": [
       { "title": "Introduction", "fullPath": "/consul" },
@@ -28,5 +29,32 @@
         "href": "https://support.hashicorp.com"
       }
     ]
-  }
+  },
+  "navigationHeaderItems": [
+    {
+      "label": "Overview",
+      "path": "/consul",
+      "id": "overview"
+    },
+    {
+      "label": "Docs",
+      "id": "docs",
+      "path": "/consul/docs"
+    },
+    {
+      "label": "API",
+      "path": "/consul/api-docs",
+      "id": "api-docs"
+    },
+    {
+      "label": "CLI",
+      "path": "/consul/commands",
+      "id": "commands"
+    },
+    {
+      "label": "Install",
+      "path": "/consul/downloads",
+      "id": "downloads"
+    }
+  ]
 }

--- a/src/data/consul.json
+++ b/src/data/consul.json
@@ -4,10 +4,10 @@
   "basePaths": ["docs", "api-docs", "commands"],
   "sidebar": {
     "landingPageNavData": [
-      { "title": "Introduction", "fullPath": "/consul" },
+      { "title": "Introduction", "fullPath": "/consul/docs/intro" },
       {
         "title": "Getting Started",
-        "fullPath": "/consul"
+        "fullPath": "/consul/docs/install"
       }
     ],
     "resourcesNavData": [

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -70,17 +70,32 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
       id: slugify(`menu-item-${node.path}`, { lower: true }),
     }
   } else if (isNavDirectLink(node)) {
-    // For direct links, if they're absolute URLs,
-    // such as https://www.example.com, then leave them untouched.
-    // Otherwise, prefix them with the product slug (basePath[0])
-    const adjustedHref = isAbsoluteUrl(node.href)
-      ? node.href
-      : `/${basePaths[0]}${node.href}`
-    // Also add `id` for direct links
-    return {
-      ...node,
-      href: adjustedHref,
-      id: slugify(`external-url-${node.title}`, { lower: true }),
+    const id = slugify(`external-url-${node.title}`, { lower: true })
+    // Check if there is data that disagrees with DevDot's assumptions.
+    // This can happen because in the context of dot-io domains,
+    // authors may write NavDirectLinks with href values that are
+    // internal to the site, but outside the current docs route.
+    // For example, an author working in the Consul sidebar may
+    // create a NavDirectLink with an href of "/downloads".
+    // Here in DevDot, we want this URL to be "/consul/downloads",
+    // and we want to use an internal rather than external link.
+    const hrefIsNotAbsolute = !isAbsoluteUrl(node.href)
+    if (hrefIsNotAbsolute) {
+      // If we have a non-absolute NavDirectLink,
+      // convert it to a NavLeaf node, and treat it similarly.
+      // Note that the `fullPath` added here differs from typical
+      // NavLeaf treatment, as we only use the first part of the `basePath`.
+      // (We expect this to be the product slug, eg "consul").
+      return {
+        title: node.title,
+        path: node.href,
+        id,
+        fullPath: `/${basePaths[0]}${node.href}`,
+      }
+    } else {
+      // Otherwise, this is a genuinely external NavDirectLink,
+      // so we only need to add an `id` to it.
+      return { ...node, id }
     }
   } else {
     // Otherwise return the node unmodified

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -70,21 +70,6 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
       id: slugify(`menu-item-${node.path}`, { lower: true }),
     }
   } else if (isNavDirectLink(node)) {
-    // TODO: Previous implementation assumed  all direct link nodes
-    // TODO: would be absolute, external URLs.
-    // TODO: This assumption is not correct, I think... we have some
-    // TODO: direct link nodes which use absolute URLs, eg `/api-docs`
-    // TODO: or `/commands`. These need to be adjusted, as such URLs would
-    // TODO: assume {product}.io/{href}, while here in dev-portal, our URL
-    // TODO: structure needs to be dev.hashicorp.com/{productSlug}/{href}.
-    // TODO:
-    // TODO: productSlug is already available in this context as basePaths[0].
-    // TODO:
-    // TODO: For example, if basePaths[0] is "consul", `/api-docs` should
-    // TODO: become `/consul/api-docs`, `/commands` should become
-    // TODO: `/consul/commands`, and so on.
-    // TODO:
-    // TODO: First cut at fixing this below, with adjustedHref...
     // For direct links, if they're absolute URLs,
     // such as https://www.example.com, then leave them untouched.
     // Otherwise, prefix them with the product slug (basePath[0])

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -87,10 +87,11 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
       // NavLeaf treatment, as we only use the first part of the `basePath`.
       // (We expect this to be the product slug, eg "consul").
       return {
-        title: node.title,
-        path: node.href,
-        id,
+        ...node,
         fullPath: `/${basePaths[0]}${node.href}`,
+        href: null,
+        id,
+        path: node.href,
       }
     } else {
       // Otherwise, this is a genuinely external NavDirectLink,

--- a/src/layouts/sidebar-sidecar/utils/product-url-adjusters.ts
+++ b/src/layouts/sidebar-sidecar/utils/product-url-adjusters.ts
@@ -14,12 +14,16 @@ import remarkPluginAdjustLinkUrls from 'lib/remark-plugin-adjust-link-urls'
  */
 export const vaultUrlAdjuster: Pluggable = [
   remarkPluginAdjustLinkUrls,
-  {
-    urlAdjustFn: (sourceUrl: string): string => {
-      let url = sourceUrl.slice()
-      const isBadApiUrl = url == '/api' || url.startsWith('/api/')
-      if (isBadApiUrl) url = url.replace(/^\/api/, '/api-docs')
-      return url
-    },
-  },
+  { urlAdjustFn: rewriteApiToApiDocs },
 ]
+export const consulUrlAdjuster: Pluggable = [
+  remarkPluginAdjustLinkUrls,
+  { urlAdjustFn: rewriteApiToApiDocs },
+]
+
+function rewriteApiToApiDocs(inputUrl: string): string {
+  let outputUrl = inputUrl.slice()
+  const isBadApiUrl = outputUrl == '/api' || outputUrl.startsWith('/api/')
+  if (isBadApiUrl) outputUrl = outputUrl.replace(/^\/api/, '/api-docs')
+  return outputUrl
+}

--- a/src/pages/consul/api-docs/[[...page]].tsx
+++ b/src/pages/consul/api-docs/[[...page]].tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react'
+import consulData from 'data/consul.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
+
+const basePath = 'api-docs'
+const baseName = 'API'
+const product = consulData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const consulDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+  additionalRemarkPlugins: [consulUrlAdjuster],
+})
+
+consulDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default consulDocsPage

--- a/src/pages/consul/api-docs/[[...page]].tsx
+++ b/src/pages/consul/api-docs/[[...page]].tsx
@@ -11,7 +11,7 @@ const baseName = 'API'
 const product = consulData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const consulDocsPage = ({ mdxSource }): ReactElement => {
+const ConsulApiDocsPage = ({ mdxSource }): ReactElement => {
   return <DocsView {...mdxSource} />
 }
 
@@ -22,7 +22,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-consulDocsPage.layout = SidebarSidecarLayout
+ConsulApiDocsPage.layout = SidebarSidecarLayout
 
 export { getStaticPaths, getStaticProps }
-export default consulDocsPage
+export default ConsulApiDocsPage

--- a/src/pages/consul/commands/[[...page]].tsx
+++ b/src/pages/consul/commands/[[...page]].tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react'
+import consulData from 'data/consul.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
+
+const basePath = 'commands'
+const baseName = 'CLI'
+const product = consulData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const consulDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+  additionalRemarkPlugins: [consulUrlAdjuster],
+})
+
+consulDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default consulDocsPage

--- a/src/pages/consul/commands/[[...page]].tsx
+++ b/src/pages/consul/commands/[[...page]].tsx
@@ -11,7 +11,7 @@ const baseName = 'CLI'
 const product = consulData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const consulDocsPage = ({ mdxSource }): ReactElement => {
+const ConsulCommandsPage = ({ mdxSource }): ReactElement => {
   return <DocsView {...mdxSource} />
 }
 
@@ -22,7 +22,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-consulDocsPage.layout = SidebarSidecarLayout
+ConsulCommandsPage.layout = SidebarSidecarLayout
 
 export { getStaticPaths, getStaticProps }
-export default consulDocsPage
+export default ConsulCommandsPage

--- a/src/pages/consul/docs/[[...page]].tsx
+++ b/src/pages/consul/docs/[[...page]].tsx
@@ -13,7 +13,7 @@ const product = consulData as Product
 const additionalComponents = { ConfigEntryReference }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const consulDocsPage = ({ mdxSource }): ReactElement => {
+const ConsulDocsPage = ({ mdxSource }): ReactElement => {
   return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
 }
 
@@ -24,7 +24,7 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-consulDocsPage.layout = SidebarSidecarLayout
+ConsulDocsPage.layout = SidebarSidecarLayout
 
 export { getStaticPaths, getStaticProps }
-export default consulDocsPage
+export default ConsulDocsPage

--- a/src/pages/consul/docs/[[...page]].tsx
+++ b/src/pages/consul/docs/[[...page]].tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react'
+import consulData from 'data/consul.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+import ConfigEntryReference from 'components/author-primitives/consul/config-entry-reference'
+import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
+
+const basePath = 'docs'
+const baseName = 'Docs'
+const product = consulData as Product
+const additionalComponents = { ConfigEntryReference }
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const consulDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+  additionalRemarkPlugins: [consulUrlAdjuster],
+})
+
+consulDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default consulDocsPage


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][docs] 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201647459964504/f) 🎟️

## What

This PR adds `docs-page` routes for `/consul`.

## Why

To iterate towards supporting all product docs content within the `dev-portal` project.

## How

- Re-uses existing templates, as used for `vault` and `waypoint`
- Builds on work done for `vault` to rewrite `/consul/api/*` links to `/consul/api-docs/*` with a `remark` plugin
    - We have [a related task for Vault](https://app.asana.com/0/1100423001970639/1201655704127120/f) that details a longer-term fix - for example, doing this transform as part of our content pipeline.

## Testing

- [ ] Navigate to the docs views, click around and confirm behaviour is expected
    - [ ] [/consul/docs][docs]
    - [ ] [/consul/api-docs][api-docs]
    - [ ] [/consul/commands][commands]

## Anything else?

One known issue is that on the [/consul/docs][docs] view, the links in the sidebar to `API` and `Commands (CLI)`, with the "external" icons, did not initially function as expected, as they reference absolute URLs as organized on `consul.io`.

To address this issue, I've modified the `prepareNavNodeForClient` function. Previously this function did not touch the `href` of `NavDirectLink` nodes. This PR changes this - now, `NavDirectLink` nodes will be tested to see if they're absolute, and:
- If absolute, eg `https://www.example.com`, will be unchanged
- If not absolute, eg `/api-docs`, will be prefixed with the `product.slug`. In this case specifically, `/api-docs` becomes `/consul/api-docs`.

[docs]: https://dev-portal-git-zsadd-consul-docs-views-hashicorp.vercel.app/consul/docs
[api-docs]: https://dev-portal-git-zsadd-consul-docs-views-hashicorp.vercel.app/consul/api-docs
[commands]: https://dev-portal-git-zsadd-consul-docs-views-hashicorp.vercel.app/consul/commands