### PR TITLE
Add AllProductData context, useIsBetaProduct hook, and getIsBetaProduct utility

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -7,7 +7,7 @@
     "max_static_paths": 0,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",
-    "products_with_content_preview_branch": ["waypoint", "vault"]
+    "beta_product_slugs": ["waypoint", "vault"]
   },
   "learn": {
     "max_static_paths": 0

--- a/config/preview.json
+++ b/config/preview.json
@@ -7,7 +7,7 @@
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",
-    "products_with_content_preview_branch": ["waypoint", "vault"]
+    "beta_product_slugs": ["waypoint", "vault"]
   },
   "learn": {
     "max_static_paths": 10

--- a/config/production.json
+++ b/config/production.json
@@ -7,7 +7,7 @@
     "max_static_paths": 10,
     "revalidate": 360,
     "content_preview_branch": "dev-portal",
-    "products_with_content_preview_branch": ["waypoint", "vault"]
+    "beta_product_slugs": ["waypoint", "vault"]
   },
   "learn": {
     "max_static_paths": 10

--- a/config/products.ts
+++ b/config/products.ts
@@ -44,4 +44,4 @@ const products: ProductGroup[] = productSwitcherSlugs.map(
   }
 )
 
-export { products }
+export { products, productSlugsToNames }

--- a/src/contexts/all-product-data.tsx
+++ b/src/contexts/all-product-data.tsx
@@ -1,0 +1,97 @@
+import { createContext, ReactNode, useContext, useMemo } from 'react'
+import { ProductSlug } from 'types/products'
+import { productSlugsToNames } from '../../config/products'
+
+/**
+ * Describes the shape of each product's state manged by this Context.
+ */
+interface ProductState {
+  isBetaProduct: boolean
+}
+
+/**
+ * Describes the shape of the state object this Context manages.
+ *
+ * NOTE this cannot be an interface or an error occurs: "A mapped type may not
+ * declare properties or methods"
+ *
+ * see: https://www.typescriptlang.org/docs/handbook/2/mapped-types.html
+ */
+type ContextState = {
+  [key in ProductSlug]?: ProductState
+}
+
+/**
+ * Returns an array of all product slugs.
+ */
+const initializeAllProductSlugs = () => {
+  return Object.keys(productSlugsToNames) as ProductSlug[]
+}
+
+/**
+ * Returns the inital state this Context manages. Currently derives an
+ * `isBetaProduct` boolean for each product, and can be extended here to derive
+ * more booleans in the future.
+ */
+const initalizeState = (allProductSlugs: ProductSlug[]): ContextState => {
+  const result = {}
+
+  // initalize the state object for each product
+  const defaultProductState: ProductState = { isBetaProduct: false }
+  allProductSlugs.forEach(
+    (slug: ProductSlug) => (result[slug] = defaultProductState)
+  )
+
+  // derive `isBetaProduct` state booleans from config
+  const betaProductSlugs = __config.dev_dot.beta_product_slugs
+  betaProductSlugs.forEach((slug: ProductSlug) => {
+    result[slug].isBetaProduct = true
+  })
+
+  return result
+}
+
+const AllProductDataContext = createContext<ContextState>(undefined)
+
+/**
+ * Describes the props interface for this Context's Provider.
+ */
+interface AllProductDataProviderProps {
+  children: ReactNode
+}
+
+/**
+ * Maintains a state object with derived Product data for every Product. Enables
+ * us to derive information about Products (such as `isBetaProduct`) one time
+ * for the entire app, rather than having to derive the same information each
+ * time it is needed.
+ */
+const AllProductDataProvider = ({ children }: AllProductDataProviderProps) => {
+  const allProductSlugs = useMemo(initializeAllProductSlugs, [])
+  // NOTE: can safely disable since `allProductSlugs` is static
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const state: ContextState = useMemo(() => initalizeState(allProductSlugs), [])
+
+  return (
+    <AllProductDataContext.Provider value={state}>
+      {children}
+    </AllProductDataContext.Provider>
+  )
+}
+
+/**
+ * Given a `ProductSlug`, returns `true` if the associated Product is a beta
+ * product and `false` otherwise.
+ */
+const useIsBetaProduct = (productSlug: ProductSlug): boolean => {
+  const context = useContext(AllProductDataContext)
+  if (context === undefined) {
+    throw new Error(
+      'useIsBetaProduct must be used within a CurrentProductProvider'
+    )
+  }
+
+  return context[productSlug].isBetaProduct
+}
+
+export { AllProductDataProvider, useIsBetaProduct }

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,2 +1,3 @@
+export * from './all-product-data'
 export * from './current-product'
 export * from './device-size'

