### PR TITLE
feat: next prev tutorial chrome

### DIFF
--- a/src/components/card-link/index.tsx
+++ b/src/components/card-link/index.tsx
@@ -9,7 +9,7 @@ const CardLink = ({
   children,
   className,
   href,
-  'aria-label': ariaLabel,
+  ariaLabel,
 }: CardLinkProps): ReactElement => {
   const classes = classNames(s.root, className)
 

--- a/src/components/card-link/index.tsx
+++ b/src/components/card-link/index.tsx
@@ -9,13 +9,12 @@ const CardLink = ({
   children,
   className,
   href,
-  as,
   'aria-label': ariaLabel,
 }: CardLinkProps): ReactElement => {
   const classes = classNames(s.root, className)
 
   return (
-    <MaybeInternalLink href={href} as={as} aria-label={ariaLabel}>
+    <MaybeInternalLink href={href} aria-label={ariaLabel}>
       <Card className={classes}>{children}</Card>
     </MaybeInternalLink>
   )

--- a/src/components/card-link/index.tsx
+++ b/src/components/card-link/index.tsx
@@ -9,12 +9,13 @@ const CardLink = ({
   children,
   className,
   href,
+  as,
   'aria-label': ariaLabel,
 }: CardLinkProps): ReactElement => {
   const classes = classNames(s.root, className)
 
   return (
-    <MaybeInternalLink href={href} aria-label={ariaLabel}>
+    <MaybeInternalLink href={href} as={as} aria-label={ariaLabel}>
       <Card className={classes}>{children}</Card>
     </MaybeInternalLink>
   )

--- a/src/components/card-link/index.tsx
+++ b/src/components/card-link/index.tsx
@@ -9,11 +9,12 @@ const CardLink = ({
   children,
   className,
   href,
+  'aria-label': ariaLabel,
 }: CardLinkProps): ReactElement => {
   const classes = classNames(s.root, className)
 
   return (
-    <MaybeInternalLink href={href}>
+    <MaybeInternalLink href={href} aria-label={ariaLabel}>
       <Card className={classes}>{children}</Card>
     </MaybeInternalLink>
   )

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -20,7 +20,7 @@ export interface CardLinkProps {
   /**
    * Optional decorator for the path that will be shown in the browser URL bar.
    */
-  as?: string
+  as?: LinkProps['as']
 
   /**
    * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -1,3 +1,4 @@
+import { LinkProps } from 'next/link'
 import { ReactNode } from 'react'
 
 export interface CardLinkProps {
@@ -15,6 +16,11 @@ export interface CardLinkProps {
    * The destination of the link.
    */
   href: string
+
+  /**
+   * Optional decorator for the path that will be shown in the browser URL bar.
+   */
+  as?: string
 
   /**
    * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -1,5 +1,5 @@
-import { MaybeInternalLinkProps } from 'components/maybe-internal-link/types'
 import { ReactNode } from 'react'
+import { MaybeInternalLinkProps } from 'components/maybe-internal-link'
 
 export interface CardLinkProps {
   /**

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -20,5 +20,5 @@ export interface CardLinkProps {
   /**
    * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.
    */
-  'aria-label'?: string
+  ariaLabel?: string
 }

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -15,4 +15,9 @@ export interface CardLinkProps {
    * The destination of the link.
    */
   href: string
+
+  /**
+   * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.
+   */
+  'aria-label'?: string
 }

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -18,7 +18,9 @@ export interface CardLinkProps {
   href: string
 
   /**
-   * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.
+   * An optional string value that labels the link. For use when content visible
+   * in the DOM meant to give the link meaning is either missing, or does not
+   * accurately describe the link.
    */
   ariaLabel?: MaybeInternalLinkProps['aria-label']
 }

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -18,11 +18,6 @@ export interface CardLinkProps {
   href: string
 
   /**
-   * Optional decorator for the path that will be shown in the browser URL bar.
-   */
-  as?: LinkProps['as']
-
-  /**
    * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.
    */
   'aria-label'?: string

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -1,4 +1,4 @@
-import { LinkProps } from 'next/link'
+import { MaybeInternalLinkProps } from 'components/maybe-internal-link/types'
 import { ReactNode } from 'react'
 
 export interface CardLinkProps {
@@ -20,5 +20,5 @@ export interface CardLinkProps {
   /**
    * An optional string value that labels the link. For use when content visible in the DOM meant to give the link meaning is either missing, or does not accurately describe the link.
    */
-  ariaLabel?: string
+  ariaLabel?: MaybeInternalLinkProps['aria-label']
 }

--- a/src/components/maybe-internal-link/index.tsx
+++ b/src/components/maybe-internal-link/index.tsx
@@ -3,10 +3,7 @@ import Link from 'next/link'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import { MaybeInternalLinkProps } from './types'
 
-function MaybeInternalLink({
-  href,
-  ...rest
-}: MaybeInternalLinkProps): React.ReactElement {
+function MaybeInternalLink({ href, ...rest }: MaybeInternalLinkProps) {
   const Elem = isAbsoluteUrl(href) ? InternalLink : 'a'
   return <Elem href={href} {...rest} />
 }

--- a/src/components/maybe-internal-link/index.tsx
+++ b/src/components/maybe-internal-link/index.tsx
@@ -5,16 +5,15 @@ import { MaybeInternalLinkProps } from './types'
 
 function MaybeInternalLink({
   href,
-  as,
   ...rest
 }: MaybeInternalLinkProps): React.ReactElement {
   const Elem = isAbsoluteUrl(href) ? InternalLink : 'a'
   return <Elem href={href} {...rest} />
 }
 
-function InternalLink({ href, as, ...rest }: MaybeInternalLinkProps) {
+function InternalLink({ href, ...rest }: MaybeInternalLinkProps) {
   return (
-    <Link href={href} as={as}>
+    <Link href={href}>
       {/* Disabling anchor-has-content, children is in ...rest  */}
       {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
       <a {...rest} />

--- a/src/components/maybe-internal-link/index.tsx
+++ b/src/components/maybe-internal-link/index.tsx
@@ -1,20 +1,20 @@
+import React from 'react'
 import Link from 'next/link'
 import isAbsoluteUrl from 'lib/is-absolute-url'
-import React from 'react'
+import { MaybeInternalLinkProps } from './types'
 
 function MaybeInternalLink({
   href,
+  as,
   ...rest
-}: {
-  href: string
-} & React.HTMLProps<HTMLAnchorElement>): React.ReactElement {
+}: MaybeInternalLinkProps): React.ReactElement {
   const Elem = isAbsoluteUrl(href) ? InternalLink : 'a'
   return <Elem href={href} {...rest} />
 }
 
-function InternalLink({ href, ...rest }) {
+function InternalLink({ href, as, ...rest }: MaybeInternalLinkProps) {
   return (
-    <Link href={href}>
+    <Link href={href} as={as}>
       {/* Disabling anchor-has-content, children is in ...rest  */}
       {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
       <a {...rest} />

--- a/src/components/maybe-internal-link/index.tsx
+++ b/src/components/maybe-internal-link/index.tsx
@@ -18,4 +18,5 @@ function InternalLink({ href, ...rest }: MaybeInternalLinkProps) {
   )
 }
 
+export type { MaybeInternalLinkProps }
 export default MaybeInternalLink

--- a/src/components/maybe-internal-link/types.ts
+++ b/src/components/maybe-internal-link/types.ts
@@ -1,3 +1,5 @@
-export type MaybeInternalLinkProps = {
-  href: string
-} & React.HTMLProps<HTMLAnchorElement>
+type AnchorElementProps = JSX.IntrinsicElements['a']
+
+export interface MaybeInternalLinkProps extends AnchorElementProps {
+  href: AnchorElementProps['href']
+}

--- a/src/components/maybe-internal-link/types.ts
+++ b/src/components/maybe-internal-link/types.ts
@@ -1,6 +1,3 @@
-import { LinkProps } from 'next/link'
-
 export type MaybeInternalLinkProps = {
   href: string
-  as?: LinkProps['as']
-} & Omit<React.HTMLProps<HTMLAnchorElement>, 'as'>
+} & React.HTMLProps<HTMLAnchorElement>

--- a/src/components/maybe-internal-link/types.ts
+++ b/src/components/maybe-internal-link/types.ts
@@ -1,0 +1,6 @@
+import { LinkProps } from 'next/link'
+
+export type MaybeInternalLinkProps = {
+  href: string
+  as?: LinkProps['as']
+} & React.HTMLProps<HTMLAnchorElement>

--- a/src/components/maybe-internal-link/types.ts
+++ b/src/components/maybe-internal-link/types.ts
@@ -3,4 +3,4 @@ import { LinkProps } from 'next/link'
 export type MaybeInternalLinkProps = {
   href: string
   as?: LinkProps['as']
-} & React.HTMLProps<HTMLAnchorElement>
+} & Omit<React.HTMLProps<HTMLAnchorElement>, 'as'>

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -7,7 +7,7 @@ const Text: React.FC<TextProps> = ({
   size = 300,
   weight = 'regular',
   ...rest
-}) => {
+}: TextProps) => {
   const className = classNames(
     s.root,
     `hds-typography-body-${size}`,

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -6,7 +6,7 @@
   justify-content: center;
   height: 100%;
 
-  @media (min-width: 729px) {
+  @media (--dev-dot-tablet-up) {
     &.direction-previous {
       text-align: left;
       justify-content: flex-start;

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -5,37 +5,29 @@
 
   @media (--medium-up) {
     &.direction-previous {
-      text-align: left;
       justify-content: flex-start;
     }
 
     &.direction-next,
     &.direction-final {
-      text-align: right;
       justify-content: flex-end;
     }
   }
 }
 
 .icon {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-
-  & svg {
-    display: block;
-  }
+  display: block;
 
   @media (--medium-up) {
     &.direction-previous {
       order: 0;
-      margin-right: 12px;
+      margin-right: 8px;
     }
 
     &.direction-next,
     &.direction-final {
       order: 1;
-      margin-left: 12px;
+      margin-left: 8px;
     }
   }
 }

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -6,7 +6,7 @@
   justify-content: center;
   height: 100%;
 
-  @media (--dev-dot-tablet-up) {
+  @media (min-width: 729px) {
     &.direction-previous {
       text-align: left;
       justify-content: flex-start;

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -1,60 +1,18 @@
-.card {
-  border: 1px solid magenta; /** @TODO style these to spec, remove any prev imp styles necessary - https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Dev-Portal?node-id=6298%3A73041 */
-  position: relative;
-  display: block;
-  background: var(--white);
-  border-radius: 5px;
-  margin: 0;
-  padding: 20px;
-}
-
-/* visually hidden */
-.hidden {
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 .linkbox {
-  composes: card;
   display: flex;
   align-items: center;
-  width: 100%;
-  background-color: var(--white);
-  color: var(--black);
-  box-shadow: var(--token-surface-mid-box-shadow);
-  transition: box-shadow 0.3s;
+  justify-content: center;
 
-  &[data-direction='previous'] {
-    text-align: left;
-    justify-content: flex-start;
-    &:hover {
-      box-shadow: var(--token-surface-high-box-shadow);
-    }
-  }
-
-  &[data-direction='next'],
-  &[data-direction='final'] {
-    text-align: right;
-    justify-content: flex-end;
-
-    &:hover {
-      box-shadow: var(--token-surface-high-box-shadow);
-    }
-  }
-
-  @media (--small) {
-    &[data-direction='previous'] {
-      justify-content: center;
+  @media (--medium-up) {
+    &.direction-previous {
+      text-align: left;
+      justify-content: flex-start;
     }
 
-    &[data-direction='next'],
-    &[data-direction='final'] {
-      justify-content: center;
+    &.direction-next,
+    &.direction-final {
+      text-align: right;
+      justify-content: flex-end;
     }
   }
 }
@@ -63,39 +21,29 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  color: var(--black);
 
-  & > div {
-    display: flex;
+  & svg {
+    display: block;
   }
 
-  &[data-direction='previous'] {
-    order: 0;
-    margin-right: 12px;
-  }
-
-  &[data-direction='next'],
-  &[data-direction='final'] {
-    order: 1;
-    margin-left: 12px;
-  }
-
-  @media (--small) {
-    &[data-direction='previous'] {
-      margin-right: 0;
+  @media (--medium-up) {
+    &.direction-previous {
+      order: 0;
+      margin-right: 12px;
     }
 
-    &[data-direction='next'],
-    &[data-direction='final'] {
-      margin-left: 0;
+    &.direction-next,
+    &.direction-final {
+      order: 1;
+      margin-left: 12px;
     }
   }
 }
 
 .text {
-  text-decoration: none;
+  display: none;
 
-  @media (--small) {
-    display: none;
+  @media (--medium-up) {
+    display: block;
   }
 }

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -33,3 +33,7 @@
     margin-left: 8px;
   }
 }
+
+.text {
+  color: var(--token-color-foreground-primary);
+}

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -6,7 +6,7 @@
   justify-content: center;
   height: 100%;
 
-  @media (--medium-up) {
+  @media (--dev-dot-tablet-up) {
     &.direction-previous {
       text-align: left;
       justify-content: flex-start;

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -1,4 +1,5 @@
 .linkbox {
+  color: var(--token-color-foreground-primary);
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -1,15 +1,20 @@
 .linkbox {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  text-align: center;
   justify-content: center;
+  height: 100%;
 
   @media (--medium-up) {
     &.direction-previous {
+      text-align: left;
       justify-content: flex-start;
     }
 
     &.direction-next,
     &.direction-final {
+      text-align: right;
       justify-content: flex-end;
     }
   }
@@ -18,24 +23,14 @@
 .icon {
   display: block;
 
-  @media (--medium-up) {
-    &.direction-previous {
-      order: 0;
-      margin-right: 8px;
-    }
-
-    &.direction-next,
-    &.direction-final {
-      order: 1;
-      margin-left: 8px;
-    }
+  &.direction-previous {
+    order: 0;
+    margin-right: 8px;
   }
-}
 
-.text {
-  display: none;
-
-  @media (--medium-up) {
-    display: block;
+  &.direction-next,
+  &.direction-final {
+    order: 1;
+    margin-left: 8px;
   }
 }

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/directional-link-box.module.css
@@ -24,7 +24,6 @@
   display: block;
 
   &.direction-previous {
-    order: 0;
     margin-right: 8px;
   }
 

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
 import { IconArrowLeft16 } from '@hashicorp/flight-icons/svg-react/arrow-left-16'
-import { IconSliders24 } from '@hashicorp/flight-icons/svg-react/sliders-24'
+import { IconSliders16 } from '@hashicorp/flight-icons/svg-react/sliders-16'
 import CardLink from 'components/card-link'
 import Text from 'components/text'
 import { DirectionalLinkBoxProps, DirectionOption } from './types'
@@ -11,7 +11,7 @@ import s from './directional-link-box.module.css'
 const IconDict: { [k in DirectionOption]: typeof IconArrowRight16 } = {
   next: IconArrowRight16,
   previous: IconArrowLeft16,
-  final: IconSliders24,
+  final: IconSliders16,
 }
 
 function DirectionalLinkBox({

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -29,7 +29,7 @@ function DirectionalLinkBox({
       ariaLabel={ariaLabel}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />
-      <Text asElement="span" size={200} weight="medium">
+      <Text className={s.text} asElement="span" size={200} weight="medium">
         {label}
       </Text>
     </CardLink>

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -26,7 +26,7 @@ function DirectionalLinkBox({
     <CardLink
       className={classNames(s.linkbox, s[`direction-${direction}`])}
       href={href}
-      aria-label={title}
+      ariaLabel={title}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />
       <Text asElement="span" size={200} weight="medium">

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -15,25 +15,17 @@ const IconDict: { [k in DirectionOption]: typeof IconArrowRight16 } = {
 }
 
 function DirectionalLinkBox({
-  link,
+  href,
   label,
   title,
   direction,
 }: DirectionalLinkBoxProps) {
   const Icon = IconDict[direction]
 
-  /**
-   * DirectionalLinkBox accepts link.href to match next/link.
-   * When passing href to CardLink, we need to make sure href is a string.
-   */
-  const { href, as } = link
-  const hrefString = typeof href == 'string' ? href : href.toString()
-
   return (
     <CardLink
       className={classNames(s.linkbox, s[`direction-${direction}`])}
-      href={hrefString}
-      as={as}
+      href={href}
       aria-label={title}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -29,7 +29,7 @@ function DirectionalLinkBox({
       aria-label={title}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />
-      <Text asElement="span" className={s.text} size={200} weight="medium">
+      <Text asElement="span" size={200} weight="medium">
         {label}
       </Text>
     </CardLink>

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -1,16 +1,8 @@
 import React from 'react'
-import Link, { LinkProps } from 'next/link'
+import Link from 'next/link'
 import InlineSvg from '@hashicorp/react-inline-svg'
 import s from './directional-link-box.module.css'
-
-interface DirectionalLinkBoxProps {
-  link: LinkProps
-  label: string
-  title: string
-  direction: DirectionOption
-}
-
-type DirectionOption = 'next' | 'previous' | 'final'
+import { DirectionalLinkBoxProps, DirectionOption } from './types'
 
 const IconSrcDict: { [k in DirectionOption]: string } = {
   next: require(`@hashicorp/flight-icons/svg/arrow-right-16.svg?include`),

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -21,11 +21,19 @@ function DirectionalLinkBox({
   direction,
 }: DirectionalLinkBoxProps) {
   const Icon = IconDict[direction]
+
+  /**
+   * DirectionalLinkBox accepts link.href to match next/link.
+   * When passing href to CardLink, we need to make sure href is a string.
+   */
+  const { href, as } = link
+  const hrefString = typeof href == 'string' ? href : href.toString()
+
   return (
     <CardLink
       className={classNames(s.linkbox, s[`direction-${direction}`])}
-      href={String(link.href)}
-      as={String(link.as)}
+      href={hrefString}
+      as={as}
       aria-label={title}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -17,7 +17,7 @@ const IconDict: { [k in DirectionOption]: typeof IconArrowRight16 } = {
 function DirectionalLinkBox({
   href,
   label,
-  title,
+  ariaLabel,
   direction,
 }: DirectionalLinkBoxProps) {
   const Icon = IconDict[direction]
@@ -26,7 +26,7 @@ function DirectionalLinkBox({
     <CardLink
       className={classNames(s.linkbox, s[`direction-${direction}`])}
       href={href}
-      ariaLabel={title}
+      ariaLabel={ariaLabel}
     >
       <Icon className={classNames(s.icon, s[`direction-${direction}`])} />
       <Text asElement="span" size={200} weight="medium">

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -1,20 +1,18 @@
 import React from 'react'
-import InlineSvg from '@hashicorp/react-inline-svg'
 import classNames from 'classnames'
-import s from './directional-link-box.module.css'
-import { DirectionalLinkBoxProps, DirectionOption } from './types'
+import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
+import { IconArrowLeft16 } from '@hashicorp/flight-icons/svg-react/arrow-left-16'
+import { IconSliders24 } from '@hashicorp/flight-icons/svg-react/sliders-24'
 import CardLink from 'components/card-link'
+import Text from 'components/text'
+import { DirectionalLinkBoxProps, DirectionOption } from './types'
+import s from './directional-link-box.module.css'
 
-const IconSrcDict: { [k in DirectionOption]: string } = {
-  next: require(`@hashicorp/flight-icons/svg/arrow-right-16.svg?include`),
-  previous: require(`@hashicorp/flight-icons/svg/arrow-left-16.svg?include`),
-  final: require(`@hashicorp/flight-icons/svg/sliders-24.svg?include`),
+const IconDict: { [k in DirectionOption]: typeof IconArrowRight16 } = {
+  next: IconArrowRight16,
+  previous: IconArrowLeft16,
+  final: IconSliders24,
 }
-
-/*
- * @TODO style to spec
- * look at the `CardLink` component to use for base styles!
- */
 
 function DirectionalLinkBox({
   link,
@@ -22,17 +20,18 @@ function DirectionalLinkBox({
   title,
   direction,
 }: DirectionalLinkBoxProps) {
+  const Icon = IconDict[direction]
   return (
     <CardLink
       className={classNames(s.linkbox, s[`direction-${direction}`])}
-      href={`${link.href}`}
-      as={`${link.as}`}
+      href={String(link.href)}
+      as={String(link.as)}
       aria-label={title}
     >
-      <span className={classNames(s.icon, s[`direction-${direction}`])}>
-        <InlineSvg src={IconSrcDict[direction]} />
-      </span>
-      <span className={s.text}>{label}</span>
+      <Icon className={classNames(s.icon, s[`direction-${direction}`])} />
+      <Text asElement="span" className={s.text} size={200} weight="medium">
+        {label}
+      </Text>
     </CardLink>
   )
 }

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import Link from 'next/link'
 import InlineSvg from '@hashicorp/react-inline-svg'
+import classNames from 'classnames'
 import s from './directional-link-box.module.css'
 import { DirectionalLinkBoxProps, DirectionOption } from './types'
+import CardLink from 'components/card-link'
 
 const IconSrcDict: { [k in DirectionOption]: string } = {
   next: require(`@hashicorp/flight-icons/svg/arrow-right-16.svg?include`),
@@ -22,17 +23,17 @@ function DirectionalLinkBox({
   direction,
 }: DirectionalLinkBoxProps) {
   return (
-    <Link href={link.href} as={link.as}>
-      <a className={s.linkbox} data-direction={direction}>
-        <span className={s.icon} data-direction={direction}>
-          <InlineSvg src={IconSrcDict[direction]} />
-        </span>
-        <span className={s.text}>
-          <span aria-hidden="true">{label}</span>
-          <span className={s.hidden}>{title}</span>
-        </span>
-      </a>
-    </Link>
+    <CardLink
+      className={classNames(s.linkbox, s[`direction-${direction}`])}
+      href={`${link.href}`}
+      as={`${link.as}`}
+      aria-label={title}
+    >
+      <span className={classNames(s.icon, s[`direction-${direction}`])}>
+        <InlineSvg src={IconSrcDict[direction]} />
+      </span>
+      <span className={s.text}>{label}</span>
+    </CardLink>
   )
 }
 

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
@@ -1,9 +1,7 @@
-import { LinkProps } from 'next/link'
-
 export type DirectionOption = 'next' | 'previous' | 'final'
 
 export interface DirectionalLinkBoxProps {
-  link: LinkProps
+  href: string
   label: string
   title: string
   direction: DirectionOption

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
@@ -1,4 +1,5 @@
-import { CardLinkProps } from 'components/card-link/types'
+import { CardLinkProps } from 'components/card-link'
+
 export type DirectionOption = 'next' | 'previous' | 'final'
 
 export interface DirectionalLinkBoxProps {

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
@@ -1,0 +1,10 @@
+import { LinkProps } from 'next/link'
+
+export type DirectionOption = 'next' | 'previous' | 'final'
+
+export interface DirectionalLinkBoxProps {
+  link: LinkProps
+  label: string
+  title: string
+  direction: DirectionOption
+}

--- a/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
+++ b/src/views/tutorial-view/components/next-previous/components/directional-link-box/types.ts
@@ -1,8 +1,9 @@
+import { CardLinkProps } from 'components/card-link/types'
 export type DirectionOption = 'next' | 'previous' | 'final'
 
 export interface DirectionalLinkBoxProps {
-  href: string
+  href: CardLinkProps['href']
   label: string
-  title: string
+  ariaLabel: CardLinkProps['ariaLabel']
   direction: DirectionOption
 }

--- a/src/views/tutorial-view/components/next-previous/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/index.tsx
@@ -31,7 +31,7 @@ export function NextPrevious({
       return (
         <DirectionalLinkBox
           label="Previous"
-          link={{ href: tutorial.previous.path }}
+          href={tutorial.previous.path}
           direction={'previous'}
           title={`Go to previous tutorial: ${tutorial.previous.name}`}
         />
@@ -44,7 +44,7 @@ export function NextPrevious({
      */
     return (
       <DirectionalLinkBox
-        link={{ href: collection.current.path }}
+        href={collection.current.path}
         label="Back to Collection"
         direction={'previous'}
         title={`Go back to collection: ${collection.current.name}`}
@@ -58,7 +58,7 @@ export function NextPrevious({
       return (
         <DirectionalLinkBox
           label="Next"
-          link={{ href: tutorial.next.path }}
+          href={tutorial.next.path}
           direction="next"
           title={`Go to next tutorial: ${tutorial.next.name}`}
         />
@@ -80,9 +80,7 @@ export function NextPrevious({
     if (collection.isLast) {
       return (
         <DirectionalLinkBox
-          link={{
-            href: finalLink,
-          }}
+          href={finalLink}
           label="Browse Tutorials"
           direction="final"
           title="Browse Tutorials"
@@ -96,7 +94,7 @@ export function NextPrevious({
      */
     return (
       <DirectionalLinkBox
-        link={{ href: collection.next.path }}
+        href={collection.next.path}
         label="Next Collection"
         direction="next"
         title={`Go to next collection: ${collection.next.name}`}

--- a/src/views/tutorial-view/components/next-previous/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/index.tsx
@@ -33,7 +33,7 @@ export function NextPrevious({
           label="Previous"
           href={tutorial.previous.path}
           direction={'previous'}
-          title={`Go to previous tutorial: ${tutorial.previous.name}`}
+          ariaLabel={`Go to previous tutorial: ${tutorial.previous.name}`}
         />
       )
     }
@@ -47,7 +47,7 @@ export function NextPrevious({
         href={collection.current.path}
         label="Back to Collection"
         direction={'previous'}
-        title={`Go back to collection: ${collection.current.name}`}
+        ariaLabel={`Go back to collection: ${collection.current.name}`}
       />
     )
   }
@@ -60,7 +60,7 @@ export function NextPrevious({
           label="Next"
           href={tutorial.next.path}
           direction="next"
-          title={`Go to next tutorial: ${tutorial.next.name}`}
+          ariaLabel={`Go to next tutorial: ${tutorial.next.name}`}
         />
       )
     }
@@ -83,7 +83,7 @@ export function NextPrevious({
           href={finalLink}
           label="Browse Tutorials"
           direction="final"
-          title="Browse Tutorials"
+          ariaLabel="Browse Tutorials"
         />
       )
     }
@@ -97,7 +97,7 @@ export function NextPrevious({
         href={collection.next.path}
         label="Next Collection"
         direction="next"
-        title={`Go to next collection: ${collection.next.name}`}
+        ariaLabel={`Go to next collection: ${collection.next.name}`}
       />
     )
   }

--- a/src/views/tutorial-view/components/next-previous/next-previous.module.css
+++ b/src/views/tutorial-view/components/next-previous/next-previous.module.css
@@ -1,5 +1,8 @@
 .linkBoxWrapper {
+  border-top: 1px solid var(--token-color-border-primary);
   display: grid;
-  grid-template-columns: 1fr 1fr;
   grid-gap: 24px;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 48px;
+  padding-top: 48px;
 }


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link][/vault/tutorials/tokens/token-management] 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1202016460396717/f) 🎟️

## What

Refines styling and implementation of "Next / Previous" links in the `tutorials` end-of-page UX.

## Why

To match design specs as we build out the chromed UI for the `/tutorials` view.

## How

- Adds support for `ariaLabel` and `next/link` `as` to `CardLink`
- Refactors `DirectionalLinkBox` to use `CardLink` under the hood
- Refactors `DirectionalLinkBox` to use React icons from Flight rather than `InlineSvg`

## Testing

> Note: next & previous functionality has been validated in #226. Additional validation is never a bad thing, but for the purpose of this PR, feel free to focus on the design spec only.

Visit pages with each of the "Next / Previous" end-of-page variations, and ensure they match [the design spec](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Dev-Portal?node-id=6298%3A73041).

- [ ] starting tutorial: "back to collection / next": [/vault/tutorials/adp/transform][/vault/tutorials/adp/transform]
- [ ] middle tutorial: "previous / next": [/vault/tutorials/getting-started-ui/getting-started-auth-ui][/vault/tutorials/getting-started-ui/getting-started-auth-ui]
- [ ] end tutorial: "previous / next collection": [/vault/tutorials/encryption-as-a-service/eaas-spring-demo][/vault/tutorials/encryption-as-a-service/eaas-spring-demo]
- [ ] final collection end tutorial: "previous / browse tutorials": [/vault/tutorials/tokens/token-management][/vault/tutorials/tokens/token-management]

## Anything else?

The mobile implementation matches the design spec, but may feel off due to the long “next collection” and “back to collection” text (which I couldn't find in the design spec; they may not have been accounted for).

We could refine the mobile styles further in future iterations where we have more bandwidth to focus on the mobile experience. For example, we could make the longer text buttons wrap to a new line. However, this would likely require additional design input.

Previewing content on mobile is difficult, so it's difficult to see the exact behaviour of next / previous on small viewports:
- Swingset does not support responsive design mode
- `SidebarSidecarLayout` does not support small screens, so custom style overrides are needed to give an approximate preview of mobile behaviour

To see what this difference looks like, expand the `Design spec` & `Implementation` detail sections below:

<details>
<summary>Design spec</summary>

<img width="644" alt="design-spec" src="https://user-images.githubusercontent.com/4624598/161585268-ff4797ec-95ed-4568-b723-15a3c8f30f10.png">


</details>

<details>
<summary>Implementation</summary>

In most cases, `Previous` & `Next` appear, and look fine:

<img width="371" alt="CleanShot 2022-04-04 at 12 03 11@2x" src="https://user-images.githubusercontent.com/4624598/161585225-e81c672c-b3a3-4e7e-b81b-8a019419a681.png">

At the start or end of collections, longer text appears, which causes awkward wrapping: 

<img width="361" alt="CleanShot 2022-04-04 at 12 02 22@2x" src="https://user-images.githubusercontent.com/4624598/161585247-3f54f990-b696-4e96-9b33-7ad6fdf9e1c3.png">

</details>

[/vault/tutorials/adp/transform]: https://dev-portal-git-zstutorial-next-prev-chrome-hashicorp.vercel.app/vault/tutorials/adp/transform
[/vault/tutorials/getting-started-ui/getting-started-auth-ui]: https://dev-portal-git-zstutorial-next-prev-chrome-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-auth-ui
[/vault/tutorials/encryption-as-a-service/eaas-spring-demo]: https://dev-portal-git-zstutorial-next-prev-chrome-hashicorp.vercel.app/vault/tutorials/encryption-as-a-service/eaas-spring-demo
[/vault/tutorials/tokens/token-management]: https://dev-portal-git-zstutorial-next-prev-chrome-hashicorp.vercel.app/vault/tutorials/tokens/token-management