### PR TITLE
fix: remove usage of @ts-expect-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@hashicorp/react-code-block": "^4.5.0",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.1.0",
-        "@hashicorp/react-docs-page": "^14.14.3",
+        "@hashicorp/react-docs-page": "^14.14.5",
         "@hashicorp/react-error-view": "^0.0.1",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
@@ -3087,9 +3087,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.4",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.4.tgz",
-      "integrity": "sha512-MR+T0EroVPKbu58rhqehl18MbmcH0oleSak6KWGJZIn0bAN4mvAoDV5ngYSA6SrR+qTP4AmgEhz+9pCYGCqHkA==",
+      "version": "14.14.5",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.5.tgz",
+      "integrity": "sha512-mI+Xe9bxuuLTKm3VppVstd499P4hTFfx6shuhG6FJs9rhnnjXi+KSYhEel+X9ArmFUGIOhMFQvT0CCKWTX+KaQ==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
@@ -34661,9 +34661,9 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.4",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.4.tgz",
-      "integrity": "sha512-MR+T0EroVPKbu58rhqehl18MbmcH0oleSak6KWGJZIn0bAN4mvAoDV5ngYSA6SrR+qTP4AmgEhz+9pCYGCqHkA==",
+      "version": "14.14.5",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.5.tgz",
+      "integrity": "sha512-mI+Xe9bxuuLTKm3VppVstd499P4hTFfx6shuhG6FJs9rhnnjXi+KSYhEel+X9ArmFUGIOhMFQvT0CCKWTX+KaQ==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@hashicorp/react-code-block": "^4.5.0",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.1.0",
-    "@hashicorp/react-docs-page": "^14.14.3",
+    "@hashicorp/react-docs-page": "^14.14.5",
     "@hashicorp/react-error-view": "^0.0.1",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -27,6 +27,13 @@ async function generateStaticProps({
   params,
   product,
   remotePluginsFile,
+}: {
+  localContentDir: string
+  mainBranch?: string
+  navDataFile: string
+  params: { page?: string[] }
+  product: { name: string; slug: string }
+  remotePluginsFile: string
 }) {
   // Build the currentPath from page parameters
   const currentPath = params.page ? params.page.join('/') : ''
@@ -96,7 +103,16 @@ async function generateStaticProps({
     return mdxContent
   }
 
-  const { data: frontMatter, content: rawContent } = grayMatter(mdxString)
+  const { data, content: rawContent } = grayMatter(mdxString)
+  // We manually construct the frontMatter property here since grayMatter
+  // types data as { [key: string]: any } which doesn't satisfy the frontMatter
+  // type for DocsPage which requires specific properties.
+  const frontMatter = {
+    ...data,
+    canonical_url: data.canonical_url ?? null,
+    description: data.description,
+    page_title: data.page_title,
+  }
   const content = await mdxContentHook(rawContent)
   const { mdxSource } = await renderPageMdx(content)
 
@@ -108,6 +124,7 @@ async function generateStaticProps({
     githubFileUrl,
     navData,
     navNode,
+    versions: [],
   }
 }
 

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/utils/resolve-nav-data.js
@@ -11,6 +11,7 @@ import fetchDevPluginDocs from './fetch-dev-plugin-docs'
  * @param {string} navDataFile path to the nav-data.json file, relative to the `website` directory of the Packer GitHub repo. Example: "data/docs-nav-data.json".
  * @param {object} options optional configuration object
  * @param {string} options.remotePluginsFile path to a remote-plugins.json file, relative to the website directory of the Packer repo. Example: "data/docs-remote-plugins.json".
+ * @param {string} [options.currentPath] the path of the page that's invoking this function
  * @returns {Promise<array>} the resolved navData. This includes NavBranch nodes pulled from remote plugin repositories, as well as filePath properties on all local NavLeaf nodes, and remoteFile properties on all NavLeafRemote nodes.
  */
 async function resolveNavDataWithRemotePlugins(navDataFile, options = {}) {

--- a/src/pages/_proxied-dot-io/packer/plugins/[...page].tsx
+++ b/src/pages/_proxied-dot-io/packer/plugins/[...page].tsx
@@ -1,10 +1,10 @@
+import { InferGetStaticPropsType } from 'next'
 import PackerIoLayout from 'layouts/_proxied-dot-io/packer'
 import DocsPage from '@hashicorp/react-docs-page'
 
 import Badge from 'components/_proxied-dot-io/packer/badge'
 import BadgesHeader from 'components/_proxied-dot-io/packer/badges-header'
 import PluginBadge from 'components/_proxied-dot-io/packer/plugin-badge'
-import DevAlert from 'components/_proxied-dot-io/packer/dev-alert'
 import Checklist from 'components/_proxied-dot-io/packer/checklist'
 import productData from 'data/packer.json'
 // Imports below are only used server-side
@@ -26,43 +26,16 @@ const localContentDir = `../content/${basePath}`
 const additionalComponents = { Badge, BadgesHeader, PluginBadge, Checklist }
 const mainBranch = 'master'
 
-function DocsView({ isDevMissingRemotePlugins, ...props }) {
+function DocsView(props: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
-    <>
-      {isDevMissingRemotePlugins ? (
-        <DevAlert>
-          <strong className="g-type-label-strong">
-            Note for local development
-          </strong>
-          <p>
-            <span role="img" aria-label="Alert: ">
-              🚨
-            </span>{' '}
-            <strong>This preview is missing plugin docs</strong> pulled from
-            remote repos.
-          </p>
-
-          <p>
-            <span role="img" aria-label="Fix: ">
-              🛠
-            </span>{' '}
-            <strong>To preview docs pulled from plugin repos</strong>, please
-            include a <code>GITHUB_TOKEN</code> in{' '}
-            <code>website/.env.local</code>.
-          </p>
-        </DevAlert>
-      ) : null}
-      <DocsPage
-        additionalComponents={additionalComponents}
-        baseRoute={basePath}
-        product={product}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        staticProps={props}
-        showVersionSelect={false}
-        algoliaConfig={productData.algoliaConfig}
-      />
-    </>
+    <DocsPage
+      additionalComponents={additionalComponents}
+      baseRoute={basePath}
+      product={product}
+      staticProps={props}
+      showVersionSelect={false}
+      algoliaConfig={productData.algoliaConfig}
+    />
   )
 }
 


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

This PR fixes the TypeScript types for the Packer plugins page so that we don't need to rely on a `@ts-expect-error` directive.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
