### PR TITLE
Refactor DocsView props and usage

### DIFF
--- a/src/pages/boundary/docs/[[...page]].tsx
+++ b/src/pages/boundary/docs/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = boundaryData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const BoundaryDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/boundary/docs/[[...page]].tsx
+++ b/src/pages/boundary/docs/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import boundaryData from 'data/boundary.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = boundaryData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const BoundaryDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-BoundaryDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default BoundaryDocsPage
+export default DocsView

--- a/src/pages/consul/api-docs/[[...page]].tsx
+++ b/src/pages/consul/api-docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import consulData from 'data/consul.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'api-docs'
 const baseName = 'API'
 const product = consulData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const ConsulApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-ConsulApiDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default ConsulApiDocsPage
+export default DocsView

--- a/src/pages/consul/api-docs/[[...page]].tsx
+++ b/src/pages/consul/api-docs/[[...page]].tsx
@@ -12,7 +12,7 @@ const product = consulData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const ConsulApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/consul/commands/[[...page]].tsx
+++ b/src/pages/consul/commands/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import consulData from 'data/consul.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'commands'
 const baseName = 'CLI'
 const product = consulData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const ConsulCommandsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-ConsulCommandsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default ConsulCommandsPage
+export default DocsView

--- a/src/pages/consul/commands/[[...page]].tsx
+++ b/src/pages/consul/commands/[[...page]].tsx
@@ -12,7 +12,7 @@ const product = consulData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const ConsulCommandsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/consul/docs/[[...page]].tsx
+++ b/src/pages/consul/docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import consulData from 'data/consul.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = consulData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const ConsulDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [consulUrlAdjuster],
 })
 
-ConsulDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default ConsulDocsPage
+export default DocsView

--- a/src/pages/consul/docs/[[...page]].tsx
+++ b/src/pages/consul/docs/[[...page]].tsx
@@ -4,22 +4,15 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import ConfigEntryReference from 'components/author-primitives/consul/config-entry-reference'
 import { consulUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = consulData as Product
-const additionalComponents = { ConfigEntryReference }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const ConsulDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/consul/docs/[[...page]].tsx
+++ b/src/pages/consul/docs/[[...page]].tsx
@@ -14,7 +14,12 @@ const additionalComponents = { ConfigEntryReference }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const ConsulDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/api-docs/[[...page]].tsx
+++ b/src/pages/nomad/api-docs/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import nomadData from 'data/nomad.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'api-docs'
 const baseName = 'API'
 const product = nomadData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const NomadApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-NomadApiDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default NomadApiDocsPage
+export default DocsView

--- a/src/pages/nomad/api-docs/[[...page]].tsx
+++ b/src/pages/nomad/api-docs/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = nomadData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/docs/[[...page]].tsx
+++ b/src/pages/nomad/docs/[[...page]].tsx
@@ -13,7 +13,12 @@ const additionalComponents = { Placement }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/docs/[[...page]].tsx
+++ b/src/pages/nomad/docs/[[...page]].tsx
@@ -4,21 +4,14 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Placement from 'components/author-primitives/shared/placement-table'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = nomadData as Product
-const additionalComponents = { Placement }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/docs/[[...page]].tsx
+++ b/src/pages/nomad/docs/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import nomadData from 'data/nomad.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = nomadData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const NomadDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-NomadDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default NomadDocsPage
+export default DocsView

--- a/src/pages/nomad/intro/[[...page]].tsx
+++ b/src/pages/nomad/intro/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import nomadData from 'data/nomad.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'intro'
 const baseName = 'Intro'
 const product = nomadData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const NomadIntroDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-NomadIntroDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default NomadIntroDocsPage
+export default DocsView

--- a/src/pages/nomad/intro/[[...page]].tsx
+++ b/src/pages/nomad/intro/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = nomadData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadIntroDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/plugins/[[...page]].tsx
+++ b/src/pages/nomad/plugins/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = nomadData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadPluginsDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/nomad/plugins/[[...page]].tsx
+++ b/src/pages/nomad/plugins/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import nomadData from 'data/nomad.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'plugins'
 const baseName = 'Plugins'
 const product = nomadData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const NomadPluginsDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-NomadPluginsDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default NomadPluginsDocsPage
+export default DocsView

--- a/src/pages/nomad/tools/[[...page]].tsx
+++ b/src/pages/nomad/tools/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import nomadData from 'data/nomad.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'tools'
 const baseName = 'Tools'
 const product = nomadData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const NomadToolsDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-NomadToolsDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default NomadToolsDocsPage
+export default DocsView

--- a/src/pages/nomad/tools/[[...page]].tsx
+++ b/src/pages/nomad/tools/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = nomadData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const NomadToolsDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/packer/docs/[[...page]].tsx
+++ b/src/pages/packer/docs/[[...page]].tsx
@@ -16,7 +16,12 @@ const mainBranch = 'master'
 const additionalComponents = { Badge, BadgesHeader, Checklist, PluginBadge }
 
 const PackerDocsPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/packer/docs/[[...page]].tsx
+++ b/src/pages/packer/docs/[[...page]].tsx
@@ -1,17 +1,12 @@
 import packerData from 'data/packer.json'
 import { Product } from 'types/products'
 import DocsView from 'views/docs-view'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = packerData as Product
 const mainBranch = 'master'
-
-const PackerDocsPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   mainBranch,
 })
 
-PackerDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticProps, getStaticPaths }
-export default PackerDocsPage
+export default DocsView

--- a/src/pages/packer/docs/[[...page]].tsx
+++ b/src/pages/packer/docs/[[...page]].tsx
@@ -3,25 +3,14 @@ import { Product } from 'types/products'
 import DocsView from 'views/docs-view'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-// Author primitives
-import Badge from 'components/author-primitives/packer/badge'
-import BadgesHeader from 'components/author-primitives/packer/badges-header'
-import PluginBadge from 'components/author-primitives/packer/plugin-badge'
-import Checklist from 'components/author-primitives/packer/checklist'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = packerData as Product
 const mainBranch = 'master'
-const additionalComponents = { Badge, BadgesHeader, Checklist, PluginBadge }
 
 const PackerDocsPage = ({ mdxSource }): React.ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/packer/guides/[[...page]].tsx
+++ b/src/pages/packer/guides/[[...page]].tsx
@@ -1,17 +1,12 @@
 import packerData from 'data/packer.json'
 import { Product } from 'types/products'
 import DocsView from 'views/docs-view'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 
 const basePath = 'guides'
 const baseName = 'Guides'
 const product = packerData as Product
 const mainBranch = 'master'
-
-const PackerGuidesPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   mainBranch,
 })
 
-PackerGuidesPage.layout = SidebarSidecarLayout
-
 export { getStaticProps, getStaticPaths }
-export default PackerGuidesPage
+export default DocsView

--- a/src/pages/packer/guides/[[...page]].tsx
+++ b/src/pages/packer/guides/[[...page]].tsx
@@ -10,7 +10,7 @@ const product = packerData as Product
 const mainBranch = 'master'
 
 const PackerGuidesPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/packer/intro/[[...page]].tsx
+++ b/src/pages/packer/intro/[[...page]].tsx
@@ -10,7 +10,7 @@ const product = packerData as Product
 const mainBranch = 'master'
 
 const PackerIntroPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/packer/intro/[[...page]].tsx
+++ b/src/pages/packer/intro/[[...page]].tsx
@@ -1,17 +1,12 @@
 import packerData from 'data/packer.json'
 import { Product } from 'types/products'
 import DocsView from 'views/docs-view'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 
 const basePath = 'intro'
 const baseName = 'Intro'
 const product = packerData as Product
 const mainBranch = 'master'
-
-const PackerIntroPage = ({ mdxSource }): React.ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   mainBranch,
 })
 
-PackerIntroPage.layout = SidebarSidecarLayout
-
 export { getStaticProps, getStaticPaths }
-export default PackerIntroPage
+export default DocsView

--- a/src/pages/sentinel/docs/[[...page]].tsx
+++ b/src/pages/sentinel/docs/[[...page]].tsx
@@ -1,9 +1,7 @@
-import { ReactElement } from 'react'
 import sentinelData from 'data/sentinel.json'
 import { Product } from 'types/products'
 import remarkSentinel from 'lib/remark-sentinel'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { sentinelUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 import DocsView from 'views/docs-view'
 
@@ -11,11 +9,6 @@ const basePath = 'docs'
 const basePathForLoader = 'sentinel'
 const baseName = 'Docs'
 const product = sentinelData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const SentinelDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -25,7 +18,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [sentinelUrlAdjuster, remarkSentinel],
 })
 
-SentinelDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default SentinelDocsPage
+export default DocsView

--- a/src/pages/sentinel/docs/[[...page]].tsx
+++ b/src/pages/sentinel/docs/[[...page]].tsx
@@ -1,5 +1,4 @@
 import { ReactElement } from 'react'
-import SentinelEmbedded from '@hashicorp/react-sentinel-embedded'
 import sentinelData from 'data/sentinel.json'
 import { Product } from 'types/products'
 import remarkSentinel from 'lib/remark-sentinel'
