### PR TITLE
Add new install view for Consul

### DIFF
--- a/src/data/consul-install.json
+++ b/src/data/consul-install.json
@@ -1,0 +1,57 @@
+{
+  "featuredTutorials": [
+    {
+      "description": "Consul is a networking tool that provides a fully featured service mesh and service discovery. Try Consul locally.",
+      "href": "https://learn.hashicorp.com/collections/consul/getting-started",
+      "title": "Get Started"
+    },
+    {
+      "description": "Quickly get hands-on with HashiCorp Cloud Platform (HCP) Consul using the HCP portal quickstart deployment, experiment with the Consul UI, and try out the key-value store.",
+      "href": "https://learn.hashicorp.com/collections/consul/cloud-get-started",
+      "title": "HashiCorp Cloud Platform (HCP) Consul"
+    },
+    {
+      "description": "Create a new HashiCorp Consul Service (HCS) on Azure and connect VMs or Azure Kubernetes Service (AKS) as Consul clients.",
+      "href": "https://learn.hashicorp.com/collections/consul/hcs-azure",
+      "title": "HashiCorp Consul Service (HCS) on Azure"
+    },
+    {
+      "description": "Setup Consul service mesh to get experience deploying service sidecar proxies and securing service with mTLS",
+      "href": "https://learn.hashicorp.com/collections/consul/gs-consul-service-mesh",
+      "title": "Get Started on Kubernetes"
+    },
+    {
+      "description": "Authenticate service-to-service communication with mTLS and authorization with Access Control Lists (ACLs).",
+      "href": "https://learn.hashicorp.com/collections/consul/service-mesh-security",
+      "title": "Secure Service Communication"
+    },
+    {
+      "description": "Consul-Terraform-Sync helps you automate infrastructure changes to react to changes in your Consul service catalog.",
+      "href": "https://learn.hashicorp.com/collections/consul/network-infrastructure-automation",
+      "title": "Network Infrastructure Automation (NIA)"
+    }
+  ],
+  "sidecarMarketingCard": {
+    "title": "About Consul",
+    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",
+    "learnMoreLink": "https://www.consul.io/",
+    "featuredDocsLinks": [
+      {
+        "href": "/consul/docs/intro",
+        "text": "Introduction"
+      },
+      {
+        "href": "/consul/docs/install",
+        "text": "Install"
+      },
+      {
+        "href": "/consul/api-docs",
+        "text": "API Introduction"
+      },
+      {
+        "href": "/consul/commands",
+        "text": "Commands (CLI)"
+      }
+    ]
+  }
+}

