### PR TITLE
fix: use npx for build:deploy-preview as it runs before npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dev-portal",
   "private": "true",
   "scripts": {
-    "build:deploy-preview": "hc-tools ./scripts/content-repo-preview/build.ts",
+    "build:deploy-preview": "npx --package @hashicorp/platform-tools hc-tools ./scripts/content-repo-preview/build.ts",
     "build:webpack-only": "hc-tools next-build-webpack-only",
     "build": "next build",
     "lint": "next-hashicorp lint",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dev-portal",
   "private": "true",
   "scripts": {
-    "build:deploy-preview": "npx --package @hashicorp/platform-tools hc-tools ./scripts/content-repo-preview/build.ts",
+    "build:deploy-preview": "npx --package @hashicorp/platform-tools@0.2.0 hc-tools ./scripts/content-repo-preview/build.ts",
     "build:webpack-only": "hc-tools next-build-webpack-only",
     "build": "next build",
     "lint": "next-hashicorp lint",


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What / Why

<!--
Briefly list out the changes proposed in this PR.
-->
Use `npx` for our `build:deploy-preview` script as it runs before `npm install`. This is necessary because we do some file moving related to `node_modules` based on the state of the build cache during a Vercel build.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
