### PR TITLE
feat: style tabs

### DIFF
--- a/src/components/tabs/components/tab-button-controls/index.tsx
+++ b/src/components/tabs/components/tab-button-controls/index.tsx
@@ -74,7 +74,11 @@ function TabButtonControls({
         const { label, tabId, panelId, isActive } = tabItem
         return (
           <button
-            className={classNames(s.tabButton, 'g-focus-ring-from-box-shadow')}
+            className={classNames(
+              s.tabButton,
+              'g-focus-ring-from-box-shadow',
+              'hds-typography-body-200'
+            )}
             aria-controls={panelId}
             aria-selected={isActive}
             id={tabId}

--- a/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
+++ b/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
@@ -6,6 +6,7 @@ the correct elements, roles, states, and properties are being set in the markup.
 .tabList[role='tablist'] {
   align-items: center;
   display: flex;
+  gap: 2px;
 }
 
 /*
@@ -13,23 +14,18 @@ Styles for each tab button.
 */
 .tabButton[role='tab'] {
   background-color: white;
-  border: none;
   border-radius: 5px;
+  border: 1px solid transparent;
   color: var(--token-color-foreground-faint);
   cursor: pointer;
-
-  /*
-  Ensure each item will not shrink, so that overflow will be triggered
-  rather than items going to multi-line.
-  */
-  flex-shrink: 0;
-  font-size: var(--token-typography-body-200-font-size);
-  font-weight: var(--token-typography-font-weight-regular);
-  padding: 8px 12px;
+  flex-shrink: 0; /* Ensure items will trigger overflow */
+  font-weight: var(--token-typography-font-weight-medium);
+  padding: 7px 12px;
 
   &[aria-selected='true'] {
-    color: var(--token-color-foreground-strong);
-    background-color: var(--token-color-palette-neutral-200);
+    color: var(--token-color-foreground-action);
+    background-color: var(--token-color-surface-action);
+    border-color: var(--token-color-foreground-action);
   }
 
   &:focus-visible {
@@ -37,7 +33,7 @@ Styles for each tab button.
   }
 
   &:hover {
-    color: var(--token-color-foreground-strong);
-    background-color: var(--token-color-palette-neutral-100);
+    color: var(--token-color-foreground-action);
+    border-color: var(--token-color-foreground-action);
   }
 }

--- a/src/components/tabs/components/tab-dropdown-controls/tab-dropdown-controls.module.css
+++ b/src/components/tabs/components/tab-dropdown-controls/tab-dropdown-controls.module.css
@@ -17,18 +17,17 @@
 .select {
   /* composition */
   composes: g-focus-ring-from-box-shadow from global;
-  composes: hds-surface-low from global;
+  composes: hds-typography-body-200 from global;
 
   /* properties */
   appearance: none;
-  background-color: white;
+  background-color: var(--token-color-surface-action);
   border-radius: 5px;
-  border: none;
+  border: 1px solid var(--token-color-foreground-action);
+  color: var(--token-color-foreground-action);
   cursor: pointer;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 40px;
-  padding-top: 8px;
+  font-weight: var(--token-typography-font-weight-medium);
+  padding: 7px 40px 7px 12px;
   width: 100%;
 }
 


### PR DESCRIPTION
## "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## Relevant links

- [Preview link](https://dev-portal-git-zsstyle-tabs-hashicorp.vercel.app/swingset/components/tabs) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202151178802272) 🎟️

## What

Implements revised styles for `Tabs`.

## Why

To finish building out components for the tutorials views, which includes tabs.

## How

- Modifies styles for existing `tab-buttons-controls` & `tab-dropdown-controls` components

## Testing

- [ ] Visit [the Swingset page for `components/tabs`][swingset-tabs], and ensure look & behaviour is as expected
- [ ] Visit [a docs page that contains tabs][docs-page], and ensure tabs look as expected
    - There's a longer list of these pages in the PR description of #104, if we want to be thorough! ☺️ 
- [ ] Visit [a tutorials page that contains tabs][tutorials-page], and ensure tabs look as expected
- [ ] Visit [a downloads view][downloads-page], and ensure tabs look as expected

> Note: Mobile behaviour & look & feel may be hard to test in situ & in Swingset due to layout constraints. A [Storybook preview][storybook-tabs] is available just in case (I found it helpful during development). Here's a preview of the mobile behaviour:

![preview](https://user-images.githubusercontent.com/4624598/164092211-9def7bde-5a10-436d-b96f-0e1b60021e61.gif)

## Anything else?

The switch from `400` to `500` `font-weight` on `:hover` & activation of tabs causes layout shift: 

![font-weight-issue](https://user-images.githubusercontent.com/4624598/164092471-d1486b07-ca34-4775-9b77-bf42ab10b359.gif)

To avoid this issue, I've set `font-weight` to always be `500`. Going to quickly check with design on what approach they'd prefer here. I think going forward we should avoid `font-weight` shifts on interactive elements, if possible (as it seems impossible for us to guarantee consistent-width typography across font weights, since we're using system fonts).

[swingset-tabs]: https://dev-portal-git-zsstyle-tabs-hashicorp.vercel.app/swingset/components/tabs
[storybook-tabs]: https://dev-portal-with-storybook.vercel.app/?path=/story/components-tabs--playground
[docs-page]: https://dev-portal-git-zsstyle-tabs-hashicorp.vercel.app/waypoint/docs/server/auth#logging-in
[tutorials-page]: https://dev-portal-git-zsstyle-tabs-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-install
[downloads-page]: https://dev-portal-git-zsstyle-tabs-hashicorp.vercel.app/waypoint/downloads