### PR TITLE
chore: sync work from hashicorp/packer#11622

### DIFF
--- a/src/components/_proxied-dot-io/packer/badge/index.tsx
+++ b/src/components/_proxied-dot-io/packer/badge/index.tsx
@@ -3,7 +3,7 @@ import InlineSvg from '@hashicorp/react-inline-svg'
 import classnames from 'classnames'
 import s from './style.module.css'
 
-type BadgeTheme = 'gray' | 'blue' | 'gold'
+type BadgeTheme = 'gray' | 'blue' | 'gold' | 'purple' | 'light-gray'
 
 interface BadgeProps {
   label: string

--- a/src/components/_proxied-dot-io/packer/badge/style.module.css
+++ b/src/components/_proxied-dot-io/packer/badge/style.module.css
@@ -1,5 +1,5 @@
 .root {
-  /* theming. Note that gold and gray
+  /* theming. Note that gold, gray, and purple
   have been set to hex values in order
   to match Terraform Registry tier labels. */
   &.theme-gray {
@@ -17,6 +17,10 @@
   &.theme-blue {
     --background-color: var(--packer);
     --text-color: var(--packer-text-on-primary);
+  }
+  &.theme-purple {
+    --background-color: #5c4ee5;
+    --text-color: var(--white);
   }
 
   align-items: center;

--- a/src/components/_proxied-dot-io/packer/plugin-badge/index.tsx
+++ b/src/components/_proxied-dot-io/packer/plugin-badge/index.tsx
@@ -3,7 +3,12 @@ import Badge, { BadgeTheme } from '../badge'
 import svgRibbonIcon from './ribbon-icon.svg?include'
 import svgCheckIcon from './check-icon.svg?include'
 
-type PluginLabelType = 'official' | 'community' | 'hcp_packer_ready'
+type PluginLabelType =
+  | 'official'
+  | 'community'
+  | 'hcp_packer_ready'
+  | 'verified'
+  | 'archived'
 
 const badgeTypes = {
   official: {
@@ -20,6 +25,16 @@ const badgeTypes = {
     label: 'HCP Packer Ready',
     theme: 'blue',
     iconSvg: svgCheckIcon,
+  },
+  verified: {
+    label: 'Verified',
+    theme: 'purple',
+    iconSvg: svgRibbonIcon,
+  },
+  archived: {
+    label: 'Archived',
+    theme: 'light-gray',
+    iconSvg: false,
   },
 }
 

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.js
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.js
@@ -72,6 +72,10 @@ async function generateStaticProps({
     if (pluginData?.isHcpPackerReady) {
       badgesMdx.push(`<PluginBadge type="hcp_packer_ready" />`)
     }
+    // If the plugin is archived, add an "Archived" badge
+    if (pluginData?.archived == true) {
+      badgesMdx.push(`<PluginBadge type="archived" />`)
+    }
     // Add badge showing the latest release version number,
     // and link this badge to the latest release
     if (latestReleaseTag) {

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/utils/resolve-nav-data.js
@@ -102,6 +102,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
     repo,
     version,
     pluginTier,
+    archived = false,
     isHcpPackerReady = false,
     sourceBranch = 'main',
     zipFile = '',
@@ -151,6 +152,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
         tier: parsedPluginTier,
         isHcpPackerReady,
         version,
+        archived,
       },
     }
   })


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

- [Preview link]() 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201908607457939/f) 🎟️

## What

Pulls in work from https://github.com/hashicorp/packer/pull/11622. This adds support for new `pluginTier` options.

## Why

At first, to make sure the ported code from `packer/website` in this repo is in sync with upstream work.
Now that https://github.com/hashicorp/packer/pull/11622 has merged, realized this has actually broken builds (since we included use of the new plugin tier types in that PR), so also to make it so that `dev-portal` builds stop failing.

## How

Replicates work from https://github.com/hashicorp/packer/pull/11622.

## Testing

> Note: links below will 404 at first, you'll need to ensure you're in "Packer" mode with the fancy preview dropdown thing in the bottom left of each view.

Visit the plugin pages below, which use the new badges, and ensure they're rendering as expected.

- Archived plugins
    - [Chef][chef]
    - [Converge][converge]
    - [Inspec][inspec]
    - [Puppet][puppet]
    - [Salt][salt]

- Verified plugins
    - [UpCloud][upcloud]
    - [Outscale][outscale]
    - [Scaleway][scaleway]

[chef]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/provisioners/chef/chef-client
[converge]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/provisioners/converge
[inspec]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/provisioners/inspec
[puppet]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/provisioners/puppet/puppet-masterless
[salt]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/provisioners/salt
[upcloud]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/builders/upcloud
[scaleway]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/builders/scaleway
[outscale]: https://dev-portal-git-zsadd-packer-plugin-badge-options-hashicorp.vercel.app/plugins/builders/outscale

## Anything else?

Nope!