@@ -12,16 +11,10 @@ const basePath = 'docs'
 const basePathForLoader = 'sentinel'
 const baseName = 'Docs'
 const product = sentinelData as Product
-const additionalComponents = { SentinelEmbedded }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const SentinelDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/sentinel/docs/[[...page]].tsx
+++ b/src/pages/sentinel/docs/[[...page]].tsx
@@ -16,7 +16,12 @@ const additionalComponents = { SentinelEmbedded }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const SentinelDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/sentinel/intro/[[...page]].tsx
+++ b/src/pages/sentinel/intro/[[...page]].tsx
@@ -13,7 +13,7 @@ const product = sentinelData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const SentinelIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/sentinel/intro/[[...page]].tsx
+++ b/src/pages/sentinel/intro/[[...page]].tsx
@@ -1,7 +1,5 @@
-import { ReactElement } from 'react'
 import sentinelData from 'data/sentinel.json'
 import { Product } from 'types/products'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import { sentinelUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 import DocsView from 'views/docs-view'
@@ -11,11 +9,6 @@ const basePathForLoader = 'sentinel/intro'
 const baseName = 'Intro'
 const product = sentinelData as Product
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const SentinelIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   basePath,
@@ -24,7 +17,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [sentinelUrlAdjuster],
 })
 
-SentinelIntroPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default SentinelIntroPage
+export default DocsView

--- a/src/pages/terraform/cdktf/[[...page]].tsx
+++ b/src/pages/terraform/cdktf/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'cdktf'
 const baseName = 'CDKTF'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-cdk'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformCdktfPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformCdktfPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformCdktfPage
+export default DocsView

--- a/src/pages/terraform/cdktf/[[...page]].tsx
+++ b/src/pages/terraform/cdktf/[[...page]].tsx
@@ -12,7 +12,7 @@ const productSlugForLoader = 'terraform-cdk'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformCdktfPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/cli/[[...page]].tsx
+++ b/src/pages/terraform/cli/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'cli'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformCliPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformCliPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformCliPage
+export default DocsView

--- a/src/pages/terraform/cli/[[...page]].tsx
+++ b/src/pages/terraform/cli/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformCliPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/cloud-docs/[[...page]].tsx
+++ b/src/pages/terraform/cloud-docs/[[...page]].tsx
@@ -12,7 +12,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformCloudDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/cloud-docs/[[...page]].tsx
+++ b/src/pages/terraform/cloud-docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'cloud-docs'
 const baseName = 'Cloud Docs'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformCloudDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformCloudDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformCloudDocsPage
+export default DocsView

--- a/src/pages/terraform/configuration/[[...page]].tsx
+++ b/src/pages/terraform/configuration/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'configuration'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformConfigPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformConfigPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformConfigPage
+export default DocsView

--- a/src/pages/terraform/configuration/[[...page]].tsx
+++ b/src/pages/terraform/configuration/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformConfigPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/docs/[[...page]].tsx
+++ b/src/pages/terraform/docs/[[...page]].tsx
@@ -15,7 +15,12 @@ const additionalComponents = { ProviderTable }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/docs/[[...page]].tsx
+++ b/src/pages/terraform/docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformDocsPage
+export default DocsView

--- a/src/pages/terraform/docs/[[...page]].tsx
+++ b/src/pages/terraform/docs/[[...page]].tsx
@@ -4,23 +4,15 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import ProviderTable from 'components/author-primitives/terraform/provider-table'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
 
-const additionalComponents = { ProviderTable }
-
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/enterprise/[[...page]].tsx
+++ b/src/pages/terraform/enterprise/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'enterprise'
 const baseName = 'Enterprise'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformEnterprisePage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformEnterprisePage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformEnterprisePage
+export default DocsView

--- a/src/pages/terraform/enterprise/[[...page]].tsx
+++ b/src/pages/terraform/enterprise/[[...page]].tsx
@@ -12,7 +12,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformEnterprisePage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/guides/[[...page]].tsx
+++ b/src/pages/terraform/guides/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformGuidesPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/guides/[[...page]].tsx
+++ b/src/pages/terraform/guides/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'guides'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformGuidesPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformGuidesPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformGuidesPage
+export default DocsView

--- a/src/pages/terraform/internals/[[...page]].tsx
+++ b/src/pages/terraform/internals/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformInternalsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/internals/[[...page]].tsx
+++ b/src/pages/terraform/internals/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'internals'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformInternalsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformInternalsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformInternalsPage
+export default DocsView

--- a/src/pages/terraform/intro/[[...page]].tsx
+++ b/src/pages/terraform/intro/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'intro'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformIntroPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformIntroPage
+export default DocsView

