### PR TITLE
feat: handle simple dev portal redirects

### DIFF
--- a/build-libs/__tests__/redirects.test.ts
+++ b/build-libs/__tests__/redirects.test.ts
@@ -160,7 +160,7 @@ describe('groupSimpleRedirects', () => {
     })
   })
 
-  test('loses simple redirects without associated product', () => {
+  test('handles simple redirects without associated product', () => {
     const groupedSimpleRedirects = groupSimpleRedirects([
       {
         source: '/source',
@@ -169,7 +169,14 @@ describe('groupSimpleRedirects', () => {
       },
     ])
 
-    expect(groupedSimpleRedirects).not.toEqual({})
+    expect(groupedSimpleRedirects).toEqual({
+      '*': {
+        '/source': {
+          destination: '/destination',
+          permanent: false,
+        },
+      },
+    })
   })
 })
 

--- a/src/__tests__/e2e/redirects.spec.ts
+++ b/src/__tests__/e2e/redirects.spec.ts
@@ -43,3 +43,9 @@ test('should use glob-based redirects', async ({ page, context, baseURL }) => {
   const { pathname } = new URL(page.url())
   expect(pathname).toBe('/security')
 })
+
+test('should use dev portal redirects', async ({ page, context, baseURL }) => {
+  await page.goto('/hashicorp-cloud-platform')
+  const { pathname } = new URL(page.url())
+  expect(pathname).toBe('/hcp')
+})

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -28,7 +28,7 @@ const HOSTNAME_MAP = {
   'test-wp.hashi-mktg.com': 'waypoint',
 }
 
-function determineProductSlug(req: NextRequest): string | null {
+function determineProductSlug(req: NextRequest): string {
   // .io preview on dev portal
   if (req.cookies.io_preview) {
     return req.cookies.io_preview
@@ -44,7 +44,8 @@ function determineProductSlug(req: NextRequest): string | null {
     return HOSTNAME_MAP[req.nextUrl.hostname]
   }
 
-  return null
+  // dev portal
+  return '*'
 }
 
 /**
@@ -58,11 +59,7 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
   if (process.env.DEBUG_REDIRECTS) {
     console.log(`[DEBUG_REDIRECTS] determined product to be: ${product}`)
   }
-  if (
-    product &&
-    redirects[product] &&
-    req.nextUrl.pathname in redirects[product]
-  ) {
+  if (redirects[product] && req.nextUrl.pathname in redirects[product]) {
     const { destination, permanent } = redirects[product][req.nextUrl.pathname]
     if (process.env.DEBUG_REDIRECTS) {
       console.log(


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-pagpypbxe-hashicorp.vercel.app) 🔎
- [Asana task](url) 🎟️

## What

Adds handling for simple redirects that don't use a `has` condition (which means they're redirects for Dev Portal).

## Why

We want Dev Portal to be able to support its own redirects :)

## How

Define redirects without a `has` condition as belonging to the `'*'` product, signifying Dev Portal. Incoming requests without one of the various .io signifiers will be reported as `'*'` for the product.

## Testing

- Go to preview URL: https://dev-portal-pagpypbxe-hashicorp.vercel.app
- Go to `/hashicorp-cloud-platform`
- Ensure you're redirected to `/hcp`

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
