### PR TITLE
refactor: move DevDotContent out of SidebarSidecarLayout

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -2,7 +2,6 @@ import { FC, ReactElement } from 'react'
 import BaseLayout from 'layouts/base-new'
 import TableOfContents from 'layouts/sidebar-sidecar/components/table-of-contents'
 import BreadcrumbBar from 'components/breadcrumb-bar'
-import DevDotContent from 'components/dev-dot-content'
 import EditOnGithubLink from 'components/edit-on-github-link'
 import Footer from 'components/footer'
 import Sidebar from 'components/sidebar'
@@ -56,7 +55,7 @@ const SidebarSidecarLayout: FC<SidebarSidecarLayoutProps> = ({
           <div className={s.main}>
             <main id="main">
               {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
-              <DevDotContent>{children}</DevDotContent>
+              {children}
               {githubFileUrl && (
                 <EditOnGithubLink
                   className={s.editOnGithubLink}

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -3,6 +3,7 @@ import { MDXRemote } from 'next-mdx-remote'
 import { useCurrentProduct } from 'contexts'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DevDotContent from 'components/dev-dot-content'
 import { DocsViewProps, ProductsToPrimitivesMap } from './types'
 
 // Author primitives
@@ -59,12 +60,14 @@ const DocsView = ({ mdxSource, lazy }: DocsViewProps) => {
   const components = defaultMdxComponents({ additionalComponents })
 
   return (
-    <MDXRemote
-      compiledSource={compiledSource}
-      components={components}
-      lazy={lazy}
-      scope={scope}
-    />
+    <DevDotContent>
+      <MDXRemote
+        compiledSource={compiledSource}
+        components={components}
+        lazy={lazy}
+        scope={scope}
+      />
+    </DevDotContent>
   )
 }
 

--- a/src/views/placeholder-product-downloads-view/index.tsx
+++ b/src/views/placeholder-product-downloads-view/index.tsx
@@ -4,6 +4,7 @@ import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import Card from 'components/card'
 import Text from 'components/text'
 import s from './placeholder-product-downloads-view.module.css'
+import DevDotContent from 'components/dev-dot-content'
 
 const LOREM_IPSUM =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vitae leo id nunc convallis euismod et vel erat. Fusce vel velit turpis. Vivamus fringilla consequat metus, vitae euismod sem eleifend in. Morbi in ullamcorper dui. Quisque rutrum auctor tristique. Vivamus ac turpis non arcu fringilla interdum. Aliquam feugiat lectus ipsum, eu tincidunt mi tristique id. Aliquam sodales eros semper pharetra molestie. Mauris porta, nunc in tempor eleifend, metus massa sagittis nisi, non maximus quam mauris a erat. Duis nec risus diam. Aenean auctor accumsan ipsum. Interdum et malesuada fames ac ante ipsum primis in faucibus. Fusce et sagittis nunc. Cras vel eros id purus sollicitudin lobortis. Vivamus hendrerit volutpat nulla.'
@@ -41,8 +42,10 @@ const PlaceholderDownloadsView = (): ReactElement => {
       }}
       sidecarSlot={<PlaceholderSidecarContent />}
     >
-      <h1>Install {currentProduct.name}</h1>
-      <p>{LOREM_IPSUM}</p>
+      <DevDotContent>
+        <h1>Install {currentProduct.name}</h1>
+        <p>{LOREM_IPSUM}</p>
+      </DevDotContent>
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -5,6 +5,7 @@ import { ReactElement, useMemo } from 'react'
 import { useCurrentProduct } from 'contexts'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import DevDotContent from 'components/dev-dot-content'
 
 // Local imports
 import {
@@ -80,16 +81,18 @@ const ProductDownloadsViewContent = ({
       breadcrumbLinks={breadcrumbLinks}
       sidecarSlot={<SidecarMarketingCard {...sidecarMarketingCard} />}
     >
-      <PageHeader />
-      <DownloadsSection
-        packageManagers={packageManagers}
-        selectedRelease={releases.versions[currentVersion]}
-        versionSwitcherOptions={versionSwitcherOptions}
-      />
-      <OfficialReleasesSection />
-      {featuredTutorials && (
-        <FeaturedTutorialsSection featuredTutorials={featuredTutorials} />
-      )}
+      <DevDotContent>
+        <PageHeader />
+        <DownloadsSection
+          packageManagers={packageManagers}
+          selectedRelease={releases.versions[currentVersion]}
+          versionSwitcherOptions={versionSwitcherOptions}
+        />
+        <OfficialReleasesSection />
+        {featuredTutorials && (
+          <FeaturedTutorialsSection featuredTutorials={featuredTutorials} />
+        )}
+      </DevDotContent>
     </SidebarSidecarLayout>
   )
 }

--- a/src/views/product-landing/index.tsx
+++ b/src/views/product-landing/index.tsx
@@ -4,6 +4,7 @@ import slugify from 'slugify'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import Heading, { HeadingProps } from 'components/heading'
 import Text from 'components/text'
+import DevDotContent from 'components/dev-dot-content'
 import GetStarted, { GetStartedProps } from './components/get-started'
 import Cards, { CardProps } from './components/cards'
 import s from './product-landing.module.css'
@@ -23,7 +24,7 @@ interface ProductLandingProps {
 
 function ProductLandingView({ content }: ProductLandingProps): ReactElement {
   return (
-    <>
+    <DevDotContent>
       <Heading
         className={s.pageHeading}
         size={500}
@@ -67,7 +68,7 @@ function ProductLandingView({ content }: ProductLandingProps): ReactElement {
           </pre>
         )
       })}
-    </>
+    </DevDotContent>
   )
 }
 

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -9,6 +9,7 @@ import {
 import SidebarSidecarLayout, {
   SidebarSidecarLayoutProps,
 } from 'layouts/sidebar-sidecar'
+import DevDotContent from 'components/dev-dot-content'
 import InstruqtProvider from 'contexts/instruqt-lab'
 import MDX_COMPONENTS from './utils/mdx-components'
 import { formatTutorialToMenuItem } from './utils'
@@ -121,7 +122,9 @@ export default function TutorialView({
             url={getVideoUrl({ videoId: video.id, videoHost: video.videoHost })}
           />
         )}
-        <MDXRemote {...content} components={MDX_COMPONENTS} />
+        <DevDotContent>
+          <MDXRemote {...content} components={MDX_COMPONENTS} />
+        </DevDotContent>
         <NextPrevious {...nextPreviousData} />
         <FeaturedInCollections collections={collectionCtx.featuredIn} />
       </SidebarSidecarLayout>


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsreorganize-content-style-wrapper-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1202088592959488/f) 🎟️

## What

Refactors `SidebarSidecarLayout` so that it does not wrap all `children` in `DevDotContent`.

## Why

To mitigate style leaks, as encountered in eg #257 .

## How

For all views that use `SidebarSidecarLayout`, use `DevDotContent` to wrap whatever would previously have been passed as `children`.

## Testing

Visit a page representing each of the views that uses `SidebarSidecarLayout`:

- [ ] [docs-view][docs-view]
- [ ] [tutorial-view][tutorial-view]
- [ ] [product-landing][product-landing]
- [ ] [product-downloads-view][product-downloads-view]
- [ ] `placeholder-product-downloads-view` - not sure if worth debugging since it's a placeholder; also not sure how to get it to render, so have done what I _think_ will make it work just as before, but otherwise have not tested.

## Anything else?

Not at the moment!

[docs-view]: https://dev-portal-git-zsreorganize-content-style-wrapper-hashicorp.vercel.app/vault/docs/what-is-vault
[tutorial-view]: https://dev-portal-git-zsreorganize-content-style-wrapper-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-policies-ui
[product-landing]: https://dev-portal-git-zsreorganize-content-style-wrapper-hashicorp.vercel.app/vault
[product-downloads-view]: https://dev-portal-git-zsreorganize-content-style-wrapper-hashicorp.vercel.app/vault/downloads