### PR TITLE
feat: adds product scaffold

### DIFF
--- a/src/lib/learn-client/api/product/formatting.ts
+++ b/src/lib/learn-client/api/product/formatting.ts
@@ -1,0 +1,7 @@
+import { ApiProduct } from '../api-types'
+import { ProductOption, Product } from '../../types'
+
+export function formatProduct(product: ApiProduct): Product {
+  const { id, slug, name, description, docs_url } = product
+  return { id, slug: ProductOption[slug], name, description, docsUrl: docs_url }
+}

--- a/src/lib/learn-client/api/product/index.ts
+++ b/src/lib/learn-client/api/product/index.ts
@@ -1,0 +1,43 @@
+import { identifier, Product } from 'lib/learn-client/types'
+import path from 'path'
+import { get, toError } from '../../index'
+import { formatIdentifier, formatBatchQueryStr } from '../utils'
+import { formatProduct } from './formatting'
+
+const PRODUCT_API_ROUTE = '/products'
+
+// getProduct
+export async function getProduct(idOrSlug: identifier): Promise<Product> {
+  const identifier = formatIdentifier(idOrSlug)
+
+  // /products/:identifier
+  const route = path.join(PRODUCT_API_ROUTE, identifier)
+  const getProductRes = await get(route)
+
+  if (getProductRes.ok) {
+    const res = await getProductRes.json()
+    return formatProduct(res.result)
+  }
+
+  const error = await toError(getProductRes)
+  throw error
+}
+
+// getProducts
+export async function getProducts(
+  idsOrSlugs: identifier[]
+): Promise<Product[]> {
+  const queryStr = formatBatchQueryStr(idsOrSlugs)
+
+  // /products?slugs=option,option or /products?ids=option,option
+  const route = PRODUCT_API_ROUTE + queryStr
+  const getProductsRes = await get(route)
+
+  if (getProductsRes.ok) {
+    const res = await getProductsRes.json()
+    return res.result.map(formatProduct)
+  }
+
+  const error = await toError(getProductsRes)
+  throw error
+}

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -2,15 +2,37 @@
  * TODO create proper view
  */
 
+import { getAllCollections } from 'lib/learn-client/api/collection'
+import {
+  Collection as ClientCollection,
+  ProductOption,
+} from 'lib/learn-client/types'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import Link from 'next/link'
 
 export default function WaypointTutorialHubPage() {
   return (
     <>
       <h1>Waypoint Tutorials</h1>
+      <h2>All Collections</h2>
       <Link href="/waypoint/tutorials/get-started-docker">
         <a>See this collection</a>
       </Link>
     </>
   )
+}
+
+export async function getStaticProps(): Promise<{
+  props: { collections: ClientCollection[] }
+}> {
+  // also call product, incorporate this into the client, to get description etc.
+  const collections = await getAllCollections({
+    product: ProductOption['waypoint'],
+  })
+
+  return {
+    props: {
+      collections: stripUndefinedProperties(collections),
+    },
+  }
 }

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -1,38 +1,23 @@
-/**
- * TODO create proper view
- */
-
-import { getAllCollections } from 'lib/learn-client/api/collection'
 import {
   Collection as ClientCollection,
   ProductOption,
 } from 'lib/learn-client/types'
-import { stripUndefinedProperties } from 'lib/strip-undefined-props'
-import Link from 'next/link'
+import { getProductTutorialsPageProps } from 'views/product-tutorials-view/server'
+import waypointData from 'data/waypoint.json'
+import ProductTutorialsView from 'views/product-tutorials-view'
 
