### PR TITLE
Add new install view for Packer

### DIFF
--- a/src/data/packer-install.json
+++ b/src/data/packer-install.json
@@ -1,0 +1,57 @@
+{
+  "featuredTutorials": [
+    {
+      "description": "Packer must first be installed on the machine you want to run it on.",
+      "href": "https://learn.hashicorp.com/tutorials/packer/get-started-install-cli",
+      "title": "Install Packer"
+    },
+    {
+      "description": "HashiCorp Packer automates the creation of any type of machine image, including Docker images. You'll build a Docker image on your local machine without using any paid cloud resources.",
+      "href": "https://learn.hashicorp.com/collections/packer/docker-get-started",
+      "title": "Getting Started with Docker"
+    },
+    {
+      "description": "HashiCorp Packer automates the creation of any type of machine image, including AWS AMIs. You'll build an Ubuntu machine image on AWS in this tutorial.",
+      "href": "https://learn.hashicorp.com/collections/packer/aws-get-started",
+      "title": "Getting Started with AWS"
+    },
+    {
+      "description": "HCP Packer registry stores Packer image metadata, enabling you to track your image lifecycle. Build an Ubuntu machine image, push its metadata to AWS, and reference the images in Terraform or Packer configuration.",
+      "href": "https://learn.hashicorp.com/collections/packer/hcp-get-started",
+      "title": "Get Started with HCP Packer"
+    },
+    {
+      "description": "Create an image with Packer, containing SSH keys, a new user, and a demo webapp, and deploy it with Terraform.",
+      "href": "https://learn.hashicorp.com/tutorials/terraform/packer",
+      "title": "Provision Infrastructure with Packer"
+    },
+    {
+      "description": "Create a Vagrant box with Packer post-processors.",
+      "href": "https://learn.hashicorp.com/tutorials/packer/aws-get-started-post-processors-vagrant",
+      "title": "Post-Processors - Vagrant"
+    }
+  ],
+  "sidecarMarketingCard": {
+    "title": "About Packer",
+    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",
+    "learnMoreLink": "https://www.packer.io/",
+    "featuredDocsLinks": [
+      {
+        "href": "/packer/docs/install",
+        "text": "Install"
+      },
+      {
+        "href": "/packer/docs/configure",
+        "text": "Configure"
+      },
+      {
+        "href": "/packer/docs/debugging",
+        "text": "Debug"
+      },
+      {
+        "href": "/packer/docs/plugins",
+        "text": "Plugins"
+      }
+    ]
+  }
+}

--- a/src/pages/packer/downloads/index.tsx
+++ b/src/pages/packer/downloads/index.tsx
@@ -1,0 +1,34 @@
+import { ReactElement } from 'react'
+import { GetStaticProps } from 'next'
+import packerData from 'data/packer.json'
+import installData from 'data/packer-install.json'
+import { Product } from 'types/products'
+import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import EmptyLayout from 'layouts/empty'
+import ProductDownloadsView from 'views/product-downloads-view'
+import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
+
+const PackerDownloadsPage = (props: GeneratedProps): ReactElement => {
+  if (__config.flags.enable_new_downloads_view) {
+    const { latestVersion, releases } = props
+    return (
+      <ProductDownloadsView
+        latestVersion={latestVersion}
+        pageContent={installData}
+        releases={releases}
+      />
+    )
+  } else {
+    return <PlaceholderDownloadsView />
+  }
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const product = packerData as Product
+
+  return generateStaticProps(product)
+}
+
+PackerDownloadsPage.layout = EmptyLayout
+
+export default PackerDownloadsPage


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-packer-install-view-hashicorp.vercel.app/packer/downloads) 🔎
- [Asana task](https://app.asana.com/0/1201147515801429/1201893669632606/f) 🎟️

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `src/data/packer-install.json`, which contains the data needed for Packers `ProductDownloadsView`
- Adds `src/pages/packer/downloads/index.tsx`, which conditionally renders the new downloads view based on the `enable_new_downloads_view` flag

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Using the same process as #140, #143, and #148 😊

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to https://dev-portal-git-ambadd-packer-install-view-hashicorp.vercel.app/packer/downloads
- [ ] Make sure the page renders how you expect

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!