--- a/src/pages/terraform/intro/[[...page]].tsx
+++ b/src/pages/terraform/intro/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/language/[[...page]].tsx
+++ b/src/pages/terraform/language/[[...page]].tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'language'
@@ -15,11 +13,6 @@ const product = terraformData as Product
  */
 const productSlugForLoader = 'terraform-website'
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformLanguagePage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
-
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
   productSlugForLoader,
@@ -27,7 +20,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformLanguagePage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformLanguagePage
+export default DocsView

--- a/src/pages/terraform/language/[[...page]].tsx
+++ b/src/pages/terraform/language/[[...page]].tsx
@@ -17,7 +17,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformLanguagePage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/plugin/[[...page]].tsx
+++ b/src/pages/terraform/plugin/[[...page]].tsx
@@ -12,7 +12,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformPluginPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/terraform/plugin/[[...page]].tsx
+++ b/src/pages/terraform/plugin/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'plugin'
 const baseName = 'Plugin'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformPluginPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformPluginPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformPluginPage
+export default DocsView

--- a/src/pages/terraform/registry/[[...page]].tsx
+++ b/src/pages/terraform/registry/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import terraformData from 'data/terraform.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'registry'
 const baseName = 'Registry'
 const product = terraformData as Product
 const productSlugForLoader = 'terraform-website'
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const TerraformRegistryPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-TerraformRegistryPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default TerraformRegistryPage
+export default DocsView

--- a/src/pages/terraform/registry/[[...page]].tsx
+++ b/src/pages/terraform/registry/[[...page]].tsx
@@ -12,7 +12,7 @@ const productSlugForLoader = 'terraform-website'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const TerraformRegistryPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/vagrant/docs/[[...page]].tsx
+++ b/src/pages/vagrant/docs/[[...page]].tsx
@@ -1,7 +1,5 @@
-import { ReactElement } from 'react'
 import vagrantData from 'data/vagrant.json'
 import { Product } from 'types/products'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 // imports below are used on server
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
@@ -11,11 +9,6 @@ import { makeFetchWithRetry } from 'lib/fetch-with-retry'
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = vagrantData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const VagrantDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 // Note that we require VMWARE_UTILITY_VERSION to be in { scope } for the MDX
 // on the  /vagrant/docs/providers/vmware/vagrant-vmware-utility page.
@@ -57,7 +50,5 @@ async function getLatestVagrantVmwareVersion(): Promise<string> {
     })
 }
 
-VagrantDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default VagrantDocsPage
+export default DocsView

--- a/src/pages/vagrant/docs/[[...page]].tsx
+++ b/src/pages/vagrant/docs/[[...page]].tsx
@@ -16,24 +16,27 @@ const additionalComponents = { Button }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VagrantDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 // Note that we require VMWARE_UTILITY_VERSION to be in { scope } for the MDX
 // on the  /vagrant/docs/providers/vmware/vagrant-vmware-utility page.
 // We fetch VMWARE_UTILITY_VERSION from the releases.hashicorp.com API.
 type MdxScope = { VMWARE_UTILITY_VERSION: string }
