### PR TITLE
feat: implement Featured and Tutorials Stacks

### DIFF
--- a/src/components/cards-grid-list/cards-grid-list.module.css
+++ b/src/components/cards-grid-list/cards-grid-list.module.css
@@ -1,0 +1,54 @@
+.listRoot {
+  --min-card-width: 270px;
+
+  display: grid;
+  gap: 24px;
+
+  /**
+  * Details on use of grid-template-columns:
+  *
+  * Automatically uses more columns, as long as columns are >= min-card-width.
+  * Note: minimum size may be < min-card-width, if 100% < min-card-width.
+  * So even when the container is small, cards will never overflow.
+  */
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(min(100%, var(--min-card-width)), 1fr)
+  );
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  @media (--dev-dot-tablet-up) {
+    /**
+     * TLDR; allows two columns in our content area, but not three.
+     *
+     * On larger viewports, where our content area reaches up to 780px width,
+     * cards are meant to be in two columns.
+     * 
+     * Note: we could explicitly set 2 columns here instead - it would achieve
+     * a similar effect. However, it would arguably be much more brittle,
+     * and might be more difficult to reason about.
+     * 
+     * For example, with 2 explicit columns, if our content area shrank
+     * to below 540px, or rather below 564px since we have 24px gap,
+     * we'd end up breaking our desired 270px minimum card width.
+     * Setting minimum card width instead of column count means slightly
+     * more complex CSS, but seems to provide a better guarantee that our
+     * layout will not break, even in unexpected scenarios.
+     */
+    --min-card-width: 300px;
+  }
+
+  &.allowThreeColumns {
+    @media (--dev-dot-tablet-up) {
+      /* Allows three columns in our content area. */
+      --min-card-width: 244px;
+    }
+  }
+
+  &.isOrdered {
+    /* Force cards to one column */
+    --min-card-width: 1fr;
+  }
+}

--- a/src/components/cards-grid-list/docs.mdx
+++ b/src/components/cards-grid-list/docs.mdx
@@ -1,0 +1,74 @@
+---
+componentName: CardsGridList
+---
+
+Displays cards in a grid. Intended for use in main content areas.
+
+The layout for this component is driven by minimum width settings on card children, rather than by explicit column counts. This reduces brittleness, helps ensure we never shrink cards below their desired minimum width, and opens the possibility of using this component outside of our main content area, if desired.
+
+## Props
+
+| Prop name   | Description                                            | Required? | Default value | Type      |
+| ----------- | ------------------------------------------------------ | --------- | ------------- | --------- |
+| `children`  | The cards to render within the `CardsGridList` layout. | Yes       | N/A           | ReactNode |
+| `isOrdered` | If true, layout will always use 1 column.              | No        | `false`       | `boolean` |
+
+## Playground
+
+<LiveComponent>{`
+<CardsGridList isOrdered={false}>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+</CardsGridList>
+`}</LiveComponent>
+
+## Examples
+
+### Automatic, responsive three-column layout for cards in multiple of 3
+
+<LiveComponent>{`
+<CardsGridList>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+</CardsGridList>
+`}</LiveComponent>
+
+<LiveComponent>{`
+<CardsGridList>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+      I am a fake card.
+  </div>
+</CardsGridList>
+`}</LiveComponent>

--- a/src/components/cards-grid-list/index.tsx
+++ b/src/components/cards-grid-list/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode, Children } from 'react'
+import classNames from 'classnames'
+import s from './cards-grid-list.module.css'
+
+/**
+ * Displays cards in a grid. Intended for use in main content areas.
+ *
+ * The layout for this component is driven by minimum width settings
+ * on card children, rather than by explicit column counts.
+ *
+ * The layout approach is intended to reduce brittleness, and to help ensure
+ * that we never shrink cards below their desired minimum width.
+ * It also opens the possibility of using this component
+ * outside of our main content area, if desired.
+ */
+function CardsGridList({
+  children,
+  isOrdered = false,
+}: {
+  children: ReactNode
+  isOrdered?: boolean
+}) {
+  const ListRoot = isOrdered ? 'ol' : 'ul'
+  const allowThreeColumns = !isOrdered && Children.count(children) % 3 == 0
+
+  return (
+    <ListRoot
+      className={classNames(s.listRoot, {
+        [s.isOrdered]: isOrdered,
+        [s.allowThreeColumns]: allowThreeColumns,
+      })}
+    >
+      {children}
+    </ListRoot>
+  )
+}
+
+export default CardsGridList

