### PR TITLE
fix: packer docs plugin-badge issue

### DIFF
--- a/src/components/author-primitives/packer/badge/index.tsx
+++ b/src/components/author-primitives/packer/badge/index.tsx
@@ -3,7 +3,7 @@ import InlineSvg from '@hashicorp/react-inline-svg'
 import classnames from 'classnames'
 import s from './style.module.css'
 
-type BadgeTheme = 'gray' | 'blue' | 'gold'
+type BadgeTheme = 'gray' | 'blue' | 'gold' | 'purple' | 'light-gray'
 
 interface BadgeProps {
   label: string

--- a/src/components/author-primitives/packer/badge/style.module.css
+++ b/src/components/author-primitives/packer/badge/style.module.css
@@ -1,5 +1,5 @@
 .root {
-  /* theming. Note that gold and gray
+  /* theming. Note that gold, gray, and purple
   have been set to hex values in order
   to match Terraform Registry tier labels. */
   &.theme-gray {
@@ -17,6 +17,10 @@
   &.theme-blue {
     --background-color: var(--packer);
     --text-color: var(--packer-text-on-primary);
+  }
+  &.theme-purple {
+    --background-color: #5c4ee5;
+    --text-color: var(--white);
   }
 
   align-items: center;

--- a/src/components/author-primitives/packer/plugin-badge/index.tsx
+++ b/src/components/author-primitives/packer/plugin-badge/index.tsx
@@ -3,7 +3,12 @@ import Badge, { BadgeTheme } from '../badge'
 import svgRibbonIcon from './ribbon-icon.svg?include'
 import svgCheckIcon from './check-icon.svg?include'
 
-type PluginLabelType = 'official' | 'community' | 'hcp_packer_ready'
+type PluginLabelType =
+  | 'official'
+  | 'community'
+  | 'hcp_packer_ready'
+  | 'verified'
+  | 'archived'
 
 const badgeTypes = {
   official: {
@@ -20,6 +25,16 @@ const badgeTypes = {
     label: 'HCP Packer Ready',
     theme: 'blue',
     iconSvg: svgCheckIcon,
+  },
+  verified: {
+    label: 'Verified',
+    theme: 'purple',
+    iconSvg: svgRibbonIcon,
+  },
+  archived: {
+    label: 'Archived',
+    theme: 'light-gray',
+    iconSvg: false,
   },
 }
 

--- a/src/pages/packer/docs/[[...page]].tsx
+++ b/src/pages/packer/docs/[[...page]].tsx
@@ -13,7 +13,7 @@ const basePath = 'docs'
 const baseName = 'Docs'
 const product = packerData as Product
 const mainBranch = 'master'
-const additionalComponents = { Badge, BadgesHeader, PluginBadge, Checklist }
+const additionalComponents = { Badge, BadgesHeader, Checklist, PluginBadge }
 
 const PackerDocsPage = ({ mdxSource }): React.ReactElement => {
   return <DocsView {...mdxSource} additionalComponents={additionalComponents} />


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][docs/plugins] 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201939256242568/f) 🎟️ 

## What

This PR fixes a build error issue where `/packer/docs` fails to render due to the `PluginBadge` component not being up to date.

## Why

A change upstream in the hashicorp/packer repo, merged in https://github.com/hashicorp/packer/pull/11643, used a new plugin tier label we recently added in a `/packer/docs` route. We updated the source code here in `main` in #163, but missed updating `assembly-ui-v1`, so now we're seeing broken builds.

## How

Pulls in work from `main` (see #163 for reference).

## Testing

- [ ] Build does not fail
- [ ] Visit [`/packer/docs/plugins`][docs/plugins] and confirm it renders as expected

## Anything else?

Sorry! 🇨🇦 Excited to get out of this one-foot-in-both-worlds stage we're in, and will try to be more diligent in the future around these types of "not-yet-covered-by-checks" changes 🙇‍♂️ 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201939256242568

[docs/plugins]: https://dev-portal-git-zsfix-packer-plugin-issue-hashicorp.vercel.app/packer/docs/plugins