### PR TITLE
feat: add nomad docs views

### DIFF
--- a/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
+++ b/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
@@ -89,8 +89,8 @@ function findAllPathMatchedNodes(navNodes, pathString, depth = 0) {
 }
 
 function findPathMatchedNodes(navNode, pathString, depth) {
-  // If it's a node with child routes, return true
-  // if any of the child routes are active
+  // If it's a node with child routes, look for matches
+  // within the child routes
   if (navNode.routes) {
     // Check for an index (aka "Overview") node in the child routes.
     // These nodes will have paths with a number of parts

--- a/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
+++ b/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
@@ -37,7 +37,7 @@ function getPathBreadcrumbs({
   // associated navData node. This gets slightly
   // complex due to index (aka "Overview") nodes.
   const breadcrumbNodes = breadcrumbPaths.map((p) =>
-    getPathMatchedNode(navData, p)
+    getPathMatchedNode(navData, p, basePath)
   )
   // Map the matched navData nodes into { title, url }
   // objects as needed for breadcrumb link rendering.
@@ -49,7 +49,7 @@ function getPathBreadcrumbs({
   })
 }
 
-function getPathMatchedNode(navNodes, pathString) {
+function getPathMatchedNode(navNodes, pathString, basePath) {
   const matches = findAllPathMatchedNodes(navNodes, pathString)
   // If we have exactly one match, this is great, and expected
   if (matches.length == 1) return matches[0]
@@ -63,17 +63,22 @@ function getPathMatchedNode(navNodes, pathString) {
   if (matches.length > 1) {
     if (IS_DEV) {
       console.warn(
-        `Ambiguous breadcrumb path: Found ${matches.length} matches for "${pathString}". Please ensure there is exactly one node or index-less category with the path "${pathString}" in the provided navData.`
+        `Ambiguous breadcrumb path under "${basePath}": Found ${matches.length} matches for "${pathString}". Please ensure there is exactly one node or index-less category with the path "${pathString}" in the provided navData.`
       )
     }
     return matches[0]
   }
   // Otherwise, we have zero matches, which would mean a breadcrumb with missing parts.
-  // This would feel broken to a site visitor, so should be a blocking
-  // issue we need to fix, so we throw an error.
-  throw new Error(
-    `Missing breadcrumb path: Found zero matches for "${pathString}". Please ensure there is a node (or index-less category) with the path "${pathString}" in the provided navData.`
-  )
+  // We have no nav-data to render a nice "title" for the breadcrumb bar, and
+  // there isn't a matched path to link to, but we can still render an
+  // unlinked breadcrumb item using the "pathString" as the title
+  if (IS_DEV) {
+    console.warn(
+      `Missing breadcrumb path under "${basePath}": Found zero matches for "${pathString}". Please ensure there is a node (or index-less category) with the path "${pathString}" in the provided navData.`
+    )
+  }
+  const lastPathPart = pathString.split('/').pop()
+  return { title: lastPathPart }
 }
 
 function findAllPathMatchedNodes(navNodes, pathString, depth = 0) {

--- a/src/data/nomad-landing.json
+++ b/src/data/nomad-landing.json
@@ -26,25 +26,25 @@
           "icon": "IconDocs",
           "heading": "Nomad Reference Documentation",
           "text": "This documentation is a reference for all available features and options of Nomad.",
-          "url": "https://www.nomadproject.io/docs"
+          "url": "/nomad/docs"
         },
         {
           "icon": "IconTerminal",
           "heading": "Nomad CLI",
           "text": "Nomad is controlled via a very easy to use command-line interface (CLI).",
-          "url": "https://www.nomadproject.io/docs/commands"
+          "url": "/nomad/docs/commands"
         },
         {
           "icon": "IconServer",
           "heading": "Nomad API",
           "text": "The main interface to Nomad is a RESTful HTTP API. The API can query the current state of the system...",
-          "url": "https://www.nomadproject.io/api-docs"
+          "url": "/nomad/api-docs"
         },
         {
           "icon": "IconDownload",
           "heading": "Nomad Install",
           "text": "Please download the proper package for your operating system and architecture.",
-          "url": "https://www.nomadproject.io/downloads"
+          "url": "/nomad/downloads"
         }
       ]
     },
@@ -61,17 +61,17 @@
         {
           "heading": "Nomad vs. Kubernetes",
           "text": "Kubernetes and Nomad support similar core use cases for application deployment...",
-          "url": "https://www.nomadproject.io/docs/nomad-vs-kubernetes"
+          "url": "/nomad/docs/nomad-vs-kubernetes"
         },
         {
           "heading": "Nomad Configuration",
           "text": "Nomad agents have a variety of parameters that can be specified via configuration...",
-          "url": "https://www.nomadproject.io/docs/configuration"
+          "url": "/nomad/docs/configuration"
         },
         {
           "heading": "Docker Driver",
           "text": "The docker driver provides a first-class Docker workflow on Nomad.",
-          "url": "https://www.nomadproject.io/docs/drivers/docker"
+          "url": "/nomad/docs/drivers/docker"
         }
       ]
     },
@@ -88,17 +88,17 @@
         {
           "heading": "Etiam quis in ac non quam.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ultricies nisi interdum vitae id.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         },
         {
           "heading": "Aliquet eu risus dis sed.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sit neque mattis phasellus quam.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         },
         {
           "heading": "Ornare faucibus blandit id.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Urna donec gravida viverra.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         }
       ]
     },
@@ -115,17 +115,17 @@
         {
           "heading": "Interdum sollicitudin.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed elementum lectus posuere.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         },
         {
           "heading": "Ornare nibh semper.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo facilisis diam.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         },
         {
           "heading": "Fames nibh gravida.",
           "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-          "url": "https://www.nomadproject.io"
+          "url": "/nomad"
         }
       ]
     },

--- a/src/data/nomad.json
+++ b/src/data/nomad.json
@@ -49,12 +49,12 @@
     {
       "label": "Plugins",
       "path": "/nomad/plugins",
-      "id": "commands"
+      "id": "plugins"
     },
     {
       "label": "Tools",
       "path": "/nomad/tools",
-      "id": "commands"
+      "id": "tools"
     },
     {
       "label": "Install",

--- a/src/data/nomad.json
+++ b/src/data/nomad.json
@@ -1,12 +1,13 @@
 {
   "slug": "nomad",
   "name": "Nomad",
+  "basePaths": ["docs", "api-docs", "plugins", "tools", "intro"],
   "sidebar": {
     "landingPageNavData": [
-      { "title": "Introduction", "fullPath": "/nomad" },
+      { "title": "Introduction", "fullPath": "/nomad/intro" },
       {
         "title": "Getting Started",
-        "fullPath": "/nomad"
+        "fullPath": "/nomad/docs/install"
       }
     ],
     "resourcesNavData": [
@@ -28,5 +29,37 @@
         "href": "https://support.hashicorp.com"
       }
     ]
-  }
+  },
+  "navigationHeaderItems": [
+    {
+      "label": "Overview",
+      "path": "/nomad",
+      "id": "overview"
+    },
+    {
+      "label": "Docs",
+      "id": "docs",
+      "path": "/nomad/docs"
+    },
+    {
+      "label": "API",
+      "path": "/nomad/api-docs",
+      "id": "api-docs"
+    },
+    {
+      "label": "Plugins",
+      "path": "/nomad/plugins",
+      "id": "commands"
+    },
+    {
+      "label": "Tools",
+      "path": "/nomad/tools",
+      "id": "commands"
+    },
+    {
+      "label": "Install",
+      "path": "/nomad/downloads",
+      "id": "downloads"
+    }
+  ]
 }

--- a/src/pages/nomad/api-docs/[[...page]].tsx
+++ b/src/pages/nomad/api-docs/[[...page]].tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from 'react'
+import nomadData from 'data/nomad.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+
+const basePath = 'api-docs'
+const baseName = 'API'
+const product = nomadData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const NomadApiDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+})
+
+NomadApiDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default NomadApiDocsPage

