### PR TITLE
Renaming IconTileLogo and ProductIcon product props to productSlug

### DIFF
--- a/src/components/icon-tile-logo/docs.mdx
+++ b/src/components/icon-tile-logo/docs.mdx
@@ -10,43 +10,43 @@ background coloration from [the IconTileLogo documented in the
 HashiCorp Design System](https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components-%5BWIP%5D?node-id=1377%3A11992).
 
 <LiveComponent>{`
-    <IconTileLogo product="waypoint" />
+    <IconTileLogo productSlug="waypoint" />
 `}</LiveComponent>
 
 ## Examples
 
 `hcp`
 
-<IconTileLogo product="hcp" />
+<IconTileLogo productSlug="hcp" />
 
 `boundary`
 
-<IconTileLogo product="boundary" />
+<IconTileLogo productSlug="boundary" />
 
 `consul`
 
-<IconTileLogo product="consul" />
+<IconTileLogo productSlug="consul" />
 
 `nomad`
 
-<IconTileLogo product="nomad" />
+<IconTileLogo productSlug="nomad" />
 
 `packer`
 
-<IconTileLogo product="packer" />
+<IconTileLogo productSlug="packer" />
 
 `terraform`
 
-<IconTileLogo product="terraform" />
+<IconTileLogo productSlug="terraform" />
 
 `vagrant`
 
-<IconTileLogo product="vagrant" />
+<IconTileLogo productSlug="vagrant" />
 
 `vault`
 
-<IconTileLogo product="vault" />
+<IconTileLogo productSlug="vault" />
 
 `waypoint`
 
-<IconTileLogo product="waypoint" />
+<IconTileLogo productSlug="waypoint" />

--- a/src/components/icon-tile-logo/index.tsx
+++ b/src/components/icon-tile-logo/index.tsx
@@ -18,7 +18,7 @@ function IconTileLogo({ product }: IconTileLogoProps): React.ReactElement {
       size="extra-large"
       brandColor={product == 'hcp' ? 'neutral' : product}
     >
-      <ProductIcon product={product} />
+      <ProductIcon productSlug={product} />
     </IconTile>
   )
 }

--- a/src/components/icon-tile-logo/index.tsx
+++ b/src/components/icon-tile-logo/index.tsx
@@ -1,5 +1,5 @@
-import ProductIcon from 'components/product-icon'
 import IconTile from 'components/icon-tile'
+import ProductIcon from 'components/product-icon'
 import { IconTileLogoProps } from './types'
 
 /**
@@ -12,7 +12,7 @@ import { IconTileLogoProps } from './types'
  *
  * ref: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components-%5BWIP%5D?node-id=1377%3A11992
  */
