### PR TITLE
chore: switch off vercel github bot silent mode

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "github": {
-    "silent": true
+    "silent": false
   }
 }


### PR DESCRIPTION
> Note: quoted lines are not applicable

## "Ready for Review" checklist

> - [ ] The Vercel preview link has been added to this PR's description
> - [ ] The Asana task has been added to this PR's description
> - [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
> - [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

> - Preview link 🔎
> - Asana task 🎟️

## What

Sets the Vercel bot `silent` setting to `false`.

## Why

So that we get PR comments with the long-lived deploy preview link, which can otherwise be cumbersome to track down.

## How

Edits `vercel.json` at the project root.

## Testing

- [ ] This PR should have a visible Vercel bot comment on it

## Anything else?

Nope! We had a Slack thread establishing consensus on this change, seemed there was a decent amount of support & no opposition, so figured it was a good time to open this PR as a next step 👍