-const {
-  getStaticPaths,
-  getStaticProps,
-} = getStaticGenerationFunctions<MdxScope>({
-  product,
-  basePath,
-  baseName,
-  getScope: async () => ({
-    VMWARE_UTILITY_VERSION: await getLatestVagrantVmwareVersion(),
-  }),
-})
+const { getStaticPaths, getStaticProps } =
+  getStaticGenerationFunctions<MdxScope>({
+    product,
+    basePath,
+    baseName,
+    getScope: async () => ({
+      VMWARE_UTILITY_VERSION: await getLatestVagrantVmwareVersion(),
+    }),
+  })
 
 /**
  * As noted in src/lib/fetch-release-data, we want to use fetch-with-retry

--- a/src/pages/vagrant/docs/[[...page]].tsx
+++ b/src/pages/vagrant/docs/[[...page]].tsx
@@ -3,7 +3,6 @@ import vagrantData from 'data/vagrant.json'
 import { Product } from 'types/products'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Button from '@hashicorp/react-button'
 // imports below are used on server
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import { getLatestVersionFromVersions } from 'lib/fetch-release-data'
@@ -12,16 +11,10 @@ import { makeFetchWithRetry } from 'lib/fetch-with-retry'
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = vagrantData as Product
-const additionalComponents = { Button }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VagrantDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 // Note that we require VMWARE_UTILITY_VERSION to be in { scope } for the MDX

--- a/src/pages/vagrant/intro/[[...page]].tsx
+++ b/src/pages/vagrant/intro/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import vagrantData from 'data/vagrant.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'intro'
 const baseName = 'Intro'
 const product = vagrantData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const VagrantIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-VagrantIntroPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default VagrantIntroPage
+export default DocsView

--- a/src/pages/vagrant/intro/[[...page]].tsx
+++ b/src/pages/vagrant/intro/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = vagrantData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VagrantIntroPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/vagrant/vagrant-cloud/[[...page]].tsx
+++ b/src/pages/vagrant/vagrant-cloud/[[...page]].tsx
@@ -11,7 +11,7 @@ const product = vagrantData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VagrantCloudPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/vagrant/vagrant-cloud/[[...page]].tsx
+++ b/src/pages/vagrant/vagrant-cloud/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import vagrantData from 'data/vagrant.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'vagrant-cloud'
 const baseName = 'Vagrant Cloud'
 const product = vagrantData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const VagrantCloudPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-VagrantCloudPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default VagrantCloudPage
+export default DocsView

--- a/src/pages/vault/api-docs/[[...page]].tsx
+++ b/src/pages/vault/api-docs/[[...page]].tsx
@@ -12,7 +12,7 @@ const product = vaultData as Product
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VaultApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} />
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/vault/api-docs/[[...page]].tsx
+++ b/src/pages/vault/api-docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import vaultData from 'data/vault.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 import { vaultUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'api-docs'
 const baseName = 'API'
 const product = vaultData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const VaultApiDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [vaultUrlAdjuster],
 })
 
-VaultApiDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default VaultApiDocsPage
+export default DocsView

--- a/src/pages/vault/docs/[[...page]].tsx
+++ b/src/pages/vault/docs/[[...page]].tsx
@@ -1,19 +1,12 @@
-import { ReactElement } from 'react'
 import vaultData from 'data/vault.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 import { vaultUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = vaultData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const VaultDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -22,7 +15,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   additionalRemarkPlugins: [vaultUrlAdjuster],
 })
 
-VaultDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default VaultDocsPage
+export default DocsView

--- a/src/pages/vault/docs/[[...page]].tsx
+++ b/src/pages/vault/docs/[[...page]].tsx
@@ -18,7 +18,12 @@ const additionalComponents = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VaultDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/vault/docs/[[...page]].tsx
+++ b/src/pages/vault/docs/[[...page]].tsx
@@ -4,26 +4,15 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Columns from 'components/author-primitives/vault/columns'
-import InlineTag from 'components/author-primitives/vault/inline-tag'
 import { vaultUrlAdjuster } from 'layouts/sidebar-sidecar/utils/product-url-adjusters'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = vaultData as Product
-const additionalComponents = {
-  Columns,
-  Tag: InlineTag,
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const VaultDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/commands/[[...page]].tsx
+++ b/src/pages/waypoint/commands/[[...page]].tsx
@@ -4,25 +4,14 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Placement from 'components/author-primitives/shared/placement-table'
-import NestedNode from 'components/author-primitives/waypoint/nested-node'
 
 const basePath = 'commands'
 const baseName = 'Commands'
 const product = waypointData as Product
-const additionalComponents = {
-  Placement,
-  NestedNode,
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointCommandsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/commands/[[...page]].tsx
+++ b/src/pages/waypoint/commands/[[...page]].tsx
@@ -17,7 +17,12 @@ const additionalComponents = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointCommandsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/commands/[[...page]].tsx
+++ b/src/pages/waypoint/commands/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import waypointData from 'data/waypoint.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'commands'
 const baseName = 'Commands'
 const product = waypointData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const WaypointCommandsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-WaypointCommandsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default WaypointCommandsPage
+export default DocsView

--- a/src/pages/waypoint/docs/[[...page]].tsx
+++ b/src/pages/waypoint/docs/[[...page]].tsx
@@ -4,25 +4,14 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Placement from 'components/author-primitives/shared/placement-table'
-import NestedNode from 'components/author-primitives/waypoint/nested-node'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = waypointData as Product
-const additionalComponents = {
-  Placement,
-  NestedNode,
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointDocsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/docs/[[...page]].tsx
+++ b/src/pages/waypoint/docs/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import waypointData from 'data/waypoint.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'docs'
 const baseName = 'Docs'
 const product = waypointData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const WaypointDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-WaypointDocsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default WaypointDocsPage
+export default DocsView

--- a/src/pages/waypoint/docs/[[...page]].tsx
+++ b/src/pages/waypoint/docs/[[...page]].tsx
@@ -17,7 +17,12 @@ const additionalComponents = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointDocsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/plugins/[[...page]].tsx
+++ b/src/pages/waypoint/plugins/[[...page]].tsx
@@ -17,7 +17,12 @@ const additionalComponents = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointPluginsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView {...mdxSource} additionalComponents={additionalComponents} />
+  return (
+    <DocsView
+      mdxSource={mdxSource}
+      additionalComponents={additionalComponents}
+    />
+  )
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/plugins/[[...page]].tsx
+++ b/src/pages/waypoint/plugins/[[...page]].tsx
@@ -4,25 +4,14 @@ import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
-import Placement from 'components/author-primitives/shared/placement-table'
-import NestedNode from 'components/author-primitives/waypoint/nested-node'
 
 const basePath = 'plugins'
 const baseName = 'Plugins'
 const product = waypointData as Product
-const additionalComponents = {
-  Placement,
-  NestedNode,
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const WaypointPluginsPage = ({ mdxSource }): ReactElement => {
-  return (
-    <DocsView
-      mdxSource={mdxSource}
-      additionalComponents={additionalComponents}
-    />
-  )
+  return <DocsView mdxSource={mdxSource} />
 }
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({

--- a/src/pages/waypoint/plugins/[[...page]].tsx
+++ b/src/pages/waypoint/plugins/[[...page]].tsx
@@ -1,18 +1,11 @@
-import { ReactElement } from 'react'
 import waypointData from 'data/waypoint.json'
 import { Product } from 'types/products'
 import { getStaticGenerationFunctions } from 'layouts/sidebar-sidecar/server'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DocsView from 'views/docs-view'
 
 const basePath = 'plugins'
 const baseName = 'Plugins'
 const product = waypointData as Product
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const WaypointPluginsPage = ({ mdxSource }): ReactElement => {
-  return <DocsView mdxSource={mdxSource} />
-}
 
 const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   product,
@@ -20,7 +13,5 @@ const { getStaticPaths, getStaticProps } = getStaticGenerationFunctions({
   baseName,
 })
 
-WaypointPluginsPage.layout = SidebarSidecarLayout
-
 export { getStaticPaths, getStaticProps }
-export default WaypointPluginsPage
+export default DocsView

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -1,9 +1,9 @@
-import { ReactElement } from 'react'
 import dynamic from 'next/dynamic'
-import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { MDXRemote } from 'next-mdx-remote'
 import { useCurrentProduct } from 'contexts'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { DocsViewProps, ProductsToPrimitivesMap } from './types'
 
 // Author primitives
 const Badge = dynamic(() => import('components/author-primitives/packer/badge'))
@@ -39,33 +39,23 @@ const SentinelEmbedded = dynamic(
   () => import('@hashicorp/react-sentinel-embedded')
 )
 
-const productsToAdditionalComponents = {
+const productsToPrimitives: ProductsToPrimitivesMap = {
+  boundary: null,
   consul: { ConfigEntryReference },
+  hcp: null,
   nomad: { Placement },
   packer: { Badge, BadgesHeader, Checklist, PluginBadge },
   sentinel: { SentinelEmbedded },
   terraform: { ProviderTable },
   vagrant: { Button },
-  vault: {
-    Columns,
-    Tag: InlineTag,
-  },
-  waypoint: {
-    NestedNode,
-    Placement,
-  },
+  vault: { Columns, Tag: InlineTag },
+  waypoint: { NestedNode, Placement },
 }
 
-export interface DocsViewProps {
-  mdxSource: MDXRemoteSerializeResult
-  lazy?: boolean
-}
-
-const DocsView = ({ mdxSource, lazy }: DocsViewProps): ReactElement => {
+const DocsView = ({ mdxSource, lazy }: DocsViewProps) => {
   const currentProduct = useCurrentProduct()
   const { compiledSource, scope } = mdxSource
-  const additionalComponents =
-    productsToAdditionalComponents[currentProduct.slug] || {}
+  const additionalComponents = productsToPrimitives[currentProduct.slug] || {}
   const components = defaultMdxComponents({ additionalComponents })
 
   return (
@@ -80,4 +70,5 @@ const DocsView = ({ mdxSource, lazy }: DocsViewProps): ReactElement => {
 
 DocsView.layout = SidebarSidecarLayout
 
+export type { DocsViewProps }
 export default DocsView

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -1,18 +1,19 @@
-import { ReactElement } from 'react'
-import { MDXRemote } from 'next-mdx-remote'
+import { ReactElement, ReactNode } from 'react'
+import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
+
+export interface DocsViewProps {
+  additionalComponents?: Record<string, ReactNode>
+  mdxSource: MDXRemoteSerializeResult
+  lazy?: boolean
+}
 
 const DocsView = ({
   additionalComponents = {},
-  compiledSource,
-  scope,
+  mdxSource,
   lazy,
-}: {
-  additionalComponents: Record<string, ReactElement>
-  compiledSource: string
-  scope: Record<string, unknown>
-  lazy?: boolean
-}): ReactElement => {
+}: DocsViewProps): ReactElement => {
+  const { compiledSource, scope } = mdxSource
   const components = defaultMdxComponents({ additionalComponents })
   return (
     <MDXRemote {...{ compiledSource, scope, lazy }} components={components} />

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -1,22 +1,43 @@
 import { ReactElement } from 'react'
+import dynamic from 'next/dynamic'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { useCurrentProduct } from 'contexts'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 
 // Author primitives
-import Badge from 'components/author-primitives/packer/badge'
-import BadgesHeader from 'components/author-primitives/packer/badges-header'
-import Button from '@hashicorp/react-button'
-import Checklist from 'components/author-primitives/packer/checklist'
-import Columns from 'components/author-primitives/vault/columns'
-import ConfigEntryReference from 'components/author-primitives/consul/config-entry-reference'
-import InlineTag from 'components/author-primitives/vault/inline-tag'
-import NestedNode from 'components/author-primitives/waypoint/nested-node'
-import Placement from 'components/author-primitives/shared/placement-table'
-import PluginBadge from 'components/author-primitives/packer/plugin-badge'
-import ProviderTable from 'components/author-primitives/terraform/provider-table'
-import SentinelEmbedded from '@hashicorp/react-sentinel-embedded'
+const Badge = dynamic(() => import('components/author-primitives/packer/badge'))
+const BadgesHeader = dynamic(
+  () => import('components/author-primitives/packer/badges-header')
+)
+const Button = dynamic(() => import('@hashicorp/react-button'))
+const Checklist = dynamic(
+  () => import('components/author-primitives/packer/checklist')
+)
+const Columns = dynamic(
+  () => import('components/author-primitives/vault/columns')
+)
+const ConfigEntryReference = dynamic(
+  () => import('components/author-primitives/consul/config-entry-reference')
+)
+const InlineTag = dynamic(
+  () => import('components/author-primitives/vault/inline-tag')
+)
+const NestedNode = dynamic(
+  () => import('components/author-primitives/waypoint/nested-node')
+)
+const Placement = dynamic(
+  () => import('components/author-primitives/shared/placement-table')
+)
+const PluginBadge = dynamic(
+  () => import('components/author-primitives/packer/plugin-badge')
+)
+const ProviderTable = dynamic(
+  () => import('components/author-primitives/terraform/provider-table')
+)
+const SentinelEmbedded = dynamic(
+  () => import('@hashicorp/react-sentinel-embedded')
+)
 
 const productsToAdditionalComponents = {
   consul: { ConfigEntryReference },

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -67,8 +67,14 @@ const DocsView = ({ mdxSource, lazy }: DocsViewProps): ReactElement => {
   const additionalComponents =
     productsToAdditionalComponents[currentProduct.slug] || {}
   const components = defaultMdxComponents({ additionalComponents })
+
   return (
-    <MDXRemote {...{ compiledSource, scope, lazy }} components={components} />
+    <MDXRemote
+      compiledSource={compiledSource}
+      components={components}
+      lazy={lazy}
+      scope={scope}
+    />
   )
 }
 

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -1,19 +1,49 @@
-import { ReactElement, ReactNode } from 'react'
+import { ReactElement } from 'react'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
+import { useCurrentProduct } from 'contexts'
+
+// Author primitives
+import Badge from 'components/author-primitives/packer/badge'
+import BadgesHeader from 'components/author-primitives/packer/badges-header'
+import Button from '@hashicorp/react-button'
+import Checklist from 'components/author-primitives/packer/checklist'
+import Columns from 'components/author-primitives/vault/columns'
+import ConfigEntryReference from 'components/author-primitives/consul/config-entry-reference'
+import InlineTag from 'components/author-primitives/vault/inline-tag'
+import NestedNode from 'components/author-primitives/waypoint/nested-node'
+import Placement from 'components/author-primitives/shared/placement-table'
+import PluginBadge from 'components/author-primitives/packer/plugin-badge'
+import ProviderTable from 'components/author-primitives/terraform/provider-table'
+import SentinelEmbedded from '@hashicorp/react-sentinel-embedded'
+
+const productsToAdditionalComponents = {
+  consul: { ConfigEntryReference },
+  nomad: { Placement },
+  packer: { Badge, BadgesHeader, Checklist, PluginBadge },
+  sentinel: { SentinelEmbedded },
+  terraform: { ProviderTable },
+  vagrant: { Button },
+  vault: {
+    Columns,
+    Tag: InlineTag,
+  },
+  waypoint: {
+    NestedNode,
+    Placement,
+  },
+}
 
 export interface DocsViewProps {
-  additionalComponents?: Record<string, ReactNode>
   mdxSource: MDXRemoteSerializeResult
   lazy?: boolean
 }
 
-const DocsView = ({
-  additionalComponents = {},
-  mdxSource,
-  lazy,
-}: DocsViewProps): ReactElement => {
+const DocsView = ({ mdxSource, lazy }: DocsViewProps): ReactElement => {
+  const currentProduct = useCurrentProduct()
   const { compiledSource, scope } = mdxSource
+  const additionalComponents =
+    productsToAdditionalComponents[currentProduct.slug] || {}
   const components = defaultMdxComponents({ additionalComponents })
   return (
     <MDXRemote {...{ compiledSource, scope, lazy }} components={components} />

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -1,7 +1,8 @@
 import { ReactElement } from 'react'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
-import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import { useCurrentProduct } from 'contexts'
+import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 
 // Author primitives
 import Badge from 'components/author-primitives/packer/badge'
@@ -49,5 +50,7 @@ const DocsView = ({ mdxSource, lazy }: DocsViewProps): ReactElement => {
     <MDXRemote {...{ compiledSource, scope, lazy }} components={components} />
   )
 }
+
+DocsView.layout = SidebarSidecarLayout
 
 export default DocsView

--- a/src/views/docs-view/types.ts
+++ b/src/views/docs-view/types.ts
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { ProductSlug } from 'types/products'
+
+export interface DocsViewProps {
+  mdxSource: MDXRemoteSerializeResult
+  lazy?: boolean
+}
+
+export type ProductsToPrimitivesMap = Record<
+  ProductSlug,
+  Record<string, ReactNode>
+>


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Combines the `compiledSource` and `scope` props into one `mdxSource` prop in `DocsView`
- Moves `additionalComponents` handling for pages into `DocsView`
- Removes the `additionalComponents` prop from `DocsView`
- Updates all page components that use `DocsView` to now `export default DocsView` instead of defining a new function component
- Updates `DocsView` to have a `layout` property that is `SidebarSidecarLayout`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- My main goal with this refactor is to reduce the amount of boilerplate needed for pages that render `DocsView`.
- This refactor also reduces maintenance for `DocsView` pages in terms of the author primitive components. If we need to add or remove any of those components for a single product, there is now only one place we have to do that. Waypoint is one example of where the same author primitives were needed for each `DocsView` set of pages, and there was a lot of duplicate code to make that happen.
- These refactors are also a step towards the long term goal of using all dynamic routes instead of defining nearly the same page file under every single product.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- I first refactored the `DocsView` API to combine the `compiledSource` and `scope` props into one `mdxSource` prop. In that step, I had to update every call to `DocsView` to set this new prop instead of spreading `mdxScope` onto the the `DocsView` renders.
- After this, the only thing that was in the way of making every page component `export default DocsView` was the pages that were passing `additionalComponents` to the view. For each of those pages, I moved the author primitives it was rendering into `DocsView` and placed them in a map of product slugs to objects with the primitives for that product. This allowed me to remove the `additionalComponents` prop everywhere it was used.
- At this point, now that every usage of `DocsView` was identical, I was able to update the page components that used them to `export default DocsView` and remove the code that created a new function component and set the layout. This is also where I updated `DocsView` to have a `layout` property that matched all of its uses.
- After pushing the code up, I realized the bundle size was greatly increased by all of the author primitives being imported on every `DocsView` page. I took the issue to Slack and @BRKalow recommended using `next/dynamic` to import the author primitives in `DocsView`. This worked really well and the result was an overall bundle size decrease! 🎉 

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

The following pages should have no changes in functionality:

- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/boundary/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/consul/api-docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/consul/commands
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/consul/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/nomad/api-docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/nomad/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/nomad/intro
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/nomad/plugins
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/nomad/tools
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/packer/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/packer/guides
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/packer/intro
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/sentinel/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/sentinel/intro
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/cdktf
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/cli
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/cloud-docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/configuration
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/enterprise
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/guides
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/internals
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/intro
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/language
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/plugin
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/terraform/registry
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/vagrant/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/vagrant/intro
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/vagrant/vagrant-cloud
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/vault/api-docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/vault/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/waypoint/commands
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/waypoint/docs
- [ ] https://dev-portal-git-ambrefactor-docs-view-component-hashicorp.vercel.app/waypoint/plugins

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!