### PR TITLE
chore: bump code-block, resolve related TODO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@hashicorp/react-alert-banner": "^7.0.1",
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.0",
-        "@hashicorp/react-code-block": "^4.5.0-canary-20220309165752",
+        "@hashicorp/react-code-block": "^4.5.0",
         "@hashicorp/react-consent-manager": "^7.0.3",
         "@hashicorp/react-docs-page": "^14.13.0",
         "@hashicorp/react-hashi-stack-menu": "^2.0.7",
@@ -1909,20 +1909,6 @@
         "react": ">= 16.x"
       }
     },
-    "node_modules/@hashicorp/platform-docs-mdx/node_modules/@hashicorp/react-code-block": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
-      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
-      "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.16.2",
-        "shellwords": "^0.1.1"
-      },
-      "peerDependencies": {
-        "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
-      }
-    },
     "node_modules/@hashicorp/platform-markdown-utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@hashicorp/platform-markdown-utils/-/platform-markdown-utils-0.2.0.tgz",
@@ -2108,9 +2094,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.5.0-canary-20220309165752",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0-canary-20220309165752.tgz",
-      "integrity": "sha512-jncJmjG2xfSXfVGBKMdIH7AhLbeQZNfZgi38clCeWUyfm/GxJr8Qdh/ptrh0EL4WMgHPJwy1u5J80jZWmEgAug==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0.tgz",
+      "integrity": "sha512-3Y8BNvSNFnaQFl+NTw9vpY/A9zB2sdLcjl71EDIdTWSUbUx+xdM91P50Sv+VQFhe8toFTInp6RQN3oZLZSfP5w==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -29672,18 +29658,6 @@
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
-      },
-      "dependencies": {
-        "@hashicorp/react-code-block": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
-          "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
-          "requires": {
-            "@hashicorp/react-inline-svg": "^6.0.3",
-            "@reach/listbox": "0.16.2",
-            "shellwords": "^0.1.1"
-          }
-        }
       }
     },
     "@hashicorp/platform-markdown-utils": {
@@ -29832,9 +29806,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.5.0-canary-20220309165752",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0-canary-20220309165752.tgz",
-      "integrity": "sha512-jncJmjG2xfSXfVGBKMdIH7AhLbeQZNfZgi38clCeWUyfm/GxJr8Qdh/ptrh0EL4WMgHPJwy1u5J80jZWmEgAug==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0.tgz",
+      "integrity": "sha512-3Y8BNvSNFnaQFl+NTw9vpY/A9zB2sdLcjl71EDIdTWSUbUx+xdM91P50Sv+VQFhe8toFTInp6RQN3oZLZSfP5w==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@hashicorp/react-alert-banner": "^7.0.1",
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.0",
-        "@hashicorp/react-code-block": "^4.1.5",
+        "@hashicorp/react-code-block": "^4.5.0-canary-20220309165752",
         "@hashicorp/react-consent-manager": "^7.0.3",
         "@hashicorp/react-docs-page": "^14.13.0",
         "@hashicorp/react-hashi-stack-menu": "^2.0.7",
@@ -1909,6 +1909,20 @@
         "react": ">= 16.x"
       }
     },
+    "node_modules/@hashicorp/platform-docs-mdx/node_modules/@hashicorp/react-code-block": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
+      "dependencies": {
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@reach/listbox": "0.16.2",
+        "shellwords": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "react": ">=16.x"
+      }
+    },
     "node_modules/@hashicorp/platform-markdown-utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@hashicorp/platform-markdown-utils/-/platform-markdown-utils-0.2.0.tgz",
@@ -2094,12 +2108,12 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.5.tgz",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.5.0-canary-20220309165752",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0-canary-20220309165752.tgz",
+      "integrity": "sha512-jncJmjG2xfSXfVGBKMdIH7AhLbeQZNfZgi38clCeWUyfm/GxJr8Qdh/ptrh0EL4WMgHPJwy1u5J80jZWmEgAug==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       },
       "peerDependencies": {
@@ -3677,12 +3691,12 @@
       }
     },
     "node_modules/@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3695,12 +3709,12 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3713,15 +3727,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "dependencies": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -3729,64 +3743,14 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/listbox/node_modules/@reach/popover": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
-      "dependencies": {
-        "@reach/portal": "0.15.0",
-        "@reach/rect": "0.15.0",
-        "@reach/utils": "0.15.0",
-        "tabbable": "^4.0.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/listbox/node_modules/@reach/portal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
-      "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/listbox/node_modules/@reach/rect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
-      "dependencies": {
-        "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.15.0",
-        "prop-types": "^15.7.2",
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/listbox/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
     "node_modules/@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3819,19 +3783,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/popover/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@reach/popover/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -3843,19 +3794,6 @@
       "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
       "dependencies": {
         "@reach/utils": "0.16.0",
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/portal/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
       },
@@ -3885,19 +3823,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/rect/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@reach/rect/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -3912,45 +3837,6 @@
         "@reach/descendants": "0.16.1",
         "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tabs/node_modules/@reach/auto-id": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tabs/node_modules/@reach/descendants": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
-      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tabs/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -3982,44 +3868,18 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/tooltip/node_modules/@reach/auto-id": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tooltip/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@reach/tooltip/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "dependencies": {
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -29812,6 +29672,18 @@
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
+      },
+      "dependencies": {
+        "@hashicorp/react-code-block": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+          "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
+          "requires": {
+            "@hashicorp/react-inline-svg": "^6.0.3",
+            "@reach/listbox": "0.16.2",
+            "shellwords": "^0.1.1"
+          }
+        }
       }
     },
     "@hashicorp/platform-markdown-utils": {
@@ -29960,12 +29832,12 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.5.tgz",
-      "integrity": "sha512-94IHagrdqxvoPE130b2FOvyeSZ26DIhaNSnZ3b/isKMpaNdWjoi/uo+nckRu3auiSyxldbMty8W5EXclgGkCEA==",
+      "version": "4.5.0-canary-20220309165752",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.5.0-canary-20220309165752.tgz",
+      "integrity": "sha512-jncJmjG2xfSXfVGBKMdIH7AhLbeQZNfZgi38clCeWUyfm/GxJr8Qdh/ptrh0EL4WMgHPJwy1u5J80jZWmEgAug==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
-        "@reach/listbox": "0.15.0",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       }
     },
