### PR TITLE
Add new install view for Sentinel

### DIFF
--- a/src/data/sentinel-install.json
+++ b/src/data/sentinel-install.json
@@ -1,0 +1,22 @@
+{
+  "doesNotHavePackageManagers": true,
+  "sidecarMarketingCard": {
+    "title": "About Sentinel",
+    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eros diam, fringilla ac malesuada vel, faucibus quis mauris.",
+    "learnMoreLink": "/sentinel",
+    "featuredDocsLinks": [
+      {
+        "href": "/sentinel/intro/why",
+        "text": "Why Sentinel?"
+      },
+      {
+        "href": "/sentinel/intro/getting-started",
+        "text": "Getting Started"
+      },
+      {
+        "href": "/sentinel/docs/commands",
+        "text": "CLI Commands"
+      }
+    ]
+  }
+}

--- a/src/pages/sentinel/downloads/index.tsx
+++ b/src/pages/sentinel/downloads/index.tsx
@@ -1,0 +1,34 @@
+import { ReactElement } from 'react'
+import { GetStaticProps } from 'next'
+import sentinelData from 'data/sentinel.json'
+import installData from 'data/sentinel-install.json'
+import { Product } from 'types/products'
+import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import EmptyLayout from 'layouts/empty'
+import ProductDownloadsView from 'views/product-downloads-view'
+import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
+
+const SentienlDownloadsPage = (props: GeneratedProps): ReactElement => {
+  if (__config.flags.enable_new_downloads_view) {
+    const { latestVersion, releases } = props
+    return (
+      <ProductDownloadsView
+        latestVersion={latestVersion}
+        pageContent={installData}
+        releases={releases}
+      />
+    )
+  } else {
+    return <PlaceholderDownloadsView />
+  }
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  const product = sentinelData as Product
+
+  return generateStaticProps(product)
+}
+
+SentienlDownloadsPage.layout = EmptyLayout
+
+export default SentienlDownloadsPage

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -28,6 +28,11 @@ const ProductDownloadsView = ({
   pageContent,
   releases,
 }: ProductDownloadsViewProps): ReactElement => {
+  const {
+    doesNotHavePackageManagers,
+    featuredTutorials,
+    sidecarMarketingCard,
+  } = pageContent
   const versionSwitcherOptions = useMemo(() => {
     return semverRSort(
       Object.keys(releases.versions).filter((version) => {
@@ -58,6 +63,9 @@ const ProductDownloadsView = ({
     currentProduct,
   ])
 
+  const packageManagers = doesNotHavePackageManagers
+    ? []
+    : generateDefaultPackageManagers(currentProduct)
   const pageTitle = `Install ${currentProduct.name}`
   const pageSubtitle = getPageSubtitle(
     currentProduct,
@@ -71,9 +79,7 @@ const ProductDownloadsView = ({
       navData={navData}
       productName="Waypoint"
       showFilterInput={false}
-      sidecarChildren={
-        <SidecarMarketingCard {...pageContent.sidecarMarketingCard} />
-      }
+      sidecarChildren={<SidecarMarketingCard {...sidecarMarketingCard} />}
     >
       <div className={s.pageHeader}>
         <IconTileLogo
@@ -111,13 +117,13 @@ const ProductDownloadsView = ({
       </div>
       <DownloadsSection
         latestVersionIsSelected={latestVersionIsSelected}
-        packageManagers={generateDefaultPackageManagers(currentProduct)}
+        packageManagers={packageManagers}
         selectedRelease={releases.versions[selectedVersion]}
       />
       <OfficialReleasesSection />
-      <FeaturedTutorialsSection
-        featuredTutorials={pageContent.featuredTutorials}
-      />
+      {featuredTutorials && (
+        <FeaturedTutorialsSection featuredTutorials={featuredTutorials} />
+      )}
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -20,7 +20,8 @@ export interface PackageManager {
 export interface ProductDownloadsViewProps {
   latestVersion: string
   pageContent: {
-    featuredTutorials: FeaturedTutorial[]
+    doesNotHavePackageManagers?: boolean
+    featuredTutorials?: FeaturedTutorial[]
     sidecarMarketingCard: SidecarMarketingCardProps
   }
   releases: ReleasesAPIResponse


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ambadd-sentinel-install-view-hashicorp.vercel.app/sentinel/downloads) 🔎
- [Asana task](https://app.asana.com/0/0/1201893669632608/f) 🎟️

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `src/data/sentinel-install.json`, which contains the data needed for Sentinel's `ProductDownloadsView`
- Adds `src/pages/sentinel/downloads/index.tsx`, which conditionally renders the new downloads view based on the `enable_new_downloads_view` flag

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Using the same process as:

- #140
- #143
- #148
- #150
- #151
- #170
- #171

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to https://dev-portal-git-ambadd-sentinel-install-view-hashicorp.vercel.app/sentinel/downloads
- [ ] Make sure no package managers come up with any OS
- [ ] Make sure no featured tutorials are rendered
- [ ] Make sure the rest of the page behaves how you expect

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!