### PR TITLE
Fixing Vault and Waypoint Documentation primary nav menus

### DIFF
--- a/src/components/navigation-header/components/dropdown-menu/index.tsx
+++ b/src/components/navigation-header/components/dropdown-menu/index.tsx
@@ -27,11 +27,13 @@ import {
 
 // Local imports
 import s from './dropdown-menu.module.css'
+import { IconBox16 } from '@hashicorp/flight-icons/svg-react/box-16'
 
 /**
  * The icons supported in this menu in addition to the Product logo icons.
  */
 const supportedIcons: { [key in SupportedIcon]: ReactElement } = {
+  box: <IconBox16 />,
   docs: <IconDocs16 />,
   home: <IconHome16 />,
   terminalScreen: <IconTerminalScreen16 />,

--- a/src/components/navigation-header/types.ts
+++ b/src/components/navigation-header/types.ts
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react'
 import { ProductSlug } from 'types/products'
 
-type SupportedIcon = 'docs' | 'home' | 'terminalScreen' | 'tools'
+type SupportedIcon = 'box' | 'docs' | 'home' | 'terminalScreen' | 'tools'
 
 type NavigationHeaderIcon = ProductSlug | SupportedIcon
 

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -185,14 +185,9 @@
         "pathSuffix": "docs"
       },
       {
-        "label": "CLI",
-        "icon": "terminalScreen",
-        "pathSuffix": "docs/commands"
-      },
-      {
-        "label": "Plugins",
+        "label": "API",
         "icon": "tools",
-        "pathSuffix": "docs/plugins"
+        "pathSuffix": "api-docs"
       }
     ]
   }

--- a/src/data/waypoint.json
+++ b/src/data/waypoint.json
@@ -102,7 +102,7 @@
       },
       {
         "label": "Plugins",
-        "icon": "tools",
+        "icon": "box",
         "pathSuffix": "plugins"
       }
     ]


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x]  This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-docs-nav-menu-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202110981600689/1202129912162151/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates the icon next to Plugins under Waypoint's Documentation menu to match the designs
  - This required adding support for the `box-16` icon in the primary nav dropdown component
- Updates the contents of Vault's Documentation menu for feature parity with the header at https://vaultproject.io

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Added another entry in the supported icons map in `src/components/navigation-header/components/dropdown-menu/index.tsx`
- Updated the JSON data the primary nav consumes to have the correct data

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint](https://dev-portal-git-ambfix-docs-nav-menu-hashicorp.vercel.app/waypoint)
- [ ] Open the Documentation submenu in the primary nav
- [ ] It should look like:
  ![image](https://user-images.githubusercontent.com/43934258/163610190-9df3f7b1-c0b3-44c8-9823-6d5f72b609d3.png)
- [ ] Go to [/vault](https://dev-portal-git-ambfix-docs-nav-menu-hashicorp.vercel.app/vault)
- [ ] Open the Documentation submenu in the primary nav
- [ ] It should look like:
  ![image](https://user-images.githubusercontent.com/43934258/163609869-68737b9b-ecb9-45f0-a04e-d061365652d8.png)


## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!