### PR TITLE
Update install view package managers

### DIFF
--- a/src/data/vault-install.json
+++ b/src/data/vault-install.json
@@ -31,60 +31,6 @@
       "href": "https://learn.hashicorp.com/collections/vault/custom-secrets-engine"
     }
   ],
-  "packageManagers": [
-    {
-      "label": "Homebrew",
-      "commands": [
-        "brew tap hashicorp/tap",
-        "brew install hashicorp/tap/vault"
-      ],
-      "os": "darwin"
-    },
-    {
-      "label": "Ubuntu/Debian",
-      "commands": [
-        "curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
-        "sudo apt-add-repository \"deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main\"",
-        "sudo apt-get update && sudo apt-get install vault"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "CentOS/RHEL",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo",
-        "sudo yum -y install vault"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Fedora",
-      "commands": [
-        "sudo dnf install -y dnf-plugins-core",
-        "sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
-        "sudo dnf -y install vault"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Amazon Linux",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo",
-        "sudo yum -y install vault"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Homebrew",
-      "commands": [
-        "brew tap hashicorp/tap",
-        "brew install hashicorp/tap/vault"
-      ],
-      "os": "linux"
-    }
-  ],
   "sidecarMarketingCard": {
     "title": "About Vault",
     "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",

--- a/src/data/waypoint-install.json
+++ b/src/data/waypoint-install.json
@@ -31,52 +31,6 @@
       "href": "https://learn.hashicorp.com/collections/waypoint/get-started-nomad"
     }
   ],
-  "packageManagers": [
-    {
-      "label": "Homebrew",
-      "commands": [
-        "brew tap hashicorp/tap",
-        "brew install hashicorp/tap/waypoint"
-      ],
-      "os": "darwin"
-    },
-    {
-      "label": "Ubuntu/Debian",
-      "commands": [
-        "curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
-        "sudo apt-add-repository \"deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main\"",
-        "sudo apt-get update && sudo apt-get install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "CentOS/RHEL",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo",
-        "sudo yum -y install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Fedora",
-      "commands": [
-        "sudo dnf install -y dnf-plugins-core",
-        "sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
-        "sudo dnf -y install waypoint"
-      ],
-      "os": "linux"
-    },
-    {
-      "label": "Amazon Linux",
-      "commands": [
-        "sudo yum install -y yum-utils",
-        "sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo",
-        "sudo yum -y install waypoint"
-      ],
-      "os": "linux"
-    }
-  ],
   "sidecarMarketingCard": {
     "title": "About Waypoint",
     "subtitle": "Use Waypoint to deliver a PaaS-like experience for Kubernetes, ECS, and other platforms.",

--- a/src/views/product-downloads-view/components/downloads-section/helpers.ts
+++ b/src/views/product-downloads-view/components/downloads-section/helpers.ts
@@ -1,5 +1,9 @@
 import { ReleaseVersion } from 'lib/fetch-release-data'
-import { PackageManager } from 'views/product-downloads-view/types'
+import {
+  GroupedPackageManagers,
+  PackageManager,
+  SortedReleases,
+} from 'views/product-downloads-view/types'
 import { sortPlatforms } from 'views/product-downloads-view/helpers'
 
 export const generateCodePropFromCommands = (
@@ -8,11 +12,15 @@ export const generateCodePropFromCommands = (
   return commands.map((command: string) => `$ ${command}`).join('\n')
 }
 
-export const groupDownloadsByOS = (selectedRelease: ReleaseVersion) => {
+export const groupDownloadsByOS = (
+  selectedRelease: ReleaseVersion
+): SortedReleases => {
   return sortPlatforms(selectedRelease)
 }
 
-export const groupPackageManagersByOS = (packageManagers: PackageManager[]) => {
+export const groupPackageManagersByOS = (
+  packageManagers: PackageManager[]
+): GroupedPackageManagers => {
   const result = {}
 
   packageManagers.forEach((packageManager) => {

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
 import { useCurrentProduct } from 'contexts'
-import { PackageManager } from 'views/product-downloads-view/types'
 import { prettyOs } from 'views/product-downloads-view/helpers'
 import Card from 'components/card'
 import DownloadStandaloneLink from 'components/download-standalone-link'
@@ -222,7 +221,7 @@ const DownloadsSection = ({
         </Heading>
         <Tabs showAnchorLine>
           {Object.keys(downloadsByOS).map((os) => {
-            const packageManagers: PackageManager[] = packageManagersByOS[os]
+            const packageManagers = packageManagersByOS[os]
             const prettyOSName = prettyOs(os)
 
             /**

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -3,18 +3,12 @@ import { ReleaseVersion } from 'lib/fetch-release-data'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { MenuItem } from 'components/sidebar'
-import { PackageManager } from './types'
+import { PackageManager, SortedReleases } from './types'
 
 const PLATFORM_MAP = {
   Mac: 'darwin',
   Win: 'windows',
   Linux: 'linux',
-}
-
-export interface SortedReleases {
-  [os: string]: {
-    [arch: string]: string
-  }
 }
 
 export const generateDefaultPackageManagers = (

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -111,10 +111,7 @@ const ProductDownloadsView = ({
       </div>
       <DownloadsSection
         latestVersionIsSelected={latestVersionIsSelected}
-        packageManagers={
-          pageContent.packageManagers ||
-          generateDefaultPackageManagers(currentProduct)
-        }
+        packageManagers={generateDefaultPackageManagers(currentProduct)}
         selectedRelease={releases.versions[selectedVersion]}
       />
       <OfficialReleasesSection />

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -16,7 +16,6 @@ export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
     featuredTutorials: FeaturedTutorial[]
-    packageManagers?: PackageManager[]
     sidecarMarketingCard: SidecarMarketingCardProps
   }
   releases: ReleasesAPIResponse

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -7,6 +7,10 @@ export interface FeaturedTutorial {
   title: string
 }
 
+export interface GroupedPackageManagers {
+  [os: string]: PackageManager[]
+}
+
 export interface PackageManager {
   label: string
   commands: string[]

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -6,6 +6,7 @@ export interface FeaturedTutorial {
   href: string
   title: string
 }
+
 export interface PackageManager {
   label: string
   commands: string[]
@@ -19,4 +20,10 @@ export interface ProductDownloadsViewProps {
     sidecarMarketingCard: SidecarMarketingCardProps
   }
   releases: ReleasesAPIResponse
+}
+
+export interface SortedReleases {
+  [os: string]: {
+    [arch: string]: string
+  }
 }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambupdate-install-view-package-c5529e-hashicorp.vercel.app/) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `ProductDownloadsView` to render always package managers using `generateDefaultPackageManagers`
- Removes the `packageManagers` property from:
  - `src/data/vault-install.json`
  - `src/data/waypoint-install.json`
- Adds two new interfaces in `src/views/product-downloads-view/types.ts`:
  - `GroupedPackageManagers`
  - `SortedReleases` (this was actually moved from `src/views/product-downloads-view/helpers.ts`)
- Improves the TypeScript in:
  - `src/views/product-downloads-view/components/downloads-section/helpers.ts`
  - `src/views/product-downloads-view/components/downloads-section/index.tsx`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

While working on #151, I noticed that Vagrant uses the `packageManagerOverrides` prop from [`ProductDownloadsPage`](https://github.com/hashicorp/react-components/tree/main/packages/product-download-page) and that I needed to add the same functionality to `ProductDownloadsView`. While looking deeper into [how `ProductDownloadsPage` handles rendering package managers](https://github.com/hashicorp/react-components/blob/main/packages/product-download-page/index.tsx#L71-L104), I noticed that it doesn't actually accept a `packageManagers` prop like I thought, which was an assumption I made off of Waypoint's code. I've since updated Waypoint's code in #153, and this PR updates `ProductDownloadsView` as well.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

This refactor wasn't too tricky, I just removed the data no longer needed and removed the `pageContent.packageManagers` property from the code.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to https://dev-portal-git-ambupdate-install-view-package-c5529e-hashicorp.vercel.app/vault/downloads
- [ ] Ensure that all default package managers are rendered for the latest version
- [ ] Go to https://dev-portal-git-ambupdate-install-view-package-c5529e-hashicorp.vercel.app/waypoint/downloads
- [ ] Ensure that all default package managers are rendered for the latest version

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

I have not added handling for `packageManagerOverrides` in this PR to keep the changes simpler, but plan to in #151.