### PR TITLE
fix: importFrom to expose custom-media for use

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,42 @@
+const platformPostcssConfig = require('@hashicorp/platform-postcss-config')
+
+/**
+ * TODO: this is a spike to show that this configuration may resolve
+ * the issues we're having in dev-dot when using @custom-media.
+ * We likely want to incorporate this into `@hashicorp/platform-postcss-config`.
+ * Eg, maybe it should accept an optional "options" object, where we can
+ * pass additional files to `importFrom`?
+ */
+function alsoImportDevDotCustomMedia(postcssConfig) {
+  const newPlugins = postcssConfig.plugins.map((p) => {
+    // we only want to modify postcss-preset-env
+    const isPresetEnv =
+      Array.isArray(p) && p.length == 2 && p[0] == 'postcss-preset-env'
+    if (!isPresetEnv) return p
+    // we want to modify the postcss-preset-env settings object,
+    // which we expect as a second part of a tuple in the plugin array entry.
+    // specifically, we want to add to the "importFrom" setting.
+    const existingImportFrom = p[1].features['custom-media-queries'].importFrom
+    const alsoImportFrom = require.resolve('./src/styles/custom-media.css')
+    const newImportFrom = [alsoImportFrom].concat(existingImportFrom)
+    // tack the newImportFrom on to the existing settings,
+    // while retaining the rest of the settings
+    const newPresetEnvSettings = {
+      ...p[1],
+      features: {
+        ...p[1].features,
+        'custom-media-queries': {
+          ...p[1].features['custom-media-queries'],
+          importFrom: newImportFrom,
+        },
+      },
+    }
+    return ['postcss-preset-env', newPresetEnvSettings]
+  })
+  // return the modified config
+  return { ...postcssConfig, plugins: newPlugins }
+}
+
 module.exports = {
-  ...require('@hashicorp/platform-postcss-config'),
+  ...alsoImportDevDotCustomMedia(platformPostcssConfig),
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -25,7 +25,7 @@ function alsoImportDevDotCustomMedia(postcssConfig) {
     const newImportFrom = [alsoImportFrom].concat(existingImportFrom)
     // tack the newImportFrom on to the existing settings,
     // while retaining the rest of the settings
-    const newPresetEnvSettings = [...presentEnvOptions]
+    const newPresetEnvSettings = { ...presetEnvOptions }
     newPresetEnvSettings.features['custom-media-queries'].importFrom =
       newImportFrom
     return [presetEnvName, newPresetEnvSettings]

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,30 +8,27 @@ const platformPostcssConfig = require('@hashicorp/platform-postcss-config')
  * pass additional files to `importFrom`?
  */
 function alsoImportDevDotCustomMedia(postcssConfig) {
-  const newPlugins = postcssConfig.plugins.map((p) => {
+  const newPlugins = postcssConfig.plugins.map((plugin) => {
     // we only want to modify postcss-preset-env
     const isPresetEnv =
-      Array.isArray(p) && p.length == 2 && p[0] == 'postcss-preset-env'
-    if (!isPresetEnv) return p
+      Array.isArray(plugin) &&
+      plugin.length == 2 &&
+      plugin[0] == 'postcss-preset-env'
+    if (!isPresetEnv) return plugin
     // we want to modify the postcss-preset-env settings object,
     // which we expect as a second part of a tuple in the plugin array entry.
     // specifically, we want to add to the "importFrom" setting.
-    const existingImportFrom = p[1].features['custom-media-queries'].importFrom
+    const [presetEnvName, presetEnvOptions] = plugin
+    const existingImportFrom =
+      presetEnvOptions.features['custom-media-queries'].importFrom
     const alsoImportFrom = require.resolve('./src/styles/custom-media.css')
     const newImportFrom = [alsoImportFrom].concat(existingImportFrom)
     // tack the newImportFrom on to the existing settings,
     // while retaining the rest of the settings
-    const newPresetEnvSettings = {
-      ...p[1],
-      features: {
-        ...p[1].features,
-        'custom-media-queries': {
-          ...p[1].features['custom-media-queries'],
-          importFrom: newImportFrom,
-        },
-      },
-    }
-    return ['postcss-preset-env', newPresetEnvSettings]
+    const newPresetEnvSettings = [...presentEnvOptions]
+    newPresetEnvSettings.features['custom-media-queries'].importFrom =
+      newImportFrom
+    return [presetEnvName, newPresetEnvSettings]
   })
   // return the modified config
   return { ...postcssConfig, plugins: newPlugins }

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -115,18 +115,8 @@
 }
 
 /*
-***
-* DevDot
-***
-* The custom media and classes below are helpers used in DevDot.
-***
+Mobile & tablet visibility helpers, specific to dev-dot.
 */
-
-@custom-media --dev-dot-mobile only screen and (max-width: 728px);
-@custom-media --dev-dot-tablet only screen and (min-width: 729px) and (max-width: 1000px);
-@custom-media --dev-dot-tablet-up only screen and (min-width: 729px);
-@custom-media --dev-dot-desktop only screen and (min-width: 1001px);
-
 @media (--dev-dot-mobile) {
   .g-hide-on-mobile {
     display: none;

--- a/src/styles/custom-media.css
+++ b/src/styles/custom-media.css
@@ -1,0 +1,12 @@
+/*
+***
+* DevDot
+***
+* The custom media below are helpers used in DevDot.
+***
+*/
+
+@custom-media --dev-dot-mobile only screen and (max-width: 728px);
+@custom-media --dev-dot-tablet only screen and (min-width: 729px) and (max-width: 1000px);
+@custom-media --dev-dot-tablet-up only screen and (min-width: 729px);
+@custom-media --dev-dot-desktop only screen and (min-width: 1001px);

--- a/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/featured-tutorials-section.module.css
@@ -16,11 +16,11 @@ out.
   grid-column-gap: 24px;
   grid-row-gap: 24px;
 
-  @media only screen and (min-width: 729px) and (max-width: 1000px) {
+  @media (--dev-dot-tablet) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media only screen and (max-width: 728px) {
+  @media (--dev-dot-mobile) {
     grid-template-columns: repeat(1, 1fr);
   }
 }


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsimport-postcss-custom-media-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1202080355906373/f) 🎟️

## What

Adds our `custom-media` queries specific to `dev-portal` to our `postcss.config.js`.

## Why

So that we can more reliably use `postcss-custom-media`. For example, `@media (--dev-dot-tablet-up) {}`.

## How

Clones and modifies the imported config from `@hashicorp/platform-postcss-config`

## Testing

- [ ] Visit a tutorial page, such as [`/vault/tutorials/getting-started-ui/getting-started-intro-ui`][tutorial-view], and verify that `TutorialMeta`'s use of `custom-media` still works
    - On viewports larger than 1000px, you should see some media-query styles applied. These indicate that `custom-media` is working as expected
- [ ] Visit an install page, such as [`/waypoint/downloads`][install-view], and verify that `custom-media` on `.cardGrid` works as expected
    - Note: specific `@media` styles will only be visible on viewports less than `1000px`. At viewports wider than `1000px`, there's no expectation to see `@media` styles.

## Anything else?

Nothing urgent. We may later want to support this in `@hashicorp/platform-postcss-config`, but for now this is only use case we have for extending `importFrom`, so we're choosing not to build that abstraction at the moment.

[tutorial-view]: https://dev-portal-git-zsimport-postcss-custom-media-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-intro-ui
[install-view]: https://dev-portal-git-zsimport-postcss-custom-media-hashicorp.vercel.app/waypoint/downloads