### PR TITLE
fix: featured-in-collections with empty-slot layout

### DIFF
--- a/src/views/tutorial-view/components/featured-in-collections/featured-in-collections.module.css
+++ b/src/views/tutorial-view/components/featured-in-collections/featured-in-collections.module.css
@@ -7,11 +7,22 @@
 }
 
 .listRoot {
+  --min-column-width: 240px;
+
   align-items: stretch;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 24px;
+  display: grid;
+  grid-gap: 24px;
   list-style: none;
+
+  /**
+  * Automatically use more columns, as long as columns are >= min-column-width.
+  * Note: minimum size may be < min-column-width, if 100% < min-column-width.
+  * This ensures that on small viewports, content will never overflow.
+  */
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(100%, var(--min-column-width)), 1fr)
+  );
 
   /**
    * Note: !important is necessary here as we're within a content container
@@ -29,10 +40,6 @@
 }
 
 .listItem {
-  flex-grow: 1;
-  min-width: 240px;
-  width: 0;
-
   /**
    * Note: !important is necessary here as we're within a content container
    * that uses nested generic selectors to style <li />.


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-zspatch-featured-collections-layout-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1201999966887523/f) 🎟️

## What

Makes a small layout modification to `FeaturedInCollections`.

## Why

Design feedback, spec is now defined for previously undefined scenario.

## How

Switches from `flex` layout to `grid` layout.

## Testing

- [x] Visit [a page with one "featured in" collection][one-card], and ensure the cards match the design spec layout
- [x] Visit [a page with two "featured in" collections][two-cards], and ensure the cards match the design spec layout
- [x] Visit a page with three "featured in" collections, and ensure the cards match the design spec layout
    - I couldn't find such a page, so I set up [a story in Storybook][three-cards-storybook] so that I could test the use case, while also seeing responsive behaviour
    - Storybook may also be useful for reviewing responsive behaviour for one-up and two-up layouts.

## Anything else?

Not at the moment.

[one-card]: https://dev-portal-git-zspatch-featured-collections-layout-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-install
[two-cards]: https://dev-portal-git-zspatch-featured-collections-layout-hashicorp.vercel.app/vault/tutorials/secrets-management/vault-pki-consul-connect-ca
[three-cards-storybook]: https://dev-portal-4eo06s5xx-zchsh.vercel.app/?path=/story/components-featuredincollections--three-up