### PR TITLE
feat: adds vault routes

### DIFF
--- a/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
@@ -11,11 +11,11 @@ import {
 } from 'views/tutorial-view/server'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
-export function WaypointTutorialPage({
+export function VaultTutorialPage({
   tutorial,
   layoutProps,
 }: TutorialPageProps): React.ReactElement {
-  return <TutorialView {...tutorial} layout={layoutProps} />
+  return <TutorialView tutorial={tutorial} layout={layoutProps} />
 }
 
 export async function getStaticProps({
@@ -39,5 +39,5 @@ export async function getStaticPaths(): Promise<
   }
 }
 
-WaypointTutorialPage.layout = CoreDevDotLayout
-export default WaypointTutorialPage
+VaultTutorialPage.layout = CoreDevDotLayout
+export default VaultTutorialPage

--- a/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
@@ -1,0 +1,43 @@
+import { GetStaticPathsResult } from 'next'
+import vaultData from 'data/vault.json'
+import { ProductOption } from 'lib/learn-client/types'
+import TutorialView from 'views/tutorial-view'
+import {
+  getTutorialPagePaths,
+  getTutorialPageProps,
+  TutorialPageProps,
+  TutorialPagePaths,
+  TutorialPageProduct,
+} from 'views/tutorial-view/server'
+import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
+
+export function WaypointTutorialPage({
+  tutorial,
+  layoutProps,
+}: TutorialPageProps): React.ReactElement {
+  return <TutorialView {...tutorial} layout={layoutProps} />
+}
+
+export async function getStaticProps({
+  params,
+}): Promise<{ props: TutorialPageProps }> {
+  const product = {
+    slug: vaultData.slug,
+    name: vaultData.name,
+  } as TutorialPageProduct
+  const props = await getTutorialPageProps(product, params.tutorialSlug)
+  return props
+}
+
+export async function getStaticPaths(): Promise<
+  GetStaticPathsResult<TutorialPagePaths['params']>
+> {
+  const paths = await getTutorialPagePaths(ProductOption['vault'])
+  return {
+    paths: paths.slice(0, __config.learn.max_static_paths ?? 0),
+    fallback: 'blocking',
+  }
+}
+
+WaypointTutorialPage.layout = CoreDevDotLayout
+export default WaypointTutorialPage

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -1,0 +1,48 @@
+import { ProductOption } from 'lib/learn-client/types'
+import CollectionView from 'views/collection-view'
+import {
+  getCollectionPageProps,
+  getCollectionPaths,
+  CollectionPageProduct,
+  CollectionPageProps,
+} from 'views/collection-view/server'
+import vaultData from 'data/vault.json'
+import BaseLayout from 'layouts/base-new'
+
+export function WaypointCollectionPage(
+  props: CollectionPageProps
+): React.ReactElement {
+  return <CollectionView {...props} />
+}
+
+export async function getStaticProps({
+  params,
+}): Promise<{ props: CollectionPageProps }> {
+  const { collectionSlug } = params
+  const product = {
+    slug: vaultData.slug,
+    name: vaultData.name,
+  } as CollectionPageProduct
+  const props = await getCollectionPageProps(product, collectionSlug)
+  return props
+}
+
+interface CollectionPagePaths {
+  params: {
+    collectionSlug: string
+  }
+}
+
+export async function getStaticPaths(): Promise<{
+  paths: CollectionPagePaths[]
+  fallback: boolean
+}> {
+  const paths = await getCollectionPaths(ProductOption['vault'])
+  return {
+    paths,
+    fallback: false,
+  }
+}
+
+WaypointCollectionPage.layout = BaseLayout
+export default WaypointCollectionPage

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -9,7 +9,7 @@ import {
 import vaultData from 'data/vault.json'
 import BaseLayout from 'layouts/base-new'
 
-export function WaypointCollectionPage(
+export function VaultCollectionPage(
   props: CollectionPageProps
 ): React.ReactElement {
   return <CollectionView {...props} />
@@ -44,5 +44,5 @@ export async function getStaticPaths(): Promise<{
   }
 }
 
-WaypointCollectionPage.layout = BaseLayout
-export default WaypointCollectionPage
+VaultCollectionPage.layout = BaseLayout
+export default VaultCollectionPage

--- a/src/pages/vault/tutorials/index.tsx
+++ b/src/pages/vault/tutorials/index.tsx
@@ -1,0 +1,24 @@
+import { ProductOption } from 'lib/learn-client/types'
+import {
+  getProductTutorialsPageProps,
+  ProductTutorialsPageProps,
+} from 'views/product-tutorials-view/server'
+import ProductTutorialsView from 'views/product-tutorials-view'
+import BaseLayout from 'layouts/base-new'
+
+export function WaypointTutorialHubPage(
+  props: ProductTutorialsPageProps
+): React.ReactElement {
+  return <ProductTutorialsView {...props} />
+}
+
+export async function getStaticProps(): Promise<{
+  props: ProductTutorialsPageProps
+}> {
+  const props = await getProductTutorialsPageProps(ProductOption['vault'])
+
+  return props
+}
+
+WaypointTutorialHubPage.layout = BaseLayout
+export default WaypointTutorialHubPage

--- a/src/pages/vault/tutorials/index.tsx
+++ b/src/pages/vault/tutorials/index.tsx
@@ -6,7 +6,7 @@ import {
 import ProductTutorialsView from 'views/product-tutorials-view'
 import BaseLayout from 'layouts/base-new'
 
-export function WaypointTutorialHubPage(
+export function VaultTutorialHubPage(
   props: ProductTutorialsPageProps
 ): React.ReactElement {
   return <ProductTutorialsView {...props} />
@@ -20,5 +20,5 @@ export async function getStaticProps(): Promise<{
   return props
 }
 
-WaypointTutorialHubPage.layout = BaseLayout
-export default WaypointTutorialHubPage
+VaultTutorialHubPage.layout = BaseLayout
+export default VaultTutorialHubPage

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -3,18 +3,22 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
 /**
  * takes db slug format --> waypoint/intro
  * and turns it to --> waypoint/tutorials/get-started-docker/intro
+ *
+ * We want to make sure to use the collection product in the path as
+ * that sets the proper product context. The tutorial db slug may
+ * reference a different product context
  */
 
 export function getTutorialSlug(
-  dbslug: string,
-  collectionSlug: string
+  tutorialDbSlug: string,
+  collectionDbSlug: string
 ): string {
-  const [product, tutorialFilename] = dbslug.split('/')
-  const collectionFilename = splitProductFromFilename(collectionSlug)
+  const [product, collectionFilename] = collectionDbSlug.split('/')
+  const tutorialFilename = splitProductFromFilename(tutorialDbSlug)
   return `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
 }
 
-export function getCollectionSlug(dbslug: string): string {
-  const [product, collectionFilename] = dbslug.split('/')
+export function getCollectionSlug(tutorialDbSlug: string): string {
+  const [product, collectionFilename] = tutorialDbSlug.split('/')
   return `/${product}/tutorials/${collectionFilename}`
 }

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -18,7 +18,7 @@ export function getTutorialSlug(
   return `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
 }
 
-export function getCollectionSlug(tutorialDbSlug: string): string {
-  const [product, collectionFilename] = tutorialDbSlug.split('/')
+export function getCollectionSlug(collectionDbSlug: string): string {
+  const [product, collectionFilename] = collectionDbSlug.split('/')
   return `/${product}/tutorials/${collectionFilename}`
 }

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -49,7 +49,9 @@ export async function getCollectionPaths(
   const collections = await getAllCollections({
     product,
   })
-  const paths = collections.map((collection) => ({
+  // Only build collections where this product is the main 'theme'
+  const filteredCollections = collections.filter((c) => c.theme === product) // @TODO once we implement the `theme` option, remove this
+  const paths = filteredCollections.map((collection) => ({
     params: {
       collectionSlug: splitProductFromFilename(collection.slug),
     },

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -50,7 +50,9 @@ export async function getCollectionPaths(
     product,
   })
   // Only build collections where this product is the main 'theme'
-  const filteredCollections = collections.filter((c) => c.theme === product) // @TODO once we implement the `theme` option, remove this
+  // @TODO once we implement the `theme` query option, remove the theme filtering
+  // https://app.asana.com/0/1201903760348480/1201932088801131/f
+  const filteredCollections = collections.filter((c) => c.theme === product)
   const paths = filteredCollections.map((collection) => ({
     params: {
       collectionSlug: splitProductFromFilename(collection.slug),

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -35,10 +35,7 @@ export async function getTutorialPageProps(
   slug: [string, string]
 ): Promise<{ props: TutorialPageProps }> {
   const { currentCollection, currentTutorial } =
-    await getCurrentCollectionTutorial({
-      productSlug: product.slug,
-      tutorialSlug: slug,
-    })
+    await getCurrentCollectionTutorial(product.slug, slug)
   const baseTutorialData = await getTutorial(currentTutorial.data.slug)
   const { content: serializedContent, headings } = await serializeContent(
     baseTutorialData

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -1,10 +1,7 @@
 import { Product as ProductContext } from 'types/products'
 import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getTutorial } from 'lib/learn-client/api/tutorial'
-import {
-  ProductOption,
-  Collection as ClientCollection,
-} from 'lib/learn-client/types'
+import { ProductOption } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { splitProductFromFilename } from './utils'
 import { serializeContent } from './utils/serialize-content'

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -1,5 +1,8 @@
 import { Product as ProductContext } from 'types/products'
-import { getAllCollections } from 'lib/learn-client/api/collection'
+import {
+  getAllCollections,
+  getCollection,
+} from 'lib/learn-client/api/collection'
 import { getTutorial } from 'lib/learn-client/api/tutorial'
 import { ProductOption } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
@@ -34,14 +37,33 @@ export async function getTutorialPageProps(
    * from the params. So we can assume `slug` index 1 is always the tutorial name
    * */
   const [collectionFilename, tutorialFilename] = slug
-  const tutorialDbSlug = `${product.slug}/${tutorialFilename}`
-  const baseTutorialData = await getTutorial(tutorialDbSlug)
+  const collectionDbSlug = `${product.slug}/${collectionFilename}`
+  const currentCollection = await getCollection(collectionDbSlug)
+  /**
+   * We need to get the database slug for this tutorial, which may belong in a different
+   * product directory in the filesystem. For example a tutorial with slug : `consul/get-started`
+   * may be reference in a vault collection. So we can't assume this current
+   * product context is valid for the db slug path
+   *
+   * @TODO - FOR PROD We will add a check in the content sync that
+   * ensures no two files in a collection have the same filename
+   */
+  const currentTutorial = currentCollection.tutorials.find((t) =>
+    t.slug.endsWith(tutorialFilename)
+  )
+
+  if (!currentTutorial) {
+    throw Error(
+      `Tutorial filename: ${tutorialFilename} does not exist in collection: ${collectionDbSlug}`
+    )
+  }
+
+  const baseTutorialData = await getTutorial(currentTutorial.slug)
   const { content: serializedContent, headings } = await serializeContent(
     baseTutorialData
   )
   const collectionContext = getCollectionContext(
-    product.slug,
-    collectionFilename,
+    currentCollection,
     baseTutorialData.collectionCtx
   )
   const layoutProps = {

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -34,25 +34,30 @@ export async function getTutorialPageProps(
   product: TutorialPageProduct,
   slug: [string, string]
 ): Promise<{ props: TutorialPageProps }> {
-  const { currentCollection, currentTutorial } =
-    await getCurrentCollectionTutorial(product.slug, slug)
-  const baseTutorialData = await getTutorial(currentTutorial.data.slug)
+  const { collection, tutorialReference } = await getCurrentCollectionTutorial(
+    product.slug,
+    slug
+  )
+  const fullTutorialData = await getTutorial(tutorialReference.dbSlug)
   const { content: serializedContent, headings } = await serializeContent(
-    baseTutorialData
+    fullTutorialData
   )
   const collectionContext = getCollectionContext(
-    currentCollection.data as ClientCollection,
-    baseTutorialData.collectionCtx
+    collection.data,
+    fullTutorialData.collectionCtx
   )
   const layoutProps = {
     headings,
     breadcrumbLinks: getTutorialsBreadcrumb({
       product: { name: product.name, slug: product.slug },
       collection: {
-        name: collectionContext.current.shortName,
-        slug: currentCollection.filename,
+        name: collection.data.shortName,
+        slug: collection.filename,
       },
-      tutorial: { name: baseTutorialData.name, slug: currentTutorial.filename },
+      tutorial: {
+        name: fullTutorialData.name,
+        slug: tutorialReference.filename,
+      },
     }),
   }
 
@@ -66,7 +71,7 @@ export async function getTutorialPageProps(
   return {
     props: stripUndefinedProperties({
       tutorial: {
-        ...baseTutorialData,
+        ...fullTutorialData,
         content: serializedContent,
         collectionCtx: collectionContext,
         headings,

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -52,7 +52,7 @@ export async function getTutorialPageProps(
     breadcrumbLinks: getTutorialsBreadcrumb({
       product: { name: product.name, slug: product.slug },
       collection: {
-        name: collectionContext.current.name,
+        name: collectionContext.current.shortName,
         slug: currentCollection.filename,
       },
       tutorial: { name: baseTutorialData.name, slug: currentTutorial.filename },

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -11,7 +11,9 @@ export function getCollectionContext(
 ): CollectionContext {
   const isDefault = currentCollection.id === collectionCtx.default.id
   const featuredIn = collectionCtx.featuredIn
-    .filter((c) => c.id !== currentCollection.id)
+    .filter(
+      (c) => c.id !== currentCollection.id && !c.slug.includes('onboarding') // filter out onboarding content for CS team
+    )
     .map(formatCollectionCard)
 
   return {

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -1,10 +1,69 @@
 import {
   Collection as ClientCollection,
+  ProductOption,
+  TutorialLite as ClientTutorialLite,
   TutorialFullCollectionCtx as ClientTutorialFullCollectionCtx,
 } from 'lib/learn-client/types'
+import { getCollection } from 'lib/learn-client/api/collection'
 import { CollectionContext } from '..'
 import { formatCollectionCard } from '../components/featured-in-collections/helpers'
 
+/**
+ * We need to get the database slug for this tutorial, which may belong in a different
+ * product directory in the filesystem. For example a tutorial with slug : `consul/get-started`
+ * may be reference in a vault collection. So we can't assume this current
+ * product context is valid for the db slug path
+ *
+ * @TODO - FOR PROD We will add a check in the content sync that
+ * ensures no two files in a collection have the same filename
+ */
+interface CurrentCollectionTutorialOptions {
+  productSlug: ProductOption
+  tutorialSlug: [string, string]
+}
+
+interface CurrentCollectionTutorial {
+  [key: string]: {
+    filename: string
+    data: ClientCollection | ClientTutorialLite
+  }
+}
+
+export async function getCurrentCollectionTutorial({
+  productSlug,
+  tutorialSlug,
+}: CurrentCollectionTutorialOptions): Promise<CurrentCollectionTutorial> {
+  /**
+   * In the db, slug structure for tutorials is {product}/{tutorial-filename}
+   * the tutorialSlug passed in is based on /{collection-name}/{tutorial-name}
+   * from the params. So we can assume `slug` index 1 is always the tutorial name
+   * */
+  const [collectionFilename, tutorialFilename] = tutorialSlug
+  const collectionDbSlug = `${productSlug}/${collectionFilename}`
+  const currentCollection = await getCollection(collectionDbSlug)
+  const currentTutorial = currentCollection.tutorials.find((t) =>
+    t.slug.endsWith(tutorialFilename)
+  )
+
+  if (!currentTutorial) {
+    throw Error(
+      `Tutorial filename: ${tutorialFilename} does not exist in collection: ${collectionDbSlug}`
+    )
+  }
+
+  return {
+    currentCollection: {
+      filename: collectionFilename,
+      data: currentCollection,
+    },
+    currentTutorial: {
+      filename: tutorialFilename,
+      data: currentTutorial,
+    },
+  }
+}
+
+// This function sets the default and filters the featured collections
 export function getCollectionContext(
   currentCollection: ClientCollection,
   collectionCtx: ClientTutorialFullCollectionCtx['collectionCtx']

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -1,7 +1,6 @@
 import {
   Collection as ClientCollection,
   ProductOption,
-  TutorialLite as ClientTutorialLite,
   TutorialFullCollectionCtx as ClientTutorialFullCollectionCtx,
 } from 'lib/learn-client/types'
 import { getCollection } from 'lib/learn-client/api/collection'
@@ -19,9 +18,13 @@ import { formatCollectionCard } from '../components/featured-in-collections/help
  */
 
 interface CurrentCollectionTutorial {
-  [key: string]: {
+  collection: {
     filename: string
-    data: ClientCollection | ClientTutorialLite
+    data: ClientCollection
+  }
+  tutorialReference: {
+    filename: string
+    dbSlug: string
   }
 }
 
@@ -36,8 +39,12 @@ export async function getCurrentCollectionTutorial(
    * */
   const [collectionFilename, tutorialFilename] = tutorialSlug
   const collectionDbSlug = `${productSlug}/${collectionFilename}`
-  const currentCollection = await getCollection(collectionDbSlug)
-  const currentTutorial = currentCollection.tutorials.find((t) =>
+  const collection = await getCollection(collectionDbSlug)
+  /**
+   * This type is only `TutorialLite` which doesn't have the tutorial content
+   * so we only need the slug to make another request to get the full tutorial data in server.ts
+   */
+  const currentTutorial = collection.tutorials.find((t) =>
     t.slug.endsWith(tutorialFilename)
   )
 
@@ -48,13 +55,13 @@ export async function getCurrentCollectionTutorial(
   }
 
   return {
-    currentCollection: {
+    collection: {
       filename: collectionFilename,
-      data: currentCollection,
+      data: collection,
     },
-    currentTutorial: {
+    tutorialReference: {
       filename: tutorialFilename,
-      data: currentTutorial,
+      dbSlug: currentTutorial.slug,
     },
   }
 }

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -17,10 +17,6 @@ import { formatCollectionCard } from '../components/featured-in-collections/help
  * @TODO - FOR PROD We will add a check in the content sync that
  * ensures no two files in a collection have the same filename
  */
-interface CurrentCollectionTutorialOptions {
-  productSlug: ProductOption
-  tutorialSlug: [string, string]
-}
 
 interface CurrentCollectionTutorial {
   [key: string]: {
@@ -29,10 +25,10 @@ interface CurrentCollectionTutorial {
   }
 }
 
-export async function getCurrentCollectionTutorial({
-  productSlug,
-  tutorialSlug,
-}: CurrentCollectionTutorialOptions): Promise<CurrentCollectionTutorial> {
+export async function getCurrentCollectionTutorial(
+  productSlug: ProductOption,
+  tutorialSlug: [string, string]
+): Promise<CurrentCollectionTutorial> {
   /**
    * In the db, slug structure for tutorials is {product}/{tutorial-filename}
    * the tutorialSlug passed in is based on /{collection-name}/{tutorial-name}

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -1,27 +1,22 @@
 import {
-  ProductOption,
+  Collection as ClientCollection,
   TutorialFullCollectionCtx as ClientTutorialFullCollectionCtx,
 } from 'lib/learn-client/types'
 import { CollectionContext } from '..'
 import { formatCollectionCard } from '../components/featured-in-collections/helpers'
 
 export function getCollectionContext(
-  productSlug: ProductOption,
-  filename: string,
+  currentCollection: ClientCollection,
   collectionCtx: ClientTutorialFullCollectionCtx['collectionCtx']
 ): CollectionContext {
-  const collectionDbSlug = `${productSlug}/${filename}`
-  const current = collectionCtx.featuredIn.find(
-    ({ slug }) => slug === collectionDbSlug
-  )
-  const isDefault = current.id === collectionCtx.default.id
+  const isDefault = currentCollection.id === collectionCtx.default.id
   const featuredIn = collectionCtx.featuredIn
-    .filter((c) => c.id !== current.id)
+    .filter((c) => c.id !== currentCollection.id)
     .map(formatCollectionCard)
 
   return {
     isDefault,
-    current,
+    current: currentCollection,
     featuredIn,
   }
 }

--- a/src/views/tutorial-view/utils/serialize-content.ts
+++ b/src/views/tutorial-view/utils/serialize-content.ts
@@ -13,9 +13,7 @@ import { rewriteStaticAssetsPlugin } from 'lib/remark-plugins/rewrite-static-ass
 import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
 import { splitProductFromFilename } from '.'
 
-export async function serializeContent(
-  tutorial: ClientTutorial
-): Promise<{
+export async function serializeContent(tutorial: ClientTutorial): Promise<{
   content: MDXRemoteSerializeResult
   headings: TableOfContentsHeading[]
 }> {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [X] The Asana task has been added to this PR's description
- [X] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [X] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [X] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadd-vault-tutorials-hashicorp.vercel.app/vault/tutorials) 🔎
- [Asana task](https://app.asana.com/0/1201010428539925/1201985183395374) 🎟️

## What

This sets up vault tutorials hub, collection, and individual tutorial views. 

## Why

Trying to pressure test the set-up with a bigger / more complicated dataset. Also I want to get both products in ASAP so we're building for both as we refine. To limit late-stage surprises!

## How

See my code comments for full context on decisions. There were some unexpected slug wrangling issues. 

## Testing

visit these links and click around 😄 

- [Test tutorial](https://dev-portal-git-ksadd-vault-tutorials-hashicorp.vercel.app/vault/tutorials/cross-products/vault-cred-brokering-quickstart) view. Click on some other tutorials to make sure everything works the same as it did in waypoint.
- [Collection View](https://dev-portal-git-ksadd-vault-tutorials-hashicorp.vercel.app/vault/tutorials/cross-products)
- [Vault tutorial hub view](https://dev-portal-git-ksadd-vault-tutorials-hashicorp.vercel.app/vault/tutorials)

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

_note_: Some featured collections currently link to 404 pages, as they reference collections that don't exist yet if they aren't `waypoint` or `vault` themed. [See ticket](https://app.asana.com/0/1201987349274776/1201991101510148)
