### PR TITLE
patch: only build tutorials where collection is also theme

### DIFF
--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -89,8 +89,12 @@ export async function getTutorialPagePaths(
   product: ProductOption
 ): Promise<TutorialPagePaths[]> {
   const allCollections = await getAllCollections({ product })
+  // Only build collections where this product is the main 'theme'
+  // @TODO once we implement the `theme` query option, remove the theme filtering
+  // https://app.asana.com/0/1201903760348480/1201932088801131/f
+  const filteredCollections = allCollections.filter((c) => c.theme === product)
   // go through all collections, get the collection slug
-  const paths = allCollections.flatMap((collection) => {
+  const paths = filteredCollections.flatMap((collection) => {
     const collectionSlug = splitProductFromFilename(collection.slug)
     // go through the tutorials within this collection, create a path for each
     return collection.tutorials.map((tutorial) => {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

Patch a build error for non themed collection tutorials being built even if they feature a current product. This is related to the [WAF rollout](https://github.com/hashicorp/learn/pull/4461)

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