--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -3,7 +3,7 @@ import { getStaticGenerationFunctions as _getStaticGenerationFunctions } from '@
 import RemoteContentLoader from '@hashicorp/react-docs-page/server/loaders/remote-content'
 import { anchorLinks } from '@hashicorp/remark-plugins'
 import { ProductData } from 'types/products'
-import getIsBetaProduct from 'lib/is-beta-product'
+import getIsBetaProduct from 'lib/get-is-beta-product'
 import prepareNavDataForClient from 'layouts/sidebar-sidecar/utils/prepare-nav-data-for-client'
 import getDocsBreadcrumbs from 'components/breadcrumb-bar/utils/get-docs-breadcrumbs'
 
@@ -43,15 +43,15 @@ export function getStaticGenerationFunctions<
   mainBranch?: string
 }): ReturnType<typeof _getStaticGenerationFunctions> {
   /**
-   * These products, defined in our config files, will source content from a long-lived branch named 'dev-portal'
+   * Beta products, defined in our config files, will source content from a
+   * long-lived branch named 'dev-portal'
    */
-  const isProductWithContentPreviewBranch =
-    __config.dev_dot.beta_product_slugs.includes(product.slug)
+  const isBetaProduct = getIsBetaProduct(product.slug)
 
   const loaderOptions: RemoteContentLoader['opts'] = {
     product: productSlugForLoader,
     basePath: basePathForLoader,
-    latestVersionRef: isProductWithContentPreviewBranch
+    latestVersionRef: isBetaProduct
       ? __config.dev_dot.content_preview_branch
       : undefined,
   }

--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -3,6 +3,7 @@ import { getStaticGenerationFunctions as _getStaticGenerationFunctions } from '@
 import RemoteContentLoader from '@hashicorp/react-docs-page/server/loaders/remote-content'
 import { anchorLinks } from '@hashicorp/remark-plugins'
 import { ProductData } from 'types/products'
+import getIsBetaProduct from 'lib/is-beta-product'
 import prepareNavDataForClient from 'layouts/sidebar-sidecar/utils/prepare-nav-data-for-client'
 import getDocsBreadcrumbs from 'components/breadcrumb-bar/utils/get-docs-breadcrumbs'
 
@@ -45,7 +46,7 @@ export function getStaticGenerationFunctions<
    * These products, defined in our config files, will source content from a long-lived branch named 'dev-portal'
    */
   const isProductWithContentPreviewBranch =
-    __config.dev_dot.products_with_content_preview_branch.includes(product.slug)
+    __config.dev_dot.beta_product_slugs.includes(product.slug)
 
   const loaderOptions: RemoteContentLoader['opts'] = {
     product: productSlugForLoader,

--- a/src/lib/get-is-beta-product.ts
+++ b/src/lib/get-is-beta-product.ts
@@ -1,0 +1,14 @@
+import { ProductSlug } from 'types/products'
+
+/**
+ * Given a `ProductSlug`, returns `true` if the associated Product is a beta
+ * product and `false` otherwise. Intended for use in server-side code. If this
+ * data is needed client-side, use the more optimized `useIsProductBeta` hook
+ * provided by `AllProductDataProvider`.
+ */
+const getIsBetaProduct = (productSlug: ProductSlug): boolean => {
+  const betaProductSlugs = __config.dev_dot.beta_product_slugs
+  return betaProductSlugs.some((slug: ProductSlug) => productSlug === slug)
+}
+
+export default getIsBetaProduct

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,7 +5,11 @@ import '@hashicorp/platform-util/nprogress/style.css'
 import { ErrorBoundary } from '@hashicorp/platform-runtime-error-monitoring'
 import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analytics'
 import CodeTabsProvider from '@hashicorp/react-code-block/provider'
-import { CurrentProductProvider, DeviceSizeProvider } from 'contexts'
+import {
+  AllProductDataProvider,
+  CurrentProductProvider,
+  DeviceSizeProvider,
+} from 'contexts'
 import BaseLayout from 'layouts/base'
 import { isDeployPreview, isPreview } from 'lib/env-checks'
 import fetchLayoutProps from 'lib/_proxied-dot-io/fetch-layout-props'
@@ -45,14 +49,16 @@ export default function App({ Component, pageProps, layoutProps }) {
     <SSRProvider>
       <ErrorBoundary FallbackComponent={Error}>
         <DeviceSizeProvider>
-          <CurrentProductProvider currentProduct={currentProduct}>
-            <CodeTabsProvider>
-              <Layout {...allLayoutProps} data={allLayoutProps}>
-                <Component {...pageProps} />
-              </Layout>
-              {showProductSwitcher ? <PreviewProductSwitcher /> : null}
-            </CodeTabsProvider>
-          </CurrentProductProvider>
+          <AllProductDataProvider>
+            <CurrentProductProvider currentProduct={currentProduct}>
+              <CodeTabsProvider>
+                <Layout {...allLayoutProps} data={allLayoutProps}>
+                  <Component {...pageProps} />
+                </Layout>
+                {showProductSwitcher ? <PreviewProductSwitcher /> : null}
+              </CodeTabsProvider>
+            </CurrentProductProvider>
+          </AllProductDataProvider>
         </DeviceSizeProvider>
       </ErrorBoundary>
     </SSRProvider>


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-use-is-beta-hook-hashicorp.vercel.app/waypoint) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renames `products_with_content_preview_branch` config variable to `beta_product_slugs`
- Exports existing `productSlugsToNames` from existing `config/products.ts` file
- Adds `AllProductData` context, which exposes a `useIsBetaProduct` hook
- Updates `src/pages/_app.tsx` to wrap much of the app in `AllProductDataProvider`
- Adds `getIsBetaProduct` utility under `src/lib`
- Uses `getIsBetaProduct` in `src/layouts/sidebar-sidecar/server.ts`

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- In a Slack conversation, it was decided that `beta_product_slugs` is a clearer name than  `products_with_content_preview_branch` in config
- `productSlugsToNames` is needed in the new `AllProductData` Context
- We need a global, DRY, optimized way to determine if a product is a beta product in multiple parts of the application. The existing need in `src/layouts/sidebar-sidecar/server.ts` shows that we need a utility that works in server-side code, and an upcoming need in #267 shows that we need a utility that works in client-side code. There will also be a client-side need in the in-progress primary header navigation refactor so that only beta product links are shown in the menus.
  - `AllProductData` Context solves the client-side need, and handles deriving its state once, which is why I opted for using a Context and handling the deriving there instead of in the `useIsBetaProduct` hook. The hook just handles looking up data and doesn't need to calculate it.
  - `getIsBetaProduct` solves the server-side need. It's less optimized since it calculates the boolean it returns every time it runs, but I think that's probably okay since the server-side code runs much less often than the client-side code.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Not really sure how to explain this one in a way that doesn't repeat too much of the Why section above. Please ask questions though if there are any! 💖

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

There isn't much to test here since the usage is minimal.

- [ ] The build check should pass
- [ ] Pages that use `SidebarSidecarLayout` should still work ([/waypoint](https://dev-portal-git-ambadd-use-is-beta-hook-hashicorp.vercel.app/waypoint) for example)

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- Would like to wait to add tests until after these are used more and we have determined if we want to keep them.
- Can add a follow-up PR for using the new hook in `getCollectionSlug`?
  - BTW @zchsh and @kendallstrautman, I just noticed there are two duplicate helpers by this name. They live in:
    - `src/views/collection-view/helpers.ts`
    - `src/views/product-tutorials-view/helpers.ts`
- Will have a PR Thursday or Friday that uses the new hook in the primary navigation header.