### PR TITLE
Add sidebarSlot prop to SidebarSidecarLayout

### DIFF
--- a/src/components/sidebar/style.module.css
+++ b/src/components/sidebar/style.module.css
@@ -1,6 +1,4 @@
 .sidebar {
-  padding: 24px;
-
   & ul ul {
     list-style: none;
     margin: 0;

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -29,8 +29,6 @@ const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
       </div>
       <div className={s.mainArea}>
         <div className={s.main}>
-          {/* TODO: implement version switcher (ref: https://app.asana.com/0/1201010428539925/1201342966970641/f) */}
-          {/* <div className={s.versionSwitcher}>VERSION SWITCHER</div> */}
           <main id="main">
             {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
             <div className={s.tempContentStyles}>{children}</div>

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -15,7 +15,7 @@ const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
   headings,
   openConsentManager,
   sidebarProps,
-  sidecarChildren,
+  sidecarSlot,
 }) => (
   <BaseLayout showFooter={false}>
     <div className={s.contentWrapper}>
@@ -46,8 +46,8 @@ const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
           />
         </div>
         <div className={`${s.sidecar} g-hide-on-mobile g-hide-on-tablet`}>
-          {sidecarChildren ? (
-            sidecarChildren
+          {sidecarSlot ? (
+            sidecarSlot
           ) : (
             <TableOfContents
               headings={headings.filter((heading) => heading.level <= 2)}

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC, ReactElement } from 'react'
 import BaseLayout from 'layouts/base-new'
 import BreadcrumbBar from 'components/breadcrumb-bar'
 import EditOnGithubLink from 'components/edit-on-github-link'
@@ -8,7 +8,7 @@ import TableOfContents from 'layouts/sidebar-sidecar/components/table-of-content
 import { SidebarSidecarLayoutProps } from './types'
 import s from './sidebar-sidecar-layout.module.css'
 
-const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
+const SidebarSidecarLayout: FC<SidebarSidecarLayoutProps> = ({
   breadcrumbLinks,
   children,
   githubFileUrl,
@@ -16,48 +16,56 @@ const SidebarSidecarLayout: React.FC<SidebarSidecarLayoutProps> = ({
   openConsentManager,
   sidebarProps,
   sidecarSlot,
-}) => (
-  <BaseLayout showFooter={false}>
-    <div className={s.contentWrapper}>
-      <div className={s.sidebar}>
-        <Sidebar
-          backToLinkProps={sidebarProps.backToLinkProps}
-          menuItems={sidebarProps.menuItems}
-          showFilterInput={sidebarProps.showFilterInput}
-          title={sidebarProps.title}
-        />
-      </div>
-      <div className={s.mainArea}>
-        <div className={s.main}>
-          <main id="main">
-            {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
-            <div className={s.tempContentStyles}>{children}</div>
-            {githubFileUrl && (
-              <EditOnGithubLink
-                className={s.editOnGithubLink}
-                url={githubFileUrl}
-                label="Edit this page on GitHub"
-              />
-            )}
-          </main>
-          <Footer
-            className={s.footer}
-            openConsentManager={openConsentManager}
+}) => {
+  const SidecarContent = (): ReactElement => {
+    if (sidecarSlot) {
+      return sidecarSlot
+    }
+
+    return (
+      <TableOfContents
+        headings={headings.filter((heading) => heading.level <= 2)}
+      />
+    )
+  }
+
+  return (
+    <BaseLayout showFooter={false}>
+      <div className={s.contentWrapper}>
+        <div className={s.sidebar}>
+          <Sidebar
+            backToLinkProps={sidebarProps.backToLinkProps}
+            menuItems={sidebarProps.menuItems}
+            showFilterInput={sidebarProps.showFilterInput}
+            title={sidebarProps.title}
           />
         </div>
-        <div className={`${s.sidecar} g-hide-on-mobile g-hide-on-tablet`}>
-          {sidecarSlot ? (
-            sidecarSlot
-          ) : (
-            <TableOfContents
-              headings={headings.filter((heading) => heading.level <= 2)}
+        <div className={s.mainArea}>
+          <div className={s.main}>
+            <main id="main">
+              {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
+              <div className={s.tempContentStyles}>{children}</div>
+              {githubFileUrl && (
+                <EditOnGithubLink
+                  className={s.editOnGithubLink}
+                  url={githubFileUrl}
+                  label="Edit this page on GitHub"
+                />
+              )}
+            </main>
+            <Footer
+              className={s.footer}
+              openConsentManager={openConsentManager}
             />
-          )}
+          </div>
+          <div className={`${s.sidecar} g-hide-on-mobile g-hide-on-tablet`}>
+            <SidecarContent />
+          </div>
         </div>
       </div>
-    </div>
-  </BaseLayout>
-)
+    </BaseLayout>
+  )
+}
 
 export type { SidebarSidecarLayoutProps }
 export default SidebarSidecarLayout

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -15,8 +15,24 @@ const SidebarSidecarLayout: FC<SidebarSidecarLayoutProps> = ({
   headings,
   openConsentManager,
   sidebarProps,
+  sidebarSlot,
   sidecarSlot,
 }) => {
+  const SidebarContent = (): ReactElement => {
+    if (sidebarSlot) {
+      return sidebarSlot
+    }
+
+    return (
+      <Sidebar
+        backToLinkProps={sidebarProps.backToLinkProps}
+        menuItems={sidebarProps.menuItems}
+        showFilterInput={sidebarProps.showFilterInput}
+        title={sidebarProps.title}
+      />
+    )
+  }
+
   const SidecarContent = (): ReactElement => {
     if (sidecarSlot) {
       return sidecarSlot
@@ -33,12 +49,7 @@ const SidebarSidecarLayout: FC<SidebarSidecarLayoutProps> = ({
     <BaseLayout showFooter={false}>
       <div className={s.contentWrapper}>
         <div className={s.sidebar}>
-          <Sidebar
-            backToLinkProps={sidebarProps.backToLinkProps}
-            menuItems={sidebarProps.menuItems}
-            showFilterInput={sidebarProps.showFilterInput}
-            title={sidebarProps.title}
-          />
+          <SidebarContent />
         </div>
         <div className={s.mainArea}>
           <div className={s.main}>

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -29,6 +29,7 @@ for further details.
   100vh minus the combined height of the sticky nav bars. */
   max-height: calc(100vh - var(--sticky-bars-height));
   overflow-y: auto;
+  padding: 24px;
   position: sticky;
   top: var(--sticky-bars-height);
   width: 320px;

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -5,7 +5,7 @@ import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table
 
 /**
  * The following approach enables us to require the either the `headings` prop
- * OR the `sidecarChildren` prop.
+ * OR the `sidecarSlot` prop.
  *
  * In the `PropsForTableOfContents` and `PropsForCustomSidecar` interfaces, the
  * "other" prop is marked optional with its type set to `never` so that we can
@@ -22,12 +22,12 @@ interface BaseProps {
 
 interface PropsForTableOfContents extends BaseProps {
   headings: TableOfContentsHeading[]
-  sidecarChildren?: never
+  sidecarSlot?: never
 }
 
 interface PropsForCustomSidecar extends BaseProps {
   headings?: never
-  sidecarChildren: ReactNode
+  sidecarSlot: ReactNode
 }
 
 export type SidebarSidecarLayoutProps =

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactElement } from 'react'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { SidebarProps } from 'components/sidebar'
 import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
@@ -27,7 +27,7 @@ interface PropsForTableOfContents extends BaseProps {
 
 interface PropsForCustomSidecar extends BaseProps {
   headings?: never
-  sidecarSlot: ReactNode
+  sidecarSlot: ReactElement
 }
 
 export type SidebarSidecarLayoutProps =

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -17,7 +17,16 @@ interface BaseProps {
   children: React.ReactNode
   githubFileUrl?: string
   openConsentManager?: () => void
+}
+
+interface PropsForDefaultSidebar extends BaseProps {
   sidebarProps: SidebarProps
+  sidebarSlot?: never
+}
+
+interface PropsForCustomSidebar extends BaseProps {
+  sidebarProps?: never
+  sidebarSlot: ReactElement
 }
 
 interface PropsForTableOfContents extends BaseProps {
@@ -30,6 +39,9 @@ interface PropsForCustomSidecar extends BaseProps {
   sidecarSlot: ReactElement
 }
 
-export type SidebarSidecarLayoutProps =
-  | PropsForTableOfContents
-  | PropsForCustomSidecar
+// TODO: hard to read
+export type SidebarSidecarLayoutProps = (
+  | PropsForDefaultSidebar
+  | PropsForCustomSidebar
+) &
+  (PropsForTableOfContents | PropsForCustomSidecar)

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -7,7 +7,6 @@ import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table
  * `BaseProps` represents the props that are defined for every usage of
  * `SidebarSidecarLayout`.
  */
-
 interface BaseProps {
   breadcrumbLinks?: BreadcrumbLink[]
   children: React.ReactNode

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -4,12 +4,8 @@ import { SidebarProps } from 'components/sidebar'
 import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
 
 /**
- * The following approach enables us to require the either the `headings` prop
- * OR the `sidecarSlot` prop.
- *
- * In the `PropsForTableOfContents` and `PropsForCustomSidecar` interfaces, the
- * "other" prop is marked optional with its type set to `never` so that we can
- * continue to destructure both props in the `SidebarSidecarLayout` declaration.
+ * `BaseProps` represents the props that are defined for every usage of
+ * `SidebarSidecarLayout`.
  */
 
 interface BaseProps {
@@ -19,29 +15,41 @@ interface BaseProps {
   openConsentManager?: () => void
 }
 
-interface PropsForDefaultSidebar extends BaseProps {
-  sidebarProps: SidebarProps
-  sidebarSlot?: never
-}
+/**
+ * `PropsForSidebar` defines the properties that represent `Sidebar` behavior.
+ * This approach allows us to require either (not both) `sidebarProps` and
+ * `sidebarSlot` since providing both of these props is not a case that this
+ * component handles.
+ */
+type PropsForSidebar =
+  | {
+      sidebarProps: SidebarProps
+      sidebarSlot?: never
+    }
+  | {
+      sidebarProps?: never
+      sidebarSlot: ReactElement
+    }
 
-interface PropsForCustomSidebar extends BaseProps {
-  sidebarProps?: never
-  sidebarSlot: ReactElement
-}
+/**
+ * `PropsForSidecar` defines the properties that represent `Sidecar` behavior.
+ * This approach allows us to require either (not both) `headings` and
+ * `sidecarSlot` since providing both of these props is not a case that this
+ * component handles.
+ */
+type PropsForSidecar =
+  | {
+      headings: TableOfContentsHeading[]
+      sidecarSlot?: never
+    }
+  | {
+      headings?: never
+      sidecarSlot: ReactElement
+    }
 
-interface PropsForTableOfContents extends BaseProps {
-  headings: TableOfContentsHeading[]
-  sidecarSlot?: never
-}
-
-interface PropsForCustomSidecar extends BaseProps {
-  headings?: never
-  sidecarSlot: ReactElement
-}
-
-// TODO: hard to read
-export type SidebarSidecarLayoutProps = (
-  | PropsForDefaultSidebar
-  | PropsForCustomSidebar
-) &
-  (PropsForTableOfContents | PropsForCustomSidecar)
+/**
+ * This is the final exported type, combining all types defined above into one.
+ */
+export type SidebarSidecarLayoutProps = BaseProps &
+  PropsForSidebar &
+  PropsForSidecar

--- a/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
@@ -1,4 +1,5 @@
 import { GetStaticPathsResult } from 'next'
+import waypointData from 'data/waypoint.json'
 import { ProductOption } from 'lib/learn-client/types'
 import TutorialView from 'views/tutorial-view'
 import {
@@ -8,8 +9,7 @@ import {
   TutorialPagePaths,
   TutorialPageProduct,
 } from 'views/tutorial-view/server'
-import waypointData from 'data/waypoint.json'
-import BaseLayout from 'layouts/base-new'
+import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
 export function WaypointTutorialPage({
   tutorial,
@@ -38,5 +38,5 @@ export async function getStaticPaths(): Promise<
   }
 }
 
-WaypointTutorialPage.layout = BaseLayout
+WaypointTutorialPage.layout = CoreDevDotLayout
 export default WaypointTutorialPage

--- a/src/views/placeholder-product-downloads-view/index.tsx
+++ b/src/views/placeholder-product-downloads-view/index.tsx
@@ -39,7 +39,7 @@ const PlaceholderDownloadsView = (): ReactElement => {
         menuItems: navData,
         title: currentProduct.name,
       }}
-      sidecarChildren={<PlaceholderSidecarContent />}
+      sidecarSlot={<PlaceholderSidecarContent />}
     >
       <h1>Install {currentProduct.name}</h1>
       <p>{LOREM_IPSUM}</p>

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -76,7 +76,7 @@ const ProductDownloadsViewContent = ({
         title: currentProduct.name,
       }}
       breadcrumbLinks={breadcrumbLinks}
-      sidecarChildren={<SidecarMarketingCard {...sidecarMarketingCard} />}
+      sidecarSlot={<SidecarMarketingCard {...sidecarMarketingCard} />}
     >
       <PageHeader />
       <DownloadsSection

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -1,6 +1,7 @@
 import Content from '@hashicorp/react-content'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { TutorialFullCollectionCtx as ClientTutorial } from 'lib/learn-client/types'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import MDX_COMPONENTS from './utils/mdx-components'
 
 export interface TutorialViewProps extends Omit<ClientTutorial, 'content'> {
@@ -13,11 +14,28 @@ export default function TutorialView({
   content,
 }: TutorialViewProps): React.ReactElement {
   return (
-    <main>
+    <SidebarSidecarLayout
+      sidebarSlot={
+        <>
+          {new Array(20).fill(null).map((_) => (
+            <div key={_}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
+              eros diam, fringilla ac malesuada vel, faucibus quis mauris.
+            </div>
+          ))}
+        </>
+      }
+      sidecarSlot={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
+          eros diam, fringilla ac malesuada vel, faucibus quis mauris.
+        </div>
+      }
+    >
       <h1>{name}</h1>
       <Content
         content={<MDXRemote {...content} components={MDX_COMPONENTS} />}
       />
-    </main>
+    </SidebarSidecarLayout>
   )
 }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-intro) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201959792840189/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

1. Adds `sidebarSlot` prop to `SidebarSidecarLayout`
2. Updates `src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx` to use `CoreDevDotLayout`
3. Updates `src/views/tutorial-view/index.tsx` to render `SidebarSidecarLayout` with custom `Sidebar` content
4. Moves `Sidebar` padding style from `Sidebar` component to `SidebarSidecarLayout`
5. Renames `sidecarChildren` prop to `sidecarSlot`
6. Adds two inner components to `src/layouts/sidebar-sidecar/index.tsx`
  a. `SidebarContent`
  b. `SidecarContent`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

1. `sidebarSlot` will be useful for rendering unique sidebars in Learn content. Some will need some special handling and doing this change early means it won't be a blocker when it's needed. Also went with the `slot` naming because it's a common convention on this team.
2. `CoreDevDotLayout` is the default DevDot layout that is needed on every page. Hopefully we can make this easier to consume later.
3. @kendallstrautman is working on the tutorial view currently and is the one needing these changes the soonest, so I made my changes in that file in hopes of being helpful to show custom sidebar usage.
4. Moving the placement of the `padding` style for Sidebar was necessary for making sure the `sidebarSlot` is styled and not the specific content.
5. As mentioned in 1, the `slot` naming is a common convention on this team, so this update is a clarity improvement and aligns the naming of the sidecar slot functionality.
6. These two inner components improve the markup readability. Ternaries are more difficult to read in JSX when they span over many lines. I also opted not to use ternaries in these inner components to make extending them easier if we decide to do so later on.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Left a really detailed commit log on this one that can be used to visualize the "how". My goal was to keep changes minimal and also ensure all of the current sidebars for Docs were backwards compatible by making them the default functionality.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [x] Make sure the sidebar functionality hasn't changed on these pages:
  - [ ] [Main home page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/)
  - [ ] [Waypoint Overview page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint)
  - [ ] [Waypoint Docs page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/docs)
  - [ ] [Waypoint CLI page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/commands)
  - [ ] [Waypoint Plugins page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/plugins)
  - [ ] [Waypoint Install page](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/downloads)
- [x] Go to [/waypoint/tutorials/get-started-docker/get-started-intro](https://dev-portal-git-ambadd-sidebar-slot-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-intro)
- [x] There should be a custom sidebar like pictured:
  ![image](https://user-images.githubusercontent.com/43934258/158492374-449ae2ca-b443-4e33-ad50-f8621b713288.png)

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!