### PR TITLE
feat: build collection-tutorial-list for collection views

### DIFF
--- a/src/components/tutorial-card/helpers.ts
+++ b/src/components/tutorial-card/helpers.ts
@@ -1,0 +1,22 @@
+import { getTutorialSlug } from 'views/collection-view/helpers'
+import {
+  ProductUsed,
+  TutorialLite as ClientTutorialLite,
+} from 'lib/learn-client/types'
+import { TutorialCardPropsWithId } from './types'
+
+export function formatTutorialCard(
+  tutorial: ClientTutorialLite,
+  collectionSlug: string
+): TutorialCardPropsWithId {
+  return {
+    id: tutorial.id,
+    description: tutorial.description,
+    duration: `${tutorial.readTime}min`,
+    hasInteractiveLab: Boolean(tutorial.handsOnLab),
+    hasVideo: Boolean(tutorial.video),
+    heading: tutorial.name,
+    url: getTutorialSlug(tutorial.slug, collectionSlug),
+    productsUsed: tutorial.productsUsed.map((p: ProductUsed) => p.product.slug),
+  }
+}

--- a/src/components/tutorial-card/helpers.ts
+++ b/src/components/tutorial-card/helpers.ts
@@ -1,4 +1,5 @@
 import { getTutorialSlug } from 'views/collection-view/helpers'
