### PR TITLE
feat: match collection view to spec

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -57,7 +57,7 @@ const SidebarSidecarLayoutContent = ({
   }
 
   const SidecarContent = (): ReactElement => {
-    if (sidecarSlot) {
+    if (typeof sidecarSlot !== 'undefined') {
       return sidecarSlot
     }
 

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -28,7 +28,9 @@ function CollectionView({
       }
     >
       <CollectionMeta
-        heading={{ text: name, id: 'overview' }}
+        // Note: id is passed here because it is required by <Heading />,
+        // it's not used for #anchor linking since there is no sidecar.
+        heading={{ text: name, id: collection.id }}
         description={description}
         cta={{ href: getTutorialSlug(tutorials[0].slug, slug) }}
         numTutorials={tutorials.length}

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -19,7 +19,7 @@ function CollectionView({
   return (
     <SidebarSidecarLayout
       breadcrumbLinks={layoutProps.breadcrumbLinks}
-      headings={layoutProps.headings}
+      sidecarSlot={null}
       sidebarSlot={
         <ProductCollectionsSidebar
           product={{ name: product.name, slug: product.slug }}
@@ -28,12 +28,11 @@ function CollectionView({
       }
     >
       <CollectionMeta
-        heading={{ text: name, id: layoutProps.headings[0].slug }}
+        heading={{ text: name, id: 'overview' }}
         description={description}
         cta={{ href: getTutorialSlug(tutorials[0].slug, slug) }}
         numTutorials={tutorials.length}
       />
-      <h2 id={layoutProps.headings[1].slug}>Tutorials</h2>
       <CollectionTutorialList
         isOrdered={ordered}
         tutorials={tutorials.map((t: ClientTutorialLite) =>

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -26,7 +26,7 @@ export interface CollectionPageProps {
 
 export type CollectionLayout = Pick<
   SidebarSidecarLayoutProps,
-  'headings' | 'breadcrumbLinks'
+  'breadcrumbLinks'
 > & { sidebarSections: CollectionCategorySidebarSection[] }
 
 export interface CollectionPagePath {
@@ -57,10 +57,6 @@ export async function getCollectionPageProps(
     product.slug
   )
   const layoutProps = {
-    headings: [
-      { title: 'Overview', slug: 'overview', level: 1 },
-      { title: 'Tutorials', slug: 'tutorials', level: 1 },
-    ],
     breadcrumbLinks: getTutorialsBreadcrumb({
       product: { name: product.name, filename: product.slug },
       collection: {

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -1,4 +1,5 @@
 import { LearnProductData, ProductData } from 'types/products'
+import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import { Product as ClientProduct } from 'lib/learn-client/types'
 import { getAllCollections } from 'lib/learn-client/api/collection'
 import { getProduct } from 'lib/learn-client/api/product'
@@ -7,7 +8,7 @@ import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { formatSidebarCategorySections } from 'views/collection-view/helpers'
 import getProductPageContent from './helpers/get-product-page-content'
 import { getTutorialsBreadcrumb } from 'views/tutorial-view/utils/get-tutorials-breadcrumb'
-import { CollectionLayout } from 'views/collection-view/server'
+import { CollectionCategorySidebarSection } from 'views/collection-view/helpers'
 import {
   InlineCollections,
   InlineTutorials,
@@ -25,7 +26,10 @@ export interface ProductTutorialsPageProps {
   product: ProductTutorialsPageProduct
 }
 
-type ProductTutorialsLayout = CollectionLayout
+type ProductTutorialsLayout = Pick<
+  SidebarSidecarLayoutProps,
+  'headings' | 'breadcrumbLinks'
+> & { sidebarSections: CollectionCategorySidebarSection[] }
 
 export interface ProductPageData {
   pageData: {


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][asana] 🎟️

## 🗒️ What

This PR finishes the UI implementation of `views/collection-view`. With recent work completed in #363 , the only remaining UI change needed is to remove the `Tutorials` heading and the sidecar to match design specs.

## 🤷 Why

To match the `collection-view` implementation to design specs.

## 🛠️ How

- Makes a change in `SidebarSidecarLayout` to allow `sidecarSlot` to be falsy
- Passes `null` to `sidecarSlot` in order to not render a sidecar content
- Removes `heading` generation for `collection-view` as it is now unused
- Makes related TypeScript updates to removal of `headings` from `collection-view` props

## 📸 Design Screenshots

<details>
<summary>Implementation before this PR</summary>
<img width="1754" alt="before" src="https://user-images.githubusercontent.com/4624598/165125935-f628f963-4c4e-4c4f-95e8-f8f5a487dadc.png">
</details>

<details>
<summary>Design spec</summary>
<img width="839" alt="design-spec" src="https://user-images.githubusercontent.com/4624598/165125855-1823d673-7ed7-4303-a5fb-5ec8e1a45926.png">
</details>

<details>
<summary>Implementation after this PR</summary>
<img width="1754" alt="after" src="https://user-images.githubusercontent.com/4624598/165125962-2f0c74cc-e670-47ec-9eda-0cfe37193033.png">
</details>

## 🧪 Testing

- [ ] Visit a collection view, such as [`/vault/tutorials/encryption-as-a-service`][preview]
- [ ] Ensure the `Tutorials` heading is no longer rendered, and the sidecar area is empty

## 💭 Anything else?

Not at the moment!


[preview]: https://dev-portal-git-zsfinish-collection-view-hashicorp.vercel.app/vault/tutorials/encryption-as-a-service
[asana]: https://app.asana.com/0/1202001387788447/1202168098250852/f
