### PR TITLE
feat: add VideoEmbed to tutorial view

### DIFF
--- a/src/components/video-embed/docs.mdx
+++ b/src/components/video-embed/docs.mdx
@@ -1,0 +1,61 @@
+---
+componentName: VideoEmbed
+---
+
+# Video Embed
+
+Powered by [React Player](https://github.com/CookPete/react-player), this component allows you to embed videos from the following hosts:
+
+- youtube
+- facebook
+- soundcloud
+- vimeo
+- wistia
+- mixcloud
+- dailymotion
+- twitch
+- local files
+
+## Usage
+
+### Adding a Video to a Tutorial (Default)
+
+Add a `video_id` and `video_host` to your Tutorial's frontmatter and it will automatically be prepended to the top of the tutorial.
+
+```yml
+name: Getting Started
+video_id: uxglzsJkBJg
+video_host: youtube
+```
+
+### Adding a Video Inline in a Tutorial
+
+If you want to specify where the video is displayed within your Tutorial, include the `<VideoEmbed />` component directly. A special `video` variable is available within the body of your Markdown content, containing the URL derived from your `video_id` and `video_host`:
+
+```mdx
+<!-- Within your .mdx file, after the Front-Matter -->
+
+### Video Example
+
+Follow along in this video:
+
+<!--  *video* is a constant which resolves to  'https://youtube.com/watch?v=uxglzsJkBJg' here >
+<VideoEmbed url={video} />
+```
+
+You can also just pass a regular URL - for example, if you have multiple videos on one page:
+
+```mdx
+### Another Video Example
+
+<VideoEmbed url="https://hashicorp.wistia.com/medias/abc123" />
+```
+
+### Customizing the Player
+
+Since this component is built off on top of [React Player](https://github.com/CookPete/react-player), it can be extremely customized. You can see the full list of `Props` that the `VideoEmbed` can accept at the [React Player Readme](https://github.com/CookPete/react-player#props).
+
+Additionally, there is a special prop - `start` - where you can set the start offset time for the video, in seconds. This works for Youtube and Wistia video URLs. It may work with other video hosts.
+
+Example:
+`<VideoEmbed url={video} start={1477} />`

--- a/src/components/video-embed/index.tsx
+++ b/src/components/video-embed/index.tsx
@@ -1,14 +1,43 @@
-function VideoEmbed({ url }) {
+import ReactPlayer from 'react-player'
+import { VideoEmbedProps } from './types'
+import s from './video-embed.module.css'
+
+export default function VideoEmbed({
+  start,
+  ...reactPlayerProps
+}: VideoEmbedProps) {
+  function track(event: string) {
+    window.heap?.track(event, {
+      url: reactPlayerProps.url,
+    })
+  }
+
+  //  propagating aliased `start` prop down to the actual player config
+  const config = start
+    ? {
+        youtube: {
+          playerVars: {
+            start,
+          },
+        },
+        wistia: {
+          options: { time: start },
+        },
+      }
+    : {}
+
   return (
-    <pre
-      style={{
-        border: '1px solid magenta',
-        background: `rgba(255,0,255, 0.2)`,
-      }}
-    >
-      <code>{JSON.stringify({ videoEmbed: { url } }, null, 2)}</code>
-    </pre>
+    <div className={s.playerWrapper}>
+      <ReactPlayer
+        config={config}
+        {...reactPlayerProps}
+        onStart={() => track('Video Started')}
+        onEnded={() => track('Video Ended')}
+        className={s.reactPlayer}
+        width="100%"
+        height="100%"
+        controls
+      />
+    </div>
   )
 }
-
-export default VideoEmbed

--- a/src/components/video-embed/index.tsx
+++ b/src/components/video-embed/index.tsx
@@ -1,0 +1,14 @@
+function VideoEmbed({ url }) {
+  return (
+    <pre
+      style={{
+        border: '1px solid magenta',
+        background: `rgba(255,0,255, 0.2)`,
+      }}
+    >
+      <code>{JSON.stringify({ videoEmbed: { url } }, null, 2)}</code>
+    </pre>
+  )
+}
+
+export default VideoEmbed

--- a/src/components/video-embed/types.ts
+++ b/src/components/video-embed/types.ts
@@ -1,0 +1,8 @@
+import { ReactPlayerProps } from 'react-player'
+
+export interface VideoEmbedProps extends ReactPlayerProps {
+  /**
+   * Optional starting time for the video. Works with YouTube and Wistia video URLS.
+   */
+  start?: number
+}

--- a/src/components/video-embed/types.ts
+++ b/src/components/video-embed/types.ts
@@ -1,5 +1,9 @@
 import { ReactPlayerProps } from 'react-player'
 
+/**
+ * For ReactPlayerProps documentation, see:
+ * https://github.com/CookPete/react-player#props
+ */
 export interface VideoEmbedProps extends ReactPlayerProps {
   /**
    * Optional starting time for the video. Works with YouTube and Wistia video URLS.

--- a/src/components/video-embed/video-embed.module.css
+++ b/src/components/video-embed/video-embed.module.css
@@ -1,0 +1,10 @@
+.playerWrapper {
+  position: relative;
+  padding-top: 56.25%; /* Player ratio: 100 / (1280 / 720) */
+}
+
+.reactPlayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+}

--- a/src/components/video-embed/video-embed.module.css
+++ b/src/components/video-embed/video-embed.module.css
@@ -1,10 +1,15 @@
 .playerWrapper {
-  position: relative;
+  margin-bottom: 24px;
   padding-top: 56.25%; /* Player ratio: 100 / (1280 / 720) */
+  position: relative;
 }
 
 .reactPlayer {
+  background-color: white;
+  border-radius: 6px;
+  box-shadow: var(--token-surface-base-box-shadow);
+  left: 0;
+  overflow: hidden;
   position: absolute;
   top: 0;
-  left: 0;
 }

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -76,6 +76,7 @@ export default function TutorialView({
     video,
     collectionCtx,
   } = tutorial
+  const hasVideo = Boolean(video)
   const isInteractive = Boolean(handsOnLab)
   const InteractiveLabWrapper = isInteractive ? InstruqtProvider : Fragment
   const nextPreviousData = getNextPrevious({
@@ -111,8 +112,8 @@ export default function TutorialView({
             readTime,
             edition,
             productsUsed,
-            isInteractive: Boolean(handsOnLab),
-            hasVideo: Boolean(video),
+            isInteractive,
+            hasVideo,
           }}
         />
         <pre
@@ -122,7 +123,7 @@ export default function TutorialView({
         >
           <code>{JSON.stringify({ video }, null, 2)}</code>
         </pre>
-        {video.id && !video.videoInline && (
+        {hasVideo && video.id && !video.videoInline && (
           <VideoEmbed
             url={getVideoUrl({ videoId: video.id, videoHost: video.videoHost })}
           />

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -19,7 +19,9 @@ import {
   NextPrevious,
   getNextPrevious,
 } from './components'
+import getVideoUrl from './utils/get-video-url'
 import TutorialMeta from 'components/tutorial-meta'
+import VideoEmbed from 'components/video-embed'
 
 export interface TutorialViewProps {
   tutorial: TutorialData
@@ -113,6 +115,18 @@ export default function TutorialView({
             hasVideo: Boolean(video),
           }}
         />
+        <pre
+          style={{
+            border: '1px solid magenta',
+          }}
+        >
+          <code>{JSON.stringify({ video }, null, 2)}</code>
+        </pre>
+        {video.id && !video.videoInline && (
+          <VideoEmbed
+            url={getVideoUrl({ videoId: video.id, videoHost: video.videoHost })}
+          />
+        )}
         <MDXRemote {...content} components={MDX_COMPONENTS} />
         <NextPrevious {...nextPreviousData} />
         <FeaturedInCollections collections={collectionCtx.featuredIn} />

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -116,13 +116,6 @@ export default function TutorialView({
             hasVideo,
           }}
         />
-        <pre
-          style={{
-            border: '1px solid magenta',
-          }}
-        >
-          <code>{JSON.stringify({ video }, null, 2)}</code>
-        </pre>
         {hasVideo && video.id && !video.videoInline && (
           <VideoEmbed
             url={getVideoUrl({ videoId: video.id, videoHost: video.videoHost })}

--- a/src/views/tutorial-view/utils/mdx-components.tsx
+++ b/src/views/tutorial-view/utils/mdx-components.tsx
@@ -2,6 +2,7 @@ import codeBlockPrimitives from '@hashicorp/react-code-block/mdx'
 import Tabs, { Tab } from 'components/tabs' // @TODO note that this doesn't support groups yet
 import ImageConfig from 'components/image-config'
 import Image from 'components/image'
+import VideoEmbed from 'components/video-embed'
 
 /**
  * @TODO move over these components from learn, update to new spec
@@ -25,6 +26,7 @@ const MDX_COMPONENTS = {
   CodeTabs,
   ImageConfig,
   img: Image,
+  VideoEmbed,
 }
 
 export default MDX_COMPONENTS


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview - at top of page][preview-in-meta] 🔎
- [Preview - inline in MDX][preview-inline] 🔎
- [Asana task][task] 🎟️

## What

This PR adds the `VideoEmbed` component for `/tutorials` views.

## Why

To move the `/tutorials` views towards matching design specifications.

## How

- Ports over existing logic from `learn` on using `video.videoInline` to determine whether to display the `VideoEmbed` component at the top of the tutorial (right after `TutorialMeta`), or instead inline in the tutorial (if authors have used `VideoEmbed` inline)
- Ports of the existing `VideoEmbed` component from `learn` (mainly `react-player` under the hood)
- Adds minor styling details based on most recent design specs
    - Adds `6px` border radius
    - Adds `--token-surface-base-box-shadow`

## Testing

- [ ] Visit a tutorial view with a video, but without `VideoEmbed` inline, and confirm the video renders at the top of the page, underneath `TutorialMeta`
    - Example: [`/vault/tutorials/getting-started/getting-started-install`][preview-in-meta] (vs [live site][preview-in-meta_live] for comparison)
- [ ] Visit a tutorial view that uses `VideoEmbed` inline, and confirm the video is rendering in the correct part of the page
    - Example: [`/vault/tutorials/app-integration/agent-aws`][preview-inline] (vs [live site][preview-inline_live] for comparison)

## Anything else?

Note that it is technically possible for `VideoEmbed` to be used with an arbitrary URL (rather than the `video` variable provided in MDX scope when `video_id` & `video_host` are present in frontmatter).

However, according to SourceGraph we don't have arbitrary URLs in use with `VideoEmbed` in any of our content - [we only ever use `url={video}`](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+VideoEmbed+url%3D&patternType=literal).

If this use case does end up being used, I think we'll still have a relatively high degree of confidence that the component will render as expected, at least for YouTube or Wistia URLs.

[task]: https://app.asana.com/0/1201987349274776/1202016460311392/f
[preview-in-meta]: https://dev-portal-git-zstutorial-video-embed-hashicorp.vercel.app/vault/tutorials/getting-started/getting-started-install
[preview-in-meta_live]: https://learn.hashicorp.com/tutorials/vault/getting-started-install
[preview-inline]: https://dev-portal-git-zstutorial-video-embed-hashicorp.vercel.app/vault/tutorials/app-integration/agent-aws
[preview-inline_live]: https://learn.hashicorp.com/tutorials/vault/agent-aws