### PR TITLE
Fix custom dropdown styling for H menu

### DIFF
--- a/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
+++ b/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
@@ -55,10 +55,9 @@
 
 .dropdownContainer {
   background-color: white;
-  border-bottom-left-radius: 0;
+  border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
   box-shadow: var(--token-elevation-higher-box-shadow);
-  left: calc(-1 * var(--header-padding-left-right));
   min-width: 252px;
   padding: 16px;
   position: absolute;

--- a/src/components/navigation-header/components/dropdown-menu/index.tsx
+++ b/src/components/navigation-header/components/dropdown-menu/index.tsx
@@ -45,6 +45,7 @@ const supportedIcons: { [key in SupportedIcon]: ReactElement } = {
 const NavigationHeaderDropdownMenu = ({
   ariaLabel,
   buttonClassName,
+  dropdownClassName,
   itemGroups,
   label,
   leadingIcon,
@@ -196,7 +197,7 @@ const NavigationHeaderDropdownMenu = ({
         </button>
       </div>
       <div
-        className={s.dropdownContainer}
+        className={classNames(s.dropdownContainer, dropdownClassName)}
         id={menuId}
         style={{ display: isOpen ? 'block' : 'none' }}
       >

--- a/src/components/navigation-header/components/product-page-content/index.tsx
+++ b/src/components/navigation-header/components/product-page-content/index.tsx
@@ -60,6 +60,7 @@ const ProductPageHeaderContent = () => {
         <NavigationHeaderDropdownMenu
           ariaLabel="Main menu"
           buttonClassName={s.companyLogoMenuButton}
+          dropdownClassName={s.companyLogoMenuButtonDropdown}
           itemGroups={allMainMenuItems}
           leadingIcon={companyLogo}
         />

--- a/src/components/navigation-header/components/product-page-content/product-page-content.module.css
+++ b/src/components/navigation-header/components/product-page-content/product-page-content.module.css
@@ -14,6 +14,11 @@
   padding-top: 2px;
 }
 
+.companyLogoMenuButtonDropdown {
+  border-bottom-left-radius: 0;
+  left: calc(-1 * var(--header-padding-left-right));
+}
+
 .productLogoLink {
   /* Composition */
   composes: g-focus-ring-from-box-shadow-dark from global;

--- a/src/components/navigation-header/types.ts
+++ b/src/components/navigation-header/types.ts
@@ -14,9 +14,10 @@ interface NavigationHeaderItem {
 interface NavigationHeaderDropdownMenuProps {
   ariaLabel?: string
   buttonClassName?: string
-  leadingIcon?: ReactElement
+  dropdownClassName?: string
   itemGroups: NavigationHeaderItem[][]
   label?: string
+  leadingIcon?: ReactElement
 }
 
 export type {


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-nav-dropdowns-hashicorp.vercel.app/waypoint) 🔎

## What

<!--
Briefly list out the changes proposed in this PR.
-->

The adjustments I made earlier today in #308 were made in a way that affected _all_ primary nav menus instead of just the H menu in the product nav headers. These changes ensure that only the H menu is affected, via a new `dropdownClassName` prop I added to `NavigationHeaderDropdownMenu`.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Make sure the dropdown menus have the correct left-alignment (should be left aligned with their button)
- [ ] Make sure the dropdonw menus have the correct border-radius for the bottom left and bottom right
- [ ] Go to any other page in the app
- [ ] Make sure only the H dropdown menu has unique `left` alignment and `border-bottom-left-radius`

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!