### PR TITLE
Add remaining Waypoint install view sections

### DIFF
--- a/src/data/waypoint-install.json
+++ b/src/data/waypoint-install.json
@@ -1,4 +1,36 @@
 {
+  "featuredTutorials": [
+    {
+      "title": "Introduction to Waypoint",
+      "description": "Waypoint enables you to publish any application to any platform with a single file and a single command. Build, deploy, and release applications programmatically using HashiCorp Configuration Language.",
+      "href": "https://learn.hashicorp.com/tutorials/waypoint/get-started-intro"
+    },
+    {
+      "title": "Install Waypoint",
+      "description": "Install the Waypoint binary locally on Mac, Linux, or Windows, manually or using a package manager (Homebrew).",
+      "href": "https://learn.hashicorp.com/tutorials/waypoint/get-started-install"
+    },
+    {
+      "title": "Use Waypoint with Docker",
+      "description": "Deploy a Waypoint application locally to Docker.",
+      "href": "https://learn.hashicorp.com/tutorials/waypoint/get-started-docker"
+    },
+    {
+      "title": "Deploy an Application onto AWS Lambda",
+      "description": "Deploy a Ruby application onto AWS Lambda with Waypoint",
+      "href": "https://learn.hashicorp.com/tutorials/waypoint/aws-lambda"
+    },
+    {
+      "title": "Get Started - Kubernetes",
+      "description": "Build, deploy, and release applications to a Kubernetes cluster.",
+      "href": "https://learn.hashicorp.com/collections/waypoint/get-started-kubernetes"
+    },
+    {
+      "title": "Get Started - Nomad",
+      "description": "Build, deploy, and release applications to a Nomad cluster.",
+      "href": "https://learn.hashicorp.com/collections/waypoint/get-started-nomad"
+    }
+  ],
   "sidecarMarketingCard": {
     "title": "About Waypoint",
     "subtitle": "Use Waypoint to deliver a PaaS-like experience for Kubernetes, ECS, and other platforms.",

--- a/src/lib/get-truncated-text.ts
+++ b/src/lib/get-truncated-text.ts
@@ -1,0 +1,32 @@
+/**
+ * Given a string and character limit, returns a string truncated to the given
+ * limit on full words with an ellipsis at the end.
+ */
+function getTruncatedText(string: string, characterLimit: number): string {
+  let result: string
+
+  if (string.length <= characterLimit) {
+    result = string
+  } else {
+    let characterCount = 0
+    const words = string.split(' ')
+    const wordsToInclude = []
+    words.forEach((word, index) => {
+      const wordLength = word.length
+      if (characterCount + wordLength <= characterLimit) {
+        wordsToInclude.push(word)
+        characterCount += wordLength
+
+        // count spaces since they are counted in the string.length comparison
+        if (index !== words.length) {
+          characterCount++
+        }
+      }
+    })
+    result = wordsToInclude.join(' ') + `…`
+  }
+
+  return result
+}
+
+export default getTruncatedText

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -1,3 +1,7 @@
+.root {
+  margin-bottom: 48px;
+}
+
 .operatingSystemTitle {
   color: var(--token-color-neutral-foreground-primary);
   margin-bottom: 12px;

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -209,7 +209,7 @@ const DownloadsSection = ({
   )
 
   return (
-    <article>
+    <article className={s.root}>
       <Card elevation="base">
         <Heading
           className={s.operatingSystemTitle}

--- a/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
@@ -1,0 +1,48 @@
+.sectionHeading {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 12px;
+}
+
+/*
+TODO: these @media queries come from the numbers defined in src/pages/style.css
+but I wasn't able to get the @media --mobile and @media --tablet queries to work
+like they do in that file. The code below will eventually need to be refactored,
+this is a temporary copy/paste to get the new install view out.
+*/
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-column-gap: 24px;
+  grid-row-gap: 24px;
+
+  @media only screen and (min-width: 729px) and (max-width: 1000px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media only screen and (max-width: 728px) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.cardTitle {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 4px;
+}
+
+.cardBody {
+  color: var(--token-color-neutral-foreground-faint);
+  margin-bottom: 12px;
+}
+
+.cardIcons {
+  & svg:not(:last-child) {
+    margin-right: 8px;
+  }
+}

--- a/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
@@ -32,6 +32,12 @@ const FeaturedTutorialsSection = ({
       <div className={s.cardGrid}>
         {featuredTutorials.map(({ title, description, href }) => {
           return (
+            /**
+             * TODO: these will more than likely be replaced by a future
+             * `LearnTutorialCard` component.
+             *
+             * ref: https://app.asana.com/0/1201010428539925/1201654639085737/f
+             */
             <CardLink className={s.card} key={href} href={href}>
               <div>
                 <Text className={s.cardTitle} size={300} weight="semibold">

--- a/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
@@ -1,0 +1,56 @@
+import { ReactElement } from 'react'
+import { IconPlay16 } from '@hashicorp/flight-icons/svg-react/play-16'
+import { useCurrentProduct } from 'contexts'
+import getTruncatedText from 'lib/get-truncated-text'
+import { FeaturedTutorial } from 'views/product-downloads-view/types'
+import CardLink from 'components/card-link'
+import Heading from 'components/heading'
+import ProductIcon from 'components/product-icon'
+import Text from 'components/text'
+import s from './featured-tutorials-section.module.css'
+
+interface FeaturedTutorialsSectionProps {
+  featuredTutorials: FeaturedTutorial[]
+}
+
+const FeaturedTutorialsSection = ({
+  featuredTutorials,
+}: FeaturedTutorialsSectionProps): ReactElement => {
+  const currentProduct = useCurrentProduct()
+
+  return (
+    <>
+      <Heading
+        className={s.sectionHeading}
+        level={2}
+        size={300}
+        slug="featured-tutorials"
+        weight="bold"
+      >
+        Featured Tutorials
+      </Heading>
+      <div className={s.cardGrid}>
+        {featuredTutorials.map(({ title, description, href }) => {
+          return (
+            <CardLink className={s.card} key={href} href={href}>
+              <div>
+                <Text className={s.cardTitle} size={300} weight="semibold">
+                  {title}
+                </Text>
+                <Text className={s.cardBody} size={200} weight="regular">
+                  {getTruncatedText(description, 80)}
+                </Text>
+              </div>
+              <div className={s.cardIcons}>
+                <IconPlay16 />
+                <ProductIcon product={currentProduct.slug} />
+              </div>
+            </CardLink>
+          )
+        })}
+      </div>
+    </>
+  )
+}
+
+export default FeaturedTutorialsSection

--- a/src/views/product-downloads-view/components/official-releases-section/index.tsx
+++ b/src/views/product-downloads-view/components/official-releases-section/index.tsx
@@ -1,0 +1,35 @@
+import { ReactElement } from 'react'
+import { useCurrentProduct } from 'contexts'
+import CardLink from 'components/card-link'
+import Heading from 'components/heading'
+import Text from 'components/text'
+import s from './official-releases-section.module.css'
+
+const OfficialReleasesSection = (): ReactElement => {
+  const currentProduct = useCurrentProduct()
+
+  return (
+    <div className={s.root}>
+      <Heading
+        className={s.sectionHeading}
+        level={2}
+        size={300}
+        slug="looking-for-more"
+        weight="bold"
+      >
+        Looking for more?
+      </Heading>
+      <CardLink href={`https://releases.hashicorp.com/${currentProduct.slug}`}>
+        <Text className={s.cardTitle} size={300} weight="semibold">
+          Official releases
+        </Text>
+        <Text className={s.cardBody} size={200}>
+          All officially supported HashiCorp release channels and their security
+          guarantees.
+        </Text>
+      </CardLink>
+    </div>
+  )
+}
+
+export default OfficialReleasesSection

--- a/src/views/product-downloads-view/components/official-releases-section/official-releases-section.module.css
+++ b/src/views/product-downloads-view/components/official-releases-section/official-releases-section.module.css
@@ -1,0 +1,17 @@
+.root {
+  margin-bottom: 48px;
+}
+
+.sectionHeading {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 12px;
+}
+
+.cardTitle {
+  color: var(--token-color-neutral-foreground-primary);
+  margin-bottom: 4px;
+}
+
+.cardBody {
+  color: var(--token-color-neutral-foreground-faint);
+}

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -14,6 +14,7 @@ import {
   initializeNavData,
 } from './helpers'
 import { ProductDownloadsViewProps } from './types'
+import OfficialReleasesSection from './components/official-releases-section'
 import s from './product-downloads-view.module.css'
 
 const ProductDownloadsView = ({
@@ -102,6 +103,7 @@ const ProductDownloadsView = ({
         This content should only show when the{' '}
         <code>enable_new_downloads_view</code> flag is on
       </p>
+      <OfficialReleasesSection />
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -14,6 +14,7 @@ import {
   initializeNavData,
 } from './helpers'
 import { ProductDownloadsViewProps } from './types'
+import FeaturedTutorialsSection from './components/featured-tutorials-section'
 import OfficialReleasesSection from './components/official-releases-section'
 import s from './product-downloads-view.module.css'
 
@@ -104,6 +105,9 @@ const ProductDownloadsView = ({
         <code>enable_new_downloads_view</code> flag is on
       </p>
       <OfficialReleasesSection />
+      <FeaturedTutorialsSection
+        featuredTutorials={pageContent.featuredTutorials}
+      />
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -1,10 +1,17 @@
 import { ReleasesAPIResponse } from 'lib/fetch-release-data'
 import { SidecarMarketingCardProps } from './components/sidecar-marketing-card'
 
+export interface FeaturedTutorial {
+  description: string
+  href: string
+  title: string
+}
+
 export interface ProductDownloadsViewProps {
   latestVersion: string
   releases: ReleasesAPIResponse
   pageContent: {
+    featuredTutorials: FeaturedTutorial[]
     sidecarMarketingCard: SidecarMarketingCardProps
   }
 }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-remaining-install-view-sections-hashicorp.vercel.app/waypoint/downloads) 🔎

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `OfficialReleasesSection` and `FeaturedTutorialsSection` subcomponents local to `ProductDownloadsView`. The `FeaturedTutorialsSection` may become reusable in the future across many pages, but I think we can move it to the main components folder when necessary. 
- Adds data for the "Featured Tutorials" section in `src/data/waypoint-install.json`
- Adds a `getTruncatedText` helper function under `src/lib/get-truncated-text.ts`, used for truncating the Learn Tutorial descriptions before rendering them in the "Featured Tutorials" section

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Nothing too interesting here. 😊 

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads on the preview link](https://dev-portal-git-ambadd-remaining-install-view-sections-hashicorp.vercel.app/waypoint/downloads)
- [ ] Make sure the Official Releases section behaves as you expect
- [ ] Make sure the Featured Tutorials section behaves as you expect

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

There's something wrong with the hover state of the card under Official Releases and I'm not sure what yet. But I think it's under the scope of the CardLink component, so my vote is to fix it separately from this PR unless it's a super quick fix. I tried to debug the issue but haven't had success yet.