### PR TITLE
chore: bump product-downloads-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@hashicorp/react-markdown-page": "^1.5.0",
         "@hashicorp/react-min-100-layout": "^2.0.1",
         "@hashicorp/react-open-api-page": "^2.0.1",
-        "@hashicorp/react-product-downloads-page": "^2.7.2",
+        "@hashicorp/react-product-downloads-page": "^2.8.0-canary-20220304190425",
         "@hashicorp/react-product-features-list": "^5.0.1",
         "@hashicorp/react-section-header": "^5.0.4",
         "@hashicorp/react-sentinel-embedded": "^1.0.4",
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/@hashicorp/react-product-downloads-page": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.7.2.tgz",
-      "integrity": "sha512-yp7QAPp5/jbttZzvwmCr8CeC1GWRKsVXT77XG9RInhsl2jaBeDQ6Bwatb7RWCzIADKyxrTM/b8bVkCn9PwK72g==",
+      "version": "2.8.0-canary-20220304190425",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0-canary-20220304190425.tgz",
+      "integrity": "sha512-b2b1UUTn0XD5kILL/JlrUJUAiAymiP8q8S6jBqHfh5lXVykXFtyaLOH2HSyZO5qwdwQQ2mx4hLF22pSN9DcTGQ==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",
@@ -32905,9 +32905,9 @@
       "requires": {}
     },
     "@hashicorp/react-product-downloads-page": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.7.2.tgz",
-      "integrity": "sha512-yp7QAPp5/jbttZzvwmCr8CeC1GWRKsVXT77XG9RInhsl2jaBeDQ6Bwatb7RWCzIADKyxrTM/b8bVkCn9PwK72g==",
+      "version": "2.8.0-canary-20220304190425",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0-canary-20220304190425.tgz",
+      "integrity": "sha512-b2b1UUTn0XD5kILL/JlrUJUAiAymiP8q8S6jBqHfh5lXVykXFtyaLOH2HSyZO5qwdwQQ2mx4hLF22pSN9DcTGQ==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@hashicorp/react-markdown-page": "^1.5.0",
         "@hashicorp/react-min-100-layout": "^2.0.1",
         "@hashicorp/react-open-api-page": "^2.0.1",
-        "@hashicorp/react-product-downloads-page": "^2.8.0-canary-20220304190425",
+        "@hashicorp/react-product-downloads-page": "^2.8.0",
         "@hashicorp/react-product-features-list": "^5.0.1",
         "@hashicorp/react-section-header": "^5.0.4",
         "@hashicorp/react-sentinel-embedded": "^1.0.4",
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/@hashicorp/react-product-downloads-page": {
-      "version": "2.8.0-canary-20220304190425",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0-canary-20220304190425.tgz",
-      "integrity": "sha512-b2b1UUTn0XD5kILL/JlrUJUAiAymiP8q8S6jBqHfh5lXVykXFtyaLOH2HSyZO5qwdwQQ2mx4hLF22pSN9DcTGQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0.tgz",
+      "integrity": "sha512-OzNh2CkivrINBYgMO1QPnKqoh8HRmvQbsE/c4Z5YwP2c4+CxsfVIOXajjG20S2XNMKjSVb5CY/KSoyJOBSnXVg==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",
@@ -32905,9 +32905,9 @@
       "requires": {}
     },
     "@hashicorp/react-product-downloads-page": {
-      "version": "2.8.0-canary-20220304190425",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0-canary-20220304190425.tgz",
-      "integrity": "sha512-b2b1UUTn0XD5kILL/JlrUJUAiAymiP8q8S6jBqHfh5lXVykXFtyaLOH2HSyZO5qwdwQQ2mx4hLF22pSN9DcTGQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloads-page/-/react-product-downloads-page-2.8.0.tgz",
+      "integrity": "sha512-OzNh2CkivrINBYgMO1QPnKqoh8HRmvQbsE/c4Z5YwP2c4+CxsfVIOXajjG20S2XNMKjSVb5CY/KSoyJOBSnXVg==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "@hashicorp/react-button": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@hashicorp/react-markdown-page": "^1.5.0",
     "@hashicorp/react-min-100-layout": "^2.0.1",
     "@hashicorp/react-open-api-page": "^2.0.1",
-    "@hashicorp/react-product-downloads-page": "^2.7.2",
+    "@hashicorp/react-product-downloads-page": "^2.8.0-canary-20220304190425",
     "@hashicorp/react-product-features-list": "^5.0.1",
     "@hashicorp/react-section-header": "^5.0.4",
     "@hashicorp/react-sentinel-embedded": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@hashicorp/react-markdown-page": "^1.5.0",
     "@hashicorp/react-min-100-layout": "^2.0.1",
     "@hashicorp/react-open-api-page": "^2.0.1",
-    "@hashicorp/react-product-downloads-page": "^2.8.0-canary-20220304190425",
+    "@hashicorp/react-product-downloads-page": "^2.8.0",
     "@hashicorp/react-product-features-list": "^5.0.1",
     "@hashicorp/react-section-header": "^5.0.4",
     "@hashicorp/react-sentinel-embedded": "^1.0.4",

--- a/src/pages/_proxied-dot-io/waypoint/downloads/index.tsx
+++ b/src/pages/_proxied-dot-io/waypoint/downloads/index.tsx
@@ -49,19 +49,11 @@ function WaypointDownloadsPage({
   }
 
   return (
-    /**
-     * TODO: once the source component has been updated, remove the
-     * `enterpriseMode` and `merchandisingSlot` props passed here.
-     *
-     * ref: https://app.asana.com/0/1100423001970639/1201915132498455/f
-     */
     <ProductDownloadsPage
-      enterpriseMode={false}
       getStartedDescription={getStartedDescription}
       getStartedLinks={getStartedLinks}
       latestVersion={latestVersion}
       logo={logo}
-      merchandisingSlot={null}
       product="waypoint"
       releases={releases}
       tutorialLink={tutorialLink}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][waypoint-downloads] 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201915132498455/f) 🎟️

## What

Removes the need to pass `enterpriseMode` and `merchandisingSlot` props to `@hashicorp/react-product-download-page`.

## Why

To remove the need for optional props that aren't necessary or fun to write.

## How

Bumps the `product-download-page` dependency to pull in changes from hashicorp/react-components#526.

## Testing

- [ ] Navigate to the [Waypoint downloads page][waypoint-downloads]
    - Will 404 at first. Use the switcher in the bottom left and select "Waypoint"
- [ ] Confirm that everything looks as expected, compared to the [same page upstream in main][waypoint-downloads-main]

## Anything else?

Nope!

[waypoint-downloads]: https://dev-portal-git-zsbump-product-downloads-page-hashicorp.vercel.app/downloads
[waypoint-downloads-main]: https://test-wp.hashi-mktg.com/downloads
