### PR TITLE
Add new install view for Vagrant

### DIFF
--- a/src/data/vagrant-install.json
+++ b/src/data/vagrant-install.json
@@ -31,6 +31,18 @@
       "title": "Post-Processors - Vagrant"
     }
   ],
+  "packageManagerOverrides": [
+    {
+      "label": "Homebrew",
+      "commands": ["brew install vagrant"],
+      "os": "darwin"
+    },
+    {
+      "label": "Homebrew",
+      "commands": ["brew install vagrant"],
+      "os": "linux"
+    }
+  ],
   "sidecarMarketingCard": {
     "title": "About Vagrant",
     "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",

--- a/src/data/vagrant-install.json
+++ b/src/data/vagrant-install.json
@@ -1,0 +1,65 @@
+{
+  "featuredTutorials": [
+    {
+      "description": "Development environments made easy.",
+      "href": "https://learn.hashicorp.com/collections/vagrant/getting-started",
+      "title": "Getting Started"
+    },
+    {
+      "description": "The Vagrant getting started tutorials will walk you through creating your first development environment with Vagrant. This quick start guide will give you a brief overview of the tutorial prerequisites and get you up and running.",
+      "href": "https://learn.hashicorp.com/tutorials/vagrant/getting-started-index",
+      "title": "Quick Start"
+    },
+    {
+      "description": "Vagrant uses a base image to quickly clone a virtual machine. In this tutorial specify a base image.",
+      "href": "https://learn.hashicorp.com/tutorials/vagrant/getting-started-boxes",
+      "title": "Install and Specify a Box"
+    },
+    {
+      "description": "At this point you have a web server running on a Virtual Machine in your Vagrant environment. In this tutorial, use Vagrant's networking features to access the guest machine from your host machine.",
+      "href": "https://learn.hashicorp.com/tutorials/vagrant/getting-started-networking",
+      "title": "Configure the Network"
+    },
+    {
+      "description": "In these tutorials your project was backed with VirtualBox. But Vagrant can work with a wide variety of backend providers, such as VMware, Hyper-V, and others.",
+      "href": "https://learn.hashicorp.com/tutorials/vagrant/getting-started-providers",
+      "title": "Explore Other Providers"
+    },
+    {
+      "description": "Create a Vagrant box with Packer post-processors.",
+      "href": "https://learn.hashicorp.com/tutorials/packer/aws-get-started-post-processors-vagrant",
+      "title": "Post-Processors - Vagrant"
+    }
+  ],
+  "sidecarMarketingCard": {
+    "title": "About Vagrant",
+    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",
+    "learnMoreLink": "https://www.vagrantup.com/",
+    "featuredDocsLinks": [
+      {
+        "href": "/vagrant/docs/installation",
+        "text": "Install"
+      },
+      {
+        "href": "/vagrant/docs/cli",
+        "text": "Command-Line Interface"
+      },
+      {
+        "href": "/vagrant/docs/boxes",
+        "text": "Boxes"
+      },
+      {
+        "href": "/vagrant/docs/networking",
+        "text": "Networking"
+      },
+      {
+        "href": "/vagrant/docs/synced-folders",
+        "text": "Synced Folders"
+      },
+      {
+        "href": "/vagrant/docs/providers",
+        "text": "Providers"
+      }
+    ]
+  }
+}

--- a/src/pages/vagrant/downloads/index.tsx
+++ b/src/pages/vagrant/downloads/index.tsx
@@ -1,0 +1,34 @@
+import { ReactElement } from 'react'
+import { GetStaticProps } from 'next'
+import vagrantData from 'data/vagrant.json'
+import installData from 'data/vagrant-install.json'
+import { Product } from 'types/products'
+import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import EmptyLayout from 'layouts/empty'
+import ProductDownloadsView from 'views/product-downloads-view'
+import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
+
+const VagrantDownloadsPage = (props: GeneratedProps): ReactElement => {
+  if (__config.flags.enable_new_downloads_view) {
+    const { latestVersion, releases } = props
+    return (
+      <ProductDownloadsView
+        latestVersion={latestVersion}
+        pageContent={installData}
+        releases={releases}
+      />
+    )
+  } else {
+    return <PlaceholderDownloadsView />
+  }
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const product = vagrantData as Product
+
+  return generateStaticProps(product)
+}
+
+VagrantDownloadsPage.layout = EmptyLayout
+
+export default VagrantDownloadsPage

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -72,6 +72,31 @@ export const generateDefaultPackageManagers = (
   ]
 }
 
