### PR TITLE
fix: tutorial landings table-of-contents 

### DIFF
--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -123,6 +123,7 @@ export type AllCollectionsProductOptions = {
  */
 
 export interface ProductPageBlockBrandedCallout {
+  type: 'BrandedCallout'
   heading: string
   subheading?: string
   cta: {

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -211,3 +211,35 @@ and negative margin.
     outline: none;
   }
 }
+
+/*
+***
+* Scroll offset global helper, which accounts for fixed headings
+* TODO: use this for docs and learn content as well. Will likely make sense
+* to make this shift when we move to shared MDX content components for
+* heading elements across both Docs and Learn.
+* CSS → MDX task: https://app.asana.com/0/1201987349274776/1201653123138729/f
+* "Reconcile" task: https://app.asana.com/0/1201987349274776/1202052090505082/f
+***
+*/
+.g-offset-scroll-margin-top {
+  --permalink-scroll-offset: 24px;
+  --full-header-height: calc(
+    var(--navigation-header-height) + var(--alert-bar-height)
+  );
+  --total-offset: calc(
+    var(--full-header-height) + var(--permalink-scroll-offset)
+  );
+
+  scroll-margin-top: var(--total-offset);
+
+  /*
+  Docs and Learn jump link headings have an anchor child with an `id`,
+  rather than an `id` on the element itself. These are added by our
+  anchor-links remark plugin.
+  https://github.com/hashicorp/web-platform-packages/tree/main/packages/remark-plugins/plugins/anchor-links
+  */
+  & a:global(.__target-h) {
+    scroll-margin-top: var(--total-offset);
+  }
+}

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
@@ -1,7 +1,3 @@
-.heading {
-  composes: g-offset-scroll-margin-top from global;
-}
-
 .placeholder {
   font-size: 12px;
   margin: 0;

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/branded-callout.module.css
@@ -1,3 +1,7 @@
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+}
+
 .placeholder {
   font-size: 12px;
   margin: 0;

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
@@ -3,16 +3,13 @@ import s from './branded-callout.module.css'
 
 function BrandedCallout({
   heading,
-  headingSlug,
   subheading,
   cta,
   product,
 }: BrandedCalloutProps) {
   return (
     <div>
-      <h2 id={headingSlug} className={s.heading}>
-        {heading}
-      </h2>
+      <div>{heading}</div>
       <pre className={s.placeholder}>
         <code>
           {JSON.stringify(

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/index.tsx
@@ -10,7 +10,9 @@ function BrandedCallout({
 }: BrandedCalloutProps) {
   return (
     <div>
-      <h2 id={headingSlug}>{heading}</h2>
+      <h2 id={headingSlug} className={s.heading}>
+        {heading}
+      </h2>
       <pre className={s.placeholder}>
         <code>
           {JSON.stringify(

--- a/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/branded-callout/types.ts
@@ -2,11 +2,6 @@ import { ProductOption } from 'lib/learn-client/types'
 
 export interface BrandedCalloutProps {
   heading: string
-  /**
-   * Identifier for the heading, which should unique in the context of the page
-   * Note: headingSlug is added after fetching content from the Learn API
-   */
-  headingSlug: string
   cta: {
     text: string
     url: string

--- a/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/types.ts
@@ -5,12 +5,12 @@ import {
 
 export interface CollectionsStackProps {
   /** Heading to show above the collection cards. */
-  heading: string
+  heading?: string
   /**
    * Identifier for the heading, which should unique in the context of the page.
    * Note: headingSlug is added after fetching content from the Learn API
    */
-  headingSlug: string
+  headingSlug?: string
   /** Subheading to show above the collection cards. */
   subheading?: string
   /** A product slug, used for theming */

--- a/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
+++ b/src/views/product-tutorials-view/components/product-view-content/components/featured-stack/featured-stack.module.css
@@ -1,5 +1,6 @@
 .heading {
   composes: hds-typography-display-300 from global;
+  composes: g-offset-scroll-margin-top from global;
   color: var(--token-color-foreground-strong);
   font-weight: var(--token-typography-font-weight-bold);
 }

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/types.ts
@@ -2,12 +2,12 @@ import { Tutorial as ClientTutorial } from 'lib/learn-client/types'
 
 export interface TutorialsStackProps {
   /** Heading to show above the tutorial cards. */
-  heading: string
+  heading?: string
   /**
    * Identifier for the heading, which should unique in the context of the page
    * Note: headingSlug is added after fetching content from the Learn API
    */
-  headingSlug: string
+  headingSlug?: string
   /** Subheading to show above the tutorial cards. */
   subheading?: string
   featuredTutorials: ClientTutorial[]

--- a/src/views/product-tutorials-view/components/product-view-content/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/index.tsx
@@ -58,7 +58,6 @@ function ProductViewContent({
                 // eslint-disable-next-line react/no-array-index-key
                 key={idx}
                 heading={block.heading}
-                headingSlug={block.headingSlug}
                 subheading={block.subheading}
                 product={block.product}
                 cta={block.cta}

--- a/src/views/product-tutorials-view/components/sitemap/sitemap.module.css
+++ b/src/views/product-tutorials-view/components/sitemap/sitemap.module.css
@@ -4,6 +4,7 @@
 
 .heading {
   composes: hds-typography-display-300 from global;
+  composes: g-offset-scroll-margin-top from global;
   font-weight: var(--token-typography-font-weight-bold);
   margin: 0;
 }

--- a/src/views/product-tutorials-view/helpers/heading-helpers.ts
+++ b/src/views/product-tutorials-view/helpers/heading-helpers.ts
@@ -27,7 +27,7 @@ function buildLayoutHeadings(pageData: {
    */
   const blockHeadings = blocks.reduce(
     (acc: TableOfContentsHeading[], block: ProductViewBlock) => {
-      if (isBlockWithHeadingSlug(block)) {
+      if (isReadyForTableOfContents(block)) {
         acc.push({
           title: block.heading,
           slug: block.headingSlug,
@@ -55,9 +55,9 @@ function buildLayoutHeadings(pageData: {
  * and is a block type we want to show in the table of contents,
  * in which case we can generate a headingSlug for it
  */
-function isBlockWithHeading<T extends { type: string; heading?: unknown }>(
-  block: T
-): block is T & { heading: string } {
+function isIntendedForTableOfContents<
+  T extends { type: string; heading?: unknown }
+>(block: T): block is T & { heading: string } {
   const isTargetType =
     block.type == 'CollectionsStack' ||
     block.type == 'FeaturedStack' ||
@@ -68,10 +68,12 @@ function isBlockWithHeading<T extends { type: string; heading?: unknown }>(
 /**
  * Check if a block can be added to the table of contents
  */
-function isBlockWithHeadingSlug<
+function isReadyForTableOfContents<
   T extends { type: string; headingSlug?: unknown }
 >(block: T): block is T & { headingSlug: string } {
-  return isBlockWithHeading(block) && typeof block.headingSlug == 'string'
+  return (
+    isIntendedForTableOfContents(block) && typeof block.headingSlug == 'string'
+  )
 }
 
 /**
@@ -105,7 +107,7 @@ function addHeadingSlugsToBlocks(rawPageData: {
   const { blocks } = rawPageData
   const blocksWithHeadings = blocks.map(
     (block: LearnClientProductPageBlock) => {
-      if (!isBlockWithHeading(block)) {
+      if (!isIntendedForTableOfContents(block)) {
         return block
       }
       const headingSlug = slugify(block.heading, { lower: true })

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -22,9 +22,13 @@ function ProductTutorialsView({
   } as ProductCollectionsSidebarProps['product']
 
   const PageHeading = () => {
-    const { title, level, slug } = getOverviewHeading(product.name)
+    const { title, level, slug } = getOverviewHeading()
     const HeadingElem = `h${level}` as React.ElementType
-    return <HeadingElem id={slug}>{title}</HeadingElem>
+    return (
+      <HeadingElem id={slug} className={s.heading}>
+        {title}
+      </HeadingElem>
+    )
   }
 
   return (

--- a/src/views/product-tutorials-view/product-tutorials-view.module.css
+++ b/src/views/product-tutorials-view/product-tutorials-view.module.css
@@ -1,3 +1,8 @@
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+  composes: g-screen-reader-only from global;
+}
+
 .sitemap {
   margin-top: 48px;
 }

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -89,7 +89,7 @@ export async function getProductTutorialsViewProps(
    * Build & return layout props to pass to SidebarSidecarLayout
    */
   const layoutProps = {
-    headings: buildLayoutHeadings(pageData, product.name),
+    headings: buildLayoutHeadings(pageData),
     breadcrumbLinks: getTutorialsBreadcrumb({
       product: { name: product.name, filename: product.slug },
     }),


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][/vault/tutorials] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue on product tutorial landing views, such as [/waypoint/tutorials][/waypoint/tutorials] and [/vault/tutorials][/vault/tutorials], where headings were not reflected correctly in the sidecar table-of-contents due to lack of `scroll-margin-top`.

## 🤷 Why

To fix an issue on product tutorial landing views where the sidecar table-of-contents highlighting is not working as expected.

## 🛠️ How

- Adds a new global helper class, `.g-offset-scroll-margin-top`
- Uses `.g-offset-scroll-margin-top` for all heading elements on the product tutorial landing view
- Visually hides the top-level `"Overview"` page heading, to match mockups
    - Rendering this heading element seems necessary for our table-of-contents to work as expected
- Refactors some heading logic in `product-tutorials-view`
    - `BrandedCallout` does not actually need a heading, as it isn't part of the table-of-contents
    - When generating the table of contents from authored blocks, we're now more explicit about which blocks are intended for inclusion in the table of contents.

## 📸 Design Screenshots

Screenshot of Figma page layout:

<img width="1021" alt="design" src="https://user-images.githubusercontent.com/4624598/166326272-e4286bbd-2441-4bc0-8965-174e32fe6032.png">

Table of contents behaviour before this PR:

![before](https://user-images.githubusercontent.com/4624598/166326293-b4ff9ba3-161a-403f-b7c8-dc21ac09c94d.gif)

Table of contents behaviour after this PR:

![after](https://user-images.githubusercontent.com/4624598/166326315-85d2b5a9-a624-4926-93b3-d918b0682c27.gif)

## 🧪 Testing

- [ ] Visit [/waypoint/tutorials][/waypoint/tutorials] and [/vault/tutorials][/vault/tutorials], and ensure the sidecar is working as expected on both pages

## 💭 Anything else?

Nope!

[task]: https://app.asana.com/0/1202097197789424/1202205647216548/f
[/vault/tutorials]: https://dev-portal-git-zsfix-headings-tutorial-landing-hashicorp.vercel.app/vault/tutorials
[/waypoint/tutorials]: https://dev-portal-git-zsfix-headings-tutorial-landing-hashicorp.vercel.app/waypoint/tutorials