--- a/src/components/tutorial-card/helpers/format-tutorial-card.ts
+++ b/src/components/tutorial-card/helpers/format-tutorial-card.ts
@@ -8,6 +8,14 @@ import { TutorialCardPropsWithId } from '../types'
 
 export function formatTutorialCard(
   tutorial: ClientTutorialLite,
+  /**
+   * Optional collection slug, used for URL.
+   * Note that each tutorial has a "default" collection context,
+   * which we use if `collectionSlug` is not provided.
+   * If `collectionSlug` is provided, it overrides that default
+   * collection context. Note that `collectionSlug` is not validated;
+   * please ensure it corresponds to a valid collection.
+   */
   collectionSlug?: string
 ): TutorialCardPropsWithId {
   const safeCollectionSlug = collectionSlug || tutorial.defaultContext.slug

--- a/src/components/tutorial-card/helpers/format-tutorial-card.ts
+++ b/src/components/tutorial-card/helpers/format-tutorial-card.ts
@@ -8,8 +8,9 @@ import { TutorialCardPropsWithId } from '../types'
 
 export function formatTutorialCard(
   tutorial: ClientTutorialLite,
-  collectionSlug: string
+  collectionSlug?: string
 ): TutorialCardPropsWithId {
+  const safeCollectionSlug = collectionSlug || tutorial.defaultContext.slug
   return {
     id: tutorial.id,
     description: tutorial.description,
@@ -17,7 +18,7 @@ export function formatTutorialCard(
     hasInteractiveLab: Boolean(tutorial.handsOnLab),
     hasVideo: Boolean(tutorial.video),
     heading: tutorial.name,
-    url: getTutorialSlug(tutorial.slug, collectionSlug),
+    url: getTutorialSlug(tutorial.slug, safeCollectionSlug),
     productsUsed: tutorial.productsUsed.map((p: ProductUsed) => p.product.slug),
   }
 }

--- a/src/components/tutorial-card/index.tsx
+++ b/src/components/tutorial-card/index.tsx
@@ -1,5 +1,5 @@
 import CardLink from 'components/card-link'
-import { TutorialCardProps } from './types'
+import { TutorialCardProps, TutorialCardPropsWithId } from './types'
 import {
   CardEyebrow,
   CardHeading,
@@ -52,4 +52,5 @@ function TutorialCard({
   )
 }
 
+export type { TutorialCardProps, TutorialCardPropsWithId }
 export default TutorialCard

--- a/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
+++ b/src/views/collection-view/components/collection-tutorial-list/collection-tutorial-list.module.css
@@ -1,47 +1,6 @@
-.listRoot {
-  --min-card-width: 270px;
-
+.root {
   background: var(--token-color-surface-faint);
   box-shadow: var(--token-surface-base-box-shadow);
   border-radius: 6px;
-  display: grid;
-  gap: 24px;
-
-  /**
-  * Automatically use more columns, as long as columns are >= min-column-width.
-  * Note: minimum size may be < min-column-width, if 100% < min-column-width.
-  * This ensures that on small viewports, content will never overflow.
-  */
-  grid-template-columns: repeat(
-    auto-fit,
-    minmax(min(100%, var(--min-card-width)), 1fr)
-  );
-  list-style: none;
-  margin: 0;
   padding: 16px;
-
-  @media (--dev-dot-tablet-up) {
-    /**
-     * On larger viewports, where our content area reaches up to 780px width,
-     * cards are meant to be in two columns.
-     * 
-     * Note: we could explicitly set 2 columns here instead - it would achieve
-     * a similar effect. However, it would arguably be much more brittle,
-     * and might be more difficult to reason about. For example, with 2
-     * explicit columns, if our content area shrank to below 540px
-     * for some reason, or rather below 564px since we have 24px gap,
-     * we'd end up breaking our desired 270px minimum card width.
-     * Setting minimum card width instead of column count means slightly
-     * more complex CSS, but seems to provide a better guarantee that our
-     * layout will not break, even in unexpected scenarios.
-     */
-    --min-card-width: 300px;
-  }
-
-  &.isOrdered {
-    /**
-     * For ordered collections, cards are always in one column
-     */
-    grid-template-columns: 1fr;
-  }
 }

--- a/src/views/collection-view/components/collection-tutorial-list/index.tsx
+++ b/src/views/collection-view/components/collection-tutorial-list/index.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import CardsGridList from 'components/cards-grid-list'
 import TutorialCard from 'components/tutorial-card'
 import { TutorialCardPropsWithId } from 'components/tutorial-card/types'
 import { CollectionTutorialListProps } from './types'
@@ -8,26 +8,19 @@ function CollectionTutorialList({
   tutorials,
   isOrdered,
 }: CollectionTutorialListProps) {
-  const ListRoot = isOrdered ? 'ol' : 'ul'
-
   return (
-    <ListRoot className={classNames(s.listRoot, { [s.isOrdered]: isOrdered })}>
-      {tutorials.map((tutorial: TutorialCardPropsWithId) => {
-        return (
-          <li key={tutorial.id}>
-            <TutorialCard
-              description={tutorial.description}
-              duration={tutorial.duration}
-              hasInteractiveLab={tutorial.hasInteractiveLab}
-              hasVideo={tutorial.hasVideo}
-              heading={tutorial.heading}
-              url={tutorial.url}
-              productsUsed={tutorial.productsUsed}
-            />
-          </li>
-        )
-      })}
-    </ListRoot>
+    <div className={s.root}>
+      <CardsGridList isOrdered={isOrdered}>
+        {tutorials.map((tutorial: TutorialCardPropsWithId) => {
+          const { id, ...cardProps } = tutorial
+          return (
+            <li key={tutorial.id}>
+              <TutorialCard {...cardProps} />
+            </li>
+          )
+        })}
+      </CardsGridList>
+    </div>
   )
 }
 

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
@@ -1,8 +1,16 @@
-.root {
-  border: 1px solid magenta;
+.heading {
+  composes: hds-typography-display-300 from global;
+  color: var(--token-color-foreground-strong);
+  font-weight: var(--token-typography-font-weight-bold);
 }
 
-.placeholder {
-  font-size: 12px;
-  margin: 0;
+.subheading {
+  composes: hds-typography-body-300 from global;
+  color: var(--token-color-foreground-primary);
+  font-weight: var(--token-typography-font-weight-regular);
+  margin-top: 4px;
+}
+
+.children {
+  margin-top: 16px;
 }

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/index.tsx
@@ -8,22 +8,12 @@ function FeaturedStack({
   children,
 }: FeaturedStackProps): React.ReactElement {
   return (
-    <div className={s.root}>
-      <h2 id={headingSlug}>{heading}</h2>
-      <pre className={s.placeholder}>
-        <code>
-          {JSON.stringify(
-            {
-              component: 'FeaturedStack',
-              heading,
-              subheading,
-            },
-            null,
-            2
-          )}
-        </code>
-      </pre>
-      {children}
+    <div>
+      <h2 id={headingSlug} className={s.heading}>
+        {heading}
+      </h2>
+      {subheading ? <p className={s.subheading}>{subheading}</p> : null}
+      <div className={s.children}>{children}</div>
     </div>
   )
 }

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
@@ -1,6 +1,9 @@
+import { Tutorial as ClientTutorial } from 'lib/learn-client/types'
+import CardsGrid from 'components/cards-grid-list'
+import TutorialCard, { TutorialCardPropsWithId } from 'components/tutorial-card'
+import { formatTutorialCard } from 'components/tutorial-card/helpers'
 import { FeaturedStack } from '../featured-stack'
 import { TutorialsStackProps } from './types'
-import s from './tutorials-stack.module.css'
 
 function TutorialsStack({
   featuredTutorials,
@@ -8,21 +11,31 @@ function TutorialsStack({
   headingSlug,
   subheading,
 }: TutorialsStackProps): JSX.Element {
+  /**
+   * TODO: Instead of passing full ClientTutorial data to frontend,
+   * and trimming it down here to card data, it seems like we could
+   * do this trimming server side, and end up with a much smaller
+   * bundle of static props JSON.
+   * Asana task: https://app.asana.com/0/0/1202182325935203/f
+   */
+  const tutorialCards = featuredTutorials.map((tutorial: ClientTutorial) => {
+    const defaultContext = tutorial.collectionCtx.default
+    const tutorialLiteCompat = { ...tutorial, defaultContext }
+    return formatTutorialCard(tutorialLiteCompat)
+  })
+
   return (
     <FeaturedStack
       heading={heading}
       headingSlug={headingSlug}
       subheading={subheading}
     >
-      <pre className={s.placeholder}>
-        <code>
-          {JSON.stringify(
-            { component: 'TutorialsStack', featuredTutorials },
-            null,
-            2
-          )}
-        </code>
-      </pre>
+      <CardsGrid>
+        {tutorialCards.map((cardPropsWithId: TutorialCardPropsWithId) => {
+          const { id, ...cardProps } = cardPropsWithId
+          return <TutorialCard key={id} {...cardProps} />
+        })}
+      </CardsGrid>
     </FeaturedStack>
   )
 }

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/tutorials-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/tutorials-stack.module.css
@@ -1,8 +1,0 @@
-.placeholder {
-  border: 1px solid magenta;
-  display: block;
-  font-size: 12px;
-  margin: 0;
-  max-height: 300px;
-  overflow: scroll;
-}

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
@@ -1,22 +1,4 @@
-import {
-  Collection,
-  ProductUsed,
-  Tutorial,
-  TutorialVideo,
-  TutorialHandsOnLab,
-} from 'lib/learn-client/types'
-
-export interface TutorialStackItem
-  extends Pick<Tutorial, 'id' | 'slug' | 'name' | 'description' | 'readTime'> {
-  handsOnLabId?: TutorialHandsOnLab['id']
-  handsOnLabProvider?: TutorialHandsOnLab['provider']
-  videoId?: TutorialVideo['id']
-  defaultContext?: Pick<
-    Collection,
-    'id' | 'name' | 'shortName' | 'slug' | 'theme'
-  >
-  productsUsed?: ProductUsed[]
-}
+import { Tutorial as ClientTutorial } from 'lib/learn-client/types'
 
 export interface TutorialsStackProps {
   /** Heading to show above the tutorial cards. */
@@ -28,5 +10,5 @@ export interface TutorialsStackProps {
   headingSlug: string
   /** Subheading to show above the tutorial cards. */
   subheading?: string
-  featuredTutorials: TutorialStackItem[]
+  featuredTutorials: ClientTutorial[]
 }

--- a/src/views/product-tutorials-view/components/product-view-content/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/index.tsx
@@ -6,6 +6,7 @@ import {
   LogoCardList,
 } from './components'
 import { ProductViewBlock, ProductViewContentProps } from './types'
+import s from './product-view-content.module.css'
 
 const SUPPORTED_BLOCK_TYPES = [
   'BrandedCallout',
@@ -21,7 +22,7 @@ function ProductViewContent({
   inlineTutorials,
 }: ProductViewContentProps): React.ReactElement {
   return (
-    <div>
+    <div className={s.root}>
       {blocks.map((block: ProductViewBlock, idx: number) => {
         switch (block.type) {
           case 'FeaturedStack':

--- a/src/views/product-tutorials-view/components/product-view-content/product-view-content.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/product-view-content.module.css
@@ -1,0 +1,5 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][waypoint-tutorials] 🔎
- [Asana task - `FeaturedStack`](https://app.asana.com/0/0/1202182325935207/f) 🎟️
- [Asana task - `TutorialsStack`](https://app.asana.com/0/0/1202182325935210/f) 🎟️

## 🗒️ What

Implements the `TutorialsStack` component for `views/product-tutorials-view`.

## 🤷 Why

To build out the UI for `views/product-tutorials-view`.

## 🛠️ How

- Adds a `CardsGridList` component
    - Used here in `TutorialsStack
    - Replaces duplicate CSS in `CollectionTutorialList` with `CardListGrid` (for `views/collection-view`)
- Styles FeaturedStack component
- Modifies `formatTutorialCard` to fallback to default collection context, to simplify logic in `TutorialsStack`
- Implements `TutorialsStack`, which is `CardsGridList` + `TutorialCard` + data massaging
- Adds some basic spacing to items in ProductViewContent, to make review easier
    - Note: not final, to-spec spacing, but pretty close! Might see if we can roll with this for June 20, if not will follow up with more pixel-perfect spacing in subsequent PRs

## 📸 Design Screenshots

### Design

<img width="1645" alt="design" src="https://user-images.githubusercontent.com/4624598/165802948-e2b4b4d7-919b-4675-a8ce-b2ea2be87bb5.png">

### Implementation

<img width="1590" alt="implementation" src="https://user-images.githubusercontent.com/4624598/165802964-1b9608d4-3553-4bd2-9b21-88b82890f8e7.png">


## 🧪 Testing

- [ ] Visit [the Waypoint tutorials landing][waypoint-tutorials] and ensure `TutorialsStack` looks as expected
- [ ] Visit [the Vault tutorials landing][vault-tutorials] and ensure `TutorialsStack` looks as expected
- [ ] Visit [the Swingset page for `CardsGridList`][cards-grid-list] and ensure the component makes sense
- [ ] Visit [a Waypoint collection page][waypoint-collection] & [a Vault collection page][vault-collection]
    - [ ] Ensure the use of `CardsGridList` looks as expected in `CollectionTutorialList`

## 💭 Anything else?

Not at the moment! More PRs to follow for other components.

[waypoint-tutorials]: https://dev-portal-git-zstutorials-stack-hashicorp.vercel.app/waypoint/tutorials
[vault-tutorials]: https://dev-portal-git-zstutorials-stack-hashicorp.vercel.app/vault/tutorials
[waypoint-collection]: https://dev-portal-git-zstutorials-stack-hashicorp.vercel.app/waypoint/tutorials/get-started-docker
[vault-collection]: https://dev-portal-git-zstutorials-stack-hashicorp.vercel.app/vault/tutorials/app-integration
[cards-grid-list]: https://dev-portal-git-zstutorials-stack-hashicorp.vercel.app/swingset/components/cardsgridlist