### PR TITLE
feat: collection page sidebar data

### DIFF
--- a/src/lib/learn-client/api/collection/fetch-product-collections.ts
+++ b/src/lib/learn-client/api/collection/fetch-product-collections.ts
@@ -17,8 +17,9 @@ export const PRODUCT_COLLECTION_API_ROUTE = (
  * one tutorial whose primary product (first in frontmatter array)
  * matches this product slug
  *
- * Optional query params will return collections filtered by
- * theme or sorted according to the category sidebar sort
+ * Optional query params will return collections 
+ * sorted according to the category sidebar sort (which automatically
+ * includes filtering for theme
  */
 export async function fetchAllCollectionsByProduct(
   product: AllCollectionsProductOptions

--- a/src/lib/learn-client/api/collection/fetch-product-collections.ts
+++ b/src/lib/learn-client/api/collection/fetch-product-collections.ts
@@ -17,7 +17,7 @@ export const PRODUCT_COLLECTION_API_ROUTE = (
  * one tutorial whose primary product (first in frontmatter array)
  * matches this product slug
  *
- * Optional query params will return collections 
+ * Optional query params will return collections
  * sorted according to the category sidebar sort (which automatically
  * includes filtering for theme
  */

--- a/src/lib/learn-client/api/collection/fetch-product-collections.ts
+++ b/src/lib/learn-client/api/collection/fetch-product-collections.ts
@@ -1,4 +1,9 @@
-import { Collection, uuid, ProductOption } from 'lib/learn-client/types'
+import {
+  Collection,
+  uuid,
+  ProductOption,
+  AllCollectionsProductOptions,
+} from 'lib/learn-client/types'
 import { get, toError } from '../../index'
 
 // /products/:identifier/collections
@@ -11,11 +16,30 @@ export const PRODUCT_COLLECTION_API_ROUTE = (
  * Collections will be product associated if they have at least
  * one tutorial whose primary product (first in frontmatter array)
  * matches this product slug
+ *
+ * Optional query params will return collections filtered by
+ * theme or sorted according to the category sidebar sort
  */
 export async function fetchAllCollectionsByProduct(
-  identifier: ProductOption | uuid
+  product: AllCollectionsProductOptions
 ): Promise<Collection[]> {
-  const route = PRODUCT_COLLECTION_API_ROUTE(identifier)
+  const baseUrl = PRODUCT_COLLECTION_API_ROUTE(product.slug)
+  let route = baseUrl
+  const hasQueryParams = !!(product.sidebarSort || product.filterByTheme)
+
+  if (hasQueryParams) {
+    const params = new URLSearchParams()
+
+    if (product.sidebarSort) {
+      params.append('topLevelCategorySort', 'true')
+    }
+    if (product.filterByTheme) {
+      params.append('theme', product.slug)
+    }
+
+    route = baseUrl + `?${params.toString()}`
+  }
+
   const getProductCollectionsRes = await get(route)
 
   if (getProductCollectionsRes.ok) {

--- a/src/lib/learn-client/api/collection/fetch-product-collections.ts
+++ b/src/lib/learn-client/api/collection/fetch-product-collections.ts
@@ -25,17 +25,12 @@ export async function fetchAllCollectionsByProduct(
 ): Promise<Collection[]> {
   const baseUrl = PRODUCT_COLLECTION_API_ROUTE(product.slug)
   let route = baseUrl
-  const hasQueryParams = !!(product.sidebarSort || product.filterByTheme)
 
-  if (hasQueryParams) {
-    const params = new URLSearchParams()
-
-    if (product.sidebarSort) {
-      params.append('topLevelCategorySort', 'true')
-    }
-    if (product.filterByTheme) {
-      params.append('theme', product.slug)
-    }
+  if (product.sidebarSort) {
+    const params = new URLSearchParams([
+      ['topLevelCategorySort', 'true'],
+      ['theme', product.slug],
+    ])
 
     route = baseUrl + `?${params.toString()}`
   }

--- a/src/lib/learn-client/api/collection/index.ts
+++ b/src/lib/learn-client/api/collection/index.ts
@@ -68,7 +68,7 @@ export async function getAllCollections(
   let collections = []
 
   // check if the product option is valid, i.e. not 'cloud' or 'hashicorp'
-  if (options?.product && themeIsProduct(options.product)) {
+  if (options?.product && themeIsProduct(options.product.slug)) {
     const allCollections = await fetchAllCollectionsByProduct(options.product)
 
     collections = [...allCollections]

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -110,7 +110,13 @@ export interface getAllTutorialsOptions {
 
 export interface getAllCollectionsOptions
   extends Pick<getAllTutorialsOptions, 'limit'> {
-  product?: ProductOption | ThemeOption // If theme option, empty array is returned
+  product?: AllCollectionsProductOptions
+}
+
+export type AllCollectionsProductOptions = {
+  slug: ProductOption | ThemeOption // If theme option, empty array is returned
+  sidebarSort?: boolean
+  filterByTheme?: boolean
 }
 
 /**

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -116,7 +116,6 @@ export interface getAllCollectionsOptions
 export type AllCollectionsProductOptions = {
   slug: ProductOption | ThemeOption // If theme option, empty array is returned
   sidebarSort?: boolean
-  filterByTheme?: boolean
 }
 
 /**

--- a/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticPathsResult } from 'next'
 import vaultData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import TutorialView from 'views/tutorial-view'
 import {
@@ -21,7 +21,7 @@ export function VaultTutorialPage({
 export async function getStaticProps({
   params,
 }): Promise<{ props: TutorialPageProps }> {
-  const product = vaultData as ProductData
+  const product = vaultData as LearnProductData
   return getTutorialPageProps(product, params.tutorialSlug)
 }
 

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -1,5 +1,5 @@
 import vaultData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import CollectionView from 'views/collection-view'
 import {
@@ -19,7 +19,7 @@ export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
   const { collectionSlug } = params
-  const product = vaultData as ProductData
+  const product = vaultData as LearnProductData
   return await getCollectionPageProps(product, collectionSlug)
 }
 

--- a/src/pages/vault/tutorials/index.tsx
+++ b/src/pages/vault/tutorials/index.tsx
@@ -1,5 +1,5 @@
 import productData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getProductTutorialsPageProps,
   ProductTutorialsPageProps,
@@ -16,7 +16,9 @@ export function VaultTutorialHubPage(
 export async function getStaticProps(): Promise<{
   props: ProductTutorialsPageProps
 }> {
-  const props = await getProductTutorialsPageProps(productData as ProductData)
+  const props = await getProductTutorialsPageProps(
+    productData as LearnProductData
+  )
 
   return props
 }

--- a/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticPathsResult } from 'next'
 import waypointData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import TutorialView from 'views/tutorial-view'
 import {
@@ -21,7 +21,7 @@ export function WaypointTutorialPage({
 export async function getStaticProps({
   params,
 }): Promise<{ props: TutorialPageProps }> {
-  const product = waypointData as ProductData
+  const product = waypointData as LearnProductData
   return await getTutorialPageProps(product, params.tutorialSlug)
 }
 

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -1,5 +1,5 @@
 import waypointData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import CollectionView from 'views/collection-view'
 import {
@@ -19,7 +19,7 @@ export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
   const { collectionSlug } = params
-  const product = waypointData as ProductData
+  const product = waypointData as LearnProductData
   return await getCollectionPageProps(product, collectionSlug)
 }
 

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -1,5 +1,5 @@
 import productData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getProductTutorialsPageProps,
   ProductTutorialsPageProps,
@@ -16,7 +16,9 @@ export function WaypointTutorialHubPage(
 export async function getStaticProps(): Promise<{
   props: ProductTutorialsPageProps
 }> {
-  const props = await getProductTutorialsPageProps(productData as ProductData)
+  const props = await getProductTutorialsPageProps(
+    productData as LearnProductData
+  )
 
   return props
 }

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -38,7 +38,7 @@ type LearnProductName = Exclude<
  * interface almost the same as `ProductData`, just with a limited set of
  * options for `slug`.
  */
-interface LearnProductData extends ProductData, LearnProduct {
+interface LearnProductData extends ProductData {
   name: LearnProductName
   slug: LearnProduct['slug']
 }

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,5 +1,9 @@
+import {
+  TutorialLite as ClientTutorialLite,
+  Collection as ClientCollection,
+} from 'lib/learn-client/types'
 import Link from 'next/link'
-import { getTutorialSlug } from './helpers'
+import { getCollectionSlug, getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
 
 export default function CollectionView({
@@ -8,12 +12,13 @@ export default function CollectionView({
   product,
 }: CollectionPageProps): React.ReactElement {
   const { name, slug, description, tutorials } = collection
+
   return (
     <>
       <h1>{name}</h1>
       <p>{description}</p>
       <ol>
-        {tutorials.map((tutorial) => {
+        {tutorials.map((tutorial: ClientTutorialLite) => {
           const tutorialSlug = getTutorialSlug(tutorial.slug, slug)
           return (
             <li key={tutorial.id}>
@@ -24,6 +29,19 @@ export default function CollectionView({
           )
         })}
       </ol>
+      <h2>Sidebar Data</h2>
+      <ul>
+        {allProductCollections.map((collection: ClientCollection) => {
+          const collectionSlug = getCollectionSlug(collection.slug)
+          return (
+            <li key={collection.id}>
+              <Link href={collectionSlug}>
+                <a>{collection.shortName}</a>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
     </>
   )
 }

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -37,7 +37,7 @@ export async function getCollectionPageProps(
   const collection = await getCollection(`${product.slug}/${slug}`)
   // For sidebar data
   const allProductCollections = await getAllCollections({
-    product: { slug: product.slug, sidebarSort: true, filterByTheme: true },
+    product: { slug: product.slug, sidebarSort: true },
   })
 
   return {

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -37,7 +37,7 @@ export async function getCollectionPageProps(
   const collection = await getCollection(`${product.slug}/${slug}`)
   // For sidebar data
   const allProductCollections = await getAllCollections({
-    product: ProductOption[product.slug],
+    product: { slug: product.slug, sidebarSort: true, filterByTheme: true },
   })
 
   return {
@@ -53,7 +53,7 @@ export async function getCollectionPaths(
   product: ProductOption
 ): Promise<CollectionPagePath[]> {
   const collections = await getAllCollections({
-    product,
+    product: { slug: product },
   })
   // Only build collections where this product is the main 'theme'
   // @TODO once we implement the `theme` query option, remove the theme filtering

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -1,4 +1,4 @@
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   Collection as ClientCollection,
   ProductOption,
@@ -13,7 +13,7 @@ import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 export interface CollectionPageProps {
   collection: ClientCollection
   allProductCollections: ClientCollection[]
-  product: ProductData
+  product: LearnProductData
 }
 
 export interface CollectionPagePath {
@@ -31,7 +31,7 @@ export interface CollectionPagePath {
  * which is needed for other areas of the app to function.
  */
 export async function getCollectionPageProps(
-  product: ProductData,
+  product: LearnProductData,
   slug: string
 ): Promise<{ props: CollectionPageProps }> {
   const collection = await getCollection(`${product.slug}/${slug}`)

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -34,7 +34,7 @@ export async function getProductTutorialsPageProps(
   const productSlug = productData.slug
   const product = await getProduct(productSlug)
   const allProductCollections = await getAllCollections({
-    product: ProductOption[productSlug],
+    product: { slug: productSlug },
   })
   const filteredCollections = filterCollections(
     allProductCollections,

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -2,10 +2,7 @@ import { LearnProductData, ProductData } from 'types/products'
 import { Product as ClientProduct } from 'lib/learn-client/types'
 import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getProduct } from 'lib/learn-client/api/product'
-import {
-  Collection as ClientCollection,
-  ProductOption,
-} from 'lib/learn-client/types'
+import { Collection as ClientCollection } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { filterCollections } from './helpers'
 

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,4 +1,5 @@
 import { LearnProductData, ProductData } from 'types/products'
+import { Product as ClientProduct } from 'lib/learn-client/types'
 import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getProduct } from 'lib/learn-client/api/product'
 import {
@@ -8,9 +9,13 @@ import {
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { filterCollections } from './helpers'
 
+// Some of the product data is coming from the API client on this view
+type ProductTutorialsPageProduct = ClientProduct &
+  Omit<ProductData, 'name' | 'slug'>
+
 export interface ProductTutorialsPageProps {
   collections: ClientCollection[]
-  product: LearnProductData
+  product: ProductTutorialsPageProduct
 }
 
 /**
@@ -24,7 +29,7 @@ export interface ProductTutorialsPageProps {
  * @TODO add sidebar sort capability
  */
 export async function getProductTutorialsPageProps(
-  productData: ProductData
+  productData: LearnProductData
 ): Promise<{ props: ProductTutorialsPageProps }> {
   const productSlug = productData.slug
   const product = await getProduct(productSlug)

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -102,7 +102,7 @@ export interface TutorialPagePaths {
 export async function getTutorialPagePaths(
   product: ProductOption
 ): Promise<TutorialPagePaths[]> {
-  const allCollections = await getAllCollections({ product })
+  const allCollections = await getAllCollections({ product: { slug: product } })
   // Only build collections where this product is the main 'theme'
   // @TODO once we implement the `theme` query option, remove the theme filtering
   // https://app.asana.com/0/1201903760348480/1201932088801131/f

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -1,4 +1,4 @@
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getAllCollections,
   getNextCollectionInSidebar,
@@ -20,7 +20,7 @@ import { getTutorialsBreadcrumb } from './utils/get-tutorials-breadcrumb'
 
 export interface TutorialPageProps {
   tutorial: TutorialData
-  product: ProductData
+  product: LearnProductData
   layoutProps: TutorialSidebarSidecarProps
   nextCollection?: ClientCollectionLite | null // if null, it is the last collection in the sidebar order
 }
@@ -34,7 +34,7 @@ export interface TutorialPageProps {
  * which is needed for other areas of the app to function.
  */
 export async function getTutorialPageProps(
-  product: ProductData,
+  product: LearnProductData,
   slug: [string, string]
 ): Promise<{ props: TutorialPageProps }> {
   const { collection, tutorialReference } = await getCurrentCollectionTutorial(


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kscollection-page-skeleton-hashicorp.vercel.app/vault/tutorials/adp) 🔎
- [Asana task](url) 🎟️

## What

This PR adds sidebar sort order functionality to the `getAllCollections` call, which is used for the collection and tutorial product page views. 

It also adds a basic list of the sorted sidebar items for the collection view. 

## Why

To wire up this data properly for UI consumption.

## Testing

- [Visit this page](https://dev-portal-git-kscollection-page-skeleton-hashicorp.vercel.app/vault/tutorials/adp) and look at the list of the sidebar items. It should match the [Learn version](https://learn.hashicorp.com/collections/vault/getting-started) today (even though categories aren't listed yet).

<img width="891" alt="Screen Shot 2022-04-07 at 3 01 12 PM" src="https://user-images.githubusercontent.com/36613477/162327013-ea1b98ac-247f-4ed7-9b04-7e42a053568b.png">

- [Same with Waypoint](https://dev-portal-git-kscollection-page-skeleton-hashicorp.vercel.app/waypoint/tutorials/deploy-azure)

<img width="667" alt="Screen Shot 2022-04-07 at 3 03 07 PM" src="https://user-images.githubusercontent.com/36613477/162327179-33fe07f6-56be-41b4-b28a-ddb2b79ecf6f.png">


## Anything else?

Next steps are incorporating the proper sidebar / sidecar layout!
