### PR TITLE
Removing SidebarBackToLink on product landings (/vault, /waypoint, etc.)

### DIFF
--- a/src/views/product-landing/server.ts
+++ b/src/views/product-landing/server.ts
@@ -94,10 +94,6 @@ async function generateStaticProps({
         { title: product.name, url: `/${product.slug}` },
       ],
       sidebarProps: {
-        backToLinkProps: {
-          text: 'Back to Developer',
-          url: '/',
-        },
         menuItems: navData,
         showFilterInput: false,
         title: product.name,


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambremove-product-landing-back-to-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202139025976458/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->

Removes the `SidebarBackToLink` from product landing pages.

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Details are in the comments of the [[Question][Sidebar] What are the requirements for the StandaloneLink on product landing pages?](https://app.asana.com/0/1202110981600689/1202125080890160/f) ticket.

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Removed the `sidebarProps.backToLinkProps` property that was being set in `src/views/product-landing/server.ts`.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint](https://dev-portal-git-ambremove-product-landing-back-to-hashicorp.vercel.app/waypoint)
- [ ] There should be no back to link at the top of the Sidebar
- [ ] Go to [/vault](https://dev-portal-git-ambremove-product-landing-back-to-hashicorp.vercel.app/vault)
- [ ] There should be no back to link at the top of the Sidebar

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!