### PR TITLE
fix(content-repo-preview/build): fix public folder copy logic

### DIFF
--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -43,7 +43,7 @@ async function main() {
 
   // copy public files
   console.log('📝 copying files in the public folder')
-  execFileSync('cp', ['-R', './public', '../'])
+  execFileSync('cp', ['-Rf', '../public', `./${process.env.DEV_IO}`])
 
   /**
    * exclude any imports in the global CSS file which rely on other products


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->
Adjust copy command for the public folder in the source repository.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
This is currently reversed, so it's copying the public folder out of `website-preview` and into the source repository.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
