### PR TITLE
collection view: adds stubbed layout

### DIFF
--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -8,8 +8,6 @@ import {
   CollectionPageProps,
 } from 'views/collection-view/server'
 
-export default CollectionView
-
 export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
@@ -34,3 +32,5 @@ export async function getStaticPaths(): Promise<{
     fallback: false,
   }
 }
+
+export default CollectionView

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -8,11 +8,7 @@ import {
   CollectionPageProps,
 } from 'views/collection-view/server'
 
-export default function VaultCollectionPage(
-  props: CollectionPageProps
-): React.ReactElement {
-  return <CollectionView {...props} />
-}
+export default CollectionView
 
 export async function getStaticProps({
   params,

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -7,9 +7,8 @@ import {
   getCollectionPaths,
   CollectionPageProps,
 } from 'views/collection-view/server'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
-export function VaultCollectionPage(
+export default function VaultCollectionPage(
   props: CollectionPageProps
 ): React.ReactElement {
   return <CollectionView {...props} />
@@ -39,6 +38,3 @@ export async function getStaticPaths(): Promise<{
     fallback: false,
   }
 }
-
-VaultCollectionPage.layout = CoreDevDotLayout
-export default VaultCollectionPage

--- a/src/pages/vault/tutorials/[collectionSlug].tsx
+++ b/src/pages/vault/tutorials/[collectionSlug].tsx
@@ -7,7 +7,7 @@ import {
   getCollectionPaths,
   CollectionPageProps,
 } from 'views/collection-view/server'
-import BaseLayout from 'layouts/base-new'
+import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
 export function VaultCollectionPage(
   props: CollectionPageProps
@@ -40,5 +40,5 @@ export async function getStaticPaths(): Promise<{
   }
 }
 
-VaultCollectionPage.layout = BaseLayout
+VaultCollectionPage.layout = CoreDevDotLayout
 export default VaultCollectionPage

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -8,11 +8,7 @@ import {
   CollectionPageProps,
 } from 'views/collection-view/server'
 
-export default function WaypointCollectionPage(
-  props: CollectionPageProps
-): React.ReactElement {
-  return <CollectionView {...props} />
-}
+export default CollectionView
 
 export async function getStaticProps({
   params,

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -7,9 +7,8 @@ import {
   getCollectionPaths,
   CollectionPageProps,
 } from 'views/collection-view/server'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
-export function WaypointCollectionPage(
+export default function WaypointCollectionPage(
   props: CollectionPageProps
 ): React.ReactElement {
   return <CollectionView {...props} />
@@ -39,6 +38,3 @@ export async function getStaticPaths(): Promise<{
     fallback: false,
   }
 }
-
-WaypointCollectionPage.layout = CoreDevDotLayout
-export default WaypointCollectionPage

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -8,8 +8,6 @@ import {
   CollectionPageProps,
 } from 'views/collection-view/server'
 
-export default CollectionView
-
 export async function getStaticProps({
   params,
 }): Promise<{ props: CollectionPageProps }> {
@@ -34,3 +32,5 @@ export async function getStaticPaths(): Promise<{
     fallback: false,
   }
 }
+
+export default CollectionView

--- a/src/pages/waypoint/tutorials/[collectionSlug].tsx
+++ b/src/pages/waypoint/tutorials/[collectionSlug].tsx
@@ -7,7 +7,7 @@ import {
   getCollectionPaths,
   CollectionPageProps,
 } from 'views/collection-view/server'
-import BaseLayout from 'layouts/base-new'
+import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 
 export function WaypointCollectionPage(
   props: CollectionPageProps
@@ -40,5 +40,5 @@ export async function getStaticPaths(): Promise<{
   }
 }
 
-WaypointCollectionPage.layout = BaseLayout
+WaypointCollectionPage.layout = CoreDevDotLayout
 export default WaypointCollectionPage

--- a/src/views/collection-view/components/collection-view-sidebar.tsx
+++ b/src/views/collection-view/components/collection-view-sidebar.tsx
@@ -17,7 +17,7 @@ export default function CollectionViewSidebar({
 }: CollectionViewSidebarProps) {
   return (
     <TutorialsSidebar
-      title={`${product.name} Tutorials`}
+      title="Tutorials"
       backToLink={{
         text: `${product.name} Home`,
         href: `/${product.slug}`,

--- a/src/views/collection-view/components/collection-view-sidebar.tsx
+++ b/src/views/collection-view/components/collection-view-sidebar.tsx
@@ -1,0 +1,46 @@
+import TutorialsSidebar, {
+  SectionList,
+  HorizontalRule,
+  SectionTitle,
+} from 'components/tutorials-sidebar'
+import { LearnProductData } from 'types/products'
+import { CollectionCategorySidebarSection } from '../helpers'
+
+interface CollectionViewSidebarProps {
+  product: LearnProductData
+  sections: CollectionCategorySidebarSection[]
+}
+
+export default function CollectionViewSidebar({
+  product,
+  sections,
+}: CollectionViewSidebarProps) {
+  return (
+    <TutorialsSidebar
+      title={`${product.name} Tutorials`}
+      backToLink={{
+        text: `${product.name} Home`,
+        href: `/${product.slug}`,
+      }}
+    >
+      <SectionList
+        items={[
+          {
+            text: 'Overview',
+            href: `/${product.slug}/tutorials`,
+            isActive: false,
+          },
+        ]}
+      />
+      {sections.map((section: CollectionCategorySidebarSection) => {
+        return (
+          <>
+            <HorizontalRule />
+            <SectionTitle text={section.title} />
+            <SectionList items={section.items} />
+          </>
+        )
+      })}
+    </TutorialsSidebar>
+  )
+}

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -1,6 +1,7 @@
 import { LearnProductSlug } from 'types/products'
 import getIsBetaProduct from 'lib/get-is-beta-product'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import { Collection as ClientCollection } from 'lib/learn-client/types'
 
 /**
  * takes db slug format --> waypoint/intro

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -5,7 +5,7 @@ import {
   Collection as ClientCollection,
   CollectionCategoryOption,
 } from 'lib/learn-client/types'
-import { MenuItem } from 'components/sidebar'
+import { ListItemProps } from 'components/tutorials-sidebar/types'
 
 /**
  * takes db slug format --> waypoint/intro
@@ -69,15 +69,14 @@ function filterEmptySections(sections) {
   return sections.filter((c) => c.items.length > 0)
 }
 
-export function formatCollectionToMenuItem(
+export function formatCollectionToSectionItem(
   collection: ClientCollection,
-  currentPath
-): MenuItem {
+  currentPath: string
+): ListItemProps {
   const path = getCollectionSlug(collection.slug)
   return {
-    title: collection.shortName,
-    fullPath: path,
-    id: collection.id,
+    text: collection.shortName,
+    href: path,
     isActive: path === currentPath,
   }
 }

--- a/src/views/collection-view/helpers.ts
+++ b/src/views/collection-view/helpers.ts
@@ -1,7 +1,11 @@
 import { LearnProductSlug } from 'types/products'
 import getIsBetaProduct from 'lib/get-is-beta-product'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
-import { Collection as ClientCollection } from 'lib/learn-client/types'
+import {
+  Collection as ClientCollection,
+  CollectionCategoryOption,
+} from 'lib/learn-client/types'
+import { MenuItem } from 'components/sidebar'
 
 /**
  * takes db slug format --> waypoint/intro
@@ -32,4 +36,48 @@ export function getCollectionSlug(collectionDbSlug: string): string {
   }
 
   return `/${product}/tutorials/${collectionFilename}`
+}
+
+export interface SidebarSection {
+  title: CollectionCategoryOption
+  items: ClientCollection[]
+}
+
+export function collectionsToSidebarSections(
+  collections: ClientCollection[]
+): SidebarSection[] {
+  const categorySlugs = Object.keys(CollectionCategoryOption)
+
+  const sidebarSectionsByCategory = categorySlugs.map(
+    (category: CollectionCategoryOption) => {
+      // get collections associated with that category
+      const items = collections.filter(
+        (c: ClientCollection) => c.category === category
+      )
+
+      return {
+        title: CollectionCategoryOption[category],
+        items,
+      }
+    }
+  )
+
+  return filterEmptySections(sidebarSectionsByCategory)
+}
+
+function filterEmptySections(sections) {
+  return sections.filter((c) => c.items.length > 0)
+}
+
+export function formatCollectionToMenuItem(
+  collection: ClientCollection,
+  currentPath
+): MenuItem {
+  const path = getCollectionSlug(collection.slug)
+  return {
+    title: collection.shortName,
+    fullPath: path,
+    id: collection.id,
+    isActive: path === currentPath,
+  }
 }

--- a/src/views/collection-view/helpers/format-sidebar-sections.ts
+++ b/src/views/collection-view/helpers/format-sidebar-sections.ts
@@ -1,0 +1,52 @@
+import {
+  Collection as ClientCollection,
+  CollectionCategoryOption,
+} from 'lib/learn-client/types'
+import { ListItemProps } from 'components/tutorials-sidebar/types'
+import { getCollectionSlug } from './get-slug'
+
+export interface CollectionCategorySidebarSection {
+  title: CollectionCategoryOption
+  items: ListItemProps[]
+}
+
+export function collectionsToSidebarSections(
+  collections: ClientCollection[],
+  currentSlug: string
+): CollectionCategorySidebarSection[] {
+  const categorySlugs = Object.keys(CollectionCategoryOption)
+
+  const sidebarSectionsByCategory = categorySlugs.map(
+    (category: CollectionCategoryOption) => {
+      // get collections associated with that category
+      const items = collections.filter(
+        (c: ClientCollection) => c.category === category
+      )
+
+      return {
+        title: CollectionCategoryOption[category],
+        items: items.map((collection) =>
+          formatCollectionToSectionItem(collection, currentSlug)
+        ),
+      }
+    }
+  )
+
+  return filterEmptySections(sidebarSectionsByCategory)
+}
+
+function filterEmptySections(sections) {
+  return sections.filter((c) => c.items.length > 0)
+}
+
+function formatCollectionToSectionItem(
+  collection: ClientCollection,
+  currentSlug: string
+): ListItemProps {
+  const path = getCollectionSlug(collection.slug)
+  return {
+    text: collection.shortName,
+    href: path,
+    isActive: collection.slug === currentSlug,
+  }
+}

--- a/src/views/collection-view/helpers/format-sidebar-sections.ts
+++ b/src/views/collection-view/helpers/format-sidebar-sections.ts
@@ -10,6 +10,12 @@ export interface CollectionCategorySidebarSection {
   items: ListItemProps[]
 }
 
+/**
+ * This function creates an array of collection category
+ * sections for the sidebar. The sections include the associated
+ * collections with that category. The collection category order
+ * and options are linked to the `CollectionCategoryOption` enum
+ */
 export function collectionsToSidebarSections(
   collections: ClientCollection[],
   currentSlug: string

--- a/src/views/collection-view/helpers/format-sidebar-sections.ts
+++ b/src/views/collection-view/helpers/format-sidebar-sections.ts
@@ -32,7 +32,7 @@ export function collectionsToSidebarSections(
       return {
         title: CollectionCategoryOption[category],
         items: items.map((collection: ClientCollection) =>
-          formatCollectionToSectionItem(collection, currentSlug)
+          formatCollectionToListItem(collection, currentSlug)
         ),
       }
     }
@@ -47,7 +47,7 @@ function filterEmptySections(
   return sections.filter((c) => c.items.length > 0)
 }
 
-function formatCollectionToSectionItem(
+function formatCollectionToListItem(
   collection: ClientCollection,
   currentSlug: string
 ): ListItemProps {

--- a/src/views/collection-view/helpers/format-sidebar-sections.ts
+++ b/src/views/collection-view/helpers/format-sidebar-sections.ts
@@ -25,7 +25,7 @@ export function collectionsToSidebarSections(
 
       return {
         title: CollectionCategoryOption[category],
-        items: items.map((collection) =>
+        items: items.map((collection: ClientCollection) =>
           formatCollectionToSectionItem(collection, currentSlug)
         ),
       }
@@ -35,7 +35,9 @@ export function collectionsToSidebarSections(
   return filterEmptySections(sidebarSectionsByCategory)
 }
 
-function filterEmptySections(sections) {
+function filterEmptySections(
+  sections: CollectionCategorySidebarSection[]
+): CollectionCategorySidebarSection[] {
   return sections.filter((c) => c.items.length > 0)
 }
 

--- a/src/views/collection-view/helpers/format-sidebar-sections.ts
+++ b/src/views/collection-view/helpers/format-sidebar-sections.ts
@@ -16,7 +16,7 @@ export interface CollectionCategorySidebarSection {
  * collections with that category. The collection category order
  * and options are linked to the `CollectionCategoryOption` enum
  */
-export function collectionsToSidebarSections(
+export function formatSidebarCategorySections(
   collections: ClientCollection[],
   currentSlug: string
 ): CollectionCategorySidebarSection[] {

--- a/src/views/collection-view/helpers/get-slug.ts
+++ b/src/views/collection-view/helpers/get-slug.ts
@@ -1,11 +1,6 @@
 import { LearnProductSlug } from 'types/products'
 import getIsBetaProduct from 'lib/get-is-beta-product'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
-import {
-  Collection as ClientCollection,
-  CollectionCategoryOption,
-} from 'lib/learn-client/types'
-import { ListItemProps } from 'components/tutorials-sidebar/types'
 
 /**
  * takes db slug format --> waypoint/intro
@@ -36,47 +31,4 @@ export function getCollectionSlug(collectionDbSlug: string): string {
   }
 
   return `/${product}/tutorials/${collectionFilename}`
-}
-
-export interface SidebarSection {
-  title: CollectionCategoryOption
-  items: ClientCollection[]
-}
-
-export function collectionsToSidebarSections(
-  collections: ClientCollection[]
-): SidebarSection[] {
-  const categorySlugs = Object.keys(CollectionCategoryOption)
-
-  const sidebarSectionsByCategory = categorySlugs.map(
-    (category: CollectionCategoryOption) => {
-      // get collections associated with that category
-      const items = collections.filter(
-        (c: ClientCollection) => c.category === category
-      )
-
-      return {
-        title: CollectionCategoryOption[category],
-        items,
-      }
-    }
-  )
-
-  return filterEmptySections(sidebarSectionsByCategory)
-}
-
-function filterEmptySections(sections) {
-  return sections.filter((c) => c.items.length > 0)
-}
-
-export function formatCollectionToSectionItem(
-  collection: ClientCollection,
-  currentPath: string
-): ListItemProps {
-  const path = getCollectionSlug(collection.slug)
-  return {
-    text: collection.shortName,
-    href: path,
-    isActive: path === currentPath,
-  }
 }

--- a/src/views/collection-view/helpers/index.ts
+++ b/src/views/collection-view/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './format-sidebar-sections'
+export * from './get-slug'

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,8 +1,7 @@
 import Link from 'next/link'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
-import useCurrentPath from 'hooks/use-current-path'
-import { formatCollectionToSectionItem, getTutorialSlug } from './helpers'
+import { getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
 import TutorialsSidebar, {
   HorizontalRule,
@@ -16,7 +15,6 @@ export default function CollectionView({
   layoutProps,
 }: CollectionPageProps): React.ReactElement {
   const { name, slug, description, shortName, tutorials } = collection
-  const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 
   return (
     <SidebarSidecarLayout
@@ -44,11 +42,7 @@ export default function CollectionView({
               <>
                 <HorizontalRule />
                 <SectionTitle text={section.title} />
-                <SectionList
-                  items={section.items.map((item) =>
-                    formatCollectionToSectionItem(item, currentPath)
-                  )}
-                />
+                <SectionList items={section.items} />
               </>
             )
           })}

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -3,11 +3,7 @@ import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import { getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
-import TutorialsSidebar, {
-  HorizontalRule,
-  SectionList,
-  SectionTitle,
-} from 'components/tutorials-sidebar'
+import CollectionViewSidebar from './components/collection-view-sidebar'
 
 export default function CollectionView({
   collection,
@@ -21,32 +17,10 @@ export default function CollectionView({
       breadcrumbLinks={layoutProps.breadcrumbLinks}
       headings={layoutProps.headings}
       sidebarSlot={
-        <TutorialsSidebar
-          title={`${product.name} Tutorials`}
-          backToLink={{
-            text: `${product.name} Home`,
-            href: `/${product.slug}`,
-          }}
-        >
-          <SectionList
-            items={[
-              {
-                text: 'Overview',
-                href: `/${product.slug}/tutorials`,
-                isActive: false,
-              },
-            ]}
-          />
-          {layoutProps.sidebarSections.map((section) => {
-            return (
-              <>
-                <HorizontalRule />
-                <SectionTitle text={section.title} />
-                <SectionList items={section.items} />
-              </>
-            )
-          })}
-        </TutorialsSidebar>
+        <CollectionViewSidebar
+          product={product}
+          sections={layoutProps.sidebarSections}
+        />
       }
     >
       <h1 id={layoutProps.headings[0].slug}>{name}</h1>

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -13,17 +13,15 @@ export default function CollectionView({
   collection,
   allProductCollections, // for sidebar section
   product,
+  layoutProps,
 }: CollectionPageProps): React.ReactElement {
   const { name, slug, description, shortName, tutorials } = collection
   const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 
   return (
     <SidebarSidecarLayout
-      breadcrumbLinks={[{ title: 'hi' }]}
-      headings={[
-        { title: 'Overview', slug: 'overview', level: 1 },
-        { title: 'Tutorials', slug: 'tutorials', level: 1 },
-      ]}
+      breadcrumbLinks={layoutProps.breadcrumbLinks}
+      headings={layoutProps.headings}
       sidebarSlot={
         <SidebarNav
           title={shortName}

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import { getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
 import CollectionViewSidebar from './components/collection-view-sidebar'
 
-export default function CollectionView({
+function CollectionView({
   collection,
   product,
   layoutProps,
@@ -41,3 +42,6 @@ export default function CollectionView({
     </SidebarSidecarLayout>
   )
 }
+
+CollectionView.layout = CoreDevDotLayout
+export default CollectionView

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,11 +1,14 @@
 import Link from 'next/link'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
-import SidebarNav from 'components/sidebar/components/sidebar-nav'
-import { MenuItem } from 'components/sidebar'
 import useCurrentPath from 'hooks/use-current-path'
-import { formatCollectionToMenuItem, getTutorialSlug } from './helpers'
+import { formatCollectionToSectionItem, getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
+import TutorialsSidebar, {
+  HorizontalRule,
+  SectionList,
+  SectionTitle,
+} from 'components/tutorials-sidebar'
 
 export default function CollectionView({
   collection,
@@ -20,20 +23,36 @@ export default function CollectionView({
       breadcrumbLinks={layoutProps.breadcrumbLinks}
       headings={layoutProps.headings}
       sidebarSlot={
-        <SidebarNav
-          title={shortName}
-          menuItems={[
-            ...layoutProps.sidebarSections.flatMap((category): MenuItem[] => {
-              return [
-                { divider: true },
-                { heading: category.title },
-                ...category.items.map((c) =>
-                  formatCollectionToMenuItem(c, currentPath)
-                ),
-              ]
-            }),
-          ]}
-        />
+        <TutorialsSidebar
+          title={`${product.name} Tutorials`}
+          backToLink={{
+            text: `${product.name} Home`,
+            href: `/${product.slug}`,
+          }}
+        >
+          <SectionList
+            items={[
+              {
+                text: 'Overview',
+                href: `${product.slug}/tutorials`,
+                isActive: false,
+              },
+            ]}
+          />
+          {layoutProps.sidebarSections.map((section) => {
+            return (
+              <>
+                <HorizontalRule />
+                <SectionTitle text={section.title} />
+                <SectionList
+                  items={section.items.map((item) =>
+                    formatCollectionToSectionItem(item, currentPath)
+                  )}
+                />
+              </>
+            )
+          })}
+        </TutorialsSidebar>
       }
     >
       <h1 id={layoutProps.headings[0].slug}>{name}</h1>

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -11,7 +11,7 @@ import { CollectionPageProps } from './server'
 
 export default function CollectionView({
   collection,
-  allProductCollections, // for sidebar section
+  allProductCollections, // for sidebar section and sitemap
   product,
   layoutProps,
 }: CollectionPageProps): React.ReactElement {
@@ -39,8 +39,9 @@ export default function CollectionView({
         />
       }
     >
-      <h1>{name}</h1>
+      <h1 id={layoutProps.headings[0].slug}>{name}</h1>
       <p>{description}</p>
+      <h2 id={layoutProps.headings[1].slug}>Tutorials</h2>
       <ol>
         {tutorials.map((tutorial: ClientTutorialLite) => {
           const tutorialSlug = getTutorialSlug(tutorial.slug, slug)

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,28 +1,19 @@
 import Link from 'next/link'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import {
-  TutorialLite as ClientTutorialLite,
-  Collection as ClientCollection,
-  CollectionCategoryOption,
-} from 'lib/learn-client/types'
+import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import SidebarNav from 'components/sidebar/components/sidebar-nav'
-import useCurrentPath from 'hooks/use-current-path'
-import { getCollectionSlug, getTutorialSlug } from './helpers'
-import { CollectionPageProps } from './server'
 import { MenuItem } from 'components/sidebar'
+import useCurrentPath from 'hooks/use-current-path'
+import { formatCollectionToMenuItem, getTutorialSlug } from './helpers'
+import { CollectionPageProps } from './server'
 
 export default function CollectionView({
   collection,
-  allProductCollections, // for sidebar section and sitemap
   product,
   layoutProps,
 }: CollectionPageProps): React.ReactElement {
   const { name, slug, description, shortName, tutorials } = collection
   const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
-  const sidebarSections = formatAllCollectionsMenuItems(
-    allProductCollections,
-    currentPath
-  )
 
   return (
     <SidebarSidecarLayout
@@ -32,11 +23,13 @@ export default function CollectionView({
         <SidebarNav
           title={shortName}
           menuItems={[
-            ...sidebarSections.flatMap((category): MenuItem[] => {
+            ...layoutProps.sidebarSections.flatMap((category): MenuItem[] => {
               return [
                 { divider: true },
                 { heading: category.title },
-                ...category.items,
+                ...category.items.map((c) =>
+                  formatCollectionToMenuItem(c, currentPath)
+                ),
               ]
             }),
           ]}
@@ -58,58 +51,6 @@ export default function CollectionView({
           )
         })}
       </ol>
-      <h2>Sitemap Data</h2>
-      <ul>
-        {allProductCollections.map((collection: ClientCollection) => {
-          const collectionSlug = getCollectionSlug(collection.slug)
-          return (
-            <li key={collection.id}>
-              <Link href={collectionSlug}>
-                <a>{collection.shortName}</a>
-              </Link>
-            </li>
-          )
-        })}
-      </ul>
     </SidebarSidecarLayout>
   )
-}
-
-function formatAllCollectionsMenuItems(
-  collections: ClientCollection[],
-  currentPath: string
-): { title: CollectionCategoryOption; items: MenuItem[] }[] {
-  const categorySlugs = Object.keys(CollectionCategoryOption)
-
-  const sortedSidebarCategories = categorySlugs.map(
-    (category: CollectionCategoryOption) => {
-      // get collections associated with that category
-      const associatedCollections = collections.filter(
-        (c: ClientCollection) => c.category === category
-      )
-      // sort collections alphabetically & map into DefaultCollection shape
-      const items = associatedCollections.map(
-        (collection: ClientCollection) => {
-          const path = getCollectionSlug(collection.slug)
-          return {
-            title: collection.shortName,
-            fullPath: path,
-            id: collection.id,
-            isActive: path === currentPath,
-          }
-        }
-      )
-
-      return {
-        title: CollectionCategoryOption[category],
-        items,
-      }
-    }
-  )
-
-  return filterEmptySections(sortedSidebarCategories)
-}
-
-function filterEmptySections(sections) {
-  return sections.filter((c) => c.items.length > 0)
 }

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -34,7 +34,7 @@ export default function CollectionView({
             items={[
               {
                 text: 'Overview',
-                href: `${product.slug}/tutorials`,
+                href: `/${product.slug}/tutorials`,
                 isActive: false,
               },
             ]}

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,8 +1,11 @@
+import Link from 'next/link'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import {
   TutorialLite as ClientTutorialLite,
   Collection as ClientCollection,
 } from 'lib/learn-client/types'
-import Link from 'next/link'
+import SidebarNav from 'components/sidebar/components/sidebar-nav'
+import useCurrentPath from 'hooks/use-current-path'
 import { getCollectionSlug, getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
 
@@ -11,10 +14,33 @@ export default function CollectionView({
   allProductCollections, // for sidebar section
   product,
 }: CollectionPageProps): React.ReactElement {
-  const { name, slug, description, tutorials } = collection
+  const { name, slug, description, shortName, tutorials } = collection
+  const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 
   return (
-    <>
+    <SidebarSidecarLayout
+      breadcrumbLinks={[{ title: 'hi' }]}
+      headings={[
+        { title: 'Overview', slug: 'overview', level: 1 },
+        { title: 'Tutorials', slug: 'tutorials', level: 1 },
+      ]}
+      sidebarSlot={
+        <SidebarNav
+          title={shortName}
+          menuItems={allProductCollections.map(
+            (collection: ClientCollection) => {
+              const path = getCollectionSlug(collection.slug)
+              return {
+                title: collection.shortName,
+                fullPath: path,
+                id: collection.id,
+                isActive: path === currentPath,
+              }
+            }
+          )}
+        />
+      }
+    >
       <h1>{name}</h1>
       <p>{description}</p>
       <ol>
@@ -42,6 +68,6 @@ export default function CollectionView({
           )
         })}
       </ul>
-    </>
+    </SidebarSidecarLayout>
   )
 }

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -11,14 +11,20 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
+import { SidebarSection, collectionsToSidebarSections } from './helpers'
 import { filterCollections } from '../product-tutorials-view/helpers'
 
 export interface CollectionPageProps {
   collection: ClientCollection
   allProductCollections: ClientCollection[]
   product: LearnProductData
-  layoutProps: Pick<SidebarSidecarLayoutProps, 'headings' | 'breadcrumbLinks'>
+  layoutProps: CollectionLayout
 }
+
+type CollectionLayout = Pick<
+  SidebarSidecarLayoutProps,
+  'headings' | 'breadcrumbLinks'
+> & { sidebarSections: SidebarSection[] }
 
 export interface CollectionPagePath {
   params: {
@@ -43,6 +49,10 @@ export async function getCollectionPageProps(
   const allProductCollections = await getAllCollections({
     product: { slug: product.slug, sidebarSort: true },
   })
+  const filteredCollections = filterCollections(
+    allProductCollections,
+    product.slug
+  )
   const layoutProps = {
     headings: [
       { title: 'Overview', slug: 'overview', level: 1 },
@@ -55,15 +65,12 @@ export async function getCollectionPageProps(
         filename: splitProductFromFilename(collection.slug),
       },
     }),
+    sidebarSections: collectionsToSidebarSections(filteredCollections),
   }
 
   return {
     props: stripUndefinedProperties({
       collection: collection,
-      allProductCollections: filterCollections(
-        allProductCollections,
-        product.slug
-      ),
       product,
       layoutProps,
     }),

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -11,6 +11,7 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
+import { filterCollections } from '../product-tutorials-view/helpers'
 
 export interface CollectionPageProps {
   collection: ClientCollection
@@ -59,7 +60,10 @@ export async function getCollectionPageProps(
   return {
     props: stripUndefinedProperties({
       collection: collection,
-      allProductCollections,
+      allProductCollections: filterCollections(
+        allProductCollections,
+        product.slug
+      ),
       product,
       layoutProps,
     }),

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -9,11 +9,14 @@ import {
 } from 'lib/learn-client/api/collection'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
+import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
 
 export interface CollectionPageProps {
   collection: ClientCollection
   allProductCollections: ClientCollection[]
   product: LearnProductData
+  layoutProps: Pick<SidebarSidecarLayoutProps, 'headings' | 'breadcrumbLinks'>
 }
 
 export interface CollectionPagePath {
@@ -40,11 +43,27 @@ export async function getCollectionPageProps(
     product: { slug: product.slug, sidebarSort: true },
   })
 
+  const layoutProps = {
+    // @TODO integrate so the anchor tags track
+    headings: [
+      { title: 'Overview', slug: 'overview', level: 1 },
+      { title: 'Tutorials', slug: 'tutorials', level: 1 },
+    ],
+    breadcrumbLinks: getTutorialsBreadcrumb({
+      product: { name: product.name, filename: product.slug },
+      collection: {
+        name: collection.shortName,
+        filename: splitProductFromFilename(collection.slug),
+      },
+    }),
+  }
+
   return {
     props: stripUndefinedProperties({
       collection: collection,
       allProductCollections,
       product,
+      layoutProps,
     }),
   }
 }

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -11,7 +11,10 @@ import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
-import { SidebarSection, collectionsToSidebarSections } from './helpers'
+import {
+  CollectionCategorySidebarSection,
+  collectionsToSidebarSections,
+} from './helpers'
 import { filterCollections } from '../product-tutorials-view/helpers'
 
 export interface CollectionPageProps {
@@ -24,7 +27,7 @@ export interface CollectionPageProps {
 type CollectionLayout = Pick<
   SidebarSidecarLayoutProps,
   'headings' | 'breadcrumbLinks'
-> & { sidebarSections: SidebarSection[] }
+> & { sidebarSections: CollectionCategorySidebarSection[] }
 
 export interface CollectionPagePath {
   params: {
@@ -65,7 +68,10 @@ export async function getCollectionPageProps(
         filename: splitProductFromFilename(collection.slug),
       },
     }),
-    sidebarSections: collectionsToSidebarSections(filteredCollections),
+    sidebarSections: collectionsToSidebarSections(
+      filteredCollections,
+      collection.slug
+    ),
   }
 
   return {

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -42,9 +42,7 @@ export async function getCollectionPageProps(
   const allProductCollections = await getAllCollections({
     product: { slug: product.slug, sidebarSort: true },
   })
-
   const layoutProps = {
-    // @TODO integrate so the anchor tags track
     headings: [
       { title: 'Overview', slug: 'overview', level: 1 },
       { title: 'Tutorials', slug: 'tutorials', level: 1 },

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -13,7 +13,7 @@ import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
 import {
   CollectionCategorySidebarSection,
-  collectionsToSidebarSections,
+  formatSidebarCategorySections,
 } from './helpers'
 import { filterCollections } from '../product-tutorials-view/helpers'
 
@@ -68,7 +68,7 @@ export async function getCollectionPageProps(
         filename: splitProductFromFilename(collection.slug),
       },
     }),
-    sidebarSections: collectionsToSidebarSections(
+    sidebarSections: formatSidebarCategorySections(
       filteredCollections,
       collection.slug
     ),

--- a/src/views/product-tutorials-view/helpers.ts
+++ b/src/views/product-tutorials-view/helpers.ts
@@ -1,4 +1,7 @@
-import { Collection as ClientCollection } from 'lib/learn-client/types'
+import {
+  Collection as ClientCollection,
+  ProductOption,
+} from 'lib/learn-client/types'
 
 /**
  * This function is an interim solution for filtering content from the /onboarding dir
@@ -7,10 +10,13 @@ import { Collection as ClientCollection } from 'lib/learn-client/types'
  * This function also filters collections that don't have the product as the main theme
  */
 
-export function filterCollections(collections, theme) {
-  return collections
-    .filter((c) => c.theme === theme && !c.slug.includes('onboarding'))
-    .sort(sortAlphabetically('name'))
+export function filterCollections(
+  collections: ClientCollection[],
+  theme: ProductOption
+) {
+  return collections.filter(
+    (c: ClientCollection) => c.theme === theme && !c.slug.includes('onboarding')
+  )
 }
 
 function sortAlphabetically(
@@ -28,4 +34,11 @@ function sortAlphabetically(
     }
     return 0
   }
+}
+
+export function filterAndSortCollections(
+  collections: ClientCollection[],
+  theme: ProductOption
+) {
+  return filterCollections(collections, theme).sort(sortAlphabetically('name'))
 }

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -4,7 +4,7 @@ import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getProduct } from 'lib/learn-client/api/product'
 import { Collection as ClientCollection } from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
-import { filterCollections } from './helpers'
+import { filterAndSortCollections } from './helpers'
 
 // Some of the product data is coming from the API client on this view
 type ProductTutorialsPageProduct = ClientProduct &
@@ -33,7 +33,7 @@ export async function getProductTutorialsPageProps(
   const allProductCollections = await getAllCollections({
     product: { slug: productSlug },
   })
-  const filteredCollections = filterCollections(
+  const filteredCollections = filterAndSortCollections(
     allProductCollections,
     productSlug
   )

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -52,14 +52,14 @@ export async function getTutorialPageProps(
   const layoutProps = {
     headings,
     breadcrumbLinks: getTutorialsBreadcrumb({
-      product: { name: product.name, slug: product.slug },
+      product: { name: product.name, filename: product.slug },
       collection: {
         name: collection.data.shortName,
-        slug: collection.filename,
+        filename: collection.filename,
       },
       tutorial: {
         name: fullTutorialData.name,
-        slug: tutorialReference.filename,
+        filename: tutorialReference.filename,
       },
     }),
   }

--- a/src/views/tutorial-view/utils/get-tutorials-breadcrumb.ts
+++ b/src/views/tutorial-view/utils/get-tutorials-breadcrumb.ts
@@ -8,7 +8,7 @@ interface TutorialsBreadcrumbOptions {
 
 type BasePathType = {
   name: string
-  slug: string
+  filename: string
 }
 
 export function getTutorialsBreadcrumb({
@@ -18,20 +18,20 @@ export function getTutorialsBreadcrumb({
 }: TutorialsBreadcrumbOptions): BreadcrumbLink[] {
   const paths = [
     { title: 'Developer', url: '/' },
-    { title: product.name, url: `/${product.slug}` },
-    { title: 'Tutorials', url: `/${product.slug}/tutorials` },
+    { title: product.name, url: `/${product.filename}` },
+    { title: 'Tutorials', url: `/${product.filename}/tutorials` },
   ]
 
   if (collection) {
     paths.push({
       title: collection.name,
-      url: `/${product.slug}/tutorials/${collection.slug}`,
+      url: `/${product.filename}/tutorials/${collection.filename}`,
     })
 
     if (tutorial) {
       paths.push({
         title: tutorial.name,
-        url: `/${product.slug}/tutorials/${collection.slug}/${tutorial.slug}`,
+        url: `/${product.filename}/tutorials/${collection.filename}/${tutorial.filename}`,
       })
     }
   }


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [X] The Vercel preview link has been added to this PR's description
- [X] The Asana task has been added to this PR's description
- [X] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [X] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kscollection-view-layout-hashicorp.vercel.app/vault/tutorials/adp) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202095033465927) 🎟️

## What

This PR adds the basic sidebar / sidecar layout to the collection view. This PR isn't meant to implement the collection sidebar to spec, but just getting things in place so that style refinement is easier. 

## Why

Setting things up so we can just focus on component development for this view!

## How

I adjusted the `server.js` file to organize the sidebar sections according to the collection categories. These props are passed as `layoutProps` to the view. 

## Testing

- [Visit this link](https://dev-portal-git-kscollection-view-layout-hashicorp.vercel.app/vault/tutorials/adp) and double check that the collection list matches that of [Learn today. ](https://learn.hashicorp.com/collections/vault/adp)
- Test that the sidebar links work
- Test that the breadcrumb links work
- Test that the sidecar links work. 

## Anything else?

The sidecar links in [the designs](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Dev-Portal?node-id=7053%3A54950) link to a section called 'tutorials'. In this PR I added a header with an id for this, but we'll need to think of how we link to this section without the header and still have the sidecar track properly. It seems the sidecar tracking is linked to the heading element specifically, but I could be wrong! 