+export const generatePackageManagers = ({
+  defaultPackageManagers,
+  packageManagerOverrides,
+}: {
+  defaultPackageManagers: PackageManager[]
+  packageManagerOverrides: PackageManager[]
+}): PackageManager[] => {
+  let packageManagers: PackageManager[]
+
+  if (packageManagerOverrides) {
+    packageManagers = defaultPackageManagers.map((defaultPackageManager) => {
+      const override = packageManagerOverrides.find(
+        ({ os, label }) =>
+          os === defaultPackageManager.os &&
+          label === defaultPackageManager.label
+      )
+      return override || defaultPackageManager
+    })
+  } else {
+    packageManagers = defaultPackageManagers
+  }
+
+  return packageManagers
+}
+
 export const getPageSubtitle = (
   currentProduct: Pick<Product, 'name'>,
   selectedVersion: string,

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -9,6 +9,7 @@ import IconTileLogo from 'components/icon-tile-logo'
 import Text from 'components/text'
 import {
   generateDefaultPackageManagers,
+  generatePackageManagers,
   getPageSubtitle,
   initializeBackToLink,
   initializeBreadcrumbLinks,
@@ -57,6 +58,14 @@ const ProductDownloadsView = ({
   const navData = useMemo(() => initializeNavData(currentProduct), [
     currentProduct,
   ])
+  const packageManagers = useMemo(
+    () =>
+      generatePackageManagers({
+        defaultPackageManagers: generateDefaultPackageManagers(currentProduct),
+        packageManagerOverrides: pageContent.packageManagerOverrides,
+      }),
+    [currentProduct, pageContent.packageManagerOverrides]
+  )
 
   const pageTitle = `Install ${currentProduct.name}`
   const pageSubtitle = getPageSubtitle(
@@ -111,7 +120,7 @@ const ProductDownloadsView = ({
       </div>
       <DownloadsSection
         latestVersionIsSelected={latestVersionIsSelected}
-        packageManagers={generateDefaultPackageManagers(currentProduct)}
+        packageManagers={packageManagers}
         selectedRelease={releases.versions[selectedVersion]}
       />
       <OfficialReleasesSection />

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -21,6 +21,7 @@ export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
     featuredTutorials: FeaturedTutorial[]
+    packageManagerOverrides?: PackageManager[]
     sidecarMarketingCard: SidecarMarketingCardProps
   }
   releases: ReleasesAPIResponse


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-vagrant-install-view-hashicorp.vercel.app/vagrant/downloads) 🔎
- [Asana task](https://app.asana.com/0/0/1201893669632605/f) 🎟️

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `src/data/vagrant-install.json`, which contains the data needed for Vagrant's `ProductDownloadsView`
- Adds `src/pages/vagrant/downloads/index.tsx`, which conditionally renders the new downloads view based on the `enable_new_downloads_view` flag
- Adds support for `packageManagerOverrides`
  - Adds `generatePackageManagers` helper

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Using the same process as #140, #143, #148, and #150 😊
- Referenced how [`ProductDownloadsPage` handles `packageManagerOverrides`](https://github.com/hashicorp/react-components/blob/main/packages/product-download-page/index.tsx#L70-L103)

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to https://dev-portal-git-ambadd-vagrant-install-view-hashicorp.vercel.app/vagrant/downloads
- [ ] Make sure the macOS package manager is correctly overridden
- [ ] Make sure the Linux -> Homebrew package manager is correctly overridden
- [ ] Makes sure the rest of the page still behaves as you expect

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- The current Vagrant downloads page shows a "Download Vagrant vmware Utility" link in the merchandising slot. This link will eventually live in the sidebar of the main Vagrant downloads page
- A relevant Asana ticket: [Dynamically pull titles & descriptions for cards on product landings](https://app.asana.com/0/1201010428539925/1201646299837754/f)