### PR TITLE
refactor: TS adjustment for Learn product data

### DIFF
--- a/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/vault/tutorials/[...tutorialSlug]/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticPathsResult } from 'next'
 import vaultData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import TutorialView from 'views/tutorial-view'
 import {
@@ -21,7 +21,7 @@ export function VaultTutorialPage({
 export async function getStaticProps({
   params,
 }): Promise<{ props: TutorialPageProps }> {
-  const product = vaultData as ProductData
+  const product = vaultData as LearnProductData
   return getTutorialPageProps(product, params.tutorialSlug)
 }
 

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -1,5 +1,5 @@
 import vaultData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import CollectionView from 'views/collection-view'
 import {
@@ -19,7 +19,7 @@ export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
   const { collectionSlug } = params
-  const product = vaultData as ProductData
+  const product = vaultData as LearnProductData
   return await getCollectionPageProps(product, collectionSlug)
 }
 

--- a/src/pages/vault/tutorials/index.tsx
+++ b/src/pages/vault/tutorials/index.tsx
@@ -1,5 +1,5 @@
 import productData from 'data/vault.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getProductTutorialsPageProps,
   ProductTutorialsPageProps,
@@ -16,7 +16,9 @@ export function VaultTutorialHubPage(
 export async function getStaticProps(): Promise<{
   props: ProductTutorialsPageProps
 }> {
-  const props = await getProductTutorialsPageProps(productData as ProductData)
+  const props = await getProductTutorialsPageProps(
+    productData as LearnProductData
+  )
 
   return props
 }

--- a/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/waypoint/tutorials/[...tutorialSlug]/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticPathsResult } from 'next'
 import waypointData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import TutorialView from 'views/tutorial-view'
 import {
@@ -21,7 +21,7 @@ export function WaypointTutorialPage({
 export async function getStaticProps({
   params,
 }): Promise<{ props: TutorialPageProps }> {
-  const product = waypointData as ProductData
+  const product = waypointData as LearnProductData
   return await getTutorialPageProps(product, params.tutorialSlug)
 }
 

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -1,5 +1,5 @@
 import waypointData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import { ProductOption } from 'lib/learn-client/types'
 import CollectionView from 'views/collection-view'
 import {
@@ -19,7 +19,7 @@ export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
   const { collectionSlug } = params
-  const product = waypointData as ProductData
+  const product = waypointData as LearnProductData
   return await getCollectionPageProps(product, collectionSlug)
 }
 

--- a/src/pages/waypoint/tutorials/index.tsx
+++ b/src/pages/waypoint/tutorials/index.tsx
@@ -1,5 +1,5 @@
 import productData from 'data/waypoint.json'
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getProductTutorialsPageProps,
   ProductTutorialsPageProps,
@@ -16,7 +16,9 @@ export function WaypointTutorialHubPage(
 export async function getStaticProps(): Promise<{
   props: ProductTutorialsPageProps
 }> {
-  const props = await getProductTutorialsPageProps(productData as ProductData)
+  const props = await getProductTutorialsPageProps(
+    productData as LearnProductData
+  )
 
   return props
 }

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -38,7 +38,7 @@ type LearnProductName = Exclude<
  * interface almost the same as `ProductData`, just with a limited set of
  * options for `slug`.
  */
-interface LearnProductData extends ProductData, LearnProduct {
+interface LearnProductData extends ProductData {
   name: LearnProductName
   slug: LearnProduct['slug']
 }

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -1,4 +1,4 @@
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   Collection as ClientCollection,
   ProductOption,
@@ -13,7 +13,7 @@ import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 export interface CollectionPageProps {
   collection: ClientCollection
   allProductCollections: ClientCollection[]
-  product: ProductData
+  product: LearnProductData
 }
 
 export interface CollectionPagePath {
@@ -31,7 +31,7 @@ export interface CollectionPagePath {
  * which is needed for other areas of the app to function.
  */
 export async function getCollectionPageProps(
-  product: ProductData,
+  product: LearnProductData,
   slug: string
 ): Promise<{ props: CollectionPageProps }> {
   const collection = await getCollection(`${product.slug}/${slug}`)

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,4 +1,5 @@
 import { LearnProductData, ProductData } from 'types/products'
+import { Product as ClientProduct } from 'lib/learn-client/types'
 import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getProduct } from 'lib/learn-client/api/product'
 import {
@@ -8,9 +9,13 @@ import {
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { filterCollections } from './helpers'
 
+// Some of the product data is coming from the API client on this view
+type ProductTutorialsPageProduct = ClientProduct &
+  Omit<ProductData, 'name' | 'slug'>
+
 export interface ProductTutorialsPageProps {
   collections: ClientCollection[]
-  product: LearnProductData
+  product: ProductTutorialsPageProduct
 }
 
 /**
@@ -24,7 +29,7 @@ export interface ProductTutorialsPageProps {
  * @TODO add sidebar sort capability
  */
 export async function getProductTutorialsPageProps(
-  productData: ProductData
+  productData: LearnProductData
 ): Promise<{ props: ProductTutorialsPageProps }> {
   const productSlug = productData.slug
   const product = await getProduct(productSlug)

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -1,4 +1,4 @@
-import { ProductData } from 'types/products'
+import { LearnProductData } from 'types/products'
 import {
   getAllCollections,
   getNextCollectionInSidebar,
@@ -20,7 +20,7 @@ import { getTutorialsBreadcrumb } from './utils/get-tutorials-breadcrumb'
 
 export interface TutorialPageProps {
   tutorial: TutorialData
-  product: ProductData
+  product: LearnProductData
   layoutProps: TutorialSidebarSidecarProps
   nextCollection?: ClientCollectionLite | null // if null, it is the last collection in the sidebar order
 }
@@ -34,7 +34,7 @@ export interface TutorialPageProps {
  * which is needed for other areas of the app to function.
  */
 export async function getTutorialPageProps(
-  product: ProductData,
+  product: LearnProductData,
   slug: [string, string]
 ): Promise<{ props: TutorialPageProps }> {
   const { collection, tutorialReference } = await getCurrentCollectionTutorial(


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadjust-learn-types-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## What

Adjusting types a bit as per previous conversations on #272 to ensure that the learn view slug types are scoped to the `ProductOption` requirements of the Learn API. 