-function IconTileLogo({ product }: IconTileLogoProps): React.ReactElement {
+function IconTileLogo({ product }: IconTileLogoProps) {
   return (
     <IconTile
       size="extra-large"

--- a/src/components/icon-tile-logo/index.tsx
+++ b/src/components/icon-tile-logo/index.tsx
@@ -12,13 +12,13 @@ import { IconTileLogoProps } from './types'
  *
  * ref: https://www.figma.com/file/noyY6dUMDYjmySpHcMjhkN/HDS-Product---Components-%5BWIP%5D?node-id=1377%3A11992
  */
-function IconTileLogo({ product }: IconTileLogoProps) {
+function IconTileLogo({ productSlug }: IconTileLogoProps) {
   return (
     <IconTile
       size="extra-large"
-      brandColor={product == 'hcp' ? 'neutral' : product}
+      brandColor={productSlug == 'hcp' ? 'neutral' : productSlug}
     >
-      <ProductIcon productSlug={product} />
+      <ProductIcon productSlug={productSlug} />
     </IconTile>
   )
 }

--- a/src/components/icon-tile-logo/types.ts
+++ b/src/components/icon-tile-logo/types.ts
@@ -1,5 +1,5 @@
 import { ProductSlug } from 'types/products'
 
 export interface IconTileLogoProps {
-  product: Exclude<ProductSlug, 'sentinel'>
+  productSlug: Exclude<ProductSlug, 'sentinel'>
 }

--- a/src/components/product-card-grid/index.tsx
+++ b/src/components/product-card-grid/index.tsx
@@ -36,14 +36,14 @@ function CardGridSection({ title, products }): ReactElement {
                 {hasLogo && (
                   <ProductIcon
                     className={s.sectionBodyCardLogo}
-                    product={slug}
+                    productSlug={slug}
                   />
                 )}
                 <span className={s.sectionBodyCardHeading}>
                   {headingIcon && (
                     <ProductIcon
                       className={s.sectionBodyCardHeadingIcon}
-                      product={slug}
+                      productSlug={slug}
                     />
                   )}
                   {heading}

--- a/src/components/product-icon/docs.mdx
+++ b/src/components/product-icon/docs.mdx
@@ -2,40 +2,40 @@
 componentName: 'ProductIcon'
 ---
 
-The `ProductIcon` component accepts a `product` slug, and renders the product's icon. Note that for `product="sentinel"`, `null` will be returned rather than an icon component.
+The `ProductIcon` component accepts a `productSlug`, and renders the product's icon. Note that for `productSlug="sentinel"`, `null` will be returned rather than an icon component.
 
-<LiveComponent>{`<ProductIcon product="terraform"/>`}</LiveComponent>
+<LiveComponent>{`<ProductIcon productSlug="terraform"/>`}</LiveComponent>
 
 ## Examples
 
-`product="terraform"`
+`productSlug="terraform"`
 
-<ProductIcon product="terraform" />
+<ProductIcon productSlug="terraform" />
 
-`product="vault"`
+`productSlug="vault"`
 
-<ProductIcon product="vault" />
+<ProductIcon productSlug="vault" />
 
-`product="consul"`
+`productSlug="consul"`
 
-<ProductIcon product="consul" />
+<ProductIcon productSlug="consul" />
 
-`product="nomad"`
+`productSlug="nomad"`
 
-<ProductIcon product="nomad" />
+<ProductIcon productSlug="nomad" />
 
-`product="packer"`
+`productSlug="packer"`
 
-<ProductIcon product="packer" />
+<ProductIcon productSlug="packer" />
 
-`product="vagrant"`
+`productSlug="vagrant"`
 
-<ProductIcon product="vagrant" />
+<ProductIcon productSlug="vagrant" />
 
-`product="waypoint"`
+`productSlug="waypoint"`
 
-<ProductIcon product="waypoint" />
+<ProductIcon productSlug="waypoint" />
 
-`product="boundary"`
+`productSlug="boundary"`
 
-<ProductIcon product="boundary" />
+<ProductIcon productSlug="boundary" />

--- a/src/components/product-icon/index.tsx
+++ b/src/components/product-icon/index.tsx
@@ -7,12 +7,7 @@ import { IconTerraformColor16 } from '@hashicorp/flight-icons/svg-react/terrafor
 import { IconVagrantColor16 } from '@hashicorp/flight-icons/svg-react/vagrant-color-16'
 import { IconVaultColor16 } from '@hashicorp/flight-icons/svg-react/vault-color-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
-import { ProductSlug } from 'types/products'
-
-// TODO: is there a programmatic way to build this from productNamesToIcons?
-interface ProductIconProps {
-  product: ProductSlug
-}
+import { ProductIconProps } from './types'
 
 const productNamesToIcons = {
   boundary: IconBoundaryColor16,
@@ -27,14 +22,13 @@ const productNamesToIcons = {
   waypoint: IconWaypointColor16,
 }
 
-const ProductIcon: React.FC<
-  ProductIconProps & React.HTMLProps<SVGSVGElement>
-> = ({ product, ...rest }) => {
-  const Icon = productNamesToIcons[product]
+const ProductIcon = ({ productSlug, ...rest }: ProductIconProps) => {
+  const Icon = productNamesToIcons[productSlug]
   if (!Icon) {
     return null
   }
   return <Icon {...rest} />
 }
 
+export type { ProductIconProps }
 export default ProductIcon

--- a/src/components/product-icon/types.ts
+++ b/src/components/product-icon/types.ts
@@ -1,0 +1,7 @@
+import { ProductSlug } from 'types/products'
+
+type SvgElementProps = JSX.IntrinsicElements['svg']
+
+export interface ProductIconProps extends SvgElementProps {
+  productSlug: ProductSlug
+}

--- a/src/components/product-switcher/index.tsx
+++ b/src/components/product-switcher/index.tsx
@@ -164,7 +164,7 @@ const ProductSwitcher: React.FC = () => {
           <span className={s.focusContainer}>
             <ProductIcon
               className={s[`${product.slug}ProductIcon`]}
-              product={product.slug}
+              productSlug={product.slug}
             />
             <span>{product.name}</span>
           </span>
@@ -214,7 +214,7 @@ const ProductSwitcher: React.FC = () => {
         <span className={s.switcherOptionContainer}>
           <ProductIcon
             className={s[`${currentProduct?.slug}ProductIcon`]}
-            product={currentProduct?.slug}
+            productSlug={currentProduct?.slug}
           />
           <span>{currentProduct ? currentProduct.name : 'Products'}</span>
         </span>

--- a/src/components/tutorial-meta/components/badges/components/badge/index.tsx
+++ b/src/components/tutorial-meta/components/badges/components/badge/index.tsx
@@ -62,7 +62,7 @@ export function renderProductBadges(
 ) {
   return productDisplayOptions.map((p: ProductDisplayOption) => (
     <BadgeWrapper key={p.slug}>
-      <ProductIcon product={p.slug} className={s.icon} />
+      <ProductIcon productSlug={p.slug} className={s.icon} />
       {p.label}
     </BadgeWrapper>
   ))

--- a/src/components/version-context-switcher/index.tsx
+++ b/src/components/version-context-switcher/index.tsx
@@ -51,7 +51,7 @@ const VersionContextSwitcher = ({
   return (
     <div className={s.root}>
       <span className={s.productIcon}>
-        <ProductIcon product={productIconSlug} />
+        <ProductIcon productSlug={productIconSlug} />
       </span>
       <select
         aria-label="Choose a different version to install"

--- a/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
@@ -49,7 +49,7 @@ const FeaturedTutorialsSection = ({
               </div>
               <div className={s.cardIcons}>
                 <IconPlay16 />
-                <ProductIcon product={currentProduct.slug} />
+                <ProductIcon productSlug={currentProduct.slug} />
               </div>
             </CardLink>
           )

--- a/src/views/product-downloads-view/components/page-header/index.tsx
+++ b/src/views/product-downloads-view/components/page-header/index.tsx
@@ -20,7 +20,7 @@ const PageHeader = (): ReactElement => {
   return (
     <div className={s.root}>
       <IconTileLogo
-        product={
+        productSlug={
           currentProduct.slug === 'sentinel' ? 'hcp' : currentProduct.slug
         }
       />

--- a/src/views/product-landing/components/get-started/index.tsx
+++ b/src/views/product-landing/components/get-started/index.tsx
@@ -25,7 +25,7 @@ function GetStarted({
               <IconHashicorp16 />
             </IconTile>
           ) : (
-            <IconTileLogo product={product} />
+            <IconTileLogo productSlug={product} />
           )}
         </div>
         <div className={s.textSection}>


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambrename-product-props-hashicorp.vercel.app) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renames `ProductIcon`'s `product` prop to `productSlug`
- Renames `IconTileLogo`'s `product` prop to `productSlug`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This refactor makes these component APIs clearer and prevents having to look beyond the name of the prop.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

First renamed the prop in the component APIs, then did a codebase search for uses of the components to update them.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

The following should have no change in functionality:

- [ ] `IconTileLogo` in product downloads views
- [ ] `IconTileLogo` in product landing views
- [ ] `ProductIcon` in `ProductSwitcher`
- [ ] `ProductIcon` in `VersionContextSwitcher` in product landing views
- [ ] `ProductIcon` in the featured tutorials section of product downloads views
- [ ] `ProductIcon` in `TutorialMeta` in tutorial views
- [ ] `ProductIcon` in `ProductCardGrid` in the home page

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

This PR is part of the work I did in #228, but separating out so that PR isn't so large.