### PR TITLE
chore: update @hashicorp/design-system-tokens and new import path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "dev-portal",
       "dependencies": {
-        "@hashicorp/design-system-tokens": "^0.5.1",
+        "@hashicorp/design-system-tokens": "^0.6.0",
         "@hashicorp/flight-icons": "^2.1.0",
         "@hashicorp/localstorage-polyfill": "^1.0.14",
         "@hashicorp/mktg-global-styles": "^4.0.0",
@@ -1391,9 +1391,9 @@
       }
     },
     "node_modules/@hashicorp/design-system-tokens": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.5.1.tgz",
-      "integrity": "sha512-Sw4MK6pRTuHoX+xsrwUROhPxTqxWAlyTDrxkPY347+HZwHf7uSi+BspXotFeNoZKyojM5JGX7F1IfbjDIxnc/g=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.6.0.tgz",
+      "integrity": "sha512-DXrBvF1r+rJOSbqRzB7KUqxUg+nPmmy4rFTrO5AVC0bJrb9L6V7aEVe3prIQkqZG/yYr1VZBi/a5oRkGmYYiEQ=="
     },
     "node_modules/@hashicorp/flight-icons": {
       "version": "2.1.0",
@@ -33231,9 +33231,9 @@
       }
     },
     "@hashicorp/design-system-tokens": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.5.1.tgz",
-      "integrity": "sha512-Sw4MK6pRTuHoX+xsrwUROhPxTqxWAlyTDrxkPY347+HZwHf7uSi+BspXotFeNoZKyojM5JGX7F1IfbjDIxnc/g=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-0.6.0.tgz",
+      "integrity": "sha512-DXrBvF1r+rJOSbqRzB7KUqxUg+nPmmy4rFTrO5AVC0bJrb9L6V7aEVe3prIQkqZG/yYr1VZBi/a5oRkGmYYiEQ=="
     },
     "@hashicorp/flight-icons": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@hashicorp/design-system-tokens": "^0.5.1",
+    "@hashicorp/design-system-tokens": "^0.6.0",
     "@hashicorp/flight-icons": "^2.1.0",
     "@hashicorp/localstorage-polyfill": "^1.0.14",
     "@hashicorp/mktg-global-styles": "^4.0.0",

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -6,9 +6,9 @@
 * HashiCorp Design System Tokens. These are used in DevDot pages.
 ***
 */
-@import '~@hashicorp/design-system-tokens/devdot/css/tokens.css';
-@import '~@hashicorp/design-system-tokens/devdot/css/helpers/elevation.css';
-@import '~@hashicorp/design-system-tokens/devdot/css/helpers/typography.css';
+@import '~@hashicorp/design-system-tokens/dist/devdot/css/tokens.css';
+@import '~@hashicorp/design-system-tokens/dist/devdot/css/helpers/elevation.css';
+@import '~@hashicorp/design-system-tokens/dist/devdot/css/helpers/typography.css';
 
 /* Sizing styles, used in DevDot */
 @import 'styles/sizing.css';


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-o3x9vc355-hashicorp.vercel.app/) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

Updates to consume @hashicorp/design-system-tokens@0.6.0 and updates the import path for assets

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

In order to have what's published to npm match what is actually on disk in our monorepo we've moved the published assets to `/dist` in https://github.com/hashicorp/design-system/pull/70 

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.


-->

- [ ] Verify the tokens load and everything works as expected. No actual change should be visible.
