### PR TITLE
fix: adjust copy command for public dir

### DIFF
--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -41,7 +41,12 @@ async function main() {
     execFileSync('mv', ['./.next/cache/node_modules', './node_modules'])
   }
 
-  // copy public files
+  /**
+   * Copy public files
+   *
+   * Vercel uploads the public/ directory from the root directory of the project, so we want to pull
+   * the public files from website-preview up a level.
+   */
   console.log('📝 copying files in the public folder')
   execFileSync('cp', ['-R', './public', `../`])
 

--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -43,7 +43,7 @@ async function main() {
 
   // copy public files
   console.log('📝 copying files in the public folder')
-  execFileSync('cp', ['-Rf', './public', `../`])
+  execFileSync('cp', ['-R', './public', `../`])
 
   /**
    * exclude any imports in the global CSS file which rely on other products

--- a/scripts/content-repo-preview/build.ts
+++ b/scripts/content-repo-preview/build.ts
@@ -43,7 +43,7 @@ async function main() {
 
   // copy public files
   console.log('📝 copying files in the public folder')
-  execFileSync('cp', ['-Rf', '../public', `./${process.env.DEV_IO}`])
+  execFileSync('cp', ['-Rf', './public', `../`])
 
   /**
    * exclude any imports in the global CSS file which rely on other products


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## What

Basically reverting https://github.com/hashicorp/dev-portal/pull/191

<!--
Briefly list out the changes proposed in this PR.
-->

## Why

I had originally misunderstood the logic here, @zchsh you were correct initially! Vercel uploads the `public/` directory from the root directory of the project, so we want to pull dev-portals public files out of `website-preview` up a level.

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