--- a/src/pages/nomad/docs/[[...page]].tsx
+++ b/src/pages/nomad/docs/[[...page]].tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react'
+import nomadData from 'data/nomad.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+import Placement from 'components/author-primitives/shared/placement-table'
+
+const basePath = 'docs'
+const baseName = 'Docs'
+const product = nomadData as Product
+const additionalComponents = { Placement }
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const NomadDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+})
+
+NomadDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default NomadDocsPage

--- a/src/pages/nomad/intro/[[...page]].tsx
+++ b/src/pages/nomad/intro/[[...page]].tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from 'react'
+import nomadData from 'data/nomad.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+
+const basePath = 'intro'
+const baseName = 'Intro'
+const product = nomadData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const NomadIntroDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+})
+
+NomadIntroDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default NomadIntroDocsPage

--- a/src/pages/nomad/plugins/[[...page]].tsx
+++ b/src/pages/nomad/plugins/[[...page]].tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from 'react'
+import nomadData from 'data/nomad.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+
+const basePath = 'plugins'
+const baseName = 'Plugins'
+const product = nomadData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const NomadPluginsDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+})
+
+NomadPluginsDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default NomadPluginsDocsPage

--- a/src/pages/nomad/tools/[[...page]].tsx
+++ b/src/pages/nomad/tools/[[...page]].tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from 'react'
+import nomadData from 'data/nomad.json'
+import { Product } from 'types/products'
+import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DocsView from 'views/docs-view'
+
+const basePath = 'tools'
+const baseName = 'Tools'
+const product = nomadData as Product
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const NomadToolsDocsPage = ({ mdxSource }): ReactElement => {
+  return <DocsView {...mdxSource} />
+}
+
+const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
+  product,
+  basePath,
+  baseName,
+})
+
+NomadToolsDocsPage.layout = SidebarSidecarLayout
+
+export { getStaticPaths, getStaticProps }
+export default NomadToolsDocsPage


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201647459964518/f) 🎟️