+import getReadableTime from 'components/tutorial-meta/components/badges/helpers'
 import {
   ProductUsed,
   TutorialLite as ClientTutorialLite,
@@ -12,7 +13,7 @@ export function formatTutorialCard(
   return {
     id: tutorial.id,
     description: tutorial.description,
-    duration: `${tutorial.readTime}min`,
+    duration: getReadableTime(tutorial.readTime),
     hasInteractiveLab: Boolean(tutorial.handsOnLab),
     hasVideo: Boolean(tutorial.video),
     heading: tutorial.name,

--- a/src/components/tutorial-card/types.ts
+++ b/src/components/tutorial-card/types.ts
@@ -37,3 +37,10 @@ export interface TutorialCardProps {
    */
   productsUsed: ProductOption[]
 }
+
+export interface TutorialCardPropsWithId extends TutorialCardProps {
+  /**
+   * The tutorial's unique identifier
+   */
+  id: string
+}

--- a/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
+++ b/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
@@ -1,0 +1,47 @@
+.listRoot {
+  --min-card-width: 270px;
+
+  background: var(--token-color-surface-faint);
+  box-shadow: var(--token-surface-base-box-shadow);
+  border-radius: 6px;
+  display: grid;
+  gap: 24px;
+
+  /**
+  * Automatically use more columns, as long as columns are >= min-column-width.
+  * Note: minimum size may be < min-column-width, if 100% < min-column-width.
+  * This ensures that on small viewports, content will never overflow.
+  */
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(100%, var(--min-card-width)), 1fr)
+  );
+  list-style: none;
+  margin: 0;
+  padding: 16px;
+
+  @media (--dev-dot-tablet-up) {
+    /**
+     * On larger viewports, where our content area reaches up to 780px width,
+     * cards are meant to be in two columns.
+     * 
+     * Note: we could explicitly set 2 columns here instead - it would achieve
+     * a similar effect. However, it would be arguable much more brittle,
+     * and might be more difficult to reason about. For example, with 2
+     * explicit columns, if our content area shrank to below 540px
+     * for some reason, or rather below 564px since we have 24px gap,
+     * we'd end up breaking our desired 270px minimum card width.
+     * Setting minimum card width instead of column count means slightly
+     * more complex CSS, but seems to provide a better guarantee that our
+     * layout will not break, even in unexpected scenarios.
+     */
+    --min-card-width: 300px;
+  }
+
+  &.isOrdered {
+    /**
+     * For ordered collections, cards are always in one column
+     */
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
+++ b/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
@@ -26,7 +26,7 @@
      * cards are meant to be in two columns.
      * 
      * Note: we could explicitly set 2 columns here instead - it would achieve
-     * a similar effect. However, it would be arguable much more brittle,
+     * a similar effect. However, it would arguably be much more brittle,
      * and might be more difficult to reason about. For example, with 2
      * explicit columns, if our content area shrank to below 540px
      * for some reason, or rather below 564px since we have 24px gap,

--- a/src/views/collection-view/components/collection-tutorial-list/index.tsx
+++ b/src/views/collection-view/components/collection-tutorial-list/index.tsx
@@ -1,15 +1,13 @@
 import classNames from 'classnames'
 import TutorialCard from 'components/tutorial-card'
 import { TutorialCardPropsWithId } from 'components/tutorial-card/types'
+import { CollectionTutorialListProps } from './types'
 import s from './collection-tutorial-list.module.css'
 
 function CollectionTutorialList({
   tutorials,
   isOrdered,
-}: {
-  tutorials: TutorialCardPropsWithId[]
-  isOrdered: boolean
-}) {
+}: CollectionTutorialListProps) {
   const ListRoot = isOrdered ? 'ol' : 'ul'
 
   return (

--- a/src/views/collection-view/components/collection-tutorial-list/index.tsx
+++ b/src/views/collection-view/components/collection-tutorial-list/index.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames'
+import TutorialCard from 'components/tutorial-card'
+import { TutorialCardPropsWithId } from 'components/tutorial-card/types'
+import s from './collection-tutorial-list.module.css'
+
+function CollectionTutorialList({
+  tutorials,
+  isOrdered,
+}: {
+  tutorials: TutorialCardPropsWithId[]
+  isOrdered: boolean
+}) {
+  const ListRoot = isOrdered ? 'ol' : 'ul'
+
+  return (
+    <ListRoot className={classNames(s.listRoot, { [s.isOrdered]: isOrdered })}>
+      {tutorials.map((tutorial: TutorialCardPropsWithId) => {
+        return (
+          <li key={tutorial.id}>
+            <TutorialCard
+              description={tutorial.description}
+              duration={tutorial.duration}
+              hasInteractiveLab={tutorial.hasInteractiveLab}
+              hasVideo={tutorial.hasVideo}
+              heading={tutorial.heading}
+              url={tutorial.url}
+              productsUsed={tutorial.productsUsed}
+            />
+          </li>
+        )
+      })}
+    </ListRoot>
+  )
+}
+
+export default CollectionTutorialList

--- a/src/views/collection-view/components/collection-tutorial-list/types.ts
+++ b/src/views/collection-view/components/collection-tutorial-list/types.ts
@@ -1,0 +1,6 @@
+import { TutorialCardPropsWithId } from 'components/tutorial-card/types'
+
+export interface CollectionTutorialListProps {
+  tutorials: TutorialCardPropsWithId[]
+  isOrdered: boolean
+}

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -16,10 +16,6 @@ function CollectionView({
 }: CollectionPageProps): React.ReactElement {
   const { name, slug, description, tutorials, ordered } = collection
 
-  const formattedTutorials = tutorials.map((t: ClientTutorialLite) =>
-    formatTutorialCard(t, slug)
-  )
-
   return (
     <SidebarSidecarLayout
       breadcrumbLinks={layoutProps.breadcrumbLinks}
@@ -40,7 +36,9 @@ function CollectionView({
       <h2 id={layoutProps.headings[1].slug}>Tutorials</h2>
       <CollectionTutorialList
         isOrdered={ordered}
-        tutorials={formattedTutorials}
+        tutorials={tutorials.map((t: ClientTutorialLite) =>
+          formatTutorialCard(t, slug)
+        )}
       />
     </SidebarSidecarLayout>
   )

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -6,13 +6,19 @@ import ProductCollectionsSidebar from 'components/tutorials-sidebar/compositions
 import { getTutorialSlug } from './helpers'
 import { CollectionPageProps } from './server'
 import CollectionMeta from './components/collection-meta'
+import CollectionTutorialList from './components/collection-tutorial-list'
+import { formatTutorialCard } from 'components/tutorial-card/helpers'
 
 function CollectionView({
   collection,
   product,
   layoutProps,
 }: CollectionPageProps): React.ReactElement {
-  const { name, slug, description, shortName, tutorials } = collection
+  const { name, slug, description, tutorials, ordered } = collection
+
+  const formattedTutorials = tutorials.map((t: ClientTutorialLite) =>
+    formatTutorialCard(t, slug)
+  )
 
   return (
     <SidebarSidecarLayout
@@ -32,18 +38,10 @@ function CollectionView({
         numTutorials={tutorials.length}
       />
       <h2 id={layoutProps.headings[1].slug}>Tutorials</h2>
-      <ol>
-        {tutorials.map((tutorial: ClientTutorialLite) => {
-          const tutorialSlug = getTutorialSlug(tutorial.slug, slug)
-          return (
-            <li key={tutorial.id}>
-              <Link href={tutorialSlug}>
-                <a>{tutorial.name}</a>
-              </Link>
-            </li>
-          )
-        })}
-      </ol>
+      <CollectionTutorialList
+        isOrdered={ordered}
+        tutorials={formattedTutorials}
+      />
     </SidebarSidecarLayout>
   )
 }


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-zscollection-tutorial-list-hashicorp.vercel.app/waypoint/tutorials/get-started-docker) 🔎
- [Asana task](https://app.asana.com/0/1202001387788447/1202149167439225/f) 🎟️

## 🗒️ What

Implements a `CollectionTutorialList` component, and uses it on all collection views.

## 🤷 Why

To continue building out our `collection-view` in dev-dot.

## 🛠️ How

- Uses existing `tutorial-card` component in a `display: grid` layout
- Accepts an `isOrdered` prop, as different collection types have different grid characteristics

## 📸 Design Screenshots

<details>

<summary>Ordered CollectionTutorialList</summary>

### Design spec

TO DO

### Implementation

TO DO

</details>

<details>

<summary>Unordered CollectionTutorialList</summary>

### Design spec

TO DO

### Implementation

TO DO

</details>

## 🧪 Testing

- [ ] Visit an ordered collection, such as [/waypoint/tutorials/get-started-docker][ordered-collection]
    - [ ] `CollectionTutorialList` should render in one column at all viewport sizes
- [ ] Visit an unordered collection, such as [/vault/tutorials/secrets-management][unordered-collection]
    - [ ] `CollectionTutorialList` should render in one column on mobile, and max out at 2 columns on larger viewports

> Note: you can also review [in Storybook][storybook], which I found helpful for testing responsive behaviour.

## 💭 Anything else?

Not at the moment!

[ordered-collection]: https://dev-portal-git-zscollection-tutorial-list-hashicorp.vercel.app/waypoint/tutorials/get-started-docker
[unordered-collection]: https://dev-portal-git-zscollection-tutorial-list-hashicorp.vercel.app/vault/tutorials/secrets-management
[storybook]: https://dev-portal-with-storybook.vercel.app/?path=/story/components-collectiontutoriallist--playground