### PR TITLE
fix: use faster URL to test glob redirects

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,11 +1,8 @@
 name: E2E Tests
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [deployment_status]
 jobs:
   test:
+    if: github.event.deployment_status.state == 'success' && github.event.sender.id == 35613825
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +18,8 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npm run test:e2e
+        env:
+          E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -45,15 +45,17 @@ const config: PlaywrightTestConfig = {
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'npm run start',
-    port: 3000,
-    env: {
-      // Run in preview mode to support changing the product based on the
-      // io_preview cookie
-      HASHI_ENV: 'preview',
-    },
-  },
+  webServer: !process.env.E2E_BASE_URL
+    ? {
+        command: 'npm run start',
+        port: 3000,
+        env: {
+          // Run in preview mode to support changing the product based on the
+          // io_preview cookie
+          HASHI_ENV: 'preview',
+        },
+      }
+    : undefined,
 }
 
 export default config

--- a/src/__tests__/e2e/redirects.spec.ts
+++ b/src/__tests__/e2e/redirects.spec.ts
@@ -2,40 +2,44 @@ import { test, expect } from '@playwright/test'
 
 // This test is primarily to ensure that the dev server is running in a mode
 // that supports the io_preview cookie.
-test('should render based on io_preview cookie', async ({ page, context }) => {
+test('should render based on io_preview cookie', async ({
+  page,
+  context,
+  baseURL,
+}) => {
   await context.addCookies([
     {
       name: 'io_preview',
       value: 'consul',
-      url: 'http://localhost:3000/',
+      url: baseURL,
     },
   ])
   await page.goto('/')
   await expect(page.locator('head title')).toContainText('Consul by HashiCorp')
 })
 
-test('should use middleware redirects', async ({ page, context }) => {
+test('should use middleware redirects', async ({ page, context, baseURL }) => {
   await context.addCookies([
     {
       name: 'io_preview',
       value: 'consul',
-      url: 'http://localhost:3000/',
+      url: baseURL,
     },
   ])
   await page.goto('/use-cases/network-middleware-automation')
-  expect(page.url()).toBe(
-    'http://localhost:3000/use-cases/network-infrastructure-automation'
-  )
+  const { pathname } = new URL(page.url())
+  expect(pathname).toBe('/use-cases/network-infrastructure-automation')
 })
 
-test('should use glob-based redirects', async ({ page, context }) => {
+test('should use glob-based redirects', async ({ page, context, baseURL }) => {
   await context.addCookies([
     {
       name: 'io_preview',
       value: 'consul',
-      url: 'http://localhost:3000/',
+      url: baseURL,
     },
   ])
   await page.goto('/security/index.html')
-  expect(page.url()).toBe('http://localhost:3000/security')
+  const { pathname } = new URL(page.url())
+  expect(pathname).toBe('/security')
 })

--- a/src/__tests__/e2e/redirects.spec.ts
+++ b/src/__tests__/e2e/redirects.spec.ts
@@ -36,6 +36,6 @@ test('should use glob-based redirects', async ({ page, context }) => {
       url: 'http://localhost:3000/',
     },
   ])
-  await page.goto('/docs/platform/k8s/service-sync')
-  expect(page.url()).toBe('http://localhost:3000/docs/k8s/service-sync')
+  await page.goto('/security/index.html')
+  expect(page.url()).toBe('http://localhost:3000/security')
 })

--- a/src/__tests__/e2e/rewrites.spec.ts
+++ b/src/__tests__/e2e/rewrites.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test'
 
 // This test is primarily to ensure that known dev-portal routes aren't exposed via io sites
-test('should rewrite known dev-portal routes', async ({ page, context }) => {
+test('should rewrite known dev-portal routes', async ({
+  page,
+  context,
+  baseURL,
+}) => {
   await context.addCookies([
     {
       name: 'io_preview',
       value: 'waypoint',
-      url: 'http://localhost:3000',
+      url: baseURL,
     },
   ])
   const response = await page.goto('/vault')


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

This PR switches our E2E test for glob-based redirects to use `/security/index.html` instead of a docs page.

## Why

In E2E tests, the site is running in preview mode, which generates pages on the fly. Due to a combination of factors, this leads to sometimes exceeding the default timeout for page load when we try to hit a `/docs` route (since it needs to fetch the page from the content API). This test failure leads to a flaky test, which isn't a good thing since we want PR authors to have confidence that their changes haven't broken something.

## How

By switching to `/security/index.html`, we can load a page that's generated from local data as opposed to remote data.

## Testing

A passing E2E test without a warning that the glob-based redirects test was flaky will be considered a passing test.

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