## What

This PR adds `docs-page` routes for `/nomad`.

## Why

To iterate towards supporting all product docs content within the `dev-portal` project.

## How

- Re-uses existing templates, as used for `vault`, `waypoint`, and [`consul`](https://github.com/hashicorp/dev-portal/pull/131)
- Fixes an issue in breadcrumb generation, where an unusual edge case in `/nomad` content broke typical generation
    - Previously, if there were no matches for a given nav node to be displayed in a breadcrumb bar, we would throw an error
    - In what looks like a content mishap, Nomad has a [`/docs/autoscaling/agent/source`](https://www.nomadproject.io/docs/autoscaling/agent/source) page, but does not have nav nodes or docs pages for the "parent" `/docs/autoscaling/agent` or `/docs/autoscaling` pages. This seems to be because content has moved to [`/tools/autoscaling`](https://www.nomadproject.io/tools/autoscaling).
    - The broader issue here is a content one, I think. However there is no immediate solution to prevent the build error other than changing from an error to a warning. We can still render unlinked breadcrumb bar items for `/docs/autoscaling` and `/docs/autoscaling/agent`. You can see these on [the preview's `/nomad/docs/autoscaling/agent/source`]() page.

## Testing

- [ ] Navigate to the docs views, click around, and confirm behaviour is as expected
    - [ ] [`/nomad/api-docs`](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app/nomad/api-docs)
    - [ ] [`/nomad/docs`](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app/nomad/docs)
    - [ ] [`/nomad/intro`](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app/nomad/intro)
    - [ ] [`/nomad/plugins`](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app/nomad/plugins)
    - [ ] [`/nomad/tools`](https://dev-portal-git-zsadd-nomad-docs-views-hashicorp.vercel.app/nomad/tools)

## Anything else?

Nope, do want to call out the change to `get-docs-breadcrumbs` now logging a warning and rendering fallback unlinked breadcrumb bar items (instead of throwing an error as was done previously).