-export default function WaypointTutorialHubPage() {
-  return (
-    <>
-      <h1>Waypoint Tutorials</h1>
-      <h2>All Collections</h2>
-      <Link href="/waypoint/tutorials/get-started-docker">
-        <a>See this collection</a>
-      </Link>
-    </>
-  )
+export default function WaypointTutorialHubPage(props) {
+  return <ProductTutorialsView {...props} />
 }
 
 export async function getStaticProps(): Promise<{
   props: { collections: ClientCollection[] }
 }> {
-  // also call product, incorporate this into the client, to get description etc.
-  const collections = await getAllCollections({
-    product: ProductOption['waypoint'],
-  })
-
-  return {
-    props: {
-      collections: stripUndefinedProperties(collections),
-    },
+  const product = {
+    slug: ProductOption['waypoint'],
+    name: waypointData.name,
   }
+  const props = await getProductTutorialsPageProps(product)
+
+  return props
 }

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -3,7 +3,6 @@ import {
   getProductTutorialsPageProps,
   ProductTutorialsPageProps,
 } from 'views/product-tutorials-view/server'
-import waypointData from 'data/waypoint.json'
 import ProductTutorialsView from 'views/product-tutorials-view'
 
 export default function WaypointTutorialHubPage(
@@ -15,12 +14,7 @@ export default function WaypointTutorialHubPage(
 export async function getStaticProps(): Promise<{
   props: ProductTutorialsPageProps
 }> {
-  // @TODO consider sourcing the product data from the API
-  const product = {
-    slug: ProductOption['waypoint'],
-    name: waypointData.name,
-  }
-  const props = await getProductTutorialsPageProps(product)
+  const props = await getProductTutorialsPageProps(ProductOption['waypoint'])
 
   return props
 }

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -1,18 +1,21 @@
+import { ProductOption } from 'lib/learn-client/types'
 import {
-  Collection as ClientCollection,
-  ProductOption,
-} from 'lib/learn-client/types'
-import { getProductTutorialsPageProps } from 'views/product-tutorials-view/server'
+  getProductTutorialsPageProps,
+  ProductTutorialsPageProps,
+} from 'views/product-tutorials-view/server'
 import waypointData from 'data/waypoint.json'
 import ProductTutorialsView from 'views/product-tutorials-view'
 
-export default function WaypointTutorialHubPage(props) {
+export default function WaypointTutorialHubPage(
+  props: ProductTutorialsPageProps
+): React.ReactElement {
   return <ProductTutorialsView {...props} />
 }
 
 export async function getStaticProps(): Promise<{
-  props: { collections: ClientCollection[] }
+  props: ProductTutorialsPageProps
 }> {
+  // @TODO consider sourcing the product data from the API
   const product = {
     slug: ProductOption['waypoint'],
     name: waypointData.name,

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -4,8 +4,9 @@ import {
   ProductTutorialsPageProps,
 } from 'views/product-tutorials-view/server'
 import ProductTutorialsView from 'views/product-tutorials-view'
+import BaseLayout from 'layouts/base-new'
 
-export default function WaypointTutorialHubPage(
+export function WaypointTutorialHubPage(
   props: ProductTutorialsPageProps
 ): React.ReactElement {
   return <ProductTutorialsView {...props} />
@@ -18,3 +19,6 @@ export async function getStaticProps(): Promise<{
 
   return props
 }
+
+WaypointTutorialHubPage.layout = BaseLayout
+export default WaypointTutorialHubPage

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -1,4 +1,4 @@
-import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
 
 /**
  * takes db slug format --> waypoint/intro

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -6,7 +6,7 @@ import {
   getAllCollections,
   getCollection,
 } from 'lib/learn-client/api/collection'
-import { splitProductFromFilename } from 'views/tutorial-view/helpers'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import { TutorialPageProduct } from 'views/tutorial-view/server'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 

--- a/src/views/product-tutorials-view/helpers.ts
+++ b/src/views/product-tutorials-view/helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * takes db collection slug format --> waypoint/get-started
+ * and turns it to --> waypoint/tutorials/get-started
+ */
+
+export function getCollectionSlug(dbslug: string): string {
+  const [product, collectionFilename] = dbslug.split('/')
+  return `/${product}/tutorials/${collectionFilename}`
+}

--- a/src/views/product-tutorials-view/helpers.ts
+++ b/src/views/product-tutorials-view/helpers.ts
@@ -1,9 +1,40 @@
+import { Collection as ClientCollection } from 'lib/learn-client/types'
+
 /**
- * takes db collection slug format --> waypoint/get-started
- * and turns it to --> waypoint/tutorials/get-started
+ * Takes db collection slug format: waypoint/get-started --> waypoint/tutorials/get-started
  */
 
 export function getCollectionSlug(dbslug: string): string {
   const [product, collectionFilename] = dbslug.split('/')
   return `/${product}/tutorials/${collectionFilename}`
+}
+
+/**
+ * This function is an interim solution for filtering content from the /onboarding dir
+ * to render on the frontend - esp in the product sitemaps and featured products options
+ *
+ * This function also filters collections that don't have the product as the main theme
+ */
+
+export function filterCollections(collections, theme) {
+  return collections
+    .filter((c) => c.theme === theme && !c.slug.includes('onboarding'))
+    .sort(sortAlphabetically('name'))
+}
+
+function sortAlphabetically(
+  property: keyof Pick<ClientCollection, 'shortName' | 'name'>
+) {
+  return (a: ClientCollection, b: ClientCollection) => {
+    const A = a[property].toUpperCase()
+    const B = b[property].toUpperCase()
+
+    if (A < B) {
+      return -1
+    }
+    if (A > B) {
+      return 1
+    }
+    return 0
+  }
 }

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import { getCollectionSlug } from './helpers'
+
+export default function ProductTutorialsView({ collections, product }) {
+  return (
+    <>
+      <h1>{product.name} Tutorials</h1>
+      <h2>All Collections</h2>
+      <AllProductCollections collections={collections} />
+    </>
+  )
+}
+
+function AllProductCollections({ collections }) {
+  return (
+    <ul>
+      {collections.map((collection) => (
+        <li key={collection.id}>
+          <Link href={getCollectionSlug(collection.slug)}>
+            <a>{collection.shortName}</a>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link'
+import React from 'react'
 import { getCollectionSlug } from './helpers'
+import { ProductTutorialsPageProps } from './server'
 
-export default function ProductTutorialsView({ collections, product }) {
+export default function ProductTutorialsView({
+  collections,
+  product,
+}: ProductTutorialsPageProps): React.ReactElement {
   return (
     <>
       <h1>{product.name} Tutorials</h1>
@@ -11,7 +16,9 @@ export default function ProductTutorialsView({ collections, product }) {
   )
 }
 
-function AllProductCollections({ collections }) {
+function AllProductCollections({
+  collections,
+}: Pick<ProductTutorialsPageProps, 'collections'>): React.ReactElement {
   return (
     <ul>
       {collections.map((collection) => (

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,0 +1,16 @@
+import { getAllCollections } from 'lib/learn-client/api/collection'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+
+export async function getProductTutorialsPageProps(product) {
+  // also call product, incorporate this into the client, to get description etc.
+  const collections = await getAllCollections({
+    product: product.slug,
+  })
+
+  return {
+    props: {
+      collections: stripUndefinedProperties(collections),
+      product,
+    },
+  }
+}

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,8 +1,17 @@
 import { getAllCollections } from 'lib/learn-client/api/collection'
+import { Collection as ClientCollection } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { TutorialPageProduct } from 'views/tutorial-view/server'
 
-export async function getProductTutorialsPageProps(product) {
-  // also call product, incorporate this into the client, to get description etc.
+export interface ProductTutorialsPageProps {
+  collections: ClientCollection[]
+  product: TutorialPageProduct
+}
+
+export async function getProductTutorialsPageProps(
+  product: TutorialPageProduct
+): Promise<{ props: ProductTutorialsPageProps }> {
+  // @TODO potentially call 'getProduct' here to get description etc from db
   const collections = await getAllCollections({
     product: product.slug,
   })

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,25 +1,34 @@
 import { getAllCollections } from 'lib/learn-client/api/collection'
-import { Collection as ClientCollection } from 'lib/learn-client/types'
+import { getProduct } from 'lib/learn-client/api/product'
+import {
+  Collection as ClientCollection,
+  ProductOption,
+  Product as ClientProduct,
+} from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
-import { TutorialPageProduct } from 'views/tutorial-view/server'
+import { filterCollections } from './helpers'
 
 export interface ProductTutorialsPageProps {
   collections: ClientCollection[]
-  product: TutorialPageProduct
+  product: ClientProduct
 }
 
 export async function getProductTutorialsPageProps(
-  product: TutorialPageProduct
+  productSlug: ProductOption
 ): Promise<{ props: ProductTutorialsPageProps }> {
-  // @TODO potentially call 'getProduct' here to get description etc from db
-  const collections = await getAllCollections({
-    product: product.slug,
+  const product = await getProduct(productSlug)
+  const allProductCollections = await getAllCollections({
+    product: productSlug,
   })
+  const filteredCollections = filterCollections(
+    allProductCollections,
+    productSlug
+  )
 
   return {
-    props: {
-      collections: stripUndefinedProperties(collections),
+    props: stripUndefinedProperties({
+      collections: filteredCollections,
       product,
-    },
+    }),
   }
 }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-ksadds-product-scaffold-hashicorp.vercel.app/waypoint/tutorials) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201957666036489) 🎟️

## What

This PR adds basic data fetching to the waypoint product tutorials hub page. I created a simple skeleton component without styles to list all the collections. Also, the final bit of the [learn client](https://github.com/hashicorp/learn/tree/master/client) is copied over in this PR, with the product methods. 

## Why

The purpose here is to get the basic Learn pages for waypoint in a navigable state. Listing out all the collections will help us QA the tutorial views better instead of needing to enter the manual route. 

## How

There is now a: `ProductTutorialsView` directory, with the component and server file (houses getStaticProps functions). 

## Testing

Visit the Waypoint tutorials hub page, click on a few collections. 

