### PR TITLE
feat: stub in product-view-content components

### DIFF
--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
@@ -1,0 +1,5 @@
+.placeholder {
+  font-size: 12px;
+  margin: 0;
+  border: 1px solid magenta;
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
@@ -1,0 +1,30 @@
+import { BrandedCalloutProps } from './types'
+import s from './branded-callout.module.css'
+
+function BrandedCallout({
+  heading,
+  subheading,
+  cta,
+  product,
+}: BrandedCalloutProps) {
+  return (
+    <pre className={s.placeholder}>
+      <code>
+        {JSON.stringify(
+          {
+            component: 'BrandedCallout',
+            heading,
+            subheading,
+            cta,
+            product,
+          },
+          null,
+          2
+        )}
+      </code>
+    </pre>
+  )
+}
+
+export type { BrandedCalloutProps }
+export { BrandedCallout }

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/types.ts
@@ -1,0 +1,11 @@
+import { ProductOption } from 'lib/learn-client/types'
+
+export interface BrandedCalloutProps {
+  heading: string
+  cta: {
+    text: string
+    url: string
+  }
+  subheading?: string
+  product?: ProductOption
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/collections-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/collections-stack.module.css
@@ -1,0 +1,8 @@
+.placeholder {
+  border: 1px solid magenta;
+  display: block;
+  font-size: 12px;
+  margin: 0;
+  max-height: 300px;
+  overflow: scroll;
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/index.tsx
@@ -1,0 +1,29 @@
+import { FeaturedStack } from '../featured-stack'
+import { CollectionsStackProps } from './types'
+import s from './collections-stack.module.css'
+
+// Reminder:  make sure heap stuff is carried forward
+// const HEAP_ID = 'CollectionCard'
+
+function CollectionsStack({
+  featuredCollections,
+  heading,
+  subheading,
+}: CollectionsStackProps): JSX.Element {
+  return (
+    <FeaturedStack heading={heading} subheading={subheading}>
+      <pre className={s.placeholder}>
+        <code>
+          {JSON.stringify(
+            { component: 'CollectionsStack', featuredCollections },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+    </FeaturedStack>
+  )
+}
+
+export type { CollectionsStackProps }
+export { CollectionsStack }

--- a/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/types.ts
@@ -1,0 +1,23 @@
+import {
+  ProductOption,
+  ThemeOption,
+  Collection as ClientCollection,
+} from 'lib/learn-client/types'
+
+interface CollectionStackItem
+  extends Pick<
+    ClientCollection,
+    'id' | 'slug' | 'name' | 'description' | 'icon' | 'tutorials'
+  > {
+  theme?: ProductOption | ThemeOption
+}
+
+export interface CollectionsStackProps {
+  /** Heading to show above the collection cards. */
+  heading: string
+  /** Subheading to show above the collection cards. */
+  subheading?: string
+  /** A product slug, used for theming */
+  product: ProductOption
+  featuredCollections?: CollectionStackItem[]
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
@@ -1,0 +1,8 @@
+.root {
+  border: 1px solid magenta;
+}
+
+.placeholder {
+  font-size: 12px;
+  margin: 0;
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/index.tsx
@@ -1,0 +1,30 @@
+import { FeaturedStackProps } from './types'
+import s from './featured-stack.module.css'
+
+function FeaturedStack({
+  heading,
+  subheading,
+  children,
+}: FeaturedStackProps): React.ReactElement {
+  return (
+    <div className={s.root}>
+      <pre className={s.placeholder}>
+        <code>
+          {JSON.stringify(
+            {
+              component: 'FeaturedStack',
+              heading,
+              subheading,
+            },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+      {children}
+    </div>
+  )
+}
+
+export type { FeaturedStackProps }
+export { FeaturedStack }

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/types.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+
+export interface FeaturedStackProps {
+  heading: string
+  /** An optional subheading. Supports HTML. */
+  subheading?: string
+  children: ReactNode
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/index.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/index.ts
@@ -1,0 +1,5 @@
+export * from './branded-callout'
+export * from './collections-stack'
+export * from './featured-stack'
+export * from './logo-card-list'
+export * from './tutorials-stack'

--- a/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/index.tsx
@@ -1,0 +1,15 @@
+import s from './logo-card-list.module.css'
+import { LogoCardListProps, LogoCardListItem } from './types'
+
+function LogoCardList({ items }: LogoCardListProps): JSX.Element {
+  return (
+    <pre className={s.placeholder}>
+      <code>
+        {JSON.stringify({ component: 'LogoCardList', items }, null, 2)}
+      </code>
+    </pre>
+  )
+}
+
+export type { LogoCardListProps, LogoCardListItem }
+export { LogoCardList }

--- a/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/logo-card-list.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/logo-card-list.module.css
@@ -1,0 +1,8 @@
+.placeholder {
+  border: 1px solid magenta;
+  display: block;
+  font-size: 12px;
+  margin: 0;
+  max-height: 300px;
+  overflow: scroll;
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/types.ts
@@ -1,0 +1,12 @@
+import { Collection as ClientCollection } from 'lib/learn-client/types'
+
+import { CompanyLogoOption } from 'components/collection-card/components/company-logo/types'
+
+export interface LogoCardListItem {
+  logo: CompanyLogoOption
+  collection: ClientCollection
+}
+
+export interface LogoCardListProps {
+  items: LogoCardListItem[]
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
@@ -1,0 +1,26 @@
+import { FeaturedStack } from '../featured-stack'
+import { TutorialsStackProps } from './types'
+import s from './tutorials-stack.module.css'
+
+function TutorialsStack({
+  featuredTutorials,
+  heading,
+  subheading,
+}: TutorialsStackProps): JSX.Element {
+  return (
+    <FeaturedStack heading={heading} subheading={subheading}>
+      <pre className={s.placeholder}>
+        <code>
+          {JSON.stringify(
+            { component: 'TutorialsStack', featuredTutorials },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+    </FeaturedStack>
+  )
+}
+
+export type { TutorialsStackProps }
+export { TutorialsStack }

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/tutorials-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/tutorials-stack.module.css
@@ -1,0 +1,8 @@
+.placeholder {
+  border: 1px solid magenta;
+  display: block;
+  font-size: 12px;
+  margin: 0;
+  max-height: 300px;
+  overflow: scroll;
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
@@ -1,68 +1,21 @@
-import { Collection, ProductOption } from 'lib/learn-client/types'
-
-/**
- * TODO
- * Many of these types were dropped in from the existing front-end repo.
- * Need to update to use the analogous types from lib/learn-client/types.
- * Intent is to make those updates during implementation of TutorialsStack
- */
-
-interface BaseTutorial {
-  id?: string
-  slug: string
-  name: string
-  description: string
-  readTime: number
-}
-
-type CollectionReference = Pick<
+import {
   Collection,
-  'id' | 'name' | 'shortName' | 'slug' | 'theme' | 'level' | 'ordered'
->
-
-type DefaultCollection = Omit<CollectionReference, 'level' | 'ordered'>
-
-enum VideoHostOption {
-  youtube = 'youtube',
-  wistia = 'wistia',
-}
-
-// @TODO delete katacoda option once all removed
-enum HandsOnLabProviderOption {
-  katacoda = 'katacoda',
-  instruqt = 'instruqt',
-}
-
-interface TutorialLabOptions {
-  handsOnLabId?: string
-  handsOnLabProvider?: HandsOnLabProviderOption
-}
-
-interface TutorialVideoOptions {
-  videoId?: string
-  videoHost?: VideoHostOption
-  videoInline: number // @TODO update to a boolean
-}
-
-export interface ProductUsedRow {
-  product: ProductOption
-  tutorial: string
-  isBeta: number
-  isPrimary: number
-  minVersion?: string
-  maxVersion?: string
-}
-
-//
-//
-//
+  ProductUsed,
+  Tutorial,
+  TutorialVideo,
+  TutorialHandsOnLab,
+} from 'lib/learn-client/types'
 
 export interface TutorialStackItem
-  extends BaseTutorial,
-    TutorialLabOptions,
-    Pick<TutorialVideoOptions, 'videoId'> {
-  defaultContext?: DefaultCollection
-  productsUsed?: ProductUsedRow[]
+  extends Pick<Tutorial, 'id' | 'slug' | 'name' | 'description' | 'readTime'> {
+  handsOnLabId?: TutorialHandsOnLab['id']
+  handsOnLabProvider?: TutorialHandsOnLab['provider']
+  videoId?: TutorialVideo['id']
+  defaultContext?: Pick<
+    Collection,
+    'id' | 'name' | 'shortName' | 'slug' | 'theme'
+  >
+  productsUsed?: ProductUsed[]
 }
 
 export interface TutorialsStackProps {
@@ -70,5 +23,5 @@ export interface TutorialsStackProps {
   heading: string
   /** Subheading to show above the tutorial cards. */
   subheading?: string
-  featuredTutorials: $TSFixMe[] // TutorialStackItem
+  featuredTutorials: TutorialStackItem[]
 }

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
@@ -1,0 +1,74 @@
+import { Collection, ProductOption } from 'lib/learn-client/types'
+
+/**
+ * TODO
+ * Many of these types were dropped in from the existing front-end repo.
+ * Need to update to use the analogous types from lib/learn-client/types.
+ * Intent is to make those updates during implementation of TutorialsStack
+ */
+
+interface BaseTutorial {
+  id?: string
+  slug: string
+  name: string
+  description: string
+  readTime: number
+}
+
+type CollectionReference = Pick<
+  Collection,
+  'id' | 'name' | 'shortName' | 'slug' | 'theme' | 'level' | 'ordered'
+>
+
+type DefaultCollection = Omit<CollectionReference, 'level' | 'ordered'>
+
+enum VideoHostOption {
+  youtube = 'youtube',
+  wistia = 'wistia',
+}
+
+// @TODO delete katacoda option once all removed
+enum HandsOnLabProviderOption {
+  katacoda = 'katacoda',
+  instruqt = 'instruqt',
+}
+
+interface TutorialLabOptions {
+  handsOnLabId?: string
+  handsOnLabProvider?: HandsOnLabProviderOption
+}
+
+interface TutorialVideoOptions {
+  videoId?: string
+  videoHost?: VideoHostOption
+  videoInline: number // @TODO update to a boolean
+}
+
+export interface ProductUsedRow {
+  product: ProductOption
+  tutorial: string
+  isBeta: number
+  isPrimary: number
+  minVersion?: string
+  maxVersion?: string
+}
+
+//
+//
+//
+
+export interface TutorialStackItem
+  extends BaseTutorial,
+    TutorialLabOptions,
+    Pick<TutorialVideoOptions, 'videoId'> {
+  defaultContext?: DefaultCollection
+  productsUsed?: ProductUsedRow[]
+}
+
+export interface TutorialsStackProps {
+  /** Heading to show above the tutorial cards. */
+  heading: string
+  /** Subheading to show above the tutorial cards. */
+  subheading?: string
+  featuredTutorials: $TSFixMe[] // TutorialStackItem
+}

--- a/src/views/product-tutorials-view/components/product-view-content/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/index.tsx
@@ -1,0 +1,108 @@
+import {
+  TutorialsStack,
+  CollectionsStack,
+  FeaturedStack,
+  BrandedCallout,
+  LogoCardList,
+} from './components'
+import { ProductViewBlock, ProductViewContentProps } from './types'
+
+const SUPPORTED_BLOCK_TYPES = [
+  'BrandedCallout',
+  'CardList',
+  'CollectionsStack',
+  'FeaturedStack',
+  'TutorialsStack',
+]
+
+function ProductViewContent({
+  blocks,
+  inlineCollections,
+  inlineTutorials,
+}: ProductViewContentProps): React.ReactElement {
+  return (
+    <div>
+      {blocks.map((block: ProductViewBlock, idx: number) => {
+        switch (block.type) {
+          case 'FeaturedStack':
+            return (
+              <FeaturedStack
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                heading={block.heading}
+                subheading={block.subheading}
+              >
+                <ProductViewContent
+                  blocks={block.blocks as ProductViewBlock[]}
+                  inlineCollections={inlineCollections}
+                  inlineTutorials={inlineTutorials}
+                />
+              </FeaturedStack>
+            )
+          case 'BrandedCallout':
+            return (
+              <BrandedCallout
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                heading={block.heading}
+                subheading={block.subheading}
+                product={block.product}
+                cta={block.cta}
+              />
+            )
+          case 'CardList':
+            return (
+              <LogoCardList
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                items={block.items.map((item) => {
+                  return {
+                    logo: item.logo,
+                    collection: inlineCollections[item.collectionSlug],
+                  }
+                })}
+              />
+            )
+          case 'TutorialsStack':
+            return (
+              <TutorialsStack
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                heading={block.heading}
+                subheading={block.subheading}
+                featuredTutorials={block.tutorialSlugs.map(
+                  (slug) => inlineTutorials[slug]
+                )}
+              />
+            )
+          case 'CollectionsStack':
+            return (
+              <CollectionsStack
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                heading={block.heading}
+                subheading={block.subheading}
+                product={block.product}
+                featuredCollections={block.collectionSlugs.map(
+                  (slug) => inlineCollections[slug]
+                )}
+              />
+            )
+          default:
+            // If we don't have a recognized card type,
+            // throw an error. But be nice about it.
+            throw new Error(
+              `Unrecognized block type "${
+                (block as { type: unknown }).type
+              }" passed to "ProductViewContent". Please use one of the following supported block types: ${JSON.stringify(
+                SUPPORTED_BLOCK_TYPES
+              )}.\nUnrecognized block:\n${JSON.stringify(block, null, 2)}`
+            )
+        }
+      })}
+    </div>
+  )
+}
+
+export type { ProductViewBlock }
+export default ProductViewContent

--- a/src/views/product-tutorials-view/components/product-view-content/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/types.ts
@@ -1,0 +1,66 @@
+import {
+  InlineCollections,
+  InlineTutorials,
+} from 'views/product-tutorials-view/helpers/get-inline-content'
+import {
+  BrandedCalloutProps,
+  LogoCardListItem,
+  FeaturedStackProps,
+  CollectionsStackProps,
+  TutorialsStackProps,
+} from './components'
+
+interface FeaturedStackBlock
+  extends Pick<FeaturedStackProps, 'heading' | 'subheading'> {
+  type: 'FeaturedStack'
+  /** Note that only CardLists are supported for authorable use in FeaturedStack.
+   * We may choose to change the CardList block to use FeaturedStack under the
+   * hood, as we've done for TutorialsStack & CollectionsStack.
+   */
+  blocks: CardListBlock[]
+}
+
+interface BrandedCalloutBlock extends BrandedCalloutProps {
+  type: 'BrandedCallout'
+}
+
+interface LogoCardBlock extends Pick<LogoCardListItem, 'logo'> {
+  type: 'LogoCard'
+  /** A single collection identifier string, which will be filled in
+   * using fetched inlineCollections data */
+  collectionSlug: string
+}
+
+type CardListBlock = {
+  type: 'CardList'
+  items: LogoCardBlock[]
+}
+
+interface TutorialsStackBlock
+  extends Pick<TutorialsStackProps, 'heading' | 'subheading'> {
+  type: 'TutorialsStack'
+  /** Tutorial identifier strings, which will be filled in
+   * using fetched inlineCollections data */
+  tutorialSlugs: string[]
+}
+
+interface CollectionsStackBlock
+  extends Pick<CollectionsStackProps, 'heading' | 'subheading' | 'product'> {
+  type: 'CollectionsStack'
+  /** Collection identifier strings, which will be filled in
+   * using fetched inlineCollections data */
+  collectionSlugs: string[]
+}
+
+export type ProductViewBlock =
+  | FeaturedStackBlock
+  | BrandedCalloutBlock
+  | CardListBlock
+  | TutorialsStackBlock
+  | CollectionsStackBlock
+
+export interface ProductViewContentProps {
+  blocks: ProductViewBlock[]
+  inlineCollections: InlineCollections
+  inlineTutorials: InlineTutorials
+}

--- a/src/views/product-tutorials-view/components/sitemap/index.tsx
+++ b/src/views/product-tutorials-view/components/sitemap/index.tsx
@@ -4,6 +4,7 @@ import {
   getTutorialSlug,
 } from 'views/collection-view/helpers'
 import { ProductPageData } from 'views/product-tutorials-view/server'
+import s from './sitemap.module.css'
 
 export function ProductTutorialsSitemap({
   collections,
@@ -11,7 +12,7 @@ export function ProductTutorialsSitemap({
   collections: ProductPageData['pageData']['allCollections']
 }): React.ReactElement {
   return (
-    <ul>
+    <ul className={s.root}>
       {collections.map((collection) => (
         <li key={collection.id}>
           <Link href={getCollectionSlug(collection.slug)}>

--- a/src/views/product-tutorials-view/components/sitemap/sitemap.module.css
+++ b/src/views/product-tutorials-view/components/sitemap/sitemap.module.css
@@ -1,0 +1,4 @@
+.root {
+  border: 1px solid magenta;
+  margin: 0;
+}

--- a/src/views/product-tutorials-view/helpers/get-inline-content.ts
+++ b/src/views/product-tutorials-view/helpers/get-inline-content.ts
@@ -6,11 +6,11 @@ import {
 } from 'lib/learn-client/types'
 
 export interface InlineTutorials {
-  [slug: string]: ClientTutorial[]
+  [slug: string]: ClientTutorial
 }
 
 export interface InlineCollections {
-  [slug: string]: ClientCollection[]
+  [slug: string]: ClientCollection
 }
 
 export async function getInlineTutorials(

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from 'react'
-import slugify from 'slugify'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductCollectionsSidebar, {
@@ -7,13 +5,15 @@ import ProductCollectionsSidebar, {
 } from 'components/tutorials-sidebar/compositions/product-collections-sidebar'
 import { ProductTutorialsSitemap } from './components'
 import { ProductTutorialsPageProps } from './server'
+import ProductViewContent from './components/product-view-content'
 
 function ProductTutorialsView({
   layoutProps,
   data,
   product,
 }: ProductTutorialsPageProps): React.ReactElement {
-  const { showProductSitemap, blocks, allCollections } = data.pageData
+  const { inlineCollections, inlineTutorials, pageData } = data
+  const { showProductSitemap, blocks, allCollections } = pageData
   const sidebarProduct = {
     name: product.name,
     slug: product.slug,
@@ -32,12 +32,11 @@ function ProductTutorialsView({
       }
     >
       <h1 id={layoutProps.headings[0].slug}>{product.name} Tutorials</h1>
-      {blocks.map((b, i) => (
-        <Fragment key={`${b.type}-${i}`}>
-          <h3 id={slugify(b.heading)}> {b.heading} </h3>
-          <p>Block type: {b.type}</p>
-        </Fragment>
-      ))}
+      <ProductViewContent
+        blocks={blocks}
+        inlineCollections={inlineCollections}
+        inlineTutorials={inlineTutorials}
+      />
       {showProductSitemap ? (
         <>
           <h2 id={layoutProps.headings[layoutProps.headings.length - 1].slug}>


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][waypoint] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Stubs in the `ProductViewContent` component, and all sub-components, for `ProductTutorialsView`.

## 🤷 Why

Chunking the relatively big task of implementing `ProductTutorialsView` into many smaller pieces.

## 🛠️ How

- Makes a new folder for `ProductTutorialsView`
- Adds a `components` subfolder within, and stubs out all "block" components
- Uses existing types (will iterate on these in individual component PRs)

## 📸 Design Screenshots

Not applicable, aim of this PR is to stub in placeholder components. Subsequent per-component PRs will be more relevant to design specs.

## 🧪 Testing

- [ ] Visit [`/waypoint/tutorials`][waypoint] and ensure the stubbed components look as expected
- [ ] Visit [`/vault/tutorials`][vault] and ensure the stubbed components look as expected

## 💭 Anything else?

I've broken down the broader 🎟️ [Integrate Tutorial Product Landing Pages](https://app.asana.com/0/1201903760348480/1201932088339401/f) into subtasks; those might be relevant for context on the intended scope of this PR.

[task]: https://app.asana.com/0/1202097197789424/1202182325935206/f
[waypoint]: https://dev-portal-git-zsstub-product-tutorials-content-hashicorp.vercel.app/waypoint/tutorials
[vault]: https://dev-portal-git-zsstub-product-tutorials-content-hashicorp.vercel.app/vault/tutorials
