### PR TITLE
fix: Docker arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN apk add --update --no-cache \
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install -g npm@latest
-RUN npm install
+
+# While imagemin/optipng-bin doesn't support arm64, set this env var as a workaround
+# - `npm ls imagemin`
+# - see https://github.com/imagemin/optipng-bin/issues/118
+RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install
 
 FROM docker.mirror.hashicorp.services/node:14.17.0-alpine AS builder
 WORKDIR /app


### PR DESCRIPTION
# Description

This aims to fix failing `arm64` docker builds

- see https://github.com/imagemin/optipng-bin/issues/118

Local repro:

`docker buildx build --platform=linux/arm64 -t dev-portal:local .`

<details>
<summary>Logs</summary>

```console
#12 53.73 npm ERR! code 1
#12 53.73 npm ERR! path /app/node_modules/optipng-bin
#12 53.73 npm ERR! command failed
#12 53.73 npm ERR! command sh -c node lib/install.js
#12 53.74 npm ERR! ⚠ Command failed: /app/node_modules/optipng-bin/vendor/optipng --version
#12 53.74 npm ERR! qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
#12 53.74 npm ERR! 
#12 53.74 npm ERR! 
#12 53.74 npm ERR!   ⚠ optipng pre-build test failed
#12 53.74 npm ERR!   ℹ compiling from source
#12 53.74 npm ERR!   ✖ Error: Command failed: /bin/sh -c make install
#12 53.74 npm ERR! pngrtran.c:99:1: warning: 'png_rtran_ok' defined but not used [-Wunused-function]
#12 53.74 npm ERR!    99 | png_rtran_ok(png_structrp png_ptr, int need_IHDR)
#12 53.74 npm ERR!       | ^~~~~~~~~~~~
#12 53.74 npm ERR! ar: `u' modifier ignored since `D' is the default (see `U')
#12 53.74 npm ERR! ar: `u' modifier ignored since `D' is the default (see `U')
#12 53.74 npm ERR! ar: `u' modifier ignored since `D' is the default (see `U')
#12 53.74 npm ERR! ar: `u' modifier ignored since `D' is the default (see `U')
#12 53.74 npm ERR! pngxmem.c: In function 'pngx_malloc_rows_extended':
#12 53.74 npm ERR! pngxmem.c:38:34: warning: comparison is always false due to limited range of data type [-Wtype-limits]
#12 53.74 npm ERR!    38 |        (pngx_alloc_size_t)height > (pngx_alloc_size_t)(-1) / sizeof(png_bytep))
#12 53.75 npm ERR!       |                                  ^
#12 53.75 npm ERR! ar: `u' modifier ignored since `D' is the default (see `U')
#12 53.75 npm ERR! /usr/lib/gcc/aarch64-alpine-linux-musl/9.3.0/../../../../aarch64-alpine-linux-musl/bin/ld: ../libpng/libpng.a(pngrutil.o): in function `png_read_filter_row':
#12 53.75 npm ERR! pngrutil.c:(.text+0x1f50): undefined reference to `png_init_filter_functions_neon'
#12 53.75 npm ERR! collect2: error: ld returned 1 exit status
#12 53.75 npm ERR! make[1]: *** [Makefile:100: optipng] Error 1
#12 53.75 npm ERR! make: *** [Makefile:14: install] Error 2
#12 53.75 npm ERR! 
#12 53.75 npm ERR! cd src/optipng && \
#12 53.75 npm ERR! make install && \
#12 53.75 npm ERR! cd ../..
#12 53.75 npm ERR! make[1]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/optipng'
#12 53.75 npm ERR! cd ../libpng && \
#12 53.75 npm ERR! make -f Makefile PNGLIBCONF_H_PREBUILT=pnglibconf.h.optipng && \
#12 53.75 npm ERR! cd ../optipng
#12 53.75 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/libpng'
#12 53.75 npm ERR! cp pnglibconf.h.optipng pnglibconf.h
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o png.o png.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngerror.o pngerror.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngget.o pngget.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngmem.o pngmem.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngpread.o pngpread.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngread.o pngread.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngrio.o pngrio.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngrtran.o pngrtran.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngrutil.o pngrutil.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngset.o pngset.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngtrans.o pngtrans.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngwio.o pngwio.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngwrite.o pngwrite.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngwtran.o pngwtran.c
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngwutil.o pngwutil.c
#12 53.75 npm ERR! ar rcs libpng.a png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o pngrio.o pngrtran.o pngrutil.o pngset.o pngtrans.o pngwio.o pngwrite.o pngwtran.o pngwutil.o
#12 53.75 npm ERR! ranlib libpng.a
#12 53.75 npm ERR! gcc -c -I../zlib  -O2 -Wall -Wextra -o pngtest.o pngtest.c
#12 53.75 npm ERR! gcc  -L../zlib -o pngtest pngtest.o libpng.a -lz -lm
#12 53.75 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/libpng'
#12 53.75 npm ERR! cd ../opngreduc && \
#12 53.75 npm ERR! make -f Makefile libopngreduc.a && \
#12 53.75 npm ERR! cd ../optipng
#12 53.75 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/opngreduc'
#12 53.75 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -o opngreduc.o opngreduc.c
#12 53.75 npm ERR! ar cru libopngreduc.a opngreduc.o
#12 53.75 npm ERR! ranlib libopngreduc.a
#12 53.75 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/opngreduc'
#12 53.75 npm ERR! cd ../gifread && \
#12 53.75 npm ERR! make -f Makefile libgifread.a && \
#12 53.75 npm ERR! cd ../optipng
#12 53.75 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/gifread'
#12 53.75 npm ERR! gcc -c  -O2 -Wall -Wextra -o gifread.o gifread.c
#12 53.75 npm ERR! ar cru libgifread.a gifread.o
#12 53.75 npm ERR! ranlib libgifread.a
#12 53.76 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/gifread'
#12 53.76 npm ERR! cd ../pnmio && \
#12 53.76 npm ERR! make -f Makefile libpnmio.a && \
#12 53.76 npm ERR! cd ../optipng
#12 53.78 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/pnmio'
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra -o pnmin.o pnmin.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra -o pnmout.o pnmout.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra -o pnmutil.o pnmutil.c
#12 53.78 npm ERR! ar cru libpnmio.a pnmin.o pnmout.o pnmutil.o
#12 53.78 npm ERR! ranlib libpnmio.a
#12 53.78 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/pnmio'
#12 53.78 npm ERR! cd ../minitiff && \
#12 53.78 npm ERR! make -f Makefile libminitiff.a && \
#12 53.78 npm ERR! cd ../optipng
#12 53.78 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/minitiff'
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra -o tiffread.o tiffread.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra -o tiffutil.o tiffutil.c
#12 53.78 npm ERR! ar cru libminitiff.a tiffread.o tiffutil.o 
#12 53.78 npm ERR! ranlib libminitiff.a
#12 53.78 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/minitiff'
#12 53.78 npm ERR! cd ../pngxtern && \
#12 53.78 npm ERR! make -f Makefile libpngxtern.a && \
#12 53.78 npm ERR! cd ../optipng
#12 53.78 npm ERR! make[2]: Entering directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/pngxtern'
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxread.o pngxread.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxrbmp.o pngxrbmp.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxrgif.o pngxrgif.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxrjpg.o pngxrjpg.c
#12 53.78 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxrpnm.o pngxrpnm.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxrtif.o pngxrtif.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxio.o pngxio.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxmem.o pngxmem.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxset.o pngxset.c
#12 53.79 npm ERR! ar cru libpngxtern.a pngxread.o pngxrbmp.o pngxrgif.o pngxrjpg.o pngxrpnm.o pngxrtif.o pngxio.o pngxmem.o pngxset.o
#12 53.79 npm ERR! ranlib libpngxtern.a
#12 53.79 npm ERR! make[2]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/pngxtern'
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o optipng.o optipng.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o optim.o optim.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o bitset.o bitset.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o ioutil.o ioutil.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o ratio.o ratio.c
#12 53.79 npm ERR! gcc -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o wildargs.o wildargs.c
#12 53.79 npm ERR! gcc -s -o optipng optipng.o optim.o bitset.o ioutil.o ratio.o wildargs.o ../opngreduc/libopngreduc.a ../pngxtern/libpngxtern.a ../libpng/libpng.a  ../gifread/libgifread.a ../pnmio/libpnmio.a ../minitiff/libminitiff.a  -lz -lm 
#12 53.79 npm ERR! make[1]: Leaving directory '/tmp/8372030a-adec-420a-b862-b900bfcc830b/src/optipng'
#12 53.80 npm ERR! 
#12 53.80 npm ERR!     at /app/node_modules/bin-build/node_modules/execa/index.js:231:11
#12 53.80 npm ERR!     at runMicrotasks (<anonymous>)
#12 53.80 npm ERR!     at processTicksAndRejections (internal/process/task_queues.js:95:5)
#12 53.80 npm ERR!     at async /app/node_modules/optipng-bin/lib/install.js:18:4
#12 53.80 
#12 53.81 npm ERR! A complete log of this run can be found in:
#12 53.81 npm ERR!     /root/.npm/_logs/2022-03-01T18_17_32_450Z-debug-0.log
```

</details>
