### PR TITLE
chore: address broken featured collection links

### DIFF
--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -9,6 +9,8 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
  * reference a different product context
  */
 
+const BETA_PRODUCTS = ['vault', 'waypoint']
+
 export function getTutorialSlug(
   tutorialDbSlug: string,
   collectionDbSlug: string
@@ -20,5 +22,13 @@ export function getTutorialSlug(
 
 export function getCollectionSlug(collectionDbSlug: string): string {
   const [product, collectionFilename] = collectionDbSlug.split('/')
+  const isBetaProduct = BETA_PRODUCTS.indexOf(product) === -1
+
+  // if not a 'sanctioned product', link externally to Learn
+  // interim solution for BETA where not all products are onboarded
+  if (isBetaProduct) {
+    return `https://learn.hashicorp.com/collections/${collectionDbSlug}`
+  }
+
   return `/${product}/tutorials/${collectionFilename}`
 }

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -9,8 +9,6 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
  * reference a different product context
  */
 
-const BETA_PRODUCTS = ['vault', 'waypoint']
-
 export function getTutorialSlug(
   tutorialDbSlug: string,
   collectionDbSlug: string
@@ -22,7 +20,8 @@ export function getTutorialSlug(
 
 export function getCollectionSlug(collectionDbSlug: string): string {
   const [product, collectionFilename] = collectionDbSlug.split('/')
-  const isBetaProduct = BETA_PRODUCTS.indexOf(product) === -1
+  const isBetaProduct =
+    __config.dev_dot.products_with_content_preview_branch.includes(product)
 
   // if not a 'sanctioned product', link externally to Learn
   // interim solution for BETA where not all products are onboarded

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -25,7 +25,7 @@ export function getCollectionSlug(collectionDbSlug: string): string {
 
   // if not a 'sanctioned product', link externally to Learn
   // interim solution for BETA where not all products are onboarded
-  if (isBetaProduct) {
+  if (!isBetaProduct) {
     return `https://learn.hashicorp.com/collections/${collectionDbSlug}`
   }
 

--- a/src/views/product-tutorials-view/helpers.ts
+++ b/src/views/product-tutorials-view/helpers.ts
@@ -1,15 +1,6 @@
 import { Collection as ClientCollection } from 'lib/learn-client/types'
 
 /**
- * Takes db collection slug format: waypoint/get-started --> waypoint/tutorials/get-started
- */
-
-export function getCollectionSlug(dbslug: string): string {
-  const [product, collectionFilename] = dbslug.split('/')
-  return `/${product}/tutorials/${collectionFilename}`
-}
-
-/**
  * This function is an interim solution for filtering content from the /onboarding dir
  * to render on the frontend - esp in the product sitemaps and featured products options
  *

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
-import { getCollectionSlug } from './helpers'
+import { getCollectionSlug } from 'views/collection-view/helpers'
 import { ProductTutorialsPageProps } from './server'
 
 export default function ProductTutorialsView({


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kshandle-non-beta-collection-links-hashicorp.vercel.app/vault/tutorials/cross-products/kubernetes-consul-vault-pipeline#next-steps) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1201991101510148) 🎟️


## What

This PR makes a small workaround so that featured collections in tutorial views don't link to 404 pages. If the product referenced in the collection is not a part of the beta rollout, the featured collection card links externally to Learn. 

This isn't ideal UX, but I think it's _ok_ for the sake of beta. These cards linked to a mix of external and internal routes is a bit odd, but since its not a long term solution I don't think we necessarily need to adjust the cards to support true external linking. Open to feedback on that though. 

Another option woulda be to not render cards for collections that aren't included in dev dot yet 🤷 

## Testing

- [Visit this tutorial,](https://dev-portal-git-kshandle-non-beta-collection-links-hashicorp.vercel.app/vault/tutorials/cross-products/kubernetes-consul-vault-pipeline#next-steps) go to the bottom of the page. Click on the first collection card to validate that internal links still work. Then click on a collection card that says 'terraform logo' and it should link to the proper collection in production Learn.  

