### PR TITLE
chore: update DevDot to use new "semantic" colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "dev-portal",
       "dependencies": {
-        "@hashicorp/design-system-tokens": "^0.4.7",
+        "@hashicorp/design-system-tokens": "^0.5.1",
         "@hashicorp/flight-icons": "^2.1.0",
         "@hashicorp/mktg-global-styles": "^4.0.0",
         "@hashicorp/mktg-logos": "^1.2.0",
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/@hashicorp/design-system-tokens": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.4.7.tgz",
-      "integrity": "sha512-n1q+hPA57k4fUQ7PcNMvn37O4uSSx3paPU/bn5phcvdv63vJ+SYgjojt7RdTzMwT5qYeXvboMPHhELr2KNIBCQ=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.5.1.tgz",
+      "integrity": "sha512-Sw4MK6pRTuHoX+xsrwUROhPxTqxWAlyTDrxkPY347+HZwHf7uSi+BspXotFeNoZKyojM5JGX7F1IfbjDIxnc/g=="
     },
     "node_modules/@hashicorp/flight-icons": {
       "version": "2.1.0",
@@ -29069,9 +29069,9 @@
       }
     },
     "@hashicorp/design-system-tokens": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.4.7.tgz",
-      "integrity": "sha512-n1q+hPA57k4fUQ7PcNMvn37O4uSSx3paPU/bn5phcvdv63vJ+SYgjojt7RdTzMwT5qYeXvboMPHhELr2KNIBCQ=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.5.1.tgz",
+      "integrity": "sha512-Sw4MK6pRTuHoX+xsrwUROhPxTqxWAlyTDrxkPY347+HZwHf7uSi+BspXotFeNoZKyojM5JGX7F1IfbjDIxnc/g=="
     },
     "@hashicorp/flight-icons": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "@hashicorp/design-system-tokens": "^0.4.7",
+    "@hashicorp/design-system-tokens": "^0.5.1",
     "@hashicorp/flight-icons": "^2.1.0",
     "@hashicorp/mktg-global-styles": "^4.0.0",
     "@hashicorp/mktg-logos": "^1.2.0",

