### PR TITLE
Sidebar: fixing <code> in submenus and adding support for hidden property

### DIFF
--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
@@ -86,7 +86,10 @@ const SidebarNavSubmenu: React.FC<SidebarMenuItemProps> = ({ item }) => {
         onClick={() => setIsOpen((prevState) => !prevState)}
         ref={buttonRef}
       >
-        <span className={s.navMenuItemLabel}>{item.title}</span>
+        <span
+          className={s.navMenuItemLabel}
+          dangerouslySetInnerHTML={{ __html: item.title }}
+        />
         <IconChevronRight16 />
       </button>
       {isOpen && (

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -51,10 +51,22 @@ function prepareNavDataForClient(
   nodes: NavNode[],
   basePaths: string[]
 ): MenuItem[] {
-  return nodes.map((n) => prepareNavNodeForClient(n, basePaths))
+  return nodes
+    .map((n) => prepareNavNodeForClient(n, basePaths))
+    .filter((node) => node)
 }
 
 function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
+  /**
+   * TODO: we need aligned types that will work here. NavNode (external import)
+   * does not allow the `hidden` property.
+   *
+   * ref: https://app.asana.com/0/1201010428539925/1201602267333015/f
+   */
+  if ((node as any).hidden) {
+    return null
+  }
+
   if (isNavBranch(node)) {
     // For nodes with routes, add fullPaths to all routes, and `id`
     return {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambquick-sidebar-fixes-hashicorp.vercel.app/) 🔎
- Asana tasks 🎟️
  - [[bug] `<code>` in sidebar category items](https://app.asana.com/0/1201010428539925/1201955800586848/f)
  - [SidebarNavMenuItem does not handle `hidden` property](https://app.asana.com/0/1201010428539925/1201893667095310/f)

## What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Updated `SidebarNavSubmenu` to use `dangerouslySetInnerHTML` so that we no longer see HTML code for submenu nav items
- Updated `prepareNavDataForClient` to filter out nodes with `{ "hidden": true }`, so that those nodes are no longer rendered in the sidebar

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

### `dangerouslySetHTML` fix

- [ ] Go to [/vault/docs/configuration/listener](https://dev-portal-git-ambquick-sidebar-fixes-hashicorp.vercel.app/vault/docs/configuration/listener)
- [ ] The sidebar should no longer show `<code></code>` text for submenus, like this
  ![image](https://user-images.githubusercontent.com/43934258/158653627-0dc45366-b291-4a9c-94fc-98486004e2f9.png)

### `hidden` support

- [ ] Go to [/terraform/guides/terraform-provider-development-program](https://developer.hashi-mktg.com/terraform/guides/terraform-provider-development-program)
- [ ] There should not be a menu item for this page in the sidebar
- [ ] Inspect the HTML of the Sidebar using your browser's dev tools
- [ ] There should only be 2 `<li>` elements in that portion of the markup, like this:
  ![image](https://user-images.githubusercontent.com/43934258/158652432-b929636b-93ca-4f9f-b9f0-c8f89af8b30d.png)

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!