### PR TITLE
feat: build tutorial sidebar

### DIFF
--- a/src/components/sidebar/components/sidebar-nav/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/index.tsx
@@ -1,6 +1,7 @@
 import { MenuItem } from 'components/sidebar'
 import Text from 'components/text'
 import SidebarNavMenuItem from './sidebar-nav-menu-item'
+import SkipToMainContent from './skip-to-main-content'
 import s from './sidebar-nav.module.css'
 
 const SIDEBAR_LABEL_ID = 'sidebar-label'
@@ -20,9 +21,8 @@ const SidebarNav: React.FC<SidebarNavProps> = ({ menuItems, title }) => (
     >
       {title}
     </Text>
-    <a className={s.skipToMainContent} href="#main">
-      Skip to main content
-    </a>
+
+    <SkipToMainContent />
     <ul className={s.sidebarNavList}>
       {menuItems.map((item) => (
         <SidebarNavMenuItem item={item} key={item.id} />
@@ -31,4 +31,5 @@ const SidebarNav: React.FC<SidebarNavProps> = ({ menuItems, title }) => (
   </nav>
 )
 
+export { SkipToMainContent }
 export default SidebarNav

--- a/src/components/sidebar/components/sidebar-nav/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/index.tsx
@@ -31,5 +31,4 @@ const SidebarNav: React.FC<SidebarNavProps> = ({ menuItems, title }) => (
   </nav>
 )
 
-export { SkipToMainContent }
 export default SidebarNav

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
@@ -1,4 +1,5 @@
 import { KeyboardEventHandler, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 import classNames from 'classnames'
 import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
@@ -11,21 +12,35 @@ interface SidebarMenuItemProps {
   item: MenuItem
 }
 
-function SidebarNavLink({ item }: SidebarMenuItemProps) {
-  const { isActive, fullPath, href, title } = item
+const SidebarNavLink = ({ item }) => {
+  if (item.fullPath) {
+    return (
+      <li>
+        <Link href={item.fullPath}>
+          <a
+            aria-current={item.isActive ? 'page' : undefined}
+            className={s.sidebarNavMenuItem}
+            // TODO: this might break some accessible labels, probably need aria-label
+            dangerouslySetInnerHTML={{ __html: item.title }}
+          />
+        </Link>
+      </li>
+    )
+  }
+
   return (
-    <li className={s.sidebarNavListItem}>
+    <li>
       <MaybeInternalLink
-        aria-current={isActive ? 'page' : undefined}
+        aria-current={item.isActive ? 'page' : undefined}
         className={s.sidebarNavMenuItem}
-        href={fullPath || href}
+        href={item.href}
       >
         <span
           className={s.navMenuItemLabel}
           // TODO: this might break some accessible labels, probably need aria-label
-          dangerouslySetInnerHTML={{ __html: title }}
+          dangerouslySetInnerHTML={{ __html: item.title }}
         />
-        {href ? <IconExternalLink16 /> : null}
+        <IconExternalLink16 />
       </MaybeInternalLink>
     </li>
   )

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
@@ -1,4 +1,5 @@
 import { KeyboardEventHandler, useEffect, useRef, useState } from 'react'
+import classNames from 'classnames'
 import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import MaybeInternalLink from 'components/maybe-internal-link'
@@ -92,9 +93,13 @@ const SidebarNavSubmenu: React.FC<SidebarMenuItemProps> = ({ item }) => {
   )
 }
 
+export function HorizontalRule({ className }: { className?: string }) {
+  return <hr className={classNames(s.divider, className)} />
+}
+
 const SidebarNavMenuItem: React.FC<SidebarMenuItemProps> = ({ item }) => {
   if (item.divider) {
-    return <hr className={s.divider} />
+    return <HorizontalRule />
   }
 
   // TODO: 2022-01-03: designs show a heading on the product home page,

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
@@ -108,7 +108,7 @@ const SidebarNavSubmenu: React.FC<SidebarMenuItemProps> = ({ item }) => {
   )
 }
 
-export function HorizontalRule({ className }: { className?: string }) {
+function HorizontalRule({ className }: { className?: string }) {
   return <hr className={classNames(s.divider, className)} />
 }
 
@@ -134,5 +134,5 @@ const SidebarNavMenuItem: React.FC<SidebarMenuItemProps> = ({ item }) => {
   return <SidebarNavLink item={item} />
 }
 
-export { SidebarNavLink }
+export { HorizontalRule, SidebarNavLink }
 export default SidebarNavMenuItem

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/index.tsx
@@ -1,5 +1,4 @@
 import { KeyboardEventHandler, useEffect, useRef, useState } from 'react'
-import Link from 'next/link'
 import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import MaybeInternalLink from 'components/maybe-internal-link'
@@ -11,35 +10,21 @@ interface SidebarMenuItemProps {
   item: MenuItem
 }
 
-const SidebarNavLink = ({ item }) => {
-  if (item.fullPath) {
-    return (
-      <li>
-        <Link href={item.fullPath}>
-          <a
-            aria-current={item.isActive ? 'page' : undefined}
-            className={s.sidebarNavMenuItem}
-            // TODO: this might break some accessible labels, probably need aria-label
-            dangerouslySetInnerHTML={{ __html: item.title }}
-          />
-        </Link>
-      </li>
-    )
-  }
-
+function SidebarNavLink({ item }: SidebarMenuItemProps) {
+  const { isActive, fullPath, href, title } = item
   return (
-    <li>
+    <li className={s.sidebarNavListItem}>
       <MaybeInternalLink
-        aria-current={item.isActive ? 'page' : undefined}
+        aria-current={isActive ? 'page' : undefined}
         className={s.sidebarNavMenuItem}
-        href={item.href}
+        href={fullPath || href}
       >
         <span
           className={s.navMenuItemLabel}
           // TODO: this might break some accessible labels, probably need aria-label
-          dangerouslySetInnerHTML={{ __html: item.title }}
+          dangerouslySetInnerHTML={{ __html: title }}
         />
-        <IconExternalLink16 />
+        {href ? <IconExternalLink16 /> : null}
       </MaybeInternalLink>
     </li>
   )
@@ -129,4 +114,5 @@ const SidebarNavMenuItem: React.FC<SidebarMenuItemProps> = ({ item }) => {
   return <SidebarNavLink item={item} />
 }
 
+export { SidebarNavLink }
 export default SidebarNavMenuItem

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
@@ -11,7 +11,7 @@
   color: var(--token-color-palette-neutral-500);
   display: flex;
   font-size: 14px;
-  font-weight: var(--token-typography-font-weight-regular);
+  font-weight: 400;
   gap: 8px;
   justify-content: space-between;
   line-height: 18px;
@@ -46,7 +46,7 @@
   /* AKA active and open */
   &[aria-expanded='true'],
   &[aria-current='page'] {
-    font-weight: var(--token-typography-font-weight-medium);
+    font-weight: 500;
   }
 
   &:focus {

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
@@ -1,7 +1,3 @@
-.sidebarNavListItem {
-  list-style: none;
-}
-
 .sidebarNavMenuItem {
   composes: g-focus-border-and-box-shadow-light from global;
   align-items: center;

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
@@ -8,7 +8,6 @@
   display: flex;
   font-size: 14px;
   font-weight: 400;
-  gap: 8px;
   justify-content: space-between;
   line-height: 18px;
   margin-bottom: 2px;

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
@@ -1,3 +1,7 @@
+.sidebarNavListItem {
+  list-style: none;
+}
+
 .sidebarNavMenuItem {
   composes: g-focus-border-and-box-shadow-light from global;
   align-items: center;
@@ -7,7 +11,8 @@
   color: var(--token-color-palette-neutral-500);
   display: flex;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: var(--token-typography-font-weight-regular);
+  gap: 8px;
   justify-content: space-between;
   line-height: 18px;
   margin-bottom: 2px;
@@ -41,7 +46,7 @@
   /* AKA active and open */
   &[aria-expanded='true'],
   &[aria-current='page'] {
-    font-weight: 500;
+    font-weight: var(--token-typography-font-weight-medium);
   }
 
   &:focus {

--- a/src/components/sidebar/components/sidebar-nav/sidebar-nav.module.css
+++ b/src/components/sidebar/components/sidebar-nav/sidebar-nav.module.css
@@ -9,32 +9,6 @@
   padding: 0 8px;
 }
 
-.skipToMainContent {
-  composes: g-focus-border-and-box-shadow-light from global;
-  background-color: white;
-  border-radius: 5px;
-  box-shadow: 0 0 0 3px var(--token-color-focus-action-external),
-    0 1px 1px rgba(101, 106, 118, 0.05), 0 2px 2px rgba(101, 106, 118, 0.05);
-  color: var(--token-color-palette-blue-200);
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 18px;
-  padding: 8px;
-  position: absolute;
-  right: 10000px;
-  top: 0;
-  width: fit-content;
-  z-index: 1;
-
-  &:focus {
-    right: 0;
-  }
-
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 .sidebarNavList {
   list-style: none;
   margin: 0;

--- a/src/components/sidebar/components/sidebar-nav/skip-to-main-content/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav/skip-to-main-content/index.tsx
@@ -1,0 +1,11 @@
+import s from './skip-to-main-content.module.css'
+
+function SkipToMainContent() {
+  return (
+    <a className={s.root} href="#main">
+      Skip to main content
+    </a>
+  )
+}
+
+export default SkipToMainContent

--- a/src/components/sidebar/components/sidebar-nav/skip-to-main-content/skip-to-main-content.module.css
+++ b/src/components/sidebar/components/sidebar-nav/skip-to-main-content/skip-to-main-content.module.css
@@ -1,0 +1,25 @@
+.root {
+  composes: g-focus-border-and-box-shadow-light from global;
+  background-color: white;
+  border-radius: 5px;
+  box-shadow: 0 0 0 3px var(--token-color-focus-action-external),
+    0 1px 1px rgba(101, 106, 118, 0.05), 0 2px 2px rgba(101, 106, 118, 0.05);
+  color: var(--token-color-palette-blue-200);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  padding: 8px;
+  position: absolute;
+  right: 10000px;
+  top: 0;
+  width: fit-content;
+  z-index: 1;
+
+  &:focus {
+    right: 0;
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/components/tutorials-sidebar/docs.mdx
+++ b/src/components/tutorials-sidebar/docs.mdx
@@ -1,0 +1,144 @@
+---
+componentName: 'TutorialsSidebar'
+---
+
+These are the `TutorialsSidebar` docs!
+
+## Landing View
+
+<LiveComponent>{`
+  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
+    <SectionTitle text="Tutorials" as="h1" />
+    <SectionList items={[{ text: 'Overview', href: '/', isActive: true }]} />
+    <HorizontalRule />
+    <SectionTitle text="Get Started" />
+    <SectionList
+      items={[
+        { text: 'CLI Quick Start', href: '/' },
+        { text: 'HCP Vault Quick Start', href: '/' },
+        { text: 'UI Quick Start', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Use Cases" />
+    <SectionList
+      items={[
+        { text: 'ADP', href: '/' },
+        { text: 'Data Encryption', href: '/' },
+        { text: 'Database Credentials', href: '/' },
+        { text: 'Key Management', href: '/' },
+        { text: 'Secrets Management', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Certification Prep" />
+    <SectionList
+      items={[
+        { text: 'Associate', href: '/' },
+        { text: 'Operations Pro', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Production" />
+    <SectionList
+      items={[
+        { text: 'Day One Consul Storage', href: '/' },
+        { text: 'Day One Integrated Storage', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Resources" />
+    <SectionList
+      items={[
+        { text: 'All Tutorials', href: '/', isExternal: true },
+        { text: 'Community Forum', href: '/', isExternal: true },
+        { text: 'Support', href: '/', isExternal: true },
+        { text: 'GitHub', href: '/', isExternal: true },
+      ]}
+    />
+  </TutorialsSidebar>
+`}</LiveComponent>
+
+## Collection View
+
+<LiveComponent>{`
+  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
+    <SectionTitle text="Tutorials" as="h1" />
+    <SectionList items={[{ text: 'Overview', href: '/' }]} />
+    <HorizontalRule />
+    <SectionTitle text="Get Started" />
+    <SectionList
+      items={[
+        { text: 'CLI Quick Start', href: '/' },
+        { text: 'HCP Vault Quick Start', href: '/' },
+        { text: 'UI Quick Start', href: '/', isActive: true },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Use Cases" />
+    <SectionList
+      items={[
+        { text: 'ADP', href: '/' },
+        { text: 'Data Encryption', href: '/' },
+        { text: 'Database Credentials', href: '/' },
+        { text: 'Key Management', href: '/' },
+        { text: 'Secrets Management', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Certification Prep" />
+    <SectionList
+      items={[
+        { text: 'Associate', href: '/' },
+        { text: 'Operations Pro', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Production" />
+    <SectionList
+      items={[
+        { text: 'Day One Consul Storage', href: '/' },
+        { text: 'Day One Integrated Storage', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Resources" />
+    <SectionList
+      items={[
+        { text: 'All Tutorials', href: '/', isExternal: true },
+        { text: 'Community Forum', href: '/', isExternal: true },
+        { text: 'Support', href: '/', isExternal: true },
+        { text: 'GitHub', href: '/', isExternal: true },
+      ]}
+    />
+  </TutorialsSidebar>
+`}</LiveComponent>
+
+## Tutorial View
+
+<LiveComponent>{`
+  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
+    <SectionList
+      items={[
+        { text: 'Getting Started With Vault UI', href: '/', isActive: true },
+        { text: 'Install Vault', href: '/' },
+        { text: 'Web UI', href: '/' },
+        { text: 'Create Vault Policies', href: '/' },
+        { text: 'Manage Authentication Methods', href: '/' },
+        { text: 'Manage Secrets Engine', href: '/' },
+        { text: 'API Explorer in Vault UI', href: '/' },
+        { text: 'Next Steps', href: '/' },
+      ]}
+    />
+    <HorizontalRule />
+    <SectionTitle text="Resources" />
+    <SectionList
+      items={[
+        { text: 'All Tutorials', href: '/', isExternal: true },
+        { text: 'Community Forum', href: '/', isExternal: true },
+        { text: 'Support', href: '/', isExternal: true },
+        { text: 'GitHub', href: '/', isExternal: true },
+      ]}
+    />
+  </TutorialsSidebar>
+`}</LiveComponent>

--- a/src/components/tutorials-sidebar/docs.mdx
+++ b/src/components/tutorials-sidebar/docs.mdx
@@ -7,8 +7,10 @@ These are the `TutorialsSidebar` docs!
 ## Landing View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }} ariaLabelledBy="sidebar-title">
-    <SectionTitle id="sidebar-title" text="Tutorials" as="h1" />
+  <TutorialsSidebar
+    backToLink={{ text: "Vault Home", href: "/" }}
+    title="Tutorials"
+  >
     <SectionList items={[{ text: 'Overview', href: '/', isActive: true }]} />
     <HorizontalRule />
     <SectionTitle text="Get Started" />
@@ -62,8 +64,10 @@ These are the `TutorialsSidebar` docs!
 ## Collection View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }} ariaLabelledBy="sidebar-title">
-    <SectionTitle id="sidebar-title" text="Tutorials" as="h1" />
+  <TutorialsSidebar
+    backToLink={{ text: "Vault Home", href: "/" }}
+    title="Tutorials"
+  >
     <SectionList items={[{ text: 'Overview', href: '/' }]} />
     <HorizontalRule />
     <SectionTitle text="Get Started" />
@@ -117,8 +121,11 @@ These are the `TutorialsSidebar` docs!
 ## Tutorial View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "UI Quick Start", href: "/" }} ariaLabelledBy="sidebar-title">
-    <SectionTitle id="sidebar-title" text="UI Quick Start Collection" as="h1" visuallyHidden={true} />
+  <TutorialsSidebar
+    backToLink={{ text: "UI Quick Start", href: "/" }}
+    title="UI Quick Start Collection"
+    visuallyHideTitle={true}
+  >
     <SectionList
       items={[
         { text: 'Getting Started With Vault UI', href: '/', isActive: true },

--- a/src/components/tutorials-sidebar/docs.mdx
+++ b/src/components/tutorials-sidebar/docs.mdx
@@ -7,8 +7,8 @@ These are the `TutorialsSidebar` docs!
 ## Landing View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
-    <SectionTitle text="Tutorials" as="h1" />
+  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }} ariaLabelledBy="sidebar-title">
+    <SectionTitle id="sidebar-title" text="Tutorials" as="h1" />
     <SectionList items={[{ text: 'Overview', href: '/', isActive: true }]} />
     <HorizontalRule />
     <SectionTitle text="Get Started" />
@@ -62,8 +62,8 @@ These are the `TutorialsSidebar` docs!
 ## Collection View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
-    <SectionTitle text="Tutorials" as="h1" />
+  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }} ariaLabelledBy="sidebar-title">
+    <SectionTitle id="sidebar-title" text="Tutorials" as="h1" />
     <SectionList items={[{ text: 'Overview', href: '/' }]} />
     <HorizontalRule />
     <SectionTitle text="Get Started" />

--- a/src/components/tutorials-sidebar/docs.mdx
+++ b/src/components/tutorials-sidebar/docs.mdx
@@ -117,7 +117,8 @@ These are the `TutorialsSidebar` docs!
 ## Tutorial View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "UI Quick Start", href: "/" }} ariaLabel="UI Quick Start Collection">
+  <TutorialsSidebar backToLink={{ text: "UI Quick Start", href: "/" }} ariaLabelledBy="sidebar-title">
+    <SectionTitle id="sidebar-title" text="UI Quick Start Collection" as="h1" visuallyHidden={true} />
     <SectionList
       items={[
         { text: 'Getting Started With Vault UI', href: '/', isActive: true },

--- a/src/components/tutorials-sidebar/docs.mdx
+++ b/src/components/tutorials-sidebar/docs.mdx
@@ -117,7 +117,7 @@ These are the `TutorialsSidebar` docs!
 ## Tutorial View
 
 <LiveComponent>{`
-  <TutorialsSidebar backToLink={{ text: "Vault Home", href: "/" }}>
+  <TutorialsSidebar backToLink={{ text: "UI Quick Start", href: "/" }} ariaLabel="UI Quick Start Collection">
     <SectionList
       items={[
         { text: 'Getting Started With Vault UI', href: '/', isActive: true },

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -3,7 +3,7 @@ import VisuallyHidden from '@reach/visually-hidden'
 import { IconChevronLeft16 } from '@hashicorp/flight-icons/svg-react/chevron-left-16'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import StandaloneLink from 'components/standalone-link'
-import { SkipToMainContent } from 'components/sidebar/components/sidebar-nav'
+import SkipToMainContent from 'components/sidebar/components/sidebar-nav/skip-to-main-content'
 import { SidebarNavLink } from 'components/sidebar/components/sidebar-nav/sidebar-nav-menu-item'
 import {
   ListItemProps,

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -11,9 +11,13 @@ import {
 } from './types'
 import s from './tutorials-sidebar.module.css'
 
-function TutorialsSidebar({ backToLink, children }: TutorialSidebarProps) {
+function TutorialsSidebar({
+  backToLink,
+  children,
+  ariaLabel,
+}: TutorialSidebarProps) {
   return (
-    <nav className={s.root}>
+    <nav aria-label={ariaLabel} className={s.root}>
       <SkipToMainContent />
       <StandaloneLink
         className={s.backToLink}

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -14,13 +14,19 @@ import {
 import s from './tutorials-sidebar.module.css'
 import { HorizontalRule as DocsHorizontalRule } from 'components/sidebar/components/sidebar-nav/sidebar-nav-menu-item'
 
+const NAV_LABEL_ID = 'TutorialsSidebar_label'
+
 function TutorialsSidebar({
   backToLink,
   children,
-  ariaLabelledBy,
+  title,
+  visuallyHideTitle,
 }: TutorialSidebarProps) {
+  // To visually hide the title, wrap in VisuallyHidden
+  const TitleWrapper = visuallyHideTitle ? VisuallyHidden : Fragment
+
   return (
-    <nav className={s.root} aria-labelledby={ariaLabelledBy}>
+    <nav className={s.root} aria-labelledby={NAV_LABEL_ID}>
       <div className={s.backToLink}>
         <StandaloneLink
           href={backToLink.href}
@@ -30,8 +36,14 @@ function TutorialsSidebar({
           textSize={200}
         />
       </div>
+
       <div className={s.itemsContainer}>
         <SkipToMainContent />
+        <TitleWrapper>
+          <h2 className={s.sectionTitle} id={NAV_LABEL_ID}>
+            {title}
+          </h2>
+        </TitleWrapper>
         {children}
       </div>
     </nav>
@@ -63,21 +75,8 @@ function ListItem({ href, isActive, text, isExternal }: ListItemProps) {
   return <SidebarNavLink item={{ isActive, title: text, ...hrefOrFullPath }} />
 }
 
-function SectionTitle({
-  text,
-  as = 'h2',
-  id,
-  visuallyHidden,
-}: SectionTitleProps) {
-  const Wrapper = visuallyHidden ? VisuallyHidden : Fragment
-  const Elem = as
-  return (
-    <Wrapper>
-      <Elem className={s.sectionTitle} id={id}>
-        {text}
-      </Elem>
-    </Wrapper>
-  )
+function SectionTitle({ text }: SectionTitleProps) {
+  return <h3 className={s.sectionTitle}>{text}</h3>
 }
 
 function HorizontalRule() {

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -15,9 +15,14 @@ function TutorialsSidebar({
   backToLink,
   children,
   ariaLabel,
+  ariaLabelledBy,
 }: TutorialSidebarProps) {
   return (
-    <nav aria-label={ariaLabel} className={s.root}>
+    <nav
+      className={s.root}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
       <SkipToMainContent />
       <StandaloneLink
         className={s.backToLink}
@@ -57,9 +62,13 @@ function ListItem({ href, isActive, text, isExternal }: ListItemProps) {
   return <SidebarNavLink item={{ isActive, title: text, ...hrefOrFullPath }} />
 }
 
-function SectionTitle({ text, as = 'h2' }: SectionTitleProps) {
+function SectionTitle({ text, as = 'h2', id }: SectionTitleProps) {
   const Elem = as
-  return <Elem className={s.sectionTitle}>{text}</Elem>
+  return (
+    <Elem className={s.sectionTitle} id={id}>
+      {text}
+    </Elem>
+  )
 }
 
 function HorizontalRule() {

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -12,6 +12,7 @@ import {
   TutorialSidebarProps,
 } from './types'
 import s from './tutorials-sidebar.module.css'
+import { HorizontalRule as DocsHorizontalRule } from 'components/sidebar/components/sidebar-nav/sidebar-nav-menu-item'
 
 function TutorialsSidebar({
   backToLink,
@@ -81,7 +82,7 @@ function SectionTitle({
 }
 
 function HorizontalRule() {
-  return <hr className={s.hr} />
+  return <DocsHorizontalRule className={s.hr} />
 }
 
 export { HorizontalRule, ListItem, SectionList, SectionTitle }

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -30,7 +30,6 @@ function TutorialsSidebar({
           textSize={200}
         />
       </div>
-
       <div className={s.itemsContainer}>
         <SkipToMainContent />
         {children}

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -1,0 +1,66 @@
+import { IconChevronLeft16 } from '@hashicorp/flight-icons/svg-react/chevron-left-16'
+import isAbsoluteUrl from 'lib/is-absolute-url'
+import StandaloneLink from 'components/standalone-link'
+import { SkipToMainContent } from 'components/sidebar/components/sidebar-nav'
+import { SidebarNavLink } from 'components/sidebar/components/sidebar-nav/sidebar-nav-menu-item'
+import {
+  ListItemProps,
+  SectionListProps,
+  SectionTitleProps,
+  TutorialSidebarProps,
+} from './types'
+import s from './tutorials-sidebar.module.css'
+
+function TutorialsSidebar({ backToLink, children }: TutorialSidebarProps) {
+  return (
+    <nav className={s.root}>
+      <SkipToMainContent />
+      <StandaloneLink
+        className={s.backToLink}
+        href={backToLink.href}
+        text={backToLink.text}
+        icon={<IconChevronLeft16 />}
+        iconPosition="leading"
+        textSize={200}
+      />
+      <div className={s.itemsContainer}>{children}</div>
+    </nav>
+  )
+}
+
+function SectionList({ items }: SectionListProps) {
+  return (
+    <ul className={s.listRoot}>
+      {items.map(({ text, href, isActive, isExternal }: ListItemProps) => {
+        return (
+          <ListItem
+            key={`${text}${href}`}
+            text={text}
+            href={href}
+            isActive={isActive}
+            isExternal={isExternal}
+          />
+        )
+      })}
+    </ul>
+  )
+}
+
+function ListItem({ href, isActive, text, isExternal }: ListItemProps) {
+  const parsedIsExternal =
+    typeof isExternal == 'boolean' ? isExternal : isAbsoluteUrl(href)
+  const hrefOrFullPath = parsedIsExternal ? { href } : { fullPath: href }
+  return <SidebarNavLink item={{ isActive, title: text, ...hrefOrFullPath }} />
+}
+
+function SectionTitle({ text, as = 'h2' }: SectionTitleProps) {
+  const Elem = as
+  return <Elem className={s.sectionTitle}>{text}</Elem>
+}
+
+function HorizontalRule() {
+  return <hr className={s.hr} />
+}
+
+export { HorizontalRule, ListItem, SectionList, SectionTitle }
+export default TutorialsSidebar

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -23,16 +23,20 @@ function TutorialsSidebar({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
     >
-      <SkipToMainContent />
-      <StandaloneLink
-        className={s.backToLink}
-        href={backToLink.href}
-        text={backToLink.text}
-        icon={<IconChevronLeft16 />}
-        iconPosition="leading"
-        textSize={200}
-      />
-      <div className={s.itemsContainer}>{children}</div>
+      <div className={s.backToLink}>
+        <StandaloneLink
+          href={backToLink.href}
+          text={backToLink.text}
+          icon={<IconChevronLeft16 />}
+          iconPosition="leading"
+          textSize={200}
+        />
+      </div>
+
+      <div className={s.itemsContainer}>
+        <SkipToMainContent />
+        {children}
+      </div>
     </nav>
   )
 }

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -24,7 +24,6 @@ function TutorialsSidebar({
 }: TutorialSidebarProps) {
   // To visually hide the title, wrap in VisuallyHidden
   const TitleWrapper = visuallyHideTitle ? VisuallyHidden : Fragment
-
   return (
     <nav className={s.root} aria-labelledby={NAV_LABEL_ID}>
       <div className={s.backToLink}>
@@ -36,7 +35,6 @@ function TutorialsSidebar({
           textSize={200}
         />
       </div>
-
       <div className={s.itemsContainer}>
         <SkipToMainContent />
         <TitleWrapper>

--- a/src/components/tutorials-sidebar/index.tsx
+++ b/src/components/tutorials-sidebar/index.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+import VisuallyHidden from '@reach/visually-hidden'
 import { IconChevronLeft16 } from '@hashicorp/flight-icons/svg-react/chevron-left-16'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import StandaloneLink from 'components/standalone-link'
@@ -14,15 +16,10 @@ import s from './tutorials-sidebar.module.css'
 function TutorialsSidebar({
   backToLink,
   children,
-  ariaLabel,
   ariaLabelledBy,
 }: TutorialSidebarProps) {
   return (
-    <nav
-      className={s.root}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-    >
+    <nav className={s.root} aria-labelledby={ariaLabelledBy}>
       <div className={s.backToLink}>
         <StandaloneLink
           href={backToLink.href}
@@ -66,12 +63,20 @@ function ListItem({ href, isActive, text, isExternal }: ListItemProps) {
   return <SidebarNavLink item={{ isActive, title: text, ...hrefOrFullPath }} />
 }
 
-function SectionTitle({ text, as = 'h2', id }: SectionTitleProps) {
+function SectionTitle({
+  text,
+  as = 'h2',
+  id,
+  visuallyHidden,
+}: SectionTitleProps) {
+  const Wrapper = visuallyHidden ? VisuallyHidden : Fragment
   const Elem = as
   return (
-    <Elem className={s.sectionTitle} id={id}>
-      {text}
-    </Elem>
+    <Wrapper>
+      <Elem className={s.sectionTitle} id={id}>
+        {text}
+      </Elem>
+    </Wrapper>
   )
 }
 

--- a/src/components/tutorials-sidebar/tutorials-sidebar.module.css
+++ b/src/components/tutorials-sidebar/tutorials-sidebar.module.css
@@ -24,23 +24,9 @@ Spaces all items except the "back to" link
 /*
 Horizontal rule
 */
-.hr {
-  position: relative;
-  background: none;
-  height: 1px;
-  border: none;
-  outline: none;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  margin: 0;
-
-  &::before {
-    display: block;
-    content: '';
-    background: var(--token-color-border-primary);
-    width: 100%;
-    height: 1px;
-  }
+hr.hr {
+  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 /*

--- a/src/components/tutorials-sidebar/tutorials-sidebar.module.css
+++ b/src/components/tutorials-sidebar/tutorials-sidebar.module.css
@@ -1,5 +1,4 @@
 .root {
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -19,6 +18,7 @@ Spaces all items except the "back to" link
   display: flex;
   flex-direction: column;
   gap: 12px;
+  position: relative;
 }
 
 /*

--- a/src/components/tutorials-sidebar/tutorials-sidebar.module.css
+++ b/src/components/tutorials-sidebar/tutorials-sidebar.module.css
@@ -1,0 +1,65 @@
+.root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/*
+Back to link has some padding, unlike typical StandloneLink
+*/
+.backToLink {
+  padding-left: 4px;
+}
+
+/*
+Spaces all items except the "back to" link
+*/
+.itemsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/*
+Horizontal rule
+*/
+.hr {
+  position: relative;
+  background: none;
+  height: 1px;
+  border: none;
+  outline: none;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin: 0;
+
+  &::before {
+    display: block;
+    content: '';
+    background: var(--token-color-border-primary);
+    width: 100%;
+    height: 1px;
+  }
+}
+
+/*
+Section title
+*/
+.sectionTitle {
+  composes: hds-typography-body-100 from global;
+  font-weight: var(--token-typography-font-weight-semibold);
+  padding-left: 8px;
+}
+
+/*
+Section list
+*/
+.listRoot {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}

--- a/src/components/tutorials-sidebar/tutorials-sidebar.module.css
+++ b/src/components/tutorials-sidebar/tutorials-sidebar.module.css
@@ -23,6 +23,7 @@ Spaces all items except the "back to" link
 
 /*
 Horizontal rule
+Note: overrides top and bottom margin of HorizontalRule from components/sidebar
 */
 hr.hr {
   margin-top: 8px;
@@ -31,6 +32,8 @@ hr.hr {
 
 /*
 Section title
+Note: used for the <SectionTitle /> component, and also for the top-level
+<nav> title.
 */
 .sectionTitle {
   composes: hds-typography-body-100 from global;

--- a/src/components/tutorials-sidebar/types.ts
+++ b/src/components/tutorials-sidebar/types.ts
@@ -7,8 +7,6 @@ export interface TutorialSidebarProps {
   children: ReactNode
   /** An id to point to a visible element that acts as the title of the sidebar */
   ariaLabelledBy?: string
-  /** A label to use as the title of the sidebar. */
-  ariaLabel?: string
 }
 
 export interface ListItemProps {
@@ -26,5 +24,6 @@ export interface SectionListProps {
 export interface SectionTitleProps {
   text: string
   as?: 'h1' | 'h2'
-  id: string
+  id?: string
+  visuallyHidden?: boolean
 }

--- a/src/components/tutorials-sidebar/types.ts
+++ b/src/components/tutorials-sidebar/types.ts
@@ -1,12 +1,14 @@
 import { ReactNode } from 'react'
 
 export interface TutorialSidebarProps {
+  /** Title text to show at the top of the sidebar */
+  title: string
   /** A "back" link to display at the top of the sidebar */
   backToLink: { href: string; text: string }
   /** Children to render in the main items area. Expects a mix of SectionTitle, SectionList, and HorizontalRule components. */
   children: ReactNode
-  /** An id to point to a visible element that acts as the title of the sidebar */
-  ariaLabelledBy?: string
+  /** Optional. If true, the title of the sidebar will be visually hidden. */
+  visuallyHideTitle?: string
 }
 
 export interface ListItemProps {
@@ -23,7 +25,4 @@ export interface SectionListProps {
 
 export interface SectionTitleProps {
   text: string
-  as?: 'h1' | 'h2'
-  id?: string
-  visuallyHidden?: boolean
 }

--- a/src/components/tutorials-sidebar/types.ts
+++ b/src/components/tutorials-sidebar/types.ts
@@ -5,6 +5,8 @@ export interface TutorialSidebarProps {
   backToLink: { href: string; text: string }
   /** Children to render in the main items area. Expects a mix of SectionTitle, SectionList, and HorizontalRule components. */
   children: ReactNode
+  /** An id to point to a visible element that acts as the title of the sidebar */
+  ariaLabelledBy?: string
   /** A label to use as the title of the sidebar. */
   ariaLabel?: string
 }
@@ -24,4 +26,5 @@ export interface SectionListProps {
 export interface SectionTitleProps {
   text: string
   as?: 'h1' | 'h2'
+  id: string
 }

--- a/src/components/tutorials-sidebar/types.ts
+++ b/src/components/tutorials-sidebar/types.ts
@@ -5,6 +5,8 @@ export interface TutorialSidebarProps {
   backToLink: { href: string; text: string }
   /** Children to render in the main items area. Expects a mix of SectionTitle, SectionList, and HorizontalRule components. */
   children: ReactNode
+  /** A label to use as the title of the sidebar. */
+  ariaLabel?: string
 }
 
 export interface ListItemProps {

--- a/src/components/tutorials-sidebar/types.ts
+++ b/src/components/tutorials-sidebar/types.ts
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react'
+
+export interface TutorialSidebarProps {
+  /** A "back" link to display at the top of the sidebar */
+  backToLink: { href: string; text: string }
+  /** Children to render in the main items area. Expects a mix of SectionTitle, SectionList, and HorizontalRule components. */
+  children: ReactNode
+}
+
+export interface ListItemProps {
+  href: string
+  isActive?: boolean
+  /** Optional. If true, this link will show an external icon and will open in a new tab. If false, this link will not show an icon, and will not open in a new tab. If omitted, then isExternal will be set to true if href is an absolute URL, or will be set to false otherwise. */
+  isExternal?: boolean
+  text: string
+}
+
+export interface SectionListProps {
+  items: ListItemProps[]
+}
+
+export interface SectionTitleProps {
+  text: string
+  as?: 'h1' | 'h2'
+}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zstutorial-sidebar-hashicorp.vercel.app/swingset/components/tutorialssidebar) 🔎
- [Asana task](https://app.asana.com/0/1201987349274776/1201999966887514/f) 🎟️

## What

Implements the tutorial view sidebar.

## Why

To continue with tutorial view chroming work.

## How

- Takes an approach that relies composition of smaller existing elements from the existing docs `Sidebar`, rather than adding complexity to the props API of the existing docs `Sidebar`

## Testing

- [ ] Visit the [Swingset page](), and ensure the examples look as expected
    - Looking at the markup in each `LiveComponent` may be helpful to get a sense of component use. Of course, in practice we'll be able to `map` over incoming sections and links within those sections rather than manually repeating them. But hopefully the general idea around composition is clear.

## Anything else?

- Focus in this PR is establishing implementation approach to `TutorialSidebar`. Intent is to fully match the design spec in a subsequent PR (as those changes will affect the docs `Sidebar` as well)
- Intent is to implement the _use_ of this component on the "Tutorial Product Landing", "Collection", and "Tutorial" views in subsequent PRs.
