### PR TITLE
docs: add product-landing.json authoring details

### DIFF
--- a/src/data/README.md
+++ b/src/data/README.md
@@ -112,7 +112,7 @@ The `"get_started"` block renders a heading, descriptive text, and a single link
 | Property | Type | Details |
 | --- | --- | --- |
 | `type` | `"get_started"` | Block type |
-| `product` | `"terraform" \| "vault" \| "consul" \| "nomad" \| "packer" \| "vagrant" \| "boundary" \| "waypoint" \| "sentinel" \| "hcp"` | Product icon to be shown. |
+| `product` | `"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vault" \| "vagrant" \| "waypoint" \| "sentinel" \| "hcp"` | Product icon to be shown. |
 | `heading` | `string` | Text for the heading |
 | `text` | `string` | Descriptive text shown below the heading |
 | `link` | `{ text: string, url: string }` | Link shown below the body text |
@@ -141,7 +141,26 @@ Example: Waypoint `"get_started"` block
 <details>
 <summary>Block type: <code>"cards"</code></summary>
 
-<!-- TODO: add detail here -->
+The `"cards"` block displays a grid of cards, each linked using a single `url`.
+
+| Property | Type | Details |
+| --- | --- | --- |
+| `type` | `"cards"` | Block type |
+| `columns` | `2 \| 3` | The maximum number of columns |
+| `cards` | `Array<{ icon, iconBrandColor, heading, text, url, tags }>` | An array of `card` objects, described in detail below |
+
+Each item in the `cards` array has the following structure:
+
+| Property | Type | Details |
+| --- | --- | --- |
+| `icon` | (optional) `"IconBox" \| "IconConsulColor" \| "IconDocs" \| "IconDownload" \| "IconPackerColor" \| "IconProvider" \| "IconServer" \| "IconTerminal" \| "IconTerraformColor" \| "IconVaultColor"` | Optional icon to show at the top of the card. |
+| `iconBrandColor` | (optional) `"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vault" \| "vagrant" \| "waypoint" \| "neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
+| `heading` | `string` | Text for the card heading |
+| `text` | `string` | Text for the card body |
+| `url` | `string` | URL to link to |
+| `tags` | (optional) `Array<"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vagrant" \| "vault" \| "video" \| "waypoint">` | Optional array of tags, to be displayed as icons at the bottom of the card |
+
+Example: 2-column cards with icons
 
 ```json5
 {
@@ -176,11 +195,56 @@ Example: Waypoint `"get_started"` block
 }
 ```
 
-Result:
+![](https://user-images.githubusercontent.com/4624598/158826286-cc94d884-fad7-4d5f-a3f5-52f4b931d7a6.png)
 
-<!-- TODO: update this image -->
+Example: 3-column cards with tags
 
-![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+```json5
+{
+  "type": "cards",
+  "columns": 3,
+  "cards": [
+    {
+      "heading": "Introduction to Waypoint",
+      "text": "Deploying applications in the DevOps landscape can be confusing with so many...",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/tutorials/waypoint/get-started-intro"
+    },
+    {
+      "heading": "Get Started - Kubernetes",
+      "text": "Build, deploy, and release applications to a Kubernetes cluster.",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/collections/waypoint/get-started-kubernetes"
+    },
+    {
+      "heading": "Get Started - Nomad",
+      "text": "Build, deploy, and release applications to a Nomad cluster.",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/collections/waypoint/get-started-nomad"
+    },
+    {
+      "heading": "Get Started - Docker",
+      "text": "Start using Waypoint in only a few minutes on a local Docker instance.",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/tutorials/waypoint/get-started-docker"
+    },
+    {
+      "heading": "Deploy an Application to AWS Elastic Container",
+      "text": "Run a NodeJS application onto AWS elastic container Service...",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/tutorials/waypoint/aws-ecs"
+    },
+    {
+      "heading": "Deploy an Application to Google Cloud Run",
+      "text": "Run an application on Google Cloud Run with Waypoint",
+      "tags": ["video", "waypoint"],
+      "url": "https://learn.hashicorp.com/tutorials/waypoint/google-cloud-run"
+    }
+  ]
+}
+```
+
+![](https://user-images.githubusercontent.com/4624598/158826414-e4f7a18c-cfd8-4b8b-bc4e-58e58cb0224d.png)
 
 </details>
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -18,7 +18,27 @@ TODO - describe the properties used in DevDot
 
 This file is only used in DevDot. It contains the data and content needed for each product's landing page (`/boundary`, `/consul`, etc.).
 
-TODO - describe the properties used
+### Editing product landing content
+
+Our `<product slug>-landing.json` pages take a "block"-based authoring approach for the main content area. This approach allows authors to write content in JSON instead of JSX. An example file might look like:
+
+```json5
+{
+  "heading": "string", // required
+  "subheading": "string", // required
+  "blocks": "array of objects", // required, see below for guide on "blocks"
+}
+```
+
+Each of these top-level properties is addressed in more detail below.
+
+#### `heading` and `subheading`
+
+The `heading` and `subheading` properties
+
+#### `blocks`
+
+TO DO add detail here. 
 
 ## `<product slug>-install.json`
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -20,13 +20,13 @@ This file is only used in DevDot. It contains the data and content needed for ea
 
 ### Editing product landing content
 
-Our `<product slug>-landing.json` pages take a "block"-based authoring approach for the main content area. This approach allows authors to write content in JSON instead of JSX. An example file might look like:
+Our `<product slug>-landing.json` pages take a "block"-based authoring approach for the main content area. This approach allows authors to write content in JSON instead of JSX. As an overview, each file has three properties, all are required:
 
 ```json5
 {
   "heading": "string", // required
   "subheading": "string", // required
-  "blocks": "array of objects", // required, see below for guide on "blocks"
+  "blocks": [ /*  array of objects, required */ ], 
 }
 ```
 
@@ -34,11 +34,131 @@ Each of these top-level properties is addressed in more detail below.
 
 #### `heading` and `subheading`
 
-The `heading` and `subheading` properties
+Set the heading and subheading shown on the page.
+
+<details>
+<summary>Example</summary>
+
+Source: 
+
+
+```json5
+{
+  "heading": "Waypoint Documentation", 
+  "subheading": "Use Waypoint to deliver a PaaS-like experience for Kubernetes, ECS, and other platforms.", 
+  "blocks": [ /* ... */ ],
+}
+```
+
+Result:
+
+<!-- TODO: update this image -->
+
+![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+
+</details>
 
 #### `blocks`
 
-TO DO add detail here. 
+Each item in the `blocks` array represents a component on the page. Each of these items must have a `type` property, which can be one of the types listed below.
+
+<!-- block: type heading -->
+
+<details>
+<summary>Block type: <code>"heading"</code></summary>
+
+```json5
+{
+  "type": "heading",
+  "level": 2,
+  "size": 400,
+  "heading": "Explore Waypoint Documentation"
+}
+```
+
+Result:
+
+<!-- TODO: update this image -->
+
+![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+
+</details>
+
+<!-- block type: get_started -->
+
+<details>
+<summary>Block type: <code>"get_started"</code></summary>
+
+<!-- TODO: add detail here -->
+
+```json5
+{
+  "type": "get_started",
+  "product": "waypoint",
+  "heading": "Introduction to Waypoint",
+  "text": "Welcome to Waypoint! This introduction section covers what Waypoint is, the problem Waypoint aims to solve, and how Waypoint compares to other software.",
+  "link": {
+    "text": "Get Started",
+    "url": "/waypoint/docs/intro"
+  }
+}
+```
+
+Result:
+
+<!-- TODO: update this image -->
+
+![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+
+</details>
+
+<!-- block type: cards -->
+
+<details>
+<summary>Block type: <code>"cards"</code></summary>
+
+<!-- TODO: add detail here -->
+
+```json5
+{
+  "type": "cards",
+  "columns": 2,
+  "cards": [
+    {
+      "icon": "IconDocs",
+      "heading": "Waypoint Reference Documentation",
+      "text": "Learn and develop your knowledge of Waypoint with these tutorials and code resources.",
+      "url": "/waypoint/docs"
+    },
+    {
+      "icon": "IconTerminal",
+      "heading": "Waypoint CLI",
+      "text": "Waypoint is controlled via a very easy to use command-line interface (CLI).",
+      "url": "/waypoint/commands"
+    },
+    {
+      "icon": "IconBox",
+      "heading": "Waypoint Plugins",
+      "text": "Waypoint uses a plugin architecture to provide its build, registry, deploy, and release abilities.",
+      "url": "/waypoint/plugins"
+    },
+    {
+      "icon": "IconDownload",
+      "heading": "Waypoint Downloads",
+      "text": "Please download the proper package for your operating system and architecture.",
+      "url": "/waypoint/downloads"
+    }
+  ]
+}
+```
+
+Result:
+
+<!-- TODO: update this image -->
+
+![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+
+</details>
 
 ## `<product slug>-install.json`
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -24,9 +24,9 @@ Our `<product slug>-landing.json` pages take a "block"-based authoring approach 
 
 ```json5
 {
-  "heading": "string", // required
-  "subheading": "string", // required
-  "blocks": [ /*  array of objects, required */ ], 
+  "heading": "string",
+  "subheading": "string",
+  "blocks": [ /* array of objects */ ], 
 }
 ```
 
@@ -40,7 +40,6 @@ Set the heading and subheading shown on the page.
 <summary>Example</summary>
 
 Source: 
-
 
 ```json5
 {
@@ -71,7 +70,7 @@ Heading blocks render HTML heading elements. Each block accepts the following pr
 | --- | --- | --- |
 | `type` | `"heading"` | Block type |
 | `heading` | `string` | Text for the heading |
-| `level` | `2 \| 3 \| 4 \| 5 \| 6` | Semantic heading level, for example `2` becomes `<h2>`. Note that there is already an `<h1>` rendered for the page, so only values  should be used. |
+| `level` | `2 \| 3 \| 4 \| 5 \| 6` | Semantic heading level, for example `2` becomes `<h2>`. Note that there is already an `<h1>` rendered for the page, so only these values should be used. |
 | `size` | `100 \| 200 \| 300 \| 400 \| 500` | Visual size of the heading. `500` is the largest size and `100` is the smallest. Visual size should generally reflect the semantic level, with `h2 = 300`, `h3 = 200`, and `h4` and below at the `100` size.
 
 Example: `h2` with `300` size:
@@ -115,7 +114,7 @@ The `"get_started"` block renders a heading, descriptive text, and a single link
 | `product` | `"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vault" \| "vagrant" \| "waypoint" \| "sentinel" \| "hcp"` | Product icon to be shown. |
 | `heading` | `string` | Text for the heading |
 | `text` | `string` | Descriptive text shown below the heading |
-| `link` | `{ text: string, url: string }` | Link shown below the body text |
+| `link` | `{ text: string, url: string }` | `StandaloneLink` shown below the body text |
 
 Example: Waypoint `"get_started"` block
 
@@ -141,13 +140,13 @@ Example: Waypoint `"get_started"` block
 <details>
 <summary>Block type: <code>"cards"</code></summary>
 
-The `"cards"` block displays a grid of cards, each linked using a single `url`.
+The `"cards"` block displays a grid of `CardLink`s, each linked using a single `url`.
 
 | Property | Type | Details |
 | --- | --- | --- |
 | `type` | `"cards"` | Block type |
 | `columns` | `2 \| 3` | The maximum number of columns |
-| `cards` | `Array<{ icon, iconBrandColor, heading, text, url, tags }>` | An array of `card` objects, described in detail below |
+| `cards` | `Array<{ icon, iconBrandColor, heading, text, url, tags }>` | An array of objects, described in detail below |
 
 Each item in the `cards` array has the following structure:
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -64,14 +64,14 @@ Each item in the `blocks` array represents a component on the page. Each of thes
 <details>
 <summary>Block type: <code>"heading"</code></summary>
 
-Heading blocks render HTML heading elements. Each block accepts the following properties:
+Heading blocks render HTML heading elements using [our Heading component](../components/heading/index.tsx). Each block accepts the following properties:
 
 | Property | Type | Details |
 | --- | --- | --- |
 | `type` | `"heading"` | Block type |
 | `heading` | `string` | Text for the heading |
-| `level` | `2 \| 3 \| 4 \| 5 \| 6` | Semantic heading level, for example `2` becomes `<h2>`. Note that there is already an `<h1>` rendered for the page, so only these values should be used. |
-| `size` | `100 \| 200 \| 300 \| 400 \| 500` | Visual size of the heading. `500` is the largest size and `100` is the smallest. Visual size should generally reflect the semantic level, with `h2 = 300`, `h3 = 200`, and `h4` and below at the `100` size.
+| `level` | [`2 \| 3 \| 4 \| 5 \| 6`](../components/heading/types.ts) | Semantic heading level, for example `2` becomes `<h2>`. Note that there is already an `<h1>` rendered for the page, so only these values should be used. |
+| `size` | [`100 \| 200 \| 300 \| 400 \| 500`](../components/heading/types.ts) | Visual size of the heading. `500` is the largest size and `100` is the smallest. Visual size should generally reflect the semantic level, with `h2 = 300`, `h3 = 200`, and `h4` and below at the `100` size.
 
 Example: `h2` with `300` size:
 
@@ -111,10 +111,10 @@ The `"get_started"` block renders a heading, descriptive text, and a single link
 | Property | Type | Details |
 | --- | --- | --- |
 | `type` | `"get_started"` | Block type |
-| `product` | `"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vault" \| "vagrant" \| "waypoint" \| "sentinel" \| "hcp"` | Product icon to be shown. |
+| `product` | [ProductSlug](../types/products.ts) | Product icon to be shown. |
 | `heading` | `string` | Text for the heading |
 | `text` | `string` | Descriptive text shown below the heading |
-| `link` | `{ text: string, url: string }` | `StandaloneLink` shown below the body text |
+| `link` | `{ text: string, url: string }` | [`StandaloneLink`](../components/standalone-link/index.tsx) shown below the body text |
 
 Example: Waypoint `"get_started"` block
 
@@ -152,12 +152,12 @@ Each item in the `cards` array has the following structure:
 
 | Property | Type | Details |
 | --- | --- | --- |
-| `icon` | (optional) `"IconBox" \| "IconConsulColor" \| "IconDocs" \| "IconDownload" \| "IconPackerColor" \| "IconProvider" \| "IconServer" \| "IconTerminal" \| "IconTerraformColor" \| "IconVaultColor"` | Optional icon to show at the top of the card. |
-| `iconBrandColor` | (optional) `"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vault" \| "vagrant" \| "waypoint" \| "neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
+| `icon` | (optional) `string` | Optional icon to show at the top of the card. Must be one of the keys in [the card component's icon dictionary](../views/product-landing/components/cards/icon-dict.js) |
+| `iconBrandColor` | (optional) [Products](https://github.com/hashicorp/web-platform-packages/blob/69b2cf609a254c0f469142266ecb60ffe04cbc7a/packages/product-meta/index.tsx#L11) string or `"neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
 | `heading` | `string` | Text for the card heading |
 | `text` | `string` | Text for the card body |
 | `url` | `string` | URL to link to |
-| `tags` | (optional) `Array<"boundary" \| "consul" \| "nomad" \| "packer" \| "terraform" \| "vagrant" \| "vault" \| "video" \| "waypoint">` | Optional array of tags, to be displayed as icons at the bottom of the card |
+| `tags` | (optional) `Array<string>` | Optional array of tags, to be displayed as icons at the bottom of the card. Each tag string be one of the keys in [the card component's tag dictionary](../views/product-landing/components/cards/tag-icon-dict.js) |
 
 Example: 2-column cards with icons
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -153,7 +153,7 @@ Each item in the `cards` array has the following structure:
 | Property | Type | Details |
 | --- | --- | --- |
 | `icon` | (optional) `string` | Optional icon to show at the top of the card. Must be one of the keys in [the card component's icon dictionary](../views/product-landing/components/cards/icon-dict.js) |
-| `iconBrandColor` | (optional) [Products](https://github.com/hashicorp/web-platform-packages/blob/69b2cf609a254c0f469142266ecb60ffe04cbc7a/packages/product-meta/index.tsx#L11) string or `"neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
+| `iconBrandColor` | (optional) [ProductBrandColor](../components/icon-tile/types.ts) string or `"neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
 | `heading` | `string` | Text for the card heading |
 | `text` | `string` | Text for the card body |
 | `url` | `string` | URL to link to |

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -52,9 +52,7 @@ Source:
 
 Result:
 
-<!-- TODO: update this image -->
-
-![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+![](https://user-images.githubusercontent.com/4624598/158818382-e78ea677-85c1-41aa-92b4-ca8714f06f2d.png)
 
 </details>
 
@@ -67,20 +65,40 @@ Each item in the `blocks` array represents a component on the page. Each of thes
 <details>
 <summary>Block type: <code>"heading"</code></summary>
 
+Heading blocks render HTML heading elements. Each block accepts the following properties:
+
+| Property | Type | Details |
+| --- | --- | --- |
+| `type` | `"heading"` | Block type |
+| `heading` | `string` | Text for the heading |
+| `level` | `2 \| 3 \| 4 \| 5 \| 6` | Semantic heading level, for example `2` becomes `<h2>`. Note that there is already an `<h1>` rendered for the page, so only values  should be used. |
+| `size` | `100 \| 200 \| 300 \| 400 \| 500` | Visual size of the heading. `500` is the largest size and `100` is the smallest. Visual size should generally reflect the semantic level, with `h2 = 300`, `h3 = 200`, and `h4` and below at the `100` size.
+
+Example: `h2` with `300` size:
+
 ```json5
 {
   "type": "heading",
+  "heading": "Featured Reference Docs",
   "level": 2,
-  "size": 400,
-  "heading": "Explore Waypoint Documentation"
+  "size": 300,
 }
 ```
 
-Result:
+![](https://user-images.githubusercontent.com/4624598/158818745-a20d1892-efa6-4053-9d00-811645d642aa.png)
 
-<!-- TODO: update this image -->
+Example: `h2` with `400` size:
 
-![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+```json5
+{
+  "type": "heading",
+  "heading": "Explore Waypoint Documentation",
+  "level": 2,
+  "size": 400,
+}
+```
+
+![](https://user-images.githubusercontent.com/4624598/158818617-2b8ce029-ad41-4081-8701-869d51abf40b.png)
 
 </details>
 
@@ -89,7 +107,17 @@ Result:
 <details>
 <summary>Block type: <code>"get_started"</code></summary>
 
-<!-- TODO: add detail here -->
+The `"get_started"` block renders a heading, descriptive text, and a single link alongside a product icon.
+
+| Property | Type | Details |
+| --- | --- | --- |
+| `type` | `"get_started"` | Block type |
+| `product` | `"terraform" \| "vault" \| "consul" \| "nomad" \| "packer" \| "vagrant" \| "boundary" \| "waypoint" \| "sentinel" \| "hcp"` | Product icon to be shown. |
+| `heading` | `string` | Text for the heading |
+| `text` | `string` | Descriptive text shown below the heading |
+| `link` | `{ text: string, url: string }` | Link shown below the body text |
+
+Example: Waypoint `"get_started"` block
 
 ```json5
 {
@@ -104,11 +132,7 @@ Result:
 }
 ```
 
-Result:
-
-<!-- TODO: update this image -->
-
-![](https://user-images.githubusercontent.com/4624598/155219830-f013d329-2d4c-4186-bd35-e3de495fe83d.png)
+![](https://user-images.githubusercontent.com/4624598/158821262-03798dca-12e6-487b-ac3e-e8bab51be8b1.png)
 
 </details>
 

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -153,7 +153,7 @@ Each item in the `cards` array has the following structure:
 | Property | Type | Details |
 | --- | --- | --- |
 | `icon` | (optional) `string` | Optional icon to show at the top of the card. Must be one of the keys in [the card component's icon dictionary](../views/product-landing/components/cards/icon-dict.js) |
-| `iconBrandColor` | (optional) [ProductBrandColor](../components/icon-tile/types.ts) string or `"neutral" \| "neutral-dark"` | Optional brand color override to apply to the icon. Defaults to the current product context. |
+| `iconBrandColor` | (optional) [ProductBrandColor](../components/icon-tile/types.ts) string | Optional brand color override to apply to the icon. Defaults to the current product context. |
 | `heading` | `string` | Text for the card heading |
 | `text` | `string` | Text for the card body |
 | `url` | `string` | URL to link to |


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The ~Vercel~ README preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This ~Vercel~ README preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link ` - src/data/README`](https://github.com/hashicorp/dev-portal/tree/zs.add-product-landing-json-docs/src/data#product-slug-landingjson) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201959792840200/f) 🎟️

## What

This PR adds author-oriented documentation on the `src/data/<product slug>-landing.json` files.

## Why

To make it easier for authors to understand and edit `<product slug>-landing.json` files.

## How

Adds collapsible `<details>` section to the README. Similar approach to [the `hashicorp/tutorials` product landing page docs](https://github.com/hashicorp/tutorials#editing-product-pages).

## Testing

- [ ] Review [the `{product}-landing.json` section of the `src/data/README.md`](https://github.com/hashicorp/dev-portal/tree/zs.add-product-landing-json-docs/src/data#product-slug-landingjson).
    - [ ] The documentation should feel clear and complete for someone aiming to edit product landing page content

## Anything else?

Nope!


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201959792840200