### PR TITLE
fix: filterVersions for terraform page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "react-intersection-observer": "^8.33.1",
         "react-player": "^2.9.0",
         "rivet-graphql": "^0.3.1",
+        "semver": "^7.3.5",
         "slugify": "^1.6.4",
         "swingset": "^0.11.0",
         "unified": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "react-intersection-observer": "^8.33.1",
     "react-player": "^2.9.0",
     "rivet-graphql": "^0.3.1",
+    "semver": "^7.3.5",
     "slugify": "^1.6.4",
     "swingset": "^0.11.0",
     "unified": "^9.2.0",

--- a/src/lib/fetch-release-data.ts
+++ b/src/lib/fetch-release-data.ts
@@ -73,7 +73,7 @@ export function getLatestVersionFromVersions(versions: string[]): string {
  */
 export function generateStaticProps(
   product: Product | string
-): Promise<{ props: GeneratedProps; revalidate?: number | boolean }> {
+): Promise<{ props: GeneratedProps; revalidate: number }> {
   let productSlug: string
   if (typeof product === 'string') {
     productSlug = product

--- a/src/lib/fetch-release-data.ts
+++ b/src/lib/fetch-release-data.ts
@@ -1,4 +1,3 @@
-import { GetStaticPropsResult } from 'next'
 import semverSort from 'semver/functions/rsort'
 import { Products as HashiCorpProduct } from '@hashicorp/platform-product-meta'
 import { Product } from 'types/products'
@@ -74,7 +73,7 @@ export function getLatestVersionFromVersions(versions: string[]): string {
  */
 export function generateStaticProps(
   product: Product | string
-): Promise<GetStaticPropsResult<GeneratedProps>> {
+): Promise<{ props: GeneratedProps; revalidate?: number | boolean }> {
   let productSlug: string
   if (typeof product === 'string') {
     productSlug = product

--- a/src/pages/terraform/downloads/index.tsx
+++ b/src/pages/terraform/downloads/index.tsx
@@ -1,18 +1,22 @@
 import { ReactElement } from 'react'
 import { GetStaticProps } from 'next'
-import semverGte from 'semver/functions/gte'
+import semverSatisfies from 'semver/functions/satisfies'
 import semverMajor from 'semver/functions/major'
 import semverMinor from 'semver/functions/minor'
 import semverPatch from 'semver/functions/patch'
 import terraformData from 'data/terraform.json'
 import installData from 'data/terraform-install.json'
 import { Product } from 'types/products'
-import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
+import {
+  generateStaticProps,
+  GeneratedProps,
+  ReleasesAPIResponse,
+} from 'lib/fetch-release-data'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 import PlaceholderDownloadsView from 'views/placeholder-product-downloads-view'
 
-const VERSION_DOWNLOAD_CUTOFF = '1.0.11'
+const VERSION_DOWNLOAD_CUTOFF = '>=1.0.11'
 
 const TerraformDownloadsPage = (props: GeneratedProps): ReactElement => {
   if (__config.flags.enable_new_downloads_view) {
@@ -30,33 +34,34 @@ const TerraformDownloadsPage = (props: GeneratedProps): ReactElement => {
 }
 
 /**
- * Pulled from terraform-website/pages/downloads/index.jsx on 3/9/2022:
+ * Pulled from terraform-website/pages/downloads/index.jsx on 2022-03-09:
  * https://github.com/hashicorp/terraform-website/blob/master/pages/downloads/index.jsx#L55-L98
+ *
+ * Modified 2022-03-28 to replace semverGte with semverSatisfies,
+ * as the former seemed to return pre-releases, which is not what we want.
  */
-function filterOldVersions(props) {
-  if (!props?.props?.releases?.versions) {
-    return props
-  }
-
-  const versions = props.props.releases.versions
-
-  // versions is in the form of { [version]: { ...metadata } }
+function filterVersions(
+  versions: ReleasesAPIResponse['versions'],
+  versionRange: string
+): ReleasesAPIResponse['versions'] {
   // Filter by arbitrary & reasonable version cutoff
-  const filteredVersions = Object.keys(versions).filter((version) => {
-    if (!semverGte(version, VERSION_DOWNLOAD_CUTOFF)) {
-      return false
+  const filteredVersions = Object.keys(versions).filter(
+    (versionNumber: string) => {
+      console.log({
+        versionNumber,
+        satisfies: semverSatisfies(versionNumber, versionRange),
+      })
+      return semverSatisfies(versionNumber, versionRange)
     }
-    return true
-  })
-
-  /** @type {{[x: string]:{ [y: string]: any}}} */
-  const tree = {}
+  )
 
   /**
    * Computes the latest patch versions for each major/minor
-   * e.g. given [1.1.2, 1.1.1, 1.1.0, 1.0.9, 1.0.8] -> return [1.1.2, 1.0.9]
+   * e.g. given [1.1.2, 1.1.1, 1.1.0, 1.0.9, 1.0.8]
+   * return [1.1.2, 1.0.9]
    */
-  filteredVersions.forEach((v) => {
+  const tree: { [x: number]: { [y: number]: number } } = {}
+  filteredVersions.forEach((v: string) => {
     const x = semverMajor(v)
     const y = semverMinor(v)
     const z = semverPatch(v)
@@ -70,23 +75,30 @@ function filterOldVersions(props) {
     }
   })
 
-  const newVersions = {}
-
+  // Turn the reduced tree of latest patches only into an array
+  const latestPatchesOnly = []
   Object.entries(tree).forEach(([x, xObj]) => {
     Object.entries(xObj).forEach(([y, z]) => {
-      const version = `${x}.${y}.${z}`
-      newVersions[version] = versions[version]
+      latestPatchesOnly.push(`${x}.${y}.${z}`)
     })
   })
 
-  props.props.releases.versions = newVersions
+  // Turn the array of latest patches only into an object with release data
+  const filteredVersionsObj = {}
+  latestPatchesOnly.forEach((versionNumber: string) => {
+    filteredVersionsObj[versionNumber] = versions[versionNumber]
+  })
+  return filteredVersionsObj
 }
 
 export const getStaticProps: GetStaticProps = async () => {
   const product = terraformData as Product
   const generatedProps = await generateStaticProps(product)
 
-  filterOldVersions(generatedProps)
+  // Filter versions based on VERSION_DOWNLOAD_CUTOFF
+  const rawVersions = generatedProps.props?.releases?.versions
+  const filteredVersions = filterVersions(rawVersions, VERSION_DOWNLOAD_CUTOFF)
+  generatedProps.props.releases.versions = filteredVersions
 
   return generatedProps
 }

--- a/src/pages/terraform/downloads/index.tsx
+++ b/src/pages/terraform/downloads/index.tsx
@@ -47,10 +47,6 @@ function filterVersions(
   // Filter by arbitrary & reasonable version cutoff
   const filteredVersions = Object.keys(versions).filter(
     (versionNumber: string) => {
-      console.log({
-        versionNumber,
-        satisfies: semverSatisfies(versionNumber, versionRange),
-      })
       return semverSatisfies(versionNumber, versionRange)
     }
   )


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsfix-semver-filter-versions-hashicorp.vercel.app/terraform/downloads) 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1202035288193775/f) 🎟️

## What

Fixes an issue where the `filterVersions` function for `terraform/downloads` let through pre-release versions.

## Why

With pre-releases included after `filterVersions`, we'd end up with `undefined` values in the staticProps result, which causes build errors.

## How

- Switches from `semverGte` to `semverSatisfies`. This seems to fix the issue, though requires us to specify a range (eg `>=1.0.11`) rather than a version (eg `1.0.11`) as we did previously.
    - If desired we could retain the prop as a version eg `1.0.11` and prefix it with `>=` within `filterVersions`. However I felt passing a range instead felt a bit more transparent.
- Also did some light refactoring of `filterVersions`, adding types, and making it less side-effect-y
   
## Testing

Same as #171:

- [ ] Go to https://dev-portal-git-zsfix-semver-filter-versions-hashicorp.vercel.app/terraform/downloads
- [ ] Make sure the version selected has limited versions as options
    - Specifically, we expect to see `1.0.11` and `1.1.7 (latest)`
- [ ] Make sure the rest of the page renders how you expect

## Anything else?

Not that I can think of!
