### PR TITLE
fix: increase packer checklist specificity

### DIFF
--- a/src/components/_proxied-dot-io/packer/checklist/style.module.css
+++ b/src/components/_proxied-dot-io/packer/checklist/style.module.css
@@ -1,5 +1,5 @@
 .root {
-  & ul {
+  & ul:not([class]) {
     list-style: none;
     margin-left: 2rem;
 


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1202043114644951/f) 🎟️

## What

Increases the specificity of the `ul` declaration for Packer's `<Checklist>` component.

## Why

Our content styles had a list selector with a higher specificity, causing rendering errors.

## How

By mirroring our convention to only apply styles to elements matching `:not([class])`. This matches the specificity of our content styles, and since our component styles are loaded later, they are used.

## Testing

- Go to preview URL
- Choose Packer in product selector
- Go to this URL
- Scroll to "Checklist" heading
- Ensure that the blue checkmarks don't look funky

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