@@ -31161,12 +31033,12 @@
       }
     },
     "@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "tslib": {
@@ -31177,12 +31049,12 @@
       }
     },
     "@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "tslib": {
@@ -31193,66 +31065,26 @@
       }
     },
     "@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "requires": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@reach/popover": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-          "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
-          "requires": {
-            "@reach/portal": "0.15.0",
-            "@reach/rect": "0.15.0",
-            "@reach/utils": "0.15.0",
-            "tabbable": "^4.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@reach/portal": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-          "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
-          "requires": {
-            "@reach/utils": "0.15.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@reach/rect": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-          "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
-          "requires": {
-            "@reach/observe-rect": "1.2.0",
-            "@reach/utils": "0.15.0",
-            "prop-types": "^15.7.2",
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
       }
     },
     "@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "requires": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "tslib": {
@@ -31279,15 +31111,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -31305,15 +31128,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -31333,15 +31147,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -31361,33 +31166,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/descendants": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
-          "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -31410,24 +31188,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -31436,12 +31196,12 @@
       }
     },
     "@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "requires": {
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "dependencies": {
         "tslib": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hashicorp/react-alert-banner": "^7.0.1",
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.0",
-    "@hashicorp/react-code-block": "^4.1.5",
+    "@hashicorp/react-code-block": "^4.5.0-canary-20220309165752",
     "@hashicorp/react-consent-manager": "^7.0.3",
     "@hashicorp/react-docs-page": "^14.13.0",
     "@hashicorp/react-hashi-stack-menu": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hashicorp/react-alert-banner": "^7.0.1",
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.0",
-    "@hashicorp/react-code-block": "^4.5.0-canary-20220309165752",
+    "@hashicorp/react-code-block": "^4.5.0",
     "@hashicorp/react-consent-manager": "^7.0.3",
     "@hashicorp/react-docs-page": "^14.13.0",
     "@hashicorp/react-hashi-stack-menu": "^2.0.7",

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -52,12 +52,6 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
         />
       )}
       {hasManyPackageManagers && (
-        /**
-         * TODO: this will eventually be <CodeTabs> once a bug has
-         * been fixed.
-         *
-         * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
-         */
         <CodeTabs tabs={packageManagers.map(({ label }) => label)}>
           {packageManagers.map(({ label, commands }) => {
             return (

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useMemo } from 'react'
 import classNames from 'classnames'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
+import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
 import { useCurrentProduct } from 'contexts'
 import { prettyOs } from 'views/product-downloads-view/helpers'
 import Card from 'components/card'
@@ -57,20 +58,19 @@ const PackageManagerSection = ({ packageManagers, prettyOSName }) => {
          *
          * ref: https://app.asana.com/0/1201010428539925/1201881376116200/f
          */
-        <Tabs showAnchorLine={false}>
+        <CodeTabs tabs={packageManagers.map(({ label }) => label)}>
           {packageManagers.map(({ label, commands }) => {
             return (
-              <Tab heading={label} key={label}>
-                <CodeBlock
-                  className={s.codeTabsCodeBlock}
-                  code={generateCodePropFromCommands(commands)}
-                  language="shell-session"
-                  options={{ showClipboard: true }}
-                />
-              </Tab>
+              <CodeBlock
+                key={label}
+                className={s.codeTabsCodeBlock}
+                code={generateCodePropFromCommands(commands)}
+                language="shell-session"
+                options={{ showClipboard: true }}
+              />
             )
           })}
-        </Tabs>
+        </CodeTabs>
       )}
     </>
   )


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][waypoint/downloads] 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201881376116200/f) 🎟️

## What

This PR bumps `@hashicorp/react-code-block` to pull in a bug fix, and a tabs alignment change, as implemented in https://github.com/hashicorp/react-components/pull/532.

## Why

- Fixes a bug that was preventing use of `CodeTabs` on "Install" views
- Updates tabs to be left-aligned when no `heading` is present, to match a design ask

## How

Bumps a dependency, work was mainly done in the the `code-block` package in https://github.com/hashicorp/react-components/pull/532.

## Testing

- [ ] Visit the install views, ensure `code-tabs` are rendering as expected
    - [ ] [`/waypoint/downloads`][waypoint/downloads]

Compare to the same page prior to bump the dependency:

- [ ] Visit <https://dev-portal-6dwd3gxpl-hashicorp.vercel.app/waypoint/downloads>
    - The page built successfully, and works fine for static builds...
    - But it fails with ISR, as it fails to re-hydrate on the client due to the (inaccurate) `CodeTabs` error, due to now-minified function names.

## Anything else?

Nope!

[waypoint/downloads]: https://dev-portal-git-zsbump-code-block-hashicorp.vercel.app/waypoint/downloads