### PR TITLE
fix: vagrant homepage link

### DIFF
--- a/src/pages/_proxied-dot-io/vagrant/index.jsx
+++ b/src/pages/_proxied-dot-io/vagrant/index.jsx
@@ -15,7 +15,7 @@ function HomePage({ latestVersion }) {
             Development Environments Made Easy
           </h1>
           <div className={s.buttons}>
-            <Button title="Get Started" url="/intro/index" />
+            <Button title="Get Started" url="/intro" />
             <Button
               title={`Download ${latestVersion}`}
               theme={{ variant: 'secondary' }}


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them. If one of these items is not relevant to your PR, e.g. you do not have Asana ticket to go with them, you can remove them from the list.
-->

- [x] The Vercel preview link has been added to this PR's description
> - [ ] The Asana task has been added to this PR's description (N / A)
> - [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task  (N / A)
> - [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task  (N / A)
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-zsfix-vagrant-homepage-link-hashicorp.vercel.app/) 🔎
>  [Asana task](url) 🎟️ (Not applicable)

## 🗒️ What

Fixes the `Get Started` button on the home page of https://www.vagrantup.com.

## 🤷 Why

Fixes link

## 🛠️ How

`/intro/index` becomes `/intro`

## 📸 Design Screenshots

> Not applicable

## 🧪 Testing

- [ ] Visit the homepage, with the product selector set to `Vagrant`, and ensure the `Get started` link works

## 💭 Anything else?

Nope


