### PR TITLE
chore: adds canonical url to tutorial view

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
+    "production_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 0,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/development.json
+++ b/config/development.json
@@ -4,7 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
-    "production_base_url": "https://developer.hashi-mktg.com",
+    "canonical_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 0,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,6 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
+    "production_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,7 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
-    "production_base_url": "https://developer.hashi-mktg.com",
+    "canonical_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/production.json
+++ b/config/production.json
@@ -4,6 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
+    "base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/production.json
+++ b/config/production.json
@@ -4,7 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
-    "production_base_url": "https://developer.hashi-mktg.com",
+    "canonical_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/config/production.json
+++ b/config/production.json
@@ -4,7 +4,7 @@
     "revalidate": 360
   },
   "dev_dot": {
-    "base_url": "https://developer.hashi-mktg.com",
+    "production_base_url": "https://developer.hashi-mktg.com",
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -71,7 +71,6 @@ export function getCollectionContext(
   currentCollection: ClientCollection,
   collectionCtx: ClientTutorialFullCollectionCtx['collectionCtx']
 ): CollectionContext {
-  const isDefault = currentCollection.id === collectionCtx.default.id
   const featuredIn = collectionCtx.featuredIn
     .filter(
       (c) => c.id !== currentCollection.id && !c.slug.includes('onboarding') // filter out onboarding content for CS team
@@ -79,7 +78,10 @@ export function getCollectionContext(
     .map(formatCollectionCard)
 
   return {
-    isDefault,
+    default: {
+      id: collectionCtx.default.id,
+      slug: collectionCtx.default.slug,
+    },
     current: currentCollection,
     featuredIn,
   }

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -25,7 +25,7 @@ export function generateCanonicalUrl(
   tutorialSlug: string
 ): URL {
   const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
-  const base = 'https://developer.hashi-mktg.com'
+  const base = __config.dev_dot.base_url || 'https://developer.hashi-mktg.com'
   const url = new URL(path, base)
 
   return url

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -25,7 +25,7 @@ export function generateCanonicalUrl(
   tutorialSlug: string
 ): URL {
   const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
-  const base = __config.dev_dot.production_base_url
+  const base = __config.dev_dot.canonical_base_url
   const url = new URL(path, base)
 
   return url

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -19,3 +19,14 @@ export function formatTutorialToMenuItem(
     isActive: path === currentPath,
   }
 }
+
+export function generateCanonicalUrl(
+  defaultCollectionSlug: string,
+  tutorialSlug: string
+): URL {
+  const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
+  const base = 'https://developer.hashi-mktg.com'
+  const url = new URL(path, base)
+
+  return url
+}

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -25,7 +25,7 @@ export function generateCanonicalUrl(
   tutorialSlug: string
 ): URL {
   const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
-  const base = __config.dev_dot.base_url || 'https://developer.hashi-mktg.com'
+  const base = __config?.dev_dot.base_url || 'https://developer.hashi-mktg.com'
   const url = new URL(path, base)
 
   return url

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -25,8 +25,5 @@ export function generateCanonicalUrl(
   tutorialSlug: string
 ): URL {
   const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
-  const base = __config.dev_dot.canonical_base_url
-  const url = new URL(path, base)
-
-  return url
+  return new URL(path, __config.dev_dot.canonical_base_url)
 }

--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -25,7 +25,7 @@ export function generateCanonicalUrl(
   tutorialSlug: string
 ): URL {
   const path = getTutorialSlug(tutorialSlug, defaultCollectionSlug)
-  const base = __config?.dev_dot.base_url || 'https://developer.hashi-mktg.com'
+  const base = __config.dev_dot.production_base_url
   const url = new URL(path, base)
 
   return url


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kstutorial-canonical-url-hashicorp.vercel.app/vault/tutorials/getting-started/getting-started-intro) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202016460311406) 🎟️

## What

This PR adds a canonical url tag and title tag to the tutorial view. 

## Why

Tutorials can belong to numerous collections, the canonical url will ensure that this duplication of pages does not affect SEO by setting the tutorial in the _default_ collection context is referenced as the canonical url. 

## Testing

- [Visit this page](https://dev-portal-git-kstutorial-canonical-url-hashicorp.vercel.app/vault/tutorials/getting-started/getting-started-intro) and check in `head` that the canonical url is set to this page
- [Visit another version](https://dev-portal-git-kstutorial-canonical-url-hashicorp.vercel.app/vault/tutorials/cloud/getting-started-intro) of this tutorial that isn't the default collection, check that the canonical url is still there and the same. 

