### PR TITLE
feat: support versioned URLs

### DIFF
--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -51,6 +51,7 @@ export function getStaticGenerationFunctions<
   const loaderOptions: RemoteContentLoader['opts'] = {
     product: productSlugForLoader,
     basePath: basePathForLoader,
+    enabledVersionedDocs: true,
     latestVersionRef: isBetaProduct
       ? __config.dev_dot.content_preview_branch
       : undefined,
@@ -82,7 +83,7 @@ export function getStaticGenerationFunctions<
         scope: await getScope(),
       })
 
-      const { navData, mdxSource, githubFileUrl } =
+      const { navData, mdxSource, githubFileUrl, versions } =
         await loader.loadStaticProps(ctx)
 
       /**
@@ -147,6 +148,7 @@ export function getStaticGenerationFunctions<
         },
         mdxSource,
         product,
+        versions,
       }
 
       return {

--- a/src/lib/get-version-from-path.ts
+++ b/src/lib/get-version-from-path.ts
@@ -1,0 +1,12 @@
+const REGEX = /^v\d+\.\d+\.(\d+|\w+)$/i
+
+/**
+ * Extract the version from a path string, or an array of path segments
+ */
+export function getVersionFromPath(path: string): string | undefined {
+  const pathSegments = path.split('/')
+
+  const version = pathSegments.find((el) => REGEX.test(el))
+
+  return version
+}

--- a/src/views/docs-view/components/no-index-tag-if-versioned.tsx
+++ b/src/views/docs-view/components/no-index-tag-if-versioned.tsx
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { getVersionFromPath } from 'lib/get-version-from-path'
+
+export function NoIndexTagIfVersioned() {
+  const { asPath } = useRouter()
+  const versionInPath = getVersionFromPath(asPath)
+
+  if (versionInPath) {
+    return (
+      <Head>
+        <meta name="robots" content="noindex" key="robots" />
+      </Head>
+    )
+  }
+
+  return null
+}

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -5,6 +5,7 @@ import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import DevDotContent from 'components/dev-dot-content'
 import { DocsViewProps, ProductsToPrimitivesMap } from './types'
+import { NoIndexTagIfVersioned } from './components/no-index-tag-if-versioned'
 
 // Author primitives
 const Badge = dynamic(() => import('components/author-primitives/packer/badge'))
@@ -61,6 +62,7 @@ const DocsView = ({ mdxSource, lazy }: DocsViewProps) => {
 
   return (
     <DevDotContent>
+      <NoIndexTagIfVersioned />
       <MDXRemote
         compiledSource={compiledSource}
         components={components}


### PR DESCRIPTION
## "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them.
-->

- [ ] The Vercel preview link has been added to this PR's description
- [ ] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [ ] The description template has been filled in below

---

## Relevant links

<!-- 
Make sure to remove any '.' characters from the branch name 
Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1201903760348480/1202150565840117/f) 🎟️

## What

<!--
Briefly list out the changes proposed in this PR.
-->
Support rendering of versioned docs paths

## Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
For versioned docs support!

## How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
This is already baked into the underlying content loader, just needed to set `enableVersionedDocs: true` and pass along the `versions` array. We can use the `versions` array to build out the version select after this.

## Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
- [ ] Navigate to https://dev-portal-git-brkchore-enable-versioned-docs-urls-hashicorp.vercel.app/waypoint/docs/v0.7.x
- [ ] Assert that the content renders
- [ ] Navigate to https://dev-portal-git-brkchore-enable-versioned-docs-urls-hashicorp.vercel.app/vault/docs/v1.9.x
- [ ] Assert that the content renders
- [ ] Log `__NEXT_DATA__.props.pageProps.versions` in the console
- [ ] Assert that the available versions are in the array

## Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
