### PR TITLE
Adds opt-in / opt-out analytics tracking

### DIFF
--- a/analytics/spec/events/_index.yaml
+++ b/analytics/spec/events/_index.yaml
@@ -1,2 +1,4 @@
 - $ref: ./page_viewed.yaml
 - $ref: ./page_scrolled.yaml
+- $ref: ./beta_opted_in.yaml
+- $ref: ./beta_opted_out.yaml

--- a/analytics/spec/events/beta_opted_in.yaml
+++ b/analytics/spec/events/beta_opted_in.yaml
@@ -1,0 +1,20 @@
+name: Beta Opted In
+description: The user has opted into the Dev Portal beta
+rules:
+  '$schema': http://json-schema.org/draft-04/schema#
+  type: object
+  properties:
+    context:
+      $ref: ../meta/context.yaml
+    properties:
+      type: object
+      properties:
+        bucket:
+          description: The opt-in bucket that the user has opted in from
+          type: string
+          enum:
+            - learn
+            - waypoint-io
+            - vault-io
+      required:
+        - bucket

--- a/analytics/spec/events/beta_opted_out.yaml
+++ b/analytics/spec/events/beta_opted_out.yaml
@@ -1,0 +1,20 @@
+name: Beta Opted Out
+description: The user has opted out of the Dev Portal beta
+rules:
+  '$schema': http://json-schema.org/draft-04/schema#
+  type: object
+  properties:
+    context:
+      $ref: ../meta/context.yaml
+    properties:
+      type: object
+      properties:
+        bucket:
+          description: The opt-out bucket that the user has opted out from
+          type: string
+          enum:
+            - learn
+            - waypoint-io
+            - vault-io
+      required:
+        - bucket


### PR DESCRIPTION
Includes Analytics Tracking plans for both opting in & opting out of the DevDot experience.

This will enable us to track the lifecycle of users who have opted in for the beta, which will enable us to perform analysis of data that is sandwiched between these two events.

These events will be ephemerally added into Dev Portal, only for the length of our public beta.

**Note:** this is only the specification, and is not the implementation of the analytics.

