### PR TITLE
fix: avoid tab group sync breaking other tabs

### DIFF
--- a/src/components/tabs/hooks/use-synced-tab-groups.ts
+++ b/src/components/tabs/hooks/use-synced-tab-groups.ts
@@ -55,6 +55,10 @@ function useSyncedTabGroups({
     setTabGroupToIndex(
       tabItems.reduce(
         (acc: TabGroupToIndex, { group }: TabItem, index: number) => {
+          // Avoid adding "undefined" to the map
+          if (typeof group != 'string') {
+            return acc
+          }
           // Spread acc at the end, so that the first matched tab is used
           return { ...{ [group]: index }, ...acc }
         },


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-zsfix-tab-group-sync-hashicorp.vercel.app/swingset/components/tabs) 🔎
- [Asana task](https://app.asana.com/0/1202001387788447/1202149167439221/f) 🎟️

## 🗒️ What

Fixes an issue in #343 where tab group sync broke functionality of non-`group`-using tabs.

## 🤷 Why

Tabs are broken.

## 🛠️ How

Avoids building a `group → index` map with `undefined: 0` entries, which were the result of not checking if individual `group` values were defined before trying to build this map.

## 📸 Design Screenshots

N / A, purely a code bug fix.

## 🧪 Testing

- [ ] Visit [a tutorials page that contains tabs _without_ groups][tutorials-page-ungrouped], and ensure tab groups work as expected
- [ ] Visit [a tutorials page that contains tabs with groups][tutorials-page], and ensure tab groups work as expected
- [ ] Visit [the Swingset page for `components/tabs`][swingset-tabs], and ensure both grouped and ungrouped tab examples are working

## 💭 Anything else?

Not at the moment!

[swingset-tabs]: https://dev-portal-git-zsfix-tab-group-sync-hashicorp.vercel.app/swingset/components/tabs
[tutorials-page]: https://dev-portal-git-zsfix-tab-group-sync-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-docker
[tutorials-page-ungrouped]: https://dev-portal-git-zsfix-tab-group-sync-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-install