### PR TITLE
fix(content-repo-preview/build): call isDirectory

### DIFF
--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -83,7 +83,7 @@ async function main() {
 
   const proxiedIoDirs = (
     await fs.promises.readdir(proxiedIoPagesDir, { withFileTypes: true })
-  ).filter((ent) => ent.isDirectory)
+  ).filter((ent) => ent.isDirectory())
 
   for (const dir of proxiedIoDirs) {
     if (!dir.name.includes(repo)) {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

- [Preview link](url) 🔎
- [Asana task](url) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->
`isDirectory` is a function which returns a boolean, not a boolean. Calling it so that it correctly returns `false` for non directories.

ref: https://nodejs.org/api/fs.html#direntisdirectory

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
