### PR TITLE
fix: test fix for --font-body

### DIFF
--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -38,9 +38,9 @@
     'Segoe UI Symbol';
   --font-monospace: ui-monospace, Menlo, Consolas, Ubuntu Mono, monospace;
 
-  /* We usually set this on `body`, but we're re-declaring --font-body here
-  within `body`, so I think we need to redeclare `font-family` here 
-  to have it take effect in the way we expect. */
+  /* Custom properties are calculated before they're inherited, so the
+  font-family: var(--font-body) we set on our `body` element needs to be
+  re-declared here, so that our "system-ui" font stack cascades as expected. */
   font-family: var(--font-body);
 
   /* TODO: not sure where else to put this yet */

--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -38,6 +38,11 @@
     'Segoe UI Symbol';
   --font-monospace: ui-monospace, Menlo, Consolas, Ubuntu Mono, monospace;
 
+  /* We usually set this on `body`, but we're re-declaring --font-body here
+  within `body`, so I think we need to redeclare `font-family` here 
+  to have it take effect in the way we expect. */
+  font-family: var(--font-body);
+
   /* TODO: not sure where else to put this yet */
   & button {
     font-family: var(--font-body);


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
> N / A - [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
> N / A - [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zstest-main-merge-tweaks-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201937065225337/f) 🎟️

## What

Fixes a bug where `font-family` was not inherited as expected in #175.

## Why

So that we can have our "system UI" font stack working correctly in `dev-portal`, without having to re-declare `font-family` on every individual element.

## How

Adds a `font-family` declaration to `CodeDevDotLayout`'s `.root` element.

## Testing

- [ ] Visit any page using the dev-portal context, such as [`/waypoint/docs`](https://dev-portal-git-zstest-main-merge-tweaks-hashicorp.vercel.app/waypoint/docs)
    - Delete the `io_preview` cookie if it is present, otherwise you'll see a preview for some dot-io page
- [ ] Confirm that all elements on the page use the expected `font-family`, namely the system-ui font stack
    - None of the elements on the page should use the `Metro` font family
    - This can be hard to catch since Metro looks similar to some `system-ui` fonts. To make the difference more apparent, turn off the `font-family: var(--font-body)` declaration on the `body` element.

## Anything else?

Nope!