--- a/src/pages/consul/downloads/index.tsx
+++ b/src/pages/consul/downloads/index.tsx
@@ -1,0 +1,34 @@
+import { ReactElement } from 'react'
+import { GetStaticProps } from 'next'
+import consulData from 'data/consul.json'
+import installData from 'data/consul-install.json'
+import { Product } from 'types/products'
+import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import EmptyLayout from 'layouts/empty'
+import ProductDownloadsView from 'views/product-downloads-view'
+import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
+
+const ConsulDownloadsPage = (props: GeneratedProps): ReactElement => {
+  if (__config.flags.enable_new_downloads_view) {
+    const { latestVersion, releases } = props
+    return (
+      <ProductDownloadsView
+        latestVersion={latestVersion}
+        pageContent={installData}
+        releases={releases}
+      />
+    )
+  } else {
+    return <PlaceholderDownloadsView />
+  }
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const product = consulData as Product
+
+  return generateStaticProps(product)
+}
+
+ConsulDownloadsPage.layout = EmptyLayout
+
+export default ConsulDownloadsPage

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -18,7 +18,7 @@ export interface SortedReleases {
 }
 
 export const generateDefaultPackageManagers = (
-  product: Product
+  product: Pick<Product, 'slug'>
 ): PackageManager[] => {
   const productSlug = product.slug
 

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -79,7 +79,7 @@ export const generateDefaultPackageManagers = (
 }
 
 export const getPageSubtitle = (
-  currentProduct: Product,
+  currentProduct: Pick<Product, 'name'>,
   selectedVersion: string,
   isLatestVersion: boolean
 ): string => {
@@ -90,7 +90,7 @@ export const getPageSubtitle = (
 }
 
 export const initializeBackToLink = (
-  currentProduct: Product
+  currentProduct: Pick<Product, 'name' | 'slug'>
 ): SidebarSidecarLayoutProps['backToLink'] => {
   return {
     text: `Back to ${currentProduct.name}`,
@@ -99,7 +99,7 @@ export const initializeBackToLink = (
 }
 
 export const initializeBreadcrumbLinks = (
-  currentProduct: Product,
+  currentProduct: Pick<Product, 'name' | 'slug'>,
   selectedVersion: string
 ): BreadcrumbLink[] => {
   return [
@@ -119,7 +119,9 @@ export const initializeBreadcrumbLinks = (
   ]
 }
 
-export const initializeNavData = (currentProduct: Product): MenuItem[] => {
+export const initializeNavData = (
+  currentProduct: Pick<Product, 'sidebar'>
+): MenuItem[] => {
   return [
     ...currentProduct.sidebar.landingPageNavData,
     { divider: true },

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -3,6 +3,7 @@ import { ReleaseVersion } from 'lib/fetch-release-data'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { MenuItem } from 'components/sidebar'
+import { PackageManager } from './types'
 
 const PLATFORM_MAP = {
   Mac: 'darwin',
@@ -14,6 +15,78 @@ export interface SortedReleases {
   [os: string]: {
     [arch: string]: string
   }
+}
+
+export const generateDefaultPackageManagers = (
+  product: Product
+): PackageManager[] => {
+  const productSlug = product.slug
+
+  return [
+    {
+      label: 'Homebrew',
+      commands: [
+        `brew tap hashicorp/tap`,
+        `brew install hashicorp/tap/${productSlug}`,
+      ],
+      os: 'darwin',
+    },
+    {
+      label: 'Ubuntu/Debian',
+      commands: [
+        `curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -`,
+        `sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"`,
+        `sudo apt-get update && sudo apt-get install ${productSlug}`,
+      ],
+      os: 'linux',
+    },
+    {
+      label: 'CentOS/RHEL',
+      commands: [
+        `sudo yum install -y yum-utils`,
+        `sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo`,
+        `sudo yum -y install ${productSlug}`,
+      ],
+      os: 'linux',
+    },
+    {
+      label: 'Fedora',
+      commands: [
+        `sudo dnf install -y dnf-plugins-core`,
+        `sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo`,
+        `sudo dnf -y install ${productSlug}`,
+      ],
+      os: 'linux',
+    },
+    {
+      label: 'Amazon Linux',
+      commands: [
+        `sudo yum install -y yum-utils`,
+        `sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo`,
+        `sudo yum -y install ${productSlug}`,
+      ],
+      os: 'linux',
+    },
+    {
+      label: 'Homebrew',
+      commands: [
+        `brew tap hashicorp/tap`,
+        `brew install hashicorp/tap/${productSlug}`,
+      ],
+      os: 'linux',
+    },
+  ]
+}
+
+export const getPageSubtitle = (
+  currentProduct: Product,
+  selectedVersion: string,
+  isLatestVersion: boolean
+): string => {
+  const versionText = `v${selectedVersion}${
+    isLatestVersion ? ' (latest version)' : ''
+  }`
+  return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
 }
 
 export const initializeBackToLink = (
@@ -52,17 +125,6 @@ export const initializeNavData = (currentProduct: Product): MenuItem[] => {
     { divider: true },
     ...currentProduct.sidebar.resourcesNavData,
   ]
-}
-
-export const getPageSubtitle = (
-  currentProduct: Product,
-  selectedVersion: string,
-  isLatestVersion: boolean
-): string => {
-  const versionText = `v${selectedVersion}${
-    isLatestVersion ? ' (latest version)' : ''
-  }`
-  return `Install or update to ${versionText} of ${currentProduct.name} to get started.`
 }
 
 export const sortPlatforms = (releaseData: ReleaseVersion): SortedReleases => {

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -8,6 +8,7 @@ import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
 import Text from 'components/text'
 import {
+  generateDefaultPackageManagers,
   getPageSubtitle,
   initializeBackToLink,
   initializeBreadcrumbLinks,
@@ -19,13 +20,21 @@ import FeaturedTutorialsSection from './components/featured-tutorials-section'
 import OfficialReleasesSection from './components/official-releases-section'
 import s from './product-downloads-view.module.css'
 
+// exclude pre-releases and such
+const VALID_SEMVER_REGEX = /^\d+\.\d+\.\d+$/
+
 const ProductDownloadsView = ({
   latestVersion,
   pageContent,
   releases,
 }: ProductDownloadsViewProps): ReactElement => {
   const versionSwitcherOptions = useMemo(() => {
-    return semverRSort(Object.keys(releases.versions)).map((version) => {
+    return semverRSort(
+      Object.keys(releases.versions).filter((version) => {
+        const isValidRegex = !!version.match(VALID_SEMVER_REGEX)
+        return isValidRegex
+      })
+    ).map((version) => {
       const isLatest = version === latestVersion
       return {
         label: `${version}${isLatest ? ' (latest)' : ''}`,
@@ -102,7 +111,10 @@ const ProductDownloadsView = ({
       </div>
       <DownloadsSection
         latestVersionIsSelected={latestVersionIsSelected}
-        packageManagers={pageContent.packageManagers}
+        packageManagers={
+          pageContent.packageManagers ||
+          generateDefaultPackageManagers(currentProduct)
+        }
         selectedRelease={releases.versions[selectedVersion]}
       />
       <OfficialReleasesSection />

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -16,7 +16,7 @@ export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
     featuredTutorials: FeaturedTutorial[]
-    packageManagers: PackageManager[]
+    packageManagers?: PackageManager[]
     sidecarMarketingCard: SidecarMarketingCardProps
   }
   releases: ReleasesAPIResponse


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-consul-install-view-hashicorp.vercel.app/consul/downloads) 🔎
- [Asana task](https://app.asana.com/0/0/1201893669632604/f) 🎟️

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `src/data/consul-install.json`, it contains all of the data needed for Consul's `ProductDownloadsView`, plus some placeholder data
- Adds `src/pages/consul/downloads/index.tsx`, which conditionally renders the new downloads view based on the `enable_new_downloads_view` flag
- Adds the `generateDefaultPackageManagers`, which is something I mostly copied from [react-components/product-download-page](https://github.com/hashicorp/react-components/blob/HEAD/packages/product-download-page/package-managers.ts).
  - The only change I made was for it to accept a whole product object instead of just a slug. I see this is a maintenance improvement in case we ever need to change the behavior of the helper to use more parts of a `Product` object.
- Updated `ProductDownloadsView` to use the new `generateDefaultPackageManagers` helper
- Updated the `packageManagers` prop in the `ProductDownloadsViewProps['pageContent']` shape to be optional since we now have a default array we can use

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Nothing extra to add here. [react-components/product-download-page](https://github.com/hashicorp/react-components/blob/HEAD/packages/product-download-page) was very helpful as a reference!

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/consul/downloads on the preview](https://dev-portal-git-ambadd-consul-install-view-hashicorp.vercel.app/consul/downloads)
- [ ] Make sure the page renders how you expect

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201893669632604