### PR TITLE
fix: clean up `<meta>` tag usage

### DIFF
--- a/src/layouts/_proxied-dot-io/boundary/index.tsx
+++ b/src/layouts/_proxied-dot-io/boundary/index.tsx
@@ -34,22 +34,12 @@ function BoundaryIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/_proxied-dot-io/nomad/index.tsx
+++ b/src/layouts/_proxied-dot-io/nomad/index.tsx
@@ -34,22 +34,12 @@ function NomadIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/_proxied-dot-io/packer/index.tsx
+++ b/src/layouts/_proxied-dot-io/packer/index.tsx
@@ -34,22 +34,12 @@ function PackerIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/_proxied-dot-io/sentinel/index.tsx
+++ b/src/layouts/_proxied-dot-io/sentinel/index.tsx
@@ -32,22 +32,12 @@ function SentinelIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/_proxied-dot-io/vagrant/index.tsx
+++ b/src/layouts/_proxied-dot-io/vagrant/index.tsx
@@ -34,22 +34,12 @@ function VagrantIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/_proxied-dot-io/waypoint/index.tsx
+++ b/src/layouts/_proxied-dot-io/waypoint/index.tsx
@@ -34,22 +34,12 @@ function WaypointIoLayout({
     <>
       <HashiHead
         title={productData.metadata.title}
+        pageName={productData.metadata.title}
         siteName={productData.metadata.title}
         description={productData.metadata.description}
         image={productData.metadata.image}
         icon={productData.metadata.icon}
-      >
-        <meta
-          name="og:title"
-          property="og:title"
-          content={productData.metadata.title}
-        />
-        <meta
-          name="og:description"
-          property="og:title"
-          content={productData.metadata.description}
-        />
-      </HashiHead>
+      />
 
       <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
         {productData.alertBannerActive && (

--- a/src/layouts/base/index.tsx
+++ b/src/layouts/base/index.tsx
@@ -30,14 +30,12 @@ const BaseLayout: React.FC = ({ children }) => (
   <>
     <HashiHead
       title={title}
+      pageName={title}
       siteName={title}
       description={description}
       image="https://www.waypointproject.io/img/og-image.png"
       icon={[{ href: '/_favicon.ico' }]}
-    >
-      <meta name="og:title" property="og:title" content={title} />
-      <meta name="og:description" property="og:title" content={description} />
-    </HashiHead>
+    />
     <Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
       {ALERT_BANNER_ACTIVE && (
         <AlertBanner {...alertBannerData} product="hashicorp" hideOnMobile />

--- a/src/pages/_proxied-dot-io/boundary/community/index.jsx
+++ b/src/pages/_proxied-dot-io/boundary/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import BoundaryIoLayout from 'layouts/_proxied-dot-io/boundary'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 import s from './style.module.css'
 
 function CommunityPage() {
   return (
     <div className={s.root}>
-      <Head>
-        <title key="title">Community | Boundary by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Boundary by HashiCorp"
+        pageName="Community | Boundary by HashiCorp"
+      />
       <SectionHeader
         headline="Community"
         description="Boundary is a newly-launched open source project. The project team depends on the community’s engagement and feedback. Get involved today."
@@ -20,13 +21,11 @@ function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/boundary">Boundary Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/boundary">Boundary Community Forum</a>',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/boundary/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
+            body: '<a href="https://github.com/hashicorp/boundary/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
           },
         ]}
       />

--- a/src/pages/_proxied-dot-io/consul/community/index.jsx
+++ b/src/pages/_proxied-dot-io/consul/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import ConsulIoLayout from 'layouts/_proxied-dot-io/consul'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 import s from './style.module.css'
 
 function CommunityPage() {
   return (
     <div className={s.root}>
-      <Head>
-        <title key="title">Community | Consul by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Consul by HashiCorp"
+        pageName="Community | Consul by HashiCorp"
+      />
       <SectionHeader
         headline="Community"
         description="Consul is a large project with a growing community. There are active, dedicated users willing to help you through various mediums."
@@ -20,28 +21,23 @@ function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/consul">Consul Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/consul">Consul Community Forum</a>',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/consul/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use Gitter or the mailing list for that.',
+            body: '<a href="https://github.com/hashicorp/consul/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use Gitter or the mailing list for that.',
           },
           {
             header: 'Community Tools',
-            body:
-              '<a href="/docs/download-tools">Download Community Tools</a>. Please check out some of the awesome Consul tooling our amazing community has helped build.',
+            body: '<a href="/docs/download-tools">Download Community Tools</a>. Please check out some of the awesome Consul tooling our amazing community has helped build.',
           },
           {
             header: 'Training',
-            body:
-              'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
+            body: 'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
           },
           {
             header: 'Certification',
-            body:
-              'Learn more about our <a href="https://www.hashicorp.com/certification/">Cloud Engineer Certification program</a> and <a href="https://www.hashicorp.com/certification/consul-associate/">HashiCorp&apos;s Networking Automation Certification </a> exams.',
+            body: 'Learn more about our <a href="https://www.hashicorp.com/certification/">Cloud Engineer Certification program</a> and <a href="https://www.hashicorp.com/certification/consul-associate/">HashiCorp&apos;s Networking Automation Certification </a> exams.',
           },
         ]}
       />

--- a/src/pages/_proxied-dot-io/consul/consul-on-kubernetes/index.tsx
+++ b/src/pages/_proxied-dot-io/consul/consul-on-kubernetes/index.tsx
@@ -1,5 +1,5 @@
 import ConsulIoLayout from 'layouts/_proxied-dot-io/consul'
-import ReactHead from '@hashicorp/react-head'
+import HashiHead from '@hashicorp/react-head'
 import Button from '@hashicorp/react-button'
 import ConsulOnKubernetesHero from 'components/_proxied-dot-io/consul/consul-on-kubernetes-hero'
 import FeaturesList from 'components/_proxied-dot-io/consul/features-list'
@@ -16,7 +16,7 @@ function ConsulOnKubernetesPage() {
 
   return (
     <div>
-      <ReactHead
+      <HashiHead
         title={pageTitle}
         pageName={pageTitle}
         description={pageDescription}
@@ -25,8 +25,8 @@ function ConsulOnKubernetesPage() {
       >
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
-        <meta name="author" content="@HashiCorp" />
-      </ReactHead>
+        <meta name="twitter:creator" content="@HashiCorp" />
+      </HashiHead>
 
       <ConsulOnKubernetesHero
         title="Consul on Kubernetes"
@@ -34,8 +34,7 @@ function ConsulOnKubernetesPage() {
         ctas={[
           {
             text: 'Try HCP Consul',
-            url:
-              'https://portal.cloud.hashicorp.com/?utm_source=docs&utm_content=consul_on_kubernetes_landing',
+            url: 'https://portal.cloud.hashicorp.com/?utm_source=docs&utm_content=consul_on_kubernetes_landing',
           },
           {
             text: 'Install Consul on Kubernetes',
@@ -145,8 +144,7 @@ function ConsulOnKubernetesPage() {
               ],
               cta: {
                 text: 'Start tutorial',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide?in=consul/kubernetes',
               },
               image: require('./images/features/multi-platform.svg'),
             },
@@ -178,8 +176,7 @@ function ConsulOnKubernetesPage() {
               ],
               cta: {
                 text: 'Start tutorial',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-custom-resource-definitions?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-custom-resource-definitions?in=consul/kubernetes',
               },
               image: require('./images/features/workflow.svg'),
             },
@@ -210,8 +207,7 @@ function ConsulOnKubernetesPage() {
               ],
               cta: {
                 text: 'Start tutorial',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability?in=consul/kubernetes',
               },
               image: require('./images/features/observable.svg'),
             },
@@ -246,8 +242,7 @@ function ConsulOnKubernetesPage() {
               ],
               cta: {
                 text: 'Start tutorial',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-secure-agents?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-secure-agents?in=consul/kubernetes',
               },
               image: require('./images/features/secure.svg'),
             },
@@ -266,16 +261,14 @@ function ConsulOnKubernetesPage() {
                 heading: 'Get started on Kubernetes',
                 description:
                   'Setup Consul service mesh to get experience deploying service sidecar proxies and securing service with mTLS.',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy?in=consul/gs-consul-service-mesh',
+                url: 'https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy?in=consul/gs-consul-service-mesh',
               },
               {
                 eyebrow: '22 min',
                 heading: 'Secure Consul and registered services on Kubernetes',
                 description:
                   'Secure Consul on Kubernetes using gossip encryption, TLS certificates, Access Control Lists, and Consul intentions.',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-secure-agents?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-secure-agents?in=consul/kubernetes',
               },
               {
                 eyebrow: '21 min',
@@ -283,8 +276,7 @@ function ConsulOnKubernetesPage() {
                   'Layer 7 observability with Prometheus, Grafana, and Kubernetes',
                 description:
                   'Collect and visualize layer 7 metrics from services in your Kubernetes cluster using Consul service mesh, Prometheus, and Grafana.',
-                url:
-                  'https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability?in=consul/kubernetes',
+                url: 'https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability?in=consul/kubernetes',
               },
             ]}
           />
@@ -313,8 +305,7 @@ function ConsulOnKubernetesPage() {
                   'Use Consul’s Terraform provider for deploying and maintaining Consul agents across both Kubernetes and non-Kubernetes environments.',
                 cta: {
                   text: 'Terraform provider',
-                  url:
-                    'https://registry.terraform.io/providers/hashicorp/consul/latest/docs',
+                  url: 'https://registry.terraform.io/providers/hashicorp/consul/latest/docs',
                 },
               },
             ]}

--- a/src/pages/_proxied-dot-io/nomad/community/index.jsx
+++ b/src/pages/_proxied-dot-io/nomad/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import NomadIoLayout from 'layouts/_proxied-dot-io/nomad'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 import s from './style.module.css'
 
 function CommunityPage() {
   return (
     <div className={s.root}>
-      <Head>
-        <title key="title">Community | Nomad by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Nomad by HashiCorp"
+        pageName="Community | Nomad by HashiCorp"
+      />
       <SectionHeader
         headline="Community"
         description="Nomad is an open-source project with a thriving community where active users are willing to help you via various mediums"
@@ -20,28 +21,23 @@ function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/nomad">Nomad Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/nomad">Nomad Community Forum</a>',
           },
           {
             header: 'Office Hours',
-            body:
-              '<a href="https://www.hashicorp.com/community/office-hours">Ask a question</a> during community office hours',
+            body: '<a href="https://www.hashicorp.com/community/office-hours">Ask a question</a> during community office hours',
           },
           {
             header: 'Announcement List',
-            body:
-              'High-priority, low-volume <a href="https://groups.google.com/g/hashicorp-announce">announcements about HashiCorp products</a>, including release information and security bulletins.',
+            body: 'High-priority, low-volume <a href="https://groups.google.com/g/hashicorp-announce">announcements about HashiCorp products</a>, including release information and security bulletins.',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/nomad/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the <a href="https://discuss.hashicorp.com/c/nomad">Community Forum</a> or the mailing list for that.',
+            body: '<a href="https://github.com/hashicorp/nomad/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the <a href="https://discuss.hashicorp.com/c/nomad">Community Forum</a> or the mailing list for that.',
           },
           {
             header: 'Webinars',
-            body:
-              '<a href="https://www.hashicorp.com/events?product=nomad&type=all">Register for webinars</a> or <a href="https://www.hashicorp.com/events/webinars/recorded?product=nomad&type=all">watch recorded webinars</a>.',
+            body: '<a href="https://www.hashicorp.com/events?product=nomad&type=all">Register for webinars</a> or <a href="https://www.hashicorp.com/events/webinars/recorded?product=nomad&type=all">watch recorded webinars</a>.',
           },
         ]}
       />

--- a/src/pages/_proxied-dot-io/packer/community/index.jsx
+++ b/src/pages/_proxied-dot-io/packer/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import PackerIoLayout from 'layouts/_proxied-dot-io/packer'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 import s from './style.module.css'
 
 export default function CommunityPage() {
   return (
     <div className={s.root}>
-      <Head>
-        <title key="title">Community | Packer by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Packer by HashiCorp"
+        pageName="Community | Packer by HashiCorp"
+      />
       <SectionHeader
         headline="Community"
         description="Packer is an open source project with a growing community. There are active, dedicated users willing to help you through various mediums."
@@ -20,28 +21,23 @@ export default function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/packer">Packer Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/packer">Packer Community Forum</a>',
           },
           {
             header: 'Discussion List',
-            body:
-              '<a href="https://groups.google.com/group/packer-tool">Packer Google Group</a>',
+            body: '<a href="https://groups.google.com/group/packer-tool">Packer Google Group</a>',
           },
           {
             header: 'Announcement List',
-            body:
-              '<a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>',
+            body: '<a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/packer/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. For general help, please use the Community Forum.',
+            body: '<a href="https://github.com/hashicorp/packer/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. For general help, please use the Community Forum.',
           },
           {
             header: 'Training',
-            body:
-              'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
+            body: 'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
           },
         ]}
       />

--- a/src/pages/_proxied-dot-io/vagrant/community/index.jsx
+++ b/src/pages/_proxied-dot-io/vagrant/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import VagrantIoLayout from 'layouts/_proxied-dot-io/vagrant'
 import s from './style.module.css'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 
 function CommunityPage() {
   return (
     <div className={s.root}>
-      <Head>
-        <title key="title">Community | Vagrant by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Vagrant by HashiCorp"
+        pageName="Community | Vagrant by HashiCorp"
+      />
       <SectionHeader
         headline="Community"
         description="Vagrant is an open source project with a growing community. There are active, dedicated users willing to help you through various mediums."
@@ -19,28 +20,23 @@ function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/vagrant/24">Vagrant Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/vagrant/24">Vagrant Community Forum</a>',
           },
           {
             header: 'Announcement List',
-            body:
-              '<a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>',
+            body: '<a href="https://groups.google.com/group/hashicorp-announce">HashiCorp Announcement Google Group</a>',
           },
           {
             header: 'Discussion List',
-            body:
-              '<a href="https://groups.google.com/forum/#!forum/vagrant-up">Vagrant Google Group</a>',
+            body: '<a href="https://groups.google.com/forum/#!forum/vagrant-up">Vagrant Google Group</a>',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/vagrant/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here. Use IRC or the mailing list for that.',
+            body: '<a href="https://github.com/hashicorp/vagrant/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here. Use IRC or the mailing list for that.',
           },
           {
             header: 'Training',
-            body:
-              'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
+            body: 'Paid <a href="https://www.hashicorp.com/training">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.',
           },
         ]}
       />

--- a/src/pages/_proxied-dot-io/waypoint/community/index.jsx
+++ b/src/pages/_proxied-dot-io/waypoint/community/index.jsx
@@ -1,15 +1,16 @@
+import HashiHead from '@hashicorp/react-head'
 import WaypointIoLayout from 'layouts/_proxied-dot-io/waypoint'
 import styles from './style.module.css'
 import VerticalTextBlockList from '@hashicorp/react-vertical-text-block-list'
 import SectionHeader from '@hashicorp/react-section-header'
-import Head from 'next/head'
 
 function CommunityPage() {
   return (
     <div className={styles.communityPage}>
-      <Head>
-        <title key="title">Community | Waypoint by HashiCorp</title>
-      </Head>
+      <HashiHead
+        title="Community | Waypoint by HashiCorp"
+        pageName="Community | Waypoint by HashiCorp"
+      />
       <div className={styles.sectionHeaderWrapper}>
         <SectionHeader
           headline="Community"
@@ -22,13 +23,11 @@ function CommunityPage() {
         data={[
           {
             header: 'Community Forum',
-            body:
-              '<a href="https://discuss.hashicorp.com/c/waypoint">Waypoint Community Forum</a>',
+            body: '<a href="https://discuss.hashicorp.com/c/waypoint">Waypoint Community Forum</a>',
           },
           {
             header: 'Bug Tracker',
-            body:
-              '<a href="https://github.com/hashicorp/waypoint/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
+            body: '<a href="https://github.com/hashicorp/waypoint/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use the Community Form for that.',
           },
         ]}
       />

--- a/src/views/_proxied-dot-io/security/index.jsx
+++ b/src/views/_proxied-dot-io/security/index.jsx
@@ -7,10 +7,7 @@ function SecurityPage({ productName, githubUrl }) {
     vulnerabilities found and we'll handle it quickly.`
   return (
     <>
-      <HashiHead title={title} description={description}>
-        <meta name="og:title" property="og:title" content={title} />
-        <meta name="og:description" property="og:title" content={description} />
-      </HashiHead>
+      <HashiHead title={title} pageName={title} description={description} />
       <LongformPage title="Security" className="security" alert="">
         <p>
           We understand that many users place a high level of trust in HashiCorp


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

This PR cleans up our `<meta>` tags, removing explicit tags in favor of using `HashiHead` for consistency.

## Why

Using `HashiHead` ensures that updated values are correctly overwritten, and makes rolling out larger changes easier since each `<head>` element is derived from a single component.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

Our pages that use `renderMetaTags` to render tags from Dato continue to use `next/head` since in those cases it's preferred to use a lower-level of abstraction since Dato gives a large number of `<meta>` tags.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201910552708627