### PR TITLE
Setting scroll-margin-top on heading elements

### DIFF
--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -103,6 +103,12 @@ for further details.
   & h4,
   & h5,
   & h6 {
+    /*
+    Because not all jump link headings have an anchor child, such as the ones on
+    the product landing pages
+    */
+    scroll-margin-top: 11rem; /* 176px */
+
     & a:global(.__target-h) {
       scroll-margin-top: 11rem; /* 176px */
     }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -103,38 +103,8 @@ for further details.
   & h4,
   & h5,
   & h6 {
-    /*
-    This prevents the tall ::before elements (defined next) from interfering
-    with events on elements rendered right before them. For example, this will
-    prevent a heading element directly after a CardLink from interfering with
-    the CardLink's hover state. This changes the cursor but it is still possible
-    to select text.
-
-    ref: https://app.asana.com/0/1201010428539925/1201885695157827/f
-    */
-    pointer-events: none;
-
-    /*
-    These ::before elements account for the height of the top sticky bars
-    when following #anchor-links to headings. Without the offset caused
-    by these elements, we'd jump to headings that would be hidden underneath
-    the top sticky bars.
-    */
-    & a:global(.__target-h)::before,
-    &::before {
-      --permalink-scroll-offset: 24px;
-      --full-header-height: calc(
-        var(--navigation-header-height) + var(--alert-bar-height)
-      );
-      --height: calc(
-        var(--full-header-height) + var(--permalink-scroll-offset)
-      );
-
-      display: block;
-      content: '\200B';
-      height: var(--height);
-      margin-top: calc(-1 * var(--height));
-      visibility: hidden;
+    & a:global(.__target-h) {
+      scroll-margin-top: 11rem; /* 176px */
     }
   }
 

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -104,6 +104,17 @@ for further details.
   & h5,
   & h6 {
     /*
+    This prevents the tall ::before elements (defined next) from interfering
+    with events on elements rendered right before them. For example, this will
+    prevent a heading element directly after a CardLink from interfering with
+    the CardLink's hover state. This changes the cursor but it is still possible
+    to select text.
+
+    ref: https://app.asana.com/0/1201010428539925/1201885695157827/f
+    */
+    pointer-events: none;
+
+    /*
     These ::before elements account for the height of the top sticky bars
     when following #anchor-links to headings. Without the offset caused
     by these elements, we'd jump to headings that would be hidden underneath

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -103,14 +103,20 @@ for further details.
   & h4,
   & h5,
   & h6 {
+    --permalink-scroll-offset: 24px;
+    --full-header-height: calc(
+      var(--navigation-header-height) + var(--alert-bar-height)
+    );
+    --height: calc(var(--full-header-height) + var(--permalink-scroll-offset));
+
     /*
     Because not all jump link headings have an anchor child, such as the ones on
     the product landing pages
     */
-    scroll-margin-top: 11rem; /* 176px */
+    scroll-margin-top: var(--height);
 
     & a:global(.__target-h) {
-      scroll-margin-top: 11rem; /* 176px */
+      scroll-margin-top: var(--height);
     }
   }
 


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambfix-card-link-hover-hashicorp.vercel.app/waypoint/downloads) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201885695157827/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

Replaces `::before` pseudo element styling on headings under `tempContentStyles` to use `scroll-margin-top` instead.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Previously, the affected heading elements are so tall with their `::before` elements styled that they overlap with other elements on the page and can interfere with their hover states.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Asked for review on my previous proposal of using `pointer-events: none` in our team channel and @alexcarpenter shared a CSS-tricks article which I then used as a reference: [Fixed Headers and Jump Links? The Solution is scroll-margin-top](https://css-tricks.com/fixed-headers-and-jump-links-the-solution-is-scroll-margin-top/).

`scroll-margin-top` needs to be set on the element that is being linked to. Most times that's an anchor element within a heading element (generated by [our anchor-links remark plugin](https://github.com/hashicorp/web-platform-packages/tree/main/packages/remark-plugins/plugins/anchor-links)), some times it's a heading element with an `id` set on it (like in product landing pages).

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads on the preview url](https://dev-portal-git-ambfix-card-link-hover-hashicorp.vercel.app/waypoint/downloads)
- [ ] Scroll to the "Official releases" card
- [ ] Hover around the edges of the card, away from the text it displays
- [ ] The hover state should now behave as expected for the entire card
- [ ] Go to [Waypoint's landing page](https://dev-portal-git-ambfix-card-link-hover-hashicorp.vercel.app/waypoint)
- [ ] Make sure each heading link in the sidecar scrolls to the correct place in the page
- [ ] Go to a docs page, such as [Waypoint's Introduction page](https://dev-portal-git-ambfix-card-link-hover-hashicorp.vercel.app/waypoint/docs/intro)
- [ ] Make sure each heading link in the sidecar scrolls to the correct place in the page

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Should we maybe move these styles to the `Heading` component or is it too early? I'm not sure if we've replaced all heading elements yet with the new `Heading` component.