### PR TITLE
chore: bump docs-page for table align fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@hashicorp/react-code-block": "^4.5.0",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
-        "@hashicorp/react-docs-page": "^14.16.0",
+        "@hashicorp/react-docs-page": "^14.16.1",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-error-view": "^0.0.1",
         "@hashicorp/react-featured-slider": "^5.0.1",
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/@hashicorp/react-content": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
-      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.2.tgz",
+      "integrity": "sha512-gEg71vJxOK1MG//uHzpG3BDghUFu7tEpNw7jTwV2paGat81yYX36Clu3POd0smrWiKEJbdrCSqa5/V+aPzVIQA==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
@@ -3236,14 +3236,14 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.16.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.16.0.tgz",
-      "integrity": "sha512-KCvkn5WHyDzKbZ69vMF+PPj+0YQ+w3nbTFwO2chqlC0gwP1Gga9laqV0JQP88MhjLqSoO5R4IOKhuz6EeqDIlw==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.16.1.tgz",
+      "integrity": "sha512-RC7t39cqUfV2w7wh5qUX2cNSTZ56ERrThz/ZnuBHEs1PFkJbkMUm2P5FYja6IOAwGfVhyb+VaeRBBJ1xS+q2Xw==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1",
+        "@hashicorp/react-content": "^8.2.2",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
@@ -35913,23 +35913,23 @@
       }
     },
     "@hashicorp/react-content": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
-      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.2.tgz",
+      "integrity": "sha512-gEg71vJxOK1MG//uHzpG3BDghUFu7tEpNw7jTwV2paGat81yYX36Clu3POd0smrWiKEJbdrCSqa5/V+aPzVIQA==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.16.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.16.0.tgz",
-      "integrity": "sha512-KCvkn5WHyDzKbZ69vMF+PPj+0YQ+w3nbTFwO2chqlC0gwP1Gga9laqV0JQP88MhjLqSoO5R4IOKhuz6EeqDIlw==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.16.1.tgz",
+      "integrity": "sha512-RC7t39cqUfV2w7wh5qUX2cNSTZ56ERrThz/ZnuBHEs1PFkJbkMUm2P5FYja6IOAwGfVhyb+VaeRBBJ1xS+q2Xw==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1",
+        "@hashicorp/react-content": "^8.2.2",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@hashicorp/react-code-block": "^4.5.0",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
-    "@hashicorp/react-docs-page": "^14.16.0",
+    "@hashicorp/react-docs-page": "^14.16.1",
     "@hashicorp/react-enterprise-alert": "^6.0.1",
     "@hashicorp/react-error-view": "^0.0.1",
     "@hashicorp/react-featured-slider": "^5.0.1",


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsbump-content-for-table-align-fix-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1100423001970639/1201999608008890/f) 🎟️

## What

Fixes an issue where `table`s in `docs-page` content were not left-aligned by default.

## Why

Left-aligned cells are generally more scan-able, so we'l like them to be our default.

## How

Adds `text-align: left` to `th` cells which do not have an `align` attribute set. See hashicorp/react-components#562 for details.

## Testing

A couple of Consul content examples:

> Note: to get preview links to show `consulproject.io`, you must select `Consul` in the product dropdown in the lower left of the screen.

- [/api-docs/txn](https://dev-portal-git-zsbump-content-for-table-align-fix-hashicorp.vercel.app/api-docs/txn#kv-operations) vs [live](https://www.consul.io/api-docs/txn#kv-operations)
    - first 2 columns should be left-aligned (our default)
    - last 5 columns should be centred (to properly reflect author intent in MDX)

- [/docs/install/performance](https://dev-portal-git-zsbump-content-for-table-align-fix-hashicorp.vercel.app/docs/install/performance#production) vs [live](https://www.consul.io/docs/install/performance#production)
    - first column should be left-aligned (our default)
    - last 2 columns should be right-aligned (to properly reflect author intent in MDX)

## Anything else?

Nope!
