### PR TITLE
feat: collection page scaffold

### DIFF
--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -2,15 +2,74 @@
  * TODO - create proper view
  */
 
+import {
+  getAllCollections,
+  getCollection,
+} from 'lib/learn-client/api/collection'
+import {
+  Collection as ClientCollection,
+  ProductOption,
+} from 'lib/learn-client/types'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import Link from 'next/link'
+import { splitProductFromFilename } from 'views/tutorial-view/helpers'
 
-export default function WaypointCollectionPage() {
+export default function WaypointCollectionPage(props) {
   return (
     <>
-      <h1>Collection Heading</h1>
-      <Link href="/waypoint/tutorials/get-started-docker/get-started-intro">
-        <a>Go to this tutorial</a>
-      </Link>
+      <h1>{props.collection.name}</h1>
+      <p>{props.collection.description}</p>
+      {/** TODO shape these slugs here, insert collection */}
+      <ol>
+        {props.collection.tutorials.map((tutorial) => (
+          <li key={tutorial.id}>
+            <Link href={tutorial.slug}>
+              <>
+                <a>{tutorial.name}</a> <br />
+              </>
+            </Link>
+          </li>
+        ))}
+      </ol>
     </>
   )
+}
+
+export async function getStaticProps({
+  params,
+}): Promise<{ props: { collection: ClientCollection } }> {
+  const { collectionSlug } = params
+  const collection = await getCollection(
+    `${ProductOption['waypoint']}/${collectionSlug}`
+  )
+
+  return {
+    props: {
+      collection: stripUndefinedProperties(collection),
+    },
+  }
+}
+
+interface CollectionPagePaths {
+  params: {
+    collectionSlug: string
+  }
+}
+
+export async function getStaticPaths(): Promise<{
+  paths: CollectionPagePaths[]
+  fallback: boolean
+}> {
+  const collections = await getAllCollections({
+    product: ProductOption['waypoint'],
+  })
+  const paths = collections.map((collection) => ({
+    params: {
+      collectionSlug: splitProductFromFilename(collection.slug),
+    },
+  }))
+  return {
+    paths,
+    fallback: false,
+  }
 }

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -7,8 +7,9 @@ import {
   CollectionPageProps,
 } from 'views/collection-view/server'
 import waypointData from 'data/waypoint.json'
+import BaseLayout from 'layouts/base-new'
 
-export default function WaypointCollectionPage(
+export function WaypointCollectionPage(
   props: CollectionPageProps
 ): React.ReactElement {
   return <CollectionView {...props} />
@@ -42,3 +43,6 @@ export async function getStaticPaths(): Promise<{
     fallback: false,
   }
 }
+
+WaypointCollectionPage.layout = BaseLayout
+export default WaypointCollectionPage

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -1,36 +1,29 @@
-/**
- * TODO - create proper view
- */
-
-import {
-  getAllCollections,
-  getCollection,
-} from 'lib/learn-client/api/collection'
-import {
-  Collection as ClientCollection,
-  ProductOption,
-} from 'lib/learn-client/types'
-import { stripUndefinedProperties } from 'lib/strip-undefined-props'
-import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+import { ProductOption } from 'lib/learn-client/types'
 import CollectionView from 'views/collection-view'
+import {
+  getCollectionPageProps,
+  getCollectionPaths,
+  CollectionPageProduct,
+  CollectionPageProps,
+} from 'views/collection-view/server'
+import waypointData from 'data/waypoint.json'
 
-export default function WaypointCollectionPage(props) {
-  return <CollectionView {...props.collection} />
+export default function WaypointCollectionPage({
+  collection,
+}: CollectionPageProps): React.ReactElement {
+  return <CollectionView {...collection} />
 }
 
 export async function getStaticProps({
   params,
-}): Promise<{ props: { collection: ClientCollection } }> {
+}): Promise<{ props: CollectionPageProps }> {
   const { collectionSlug } = params
-  const collection = await getCollection(
-    `${ProductOption['waypoint']}/${collectionSlug}`
-  )
-
-  return {
-    props: {
-      collection: stripUndefinedProperties(collection),
-    },
-  }
+  const product = {
+    slug: waypointData.slug,
+    name: waypointData.name,
+  } as CollectionPageProduct
+  const props = await getCollectionPageProps(product, collectionSlug)
+  return props
 }
 
 interface CollectionPagePaths {
@@ -43,14 +36,7 @@ export async function getStaticPaths(): Promise<{
   paths: CollectionPagePaths[]
   fallback: boolean
 }> {
-  const collections = await getAllCollections({
-    product: ProductOption['waypoint'],
-  })
-  const paths = collections.map((collection) => ({
-    params: {
-      collectionSlug: splitProductFromFilename(collection.slug),
-    },
-  }))
+  const paths = await getCollectionPaths(ProductOption['waypoint'])
   return {
     paths,
     fallback: false,

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -8,10 +8,10 @@ import {
 } from 'views/collection-view/server'
 import waypointData from 'data/waypoint.json'
 
-export default function WaypointCollectionPage({
-  collection,
-}: CollectionPageProps): React.ReactElement {
-  return <CollectionView {...collection} />
+export default function WaypointCollectionPage(
+  props: CollectionPageProps
+): React.ReactElement {
+  return <CollectionView {...props} />
 }
 
 export async function getStaticProps({

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -11,34 +11,11 @@ import {
   ProductOption,
 } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
-import Link from 'next/link'
 import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+import CollectionView from 'views/collection-view'
 
 export default function WaypointCollectionPage(props) {
-  return (
-    <>
-      <h1>{props.collection.name}</h1>
-      <p>{props.collection.description}</p>
-      <ol>
-        {props.collection.tutorials.map((tutorial) => {
-          const slug = getTutorialSlug(tutorial.slug, props.collection.slug)
-          return (
-            <li key={tutorial.id}>
-              <Link href={slug}>
-                <a>{tutorial.name}</a>
-              </Link>
-            </li>
-          )
-        })}
-      </ol>
-    </>
-  )
-}
-
-function getTutorialSlug(dbslug: string, collectionSlug: string) {
-  const [product, tutorialFilename] = dbslug.split('/')
-  const collectionFilename = splitProductFromFilename(collectionSlug)
-  return `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
+  return <CollectionView {...props.collection} />
 }
 
 export async function getStaticProps({

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -19,20 +19,26 @@ export default function WaypointCollectionPage(props) {
     <>
       <h1>{props.collection.name}</h1>
       <p>{props.collection.description}</p>
-      {/** TODO shape these slugs here, insert collection */}
       <ol>
-        {props.collection.tutorials.map((tutorial) => (
-          <li key={tutorial.id}>
-            <Link href={tutorial.slug}>
-              <>
-                <a>{tutorial.name}</a> <br />
-              </>
-            </Link>
-          </li>
-        ))}
+        {props.collection.tutorials.map((tutorial) => {
+          const slug = getTutorialSlug(tutorial.slug, props.collection.slug)
+          return (
+            <li key={tutorial.id}>
+              <Link href={slug}>
+                <a>{tutorial.name}</a>
+              </Link>
+            </li>
+          )
+        })}
       </ol>
     </>
   )
+}
+
+function getTutorialSlug(dbslug: string, collectionSlug: string) {
+  const [product, tutorialFilename] = dbslug.split('/')
+  const collectionFilename = splitProductFromFilename(collectionSlug)
+  return `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
 }
 
 export async function getStaticProps({

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -1,0 +1,10 @@
+import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+
+export function getTutorialSlug(
+  dbslug: string,
+  collectionSlug: string
+): string {
+  const [product, tutorialFilename] = dbslug.split('/')
+  const collectionFilename = splitProductFromFilename(collectionSlug)
+  return `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
+}

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -1,5 +1,10 @@
 import { splitProductFromFilename } from 'views/tutorial-view/helpers'
 
+/**
+ * takes db slug format --> waypoint/intro
+ * and turns it to --> waypoint/tutorials/get-started-docker/intro
+ */
+
 export function getTutorialSlug(
   dbslug: string,
   collectionSlug: string

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link'
-import { Collection as ClientCollection } from 'lib/learn-client/types'
 import { getTutorialSlug } from './helpers'
+import { CollectionPageProps } from './server'
 
 export default function CollectionView({
-  name,
-  slug,
-  description,
-  tutorials,
-}: ClientCollection): React.ReactElement {
+  collection,
+  allProductCollections, // for sidebar section
+  product,
+}: CollectionPageProps): React.ReactElement {
+  const { name, slug, description, tutorials } = collection
   return (
     <>
       <h1>{name}</h1>

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { Collection as ClientCollection } from 'lib/learn-client/types'
+import { getTutorialSlug } from './helpers'
+
+export default function CollectionView({
+  name,
+  slug,
+  description,
+  tutorials,
+}: ClientCollection): React.ReactElement {
+  return (
+    <>
+      <h1>{name}</h1>
+      <p>{description}</p>
+      <ol>
+        {tutorials.map((tutorial) => {
+          const tutorialSlug = getTutorialSlug(tutorial.slug, slug)
+          return (
+            <li key={tutorial.id}>
+              <Link href={tutorialSlug}>
+                <a>{tutorial.name}</a>
+              </Link>
+            </li>
+          )
+        })}
+      </ol>
+    </>
+  )
+}

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -12,6 +12,7 @@ import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 
 export interface CollectionPageProps {
   collection: ClientCollection
+  allProductCollections: ClientCollection[]
   product: CollectionPageProduct
 }
 
@@ -28,12 +29,17 @@ export async function getCollectionPageProps(
   slug: string
 ): Promise<{ props: CollectionPageProps }> {
   const collection = await getCollection(`${product.slug}/${slug}`)
+  // For sidebar data
+  const allProductCollections = await getAllCollections({
+    product: product.slug,
+  })
 
   return {
-    props: {
-      collection: stripUndefinedProperties(collection),
+    props: stripUndefinedProperties({
+      collection: collection,
+      allProductCollections,
       product,
-    },
+    }),
   }
 }
 

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -1,0 +1,53 @@
+import {
+  Collection as ClientCollection,
+  ProductOption,
+} from 'lib/learn-client/types'
+import {
+  getAllCollections,
+  getCollection,
+} from 'lib/learn-client/api/collection'
+import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+import { TutorialPageProduct } from 'views/tutorial-view/server'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+
+export interface CollectionPageProps {
+  collection: ClientCollection
+  product: CollectionPageProduct
+}
+
+export interface CollectionPagePath {
+  params: {
+    collectionSlug: string
+  }
+}
+
+export type CollectionPageProduct = TutorialPageProduct
+
+export async function getCollectionPageProps(
+  product: CollectionPageProduct,
+  slug: string
+): Promise<{ props: CollectionPageProps }> {
+  const collection = await getCollection(`${product.slug}/${slug}`)
+
+  return {
+    props: {
+      collection: stripUndefinedProperties(collection),
+      product,
+    },
+  }
+}
+
+export async function getCollectionPaths(
+  product: ProductOption
+): Promise<CollectionPagePath[]> {
+  const collections = await getAllCollections({
+    product,
+  })
+  const paths = collections.map((collection) => ({
+    params: {
+      collectionSlug: splitProductFromFilename(collection.slug),
+    },
+  }))
+
+  return paths
+}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-kslearn-collection-page-scaffold-hashicorp.vercel.app/waypoint/tutorials/get-started-docker) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201957666036481) 🎟️

## What

This PR adds a proper collection page scaffold. It sets up all the data fetching for the known components that will render, creates a `CollectionView`, and generates the static paths for all waypoint collections. 

The collection view now renders the tutorial list with basic links so we can start navigating through the various tutorials more easily. 

Note this is still 🛹 and all the interfaces / naming will be adjusted as we refine the views with components.

## Why

To get the data and collection page foundations set up so that when were ready to build components we can 🛳️ 

## Testing

- visit [this page](https://dev-portal-git-kslearn-collection-page-scaffold-hashicorp.vercel.app/waypoint/tutorials/get-started-docker), and [this one](https://dev-portal-git-kslearn-collection-page-scaffold-hashicorp.vercel.app/waypoint/tutorials/get-started-kubernetes)
- click on a few tutorial links to make sure the routing works correctly!


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201957666036481