--- a/src/components/disclosure/disclosure.module.css
+++ b/src/components/disclosure/disclosure.module.css
@@ -23,7 +23,7 @@
   width: 100%;
 
   & svg {
-    color: var(--token-color-neutral-foreground-faint);
+    color: var(--token-color-foreground-faint);
 
     /* Only enable animation if query is supported and value is no-preference */
     @media (prefers-reduced-motion: no-preference) {
@@ -97,12 +97,12 @@ ref: https://adrianroselli.com/2020/05/disclosure-widgets.html#CSS
 }
 
 .title {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   display: block;
 }
 
 .description {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   display: block;
   margin-top: 4px;
 }

--- a/src/components/footer/style.module.css
+++ b/src/components/footer/style.module.css
@@ -14,7 +14,7 @@
   before element acts as full-width border, no matter the container size
   */
   &::before {
-    background: var(--token-color-neutral-border-primary);
+    background: var(--token-color-border-primary);
     content: '\200B';
     height: 1px;
     left: 0;
@@ -72,11 +72,11 @@
 .linkAction {
   background: none;
   border: none;
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   padding: 0;
 
   &:hover {
-    color: var(--token-color-neutral-foreground-primary);
+    color: var(--token-color-foreground-strong);
     text-decoration: underline;
   }
 }

--- a/src/components/icon-tile/style.module.css
+++ b/src/components/icon-tile/style.module.css
@@ -47,9 +47,9 @@
  * Colors
  */
 .color-neutral {
-  --icon-color: var(--token-color-neutral-foreground-faint);
-  --border-color: var(--token-color-neutral-border-primary);
-  --background: var(--token-color-neutral-background-secondary);
+  --icon-color: var(--token-color-foreground-faint);
+  --border-color: var(--token-color-border-primary);
+  --background: var(--token-color-surface-faint);
 }
 
 /*
@@ -58,9 +58,9 @@ but is necessary for us to implement the current designs for the
 /sentinel and /hcp product landing pages.
 */
 .color-neutral-dark {
-  --icon-color: var(--token-color-neutral-background-primary);
-  --border-color: var(--token-color-neutral-foreground-primary);
-  --background: var(--token-color-neutral-foreground-secondary);
+  --icon-color: var(--token-color-foreground-high-contrast);
+  --border-color: var(--token-color-foreground-strong);
+  --background: var(--token-color-foreground-primary);
 }
 
 .color-boundary {

--- a/src/components/inline-link/inline-link.module.css
+++ b/src/components/inline-link/inline-link.module.css
@@ -5,12 +5,12 @@ ones set in the surrounding text.
 .root {
   composes: focus-ring-from-box-shadow from global;
   border-radius: 5px;
-  color: var(--token-color-action-foreground-on-faint);
+  color: var(--token-color-foreground-action);
   cursor: pointer;
   text-decoration: underline;
 
   &:active {
-    color: var(--token-color-action-foreground-high-contrast);
+    color: var(--token-color-foreground-action-active);
   }
 
   /*
@@ -24,10 +24,10 @@ ones set in the surrounding text.
   }
 
   &:hover {
-    color: var(--token-color-action-background-active);
+    color: var(--token-color-foreground-action-hover);
   }
 
   &:visited {
-    color: var(--token-color-highlight-foreground-on-faint);
+    color: var(--token-color-foreground-action-visited);
   }
 }

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/style.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/style.module.css
@@ -69,7 +69,7 @@
 }
 
 .heading {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin-bottom: 16px;
   margin-top: 24px;
   padding: 0 8px;

--- a/src/components/sidebar/components/sidebar-nav/style.module.css
+++ b/src/components/sidebar/components/sidebar-nav/style.module.css
@@ -4,7 +4,7 @@
 }
 
 .sidebarNavLabel {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin-bottom: 12px;
   padding: 0 8px;
 }

--- a/src/components/standalone-link/standalone-link.module.css
+++ b/src/components/standalone-link/standalone-link.module.css
@@ -47,10 +47,10 @@
 }
 
 .color-secondary {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
 
   &:active {
-    color: var(--token-color-neutral-foreground-secondary);
+    color: var(--token-color-foreground-primary);
   }
 }
 

--- a/src/components/standalone-link/standalone-link.module.css
+++ b/src/components/standalone-link/standalone-link.module.css
@@ -35,14 +35,14 @@
 }
 
 .color-primary {
-  color: var(--token-color-action-foreground-on-faint);
+  color: var(--token-color-foreground-action);
 
   &:active {
-    color: var(--token-color-action-foreground-high-contrast);
+    color: var(--token-color-foreground-action-active);
   }
 
   &:hover {
-    color: var(--token-color-action-foreground-on-faint);
+    color: var(--token-color-foreground-action-hover);
   }
 }
 

--- a/src/components/tabs/tabs.module.css
+++ b/src/components/tabs/tabs.module.css
@@ -26,13 +26,13 @@ Styles for each tab button.
   background-color: white;
   border: none;
   border-radius: 5px;
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   font-size: var(--token-typography-body-200-font-size);
   font-weight: var(--token-typography-font-weight-regular);
   padding: 8px 12px;
 
   &[aria-selected='true'] {
-    color: var(--token-color-neutral-foreground-primary);
+    color: var(--token-color-foreground-strong);
     background-color: var(--token-color-palette-neutral-200);
   }
 

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -126,7 +126,7 @@ for further details.
     padding-left: 24px;
 
     & li {
-      color: var(--token-color-neutral-foreground-secondary);
+      color: var(--token-color-foreground-primary);
 
       &:not(:last-child) {
         margin-bottom: 16px;

--- a/src/layouts/sidebar-sidecar/utils/_local_platform-docs-mdx/style.module.css
+++ b/src/layouts/sidebar-sidecar/utils/_local_platform-docs-mdx/style.module.css
@@ -9,18 +9,18 @@
 }
 
 .h1 {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
 }
 
 .h2 {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
   margin-top: 48px;
 }
 
 .h3 {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 8px;
   margin-top: 32px;
 }
@@ -28,7 +28,7 @@
 .h4,
 .h5,
 .h6 {
-  color: var(--token-color-neutral-foreground-secondary);
+  color: var(--token-color-foreground-primary);
   margin-bottom: 8px;
   margin-top: 24px;
 }
@@ -60,6 +60,6 @@
 }
 
 .p {
-  color: var(--token-color-neutral-foreground-secondary);
+  color: var(--token-color-foreground-primary);
   margin: 16px 0;
 }

--- a/src/views/placeholder-product-downloads-view/placeholder-product-downloads-view.module.css
+++ b/src/views/placeholder-product-downloads-view/placeholder-product-downloads-view.module.css
@@ -3,5 +3,5 @@
 }
 
 .sidecarCardText {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
 }

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -3,7 +3,7 @@
 }
 
 .operatingSystemTitle {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
 }
 
@@ -12,7 +12,7 @@
 }
 
 .subHeading {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 16px;
   margin-top: 24px;
 }
@@ -40,10 +40,10 @@
 }
 
 .textAndLinkCardLabel {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 4px;
 }
 
 .textAndLinkCardVersionLabel {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
 }

--- a/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
@@ -1,5 +1,5 @@
 .sectionHeading {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
 }
 
@@ -32,12 +32,12 @@ this is a temporary copy/paste to get the new install view out.
 }
 
 .cardTitle {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 4px;
 }
 
 .cardBody {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin-bottom: 12px;
 }
 

--- a/src/views/product-downloads-view/components/official-releases-section/official-releases-section.module.css
+++ b/src/views/product-downloads-view/components/official-releases-section/official-releases-section.module.css
@@ -3,15 +3,15 @@
 }
 
 .sectionHeading {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
 }
 
 .cardTitle {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 4px;
 }
 
 .cardBody {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
 }

--- a/src/views/product-downloads-view/components/sidecar-marketing-card/sidecar-marketing-card.module.css
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/sidecar-marketing-card.module.css
@@ -1,15 +1,15 @@
 .cardTitle {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 4px;
 }
 
 .cardSubtitle {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin-bottom: 8px;
 }
 
 .featuredDocsLabel {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 8px;
   margin-top: 24px;
 }
@@ -27,7 +27,7 @@
 }
 
 .featuredDocsLink {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   display: block;
   padding: 8px 0;
   width: fit-content;

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -9,10 +9,10 @@
 }
 
 .pageHeaderTitle {
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   margin-bottom: 12px;
 }
 
 .pageHeaderSubtitle {
-  color: var(--token-color-neutral-foreground-secondary);
+  color: var(--token-color-foreground-primary);
 }

--- a/src/views/product-landing/components/get-started/style.module.css
+++ b/src/views/product-landing/components/get-started/style.module.css
@@ -27,6 +27,6 @@
 }
 
 .text {
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin-bottom: 8px;
 }

--- a/src/views/product-landing/style.module.css
+++ b/src/views/product-landing/style.module.css
@@ -3,7 +3,7 @@
 }
 
 .pageSubheading {
-  color: var(--token-color-neutral-foreground-secondary);
+  color: var(--token-color-foreground-primary);
   margin-bottom: 48px;
 }
 


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-hdscrupdate-color-tokens-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1201687774781544/1201850678682258) 🎟️

## What

Updates the DevDot codebase to use the new/updated "semantic" design tokens for colors.

## Why

In https://github.com/hashicorp/design-system-tokens/pull/78 the HDS team has re-organized and re-named all of the "semantic" color tokens, and released them with the version `0.5.0` of the `@hashicorp/design-system-tokens` package.
The old color/semantic tokens have been deprecated and will be soon removed. All of the pages I tested (homepage, terraform, packer, packer-docs, packer-docs-commands, packer-downloads, hcp) didn't see a diff.

## How

In this PR I have:
- bumped the `@hashicorp/design-system-tokens` dependency to version `0.5.1` (latest)
- manually updated all the “semantic” colors to new design tokens

## Testing

I am not sure how to test. There's no visual regression tests, so the only thing that came to mind is to take a few screenshots of the pages before and after the changes and compare them in Figma (you overlap the two images, and set the top one blending as "difference": it's not 100% sure, but it works most of the times).

## Anything else?

🚨 **Very important**: while doing the changes, I have updated the colors for the `inline-link` component accordingly to the HDS specifications, not following the previous colors. Please @heatherlarsen double check with @braydenlove if that is correct, otherwise let me know what to do/what colors to use.

<img width="595" alt="screenshot_1028" src="https://user-images.githubusercontent.com/686239/157240334-d2da19ca-3e2b-4856-a664-da45327b2f5b.png">

/cc @hashicorp/design-systems 