### PR TITLE
Fix typo in Helm example

### DIFF
--- a/src/pages/_proxied-dot-io/waypoint/index.tsx
+++ b/src/pages/_proxied-dot-io/waypoint/index.tsx
@@ -116,7 +116,7 @@ function HomePage(): JSX.Element {
     <span class="token keyword">chart</span> = "\${<span class="token keyword">path</span>.app}<span class="token string">/chart</span>"
     <span class="token keyword">set</span> {
       <span class="token keyword">name</span>  = <span class="token string">"deployment.image"</span>
-      <span class="token keyword">value</span> = artfact.name
+      <span class="token keyword">value</span> = artifact.name
     }
   }
 }`}


### PR DESCRIPTION
Fixes a typo in the Docker + Helm example, where `artifact` is printed as "artfact"