### PR TITLE
feat: hook up product landing sidecar

### DIFF
--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -280,6 +280,6 @@ function isThemeOption(string: string): string is ThemeOption {
 /**
  * Type guard to determine if a string is a ProductOption
  */
-function isProductOption(string: string): string is ProductOption {
+export function isProductOption(string: string): string is ProductOption {
   return Object.values(ProductOption).includes(string as ProductOption)
 }

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -280,6 +280,6 @@ function isThemeOption(string: string): string is ThemeOption {
 /**
  * Type guard to determine if a string is a ProductOption
  */
-export function isProductOption(string: string): string is ProductOption {
+function isProductOption(string: string): string is ProductOption {
   return Object.values(ProductOption).includes(string as ProductOption)
 }

--- a/src/views/product-landing/components/get-started-card/get-started-card.module.css
+++ b/src/views/product-landing/components/get-started-card/get-started-card.module.css
@@ -1,0 +1,9 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+}

--- a/src/views/product-landing/components/get-started-card/index.tsx
+++ b/src/views/product-landing/components/get-started-card/index.tsx
@@ -1,0 +1,29 @@
+import { GetStartedCardProps } from './types'
+import s from './get-started-card.module.css'
+
+function GetStartedCard({
+  heading,
+  headingSlug,
+  body,
+  ctas,
+}: GetStartedCardProps) {
+  return (
+    <>
+      <pre className={s.placeholder}>
+        <code>
+          <h2 id={headingSlug} className={s.heading}>
+            {heading} [id={headingSlug}]
+          </h2>
+          {JSON.stringify(
+            { component: 'GetStartedCard', heading, body, ctas },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+    </>
+  )
+}
+
+export { GetStartedCard }
+export default GetStartedCard

--- a/src/views/product-landing/components/get-started-card/types.ts
+++ b/src/views/product-landing/components/get-started-card/types.ts
@@ -1,0 +1,9 @@
+export interface GetStartedCardProps {
+  heading: string
+  headingSlug: string
+  body: string
+  ctas: {
+    text: string
+    url: string
+  }[]
+}

--- a/src/views/product-landing/components/hero-heading-visual/hero-heading-visual.module.css
+++ b/src/views/product-landing/components/hero-heading-visual/hero-heading-visual.module.css
@@ -1,0 +1,5 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}

--- a/src/views/product-landing/components/hero-heading-visual/index.tsx
+++ b/src/views/product-landing/components/hero-heading-visual/index.tsx
@@ -4,14 +4,14 @@ import s from './hero-heading-visual.module.css'
 function HeroHeadingVisual({
   heading,
   image,
-  productTheme,
+  productSlug,
 }: HeroHeadingVisualProps) {
   return (
     <>
       <pre className={s.placeholder}>
         <code>
           {JSON.stringify(
-            { component: 'HeroHeadingVisual', heading, image, productTheme },
+            { component: 'HeroHeadingVisual', heading, image, productSlug },
             null,
             2
           )}

--- a/src/views/product-landing/components/hero-heading-visual/index.tsx
+++ b/src/views/product-landing/components/hero-heading-visual/index.tsx
@@ -1,0 +1,25 @@
+import { HeroHeadingVisualProps } from './types'
+import s from './hero-heading-visual.module.css'
+
+function HeroHeadingVisual({
+  heading,
+  image,
+  productTheme,
+}: HeroHeadingVisualProps) {
+  return (
+    <>
+      <pre className={s.placeholder}>
+        <code>
+          {JSON.stringify(
+            { component: 'HeroHeadingVisual', heading, image, productTheme },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+    </>
+  )
+}
+
+export { HeroHeadingVisual }
+export default HeroHeadingVisual

--- a/src/views/product-landing/components/hero-heading-visual/types.ts
+++ b/src/views/product-landing/components/hero-heading-visual/types.ts
@@ -1,0 +1,7 @@
+import { ProductOption } from 'lib/learn-client/types'
+
+export interface HeroHeadingVisualProps {
+  heading: string
+  image: string
+  productTheme: ProductOption
+}

--- a/src/views/product-landing/components/hero-heading-visual/types.ts
+++ b/src/views/product-landing/components/hero-heading-visual/types.ts
@@ -1,7 +1,7 @@
-import { ProductOption } from 'lib/learn-client/types'
+import { ProductSlug } from 'types/products'
 
 export interface HeroHeadingVisualProps {
   heading: string
   image: string
-  productTheme: ProductOption
+  productSlug: ProductSlug
 }

--- a/src/views/product-landing/components/overview-cta/index.tsx
+++ b/src/views/product-landing/components/overview-cta/index.tsx
@@ -1,0 +1,30 @@
+import { OverviewCtaProps } from './types'
+import s from './overview-cta.module.css'
+
+function OverviewCta({
+  heading,
+  headingSlug,
+  body,
+  cta,
+  image,
+}: OverviewCtaProps) {
+  return (
+    <>
+      <pre className={s.placeholder}>
+        <code>
+          <h2 id={headingSlug} className={s.heading}>
+            {heading} [id={headingSlug}]
+          </h2>
+          {JSON.stringify(
+            { component: 'OverviewCta', heading, body, cta, image },
+            null,
+            2
+          )}
+        </code>
+      </pre>
+    </>
+  )
+}
+
+export { OverviewCta }
+export default OverviewCta

--- a/src/views/product-landing/components/overview-cta/overview-cta.module.css
+++ b/src/views/product-landing/components/overview-cta/overview-cta.module.css
@@ -1,0 +1,9 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+}

--- a/src/views/product-landing/components/overview-cta/types.ts
+++ b/src/views/product-landing/components/overview-cta/types.ts
@@ -1,0 +1,10 @@
+export interface OverviewCtaProps {
+  heading: string
+  headingSlug: string
+  body: string
+  cta: {
+    text: string
+    url: string
+  }
+  image: string
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/heading-block.module.css
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/heading-block.module.css
@@ -1,0 +1,9 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/index.tsx
@@ -1,0 +1,17 @@
+import { HeadingBlockProps } from './types'
+import s from './heading-block.module.css'
+
+function HeadingBlock({ heading, headingSlug }: HeadingBlockProps) {
+  return (
+    <pre className={s.placeholder}>
+      <code>
+        <h2 id={headingSlug} className={s.heading}>
+          {heading} [id={headingSlug}]
+        </h2>
+      </code>
+    </pre>
+  )
+}
+
+export type { HeadingBlockProps }
+export { HeadingBlock }

--- a/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/types.ts
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/heading-block/types.ts
@@ -1,0 +1,4 @@
+export interface HeadingBlockProps {
+  heading: string
+  headingSlug: string
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/index.ts
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/index.ts
@@ -1,0 +1,3 @@
+export * from './heading-block'
+export * from './linked-cards'
+export * from './tutorial-cards'

--- a/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/index.tsx
@@ -1,0 +1,15 @@
+import { LinkedCardsProps } from './types'
+import s from './linked-cards.module.css'
+
+function LinkedCards({ cards }: LinkedCardsProps) {
+  return (
+    <pre className={s.placeholder}>
+      <code>
+        {JSON.stringify({ component: 'LinkedCards', cards }, null, 2)}
+      </code>
+    </pre>
+  )
+}
+
+export type { LinkedCardsProps }
+export { LinkedCards }

--- a/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/linked-cards.module.css
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/linked-cards.module.css
@@ -1,0 +1,5 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/types.ts
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/types.ts
@@ -1,0 +1,7 @@
+export interface LinkedCardsProps {
+  cards: {
+    heading: string
+    body: string
+    url: string
+  }[]
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
@@ -1,0 +1,15 @@
+import { TutorialCardsProps } from './types'
+import s from './tutorial-cards.module.css'
+
+function TutorialCards({ tutorialSlugs }: TutorialCardsProps) {
+  return (
+    <pre className={s.placeholder}>
+      <code>
+        {JSON.stringify({ component: 'TutorialCards', tutorialSlugs }, null, 2)}
+      </code>
+    </pre>
+  )
+}
+
+export type { TutorialCardsProps }
+export { TutorialCards }

--- a/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/tutorial-cards.module.css
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/tutorial-cards.module.css
@@ -1,0 +1,5 @@
+.placeholder {
+  border: 1px solid magenta;
+  font-size: 12px;
+  white-space: pre-wrap;
+}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/types.ts
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/types.ts
@@ -1,0 +1,3 @@
+export interface TutorialCardsProps {
+  tutorialSlugs: string[]
+}

--- a/src/views/product-landing/components/product-landing-blocks/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/index.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/no-array-index-key */
+import { ProductLandingBlocksProps, ProductLandingBlock } from './types'
+import { HeadingBlock, LinkedCards, TutorialCards } from './blocks'
+
+function ProductLandingBlocks({ blocks }: ProductLandingBlocksProps) {
+  return (
+    <>
+      {blocks.map((block: ProductLandingBlock, idx: number) => {
+        const { type } = block
+        switch (type) {
+          case 'heading':
+            return (
+              <HeadingBlock
+                key={idx}
+                heading={block.heading}
+                headingSlug={block.headingSlug}
+              />
+            )
+          case 'tutorial_cards':
+            return (
+              <TutorialCards key={idx} tutorialSlugs={block.tutorialSlugs} />
+            )
+          case 'linked_cards':
+            return <LinkedCards key={idx} cards={block.cards} />
+          default:
+            /**
+             * Note: any invalid block types are expected to have been caught
+             * by server-side validation against our content schema.
+             * At this point, we don't want to throw an error...
+             * so we render null for unrecognized block types.
+             */
+            return null
+        }
+      })}
+    </>
+  )
+}
+
+export default ProductLandingBlocks

--- a/src/views/product-landing/components/product-landing-blocks/types.ts
+++ b/src/views/product-landing/components/product-landing-blocks/types.ts
@@ -1,0 +1,14 @@
+import {
+  HeadingBlockProps,
+  TutorialCardsProps,
+  LinkedCardsProps,
+} from './blocks'
+
+export type ProductLandingBlock =
+  | ({ type: 'tutorial_cards' } & TutorialCardsProps)
+  | ({ type: 'linked_cards' } & LinkedCardsProps)
+  | ({ type: 'heading' } & HeadingBlockProps)
+
+export interface ProductLandingBlocksProps {
+  blocks: ProductLandingBlock[]
+}

--- a/src/views/product-landing/helpers/__tests__/make-heading-slug-scope.test.ts
+++ b/src/views/product-landing/helpers/__tests__/make-heading-slug-scope.test.ts
@@ -1,0 +1,24 @@
+import { makeHeadingSlugScope } from '../'
+
+describe('makeHeadingSlugScope', () => {
+  test('returns already-unique headings unmodified', () => {
+    const makeHeadingSlug = makeHeadingSlugScope()
+    expect(makeHeadingSlug('Foo Heading')).toBe('foo-heading')
+    expect(makeHeadingSlug('Bar Heading')).toBe('bar-heading')
+    expect(makeHeadingSlug('Baz Heading')).toBe('baz-heading')
+  })
+
+  test('appends duplicate headings with an index', () => {
+    const makeHeadingSlug = makeHeadingSlugScope()
+    expect(makeHeadingSlug('Foo Heading')).toBe('foo-heading')
+    expect(makeHeadingSlug('Foo Heading')).toBe('foo-heading-2')
+    expect(makeHeadingSlug('Foo headinG')).toBe('foo-heading-3')
+  })
+
+  test('detects duplicates within specific scopes', () => {
+    const makeHeadingSlugScope1 = makeHeadingSlugScope()
+    const makeHeadingSlugScope2 = makeHeadingSlugScope()
+    expect(makeHeadingSlugScope1('Foo Heading')).toBe('foo-heading')
+    expect(makeHeadingSlugScope2('Foo Heading')).toBe('foo-heading')
+  })
+})

--- a/src/views/product-landing/helpers/extract-headings.ts
+++ b/src/views/product-landing/helpers/extract-headings.ts
@@ -2,6 +2,16 @@ import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table
 import { ProductLandingViewProps } from '../types'
 import { ProductLandingBlock } from '../components/product-landing-blocks/types'
 
+/**
+ * Extracts headings from product-landing page content .
+ *
+ * Note: could potentially use `traverse` here to make this more generic.
+ * We could target any & all objects that have { heading, headingSlug }
+ * However, right now that felt more opaque and cryptic than being more
+ * explicit around which headings are being used and in what order.
+ * As well, I think a generic implementation should better account for "level".
+ * So, deferred creating a generic implementation, for now.
+ */
 export function extractHeadings(
   content: ProductLandingViewProps['content']
 ): TableOfContentsHeading[] {

--- a/src/views/product-landing/helpers/extract-headings.ts
+++ b/src/views/product-landing/helpers/extract-headings.ts
@@ -1,0 +1,47 @@
+import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
+import { ProductLandingViewProps } from '../types'
+import { ProductLandingBlock } from '../components/product-landing-blocks/types'
+
+export function extractHeadings(
+  content: ProductLandingViewProps['content']
+): TableOfContentsHeading[] {
+  /**
+   * TODO: content is raw placeholder for now
+   * - Need to add "headings" that aren't placeholders.
+   *   These will be derived from content blocks
+   *   (mainly heading blocks, but also others, based on design intent)
+   * - Need to augment things like tutorialSlugs to fill in that data
+   *   Will close: https://app.asana.com/0/1201010428539925/1201654639085764/f
+   * - Need to build out the client-side components, whose props APIs will
+   *   inform what content structure we'll want to return for use on the client.
+   *   Intent being to return the minimum data necessary to render
+   *   all content block components on the page.
+   */
+  const headings: TableOfContentsHeading[] = [
+    {
+      title: content.overview.heading,
+      slug: content.overview.headingSlug,
+      level: 2,
+    },
+    {
+      title: content.get_started.heading,
+      slug: content.get_started.headingSlug,
+      level: 2,
+    },
+    ...content.blocks.reduce(
+      (acc: TableOfContentsHeading[], b: ProductLandingBlock) => {
+        if (b.type === 'heading') {
+          acc.push({
+            title: b.heading,
+            slug: b.headingSlug,
+            level: 2,
+          })
+        }
+        return acc
+      },
+      []
+    ),
+  ]
+
+  return headings
+}

--- a/src/views/product-landing/helpers/extract-headings.ts
+++ b/src/views/product-landing/helpers/extract-headings.ts
@@ -5,18 +5,6 @@ import { ProductLandingBlock } from '../components/product-landing-blocks/types'
 export function extractHeadings(
   content: ProductLandingViewProps['content']
 ): TableOfContentsHeading[] {
-  /**
-   * TODO: content is raw placeholder for now
-   * - Need to add "headings" that aren't placeholders.
-   *   These will be derived from content blocks
-   *   (mainly heading blocks, but also others, based on design intent)
-   * - Need to augment things like tutorialSlugs to fill in that data
-   *   Will close: https://app.asana.com/0/1201010428539925/1201654639085764/f
-   * - Need to build out the client-side components, whose props APIs will
-   *   inform what content structure we'll want to return for use on the client.
-   *   Intent being to return the minimum data necessary to render
-   *   all content block components on the page.
-   */
   const headings: TableOfContentsHeading[] = [
     {
       title: content.overview.heading,
@@ -42,6 +30,5 @@ export function extractHeadings(
       []
     ),
   ]
-
   return headings
 }

--- a/src/views/product-landing/helpers/index.ts
+++ b/src/views/product-landing/helpers/index.ts
@@ -1,1 +1,4 @@
 export * from './validate-against-schema'
+export * from './extract-headings'
+export * from './transform-raw-content-to-prop'
+export * from './make-heading-slug-scope'

--- a/src/views/product-landing/helpers/make-heading-slug-scope.ts
+++ b/src/views/product-landing/helpers/make-heading-slug-scope.ts
@@ -1,5 +1,10 @@
 import slugify from 'slugify'
 
+/**
+ * Returns a function that generates slugs from heading strings,
+ * while ensuring those slugs are unique across calls of the returned function
+ * by suffixing with a `-{number}` where needed.
+ */
 export function makeHeadingSlugScope(): (string) => string {
   /**
    * Track which headings slugs have been used, to avoid potential duplicates

--- a/src/views/product-landing/helpers/make-heading-slug-scope.ts
+++ b/src/views/product-landing/helpers/make-heading-slug-scope.ts
@@ -1,0 +1,26 @@
+import slugify from 'slugify'
+
+export function makeHeadingSlugScope(): (string) => string {
+  /**
+   * Track which headings slugs have been used, to avoid potential duplicates
+   */
+  const USED_SLUGS = []
+
+  /**
+   * Generate a heading slug, but avoid potential duplicates.
+   * Duplicates are determined based on USED_SLUGS in this scope.
+   */
+  function makeHeadingSlug(heading: string): string {
+    let suffix = 1
+    const baseSlug = slugify(heading, { lower: true })
+    let headingSlug = baseSlug
+    while (USED_SLUGS.indexOf(headingSlug) !== -1) {
+      suffix++
+      headingSlug = `${baseSlug}-${suffix}`
+    }
+    USED_SLUGS.push(headingSlug)
+    return headingSlug
+  }
+
+  return makeHeadingSlug
+}

--- a/src/views/product-landing/helpers/transform-raw-content-to-prop.ts
+++ b/src/views/product-landing/helpers/transform-raw-content-to-prop.ts
@@ -1,0 +1,72 @@
+import { isProductOption } from 'lib/learn-client/types'
+import { ProductData } from 'types/products'
+// raw content types
+import { ProductLandingContent, ProductLandingContentBlock } from '../schema'
+// component prop utilities & types
+import { makeHeadingSlugScope } from './'
+import { ProductLandingViewProps } from '../types'
+import { ProductLandingBlock } from '../components/product-landing-blocks/types'
+
+export async function transformRawContentToProp(
+  { hero, overview, get_started, blocks }: ProductLandingContent,
+  product: ProductData
+): Promise<ProductLandingViewProps['content']> {
+  /**
+   * Handle "hcp" or "sentinel" product.slug cases
+   * (these options are valid from a type perspective,
+   * but are not yet supported by the UI)
+   */
+  if (!isProductOption(product.slug)) {
+    throw new Error(
+      `Product landing pages do not yet support all products. Product slug "${product.slug}" is not yet supported.`
+    )
+  }
+
+  /**
+   * Set up a function to make heading slugs, while avoiding duplicates
+   */
+  const makeHeadingSlug = makeHeadingSlugScope()
+
+  /**
+   * Build HeroHeadingVisualProps
+   */
+  const heroProps = { ...hero, productTheme: product.slug }
+
+  /**
+   * Build OverviewCtaProps
+   */
+  const overviewCtaProps = {
+    ...overview,
+    headingSlug: makeHeadingSlug(overview.heading),
+  }
+
+  /**
+   * Build GetStartedCardProps
+   */
+  const getStartedProps = {
+    ...get_started,
+    headingSlug: makeHeadingSlug(get_started.heading),
+  }
+
+  /**
+   * Build ProductLandingBlock[]
+   */
+  const transformedBlocks: ProductLandingBlock[] = blocks.map(
+    (block: ProductLandingContentBlock) => {
+      const { type } = block
+      switch (type) {
+        case 'heading':
+          return { ...block, headingSlug: makeHeadingSlug(block.heading) }
+        default:
+          return block
+      }
+    }
+  )
+
+  return {
+    hero: heroProps,
+    overview: overviewCtaProps,
+    get_started: getStartedProps,
+    blocks: transformedBlocks,
+  }
+}

--- a/src/views/product-landing/helpers/transform-raw-content-to-prop.ts
+++ b/src/views/product-landing/helpers/transform-raw-content-to-prop.ts
@@ -1,4 +1,3 @@
-import { isProductOption } from 'lib/learn-client/types'
 import { ProductData } from 'types/products'
 // raw content types
 import { ProductLandingContent, ProductLandingContentBlock } from '../schema'
@@ -12,17 +11,6 @@ export async function transformRawContentToProp(
   product: ProductData
 ): Promise<ProductLandingViewProps['content']> {
   /**
-   * Handle "hcp" or "sentinel" product.slug cases
-   * (these options are valid from a type perspective,
-   * but are not yet supported by the UI)
-   */
-  if (!isProductOption(product.slug)) {
-    throw new Error(
-      `Product landing pages do not yet support all products. Product slug "${product.slug}" is not yet supported.`
-    )
-  }
-
-  /**
    * Set up a function to make heading slugs, while avoiding duplicates
    */
   const makeHeadingSlug = makeHeadingSlugScope()
@@ -30,7 +18,7 @@ export async function transformRawContentToProp(
   /**
    * Build HeroHeadingVisualProps
    */
-  const heroProps = { ...hero, productTheme: product.slug }
+  const heroProps = { ...hero, productSlug: product.slug }
 
   /**
    * Build OverviewCtaProps

--- a/src/views/product-landing/index.tsx
+++ b/src/views/product-landing/index.tsx
@@ -1,44 +1,38 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement } from 'react'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import { ProductLandingContent, ProductLandingContentBlock } from './schema'
-import s from './product-landing.module.css'
-
-/**
- * TODO: make view-specific types as components are built out
- * (authored content structure and content structure passed to the client
- * will differ; eg tutorial card data will be filled in for client)
- */
-interface ProductLandingViewProps {
-  content: ProductLandingContent
-}
+import { ProductLandingViewProps } from './types'
+import ProductLandingBlocks from './components/product-landing-blocks'
+import HeroHeadingVisual from './components/hero-heading-visual'
+import OverviewCta from './components/overview-cta'
+import GetStartedCard from './components/get-started-card'
 
 function ProductLandingView({
   content,
 }: ProductLandingViewProps): ReactElement {
+  const { hero, overview, get_started, blocks } = content
   return (
-    <div>
-      <pre className={s.placeholder}>
-        <code>
-          {JSON.stringify({ ...content, blocks: undefined }, null, 2)}
-        </code>
-      </pre>
-      {content.blocks.map((block: ProductLandingContentBlock, idx: number) => {
-        const { type } = block
-        switch (type) {
-          default:
-            // If we don't have a recognized block type,
-            // return a dev-oriented debug view of the block data
-            // TODO: remove this for production, this is here
-            // TODO: temporarily as we work through demo-oriented implementation
-            return (
-              <pre key={idx} className={s.placeholder}>
-                <code>{JSON.stringify({ block }, null, 2)}</code>
-              </pre>
-            )
-        }
-      })}
-    </div>
+    <>
+      <HeroHeadingVisual
+        heading={hero.heading}
+        image={hero.image}
+        productTheme={hero.productTheme}
+      />
+      <OverviewCta
+        heading={overview.heading}
+        headingSlug={overview.headingSlug}
+        body={overview.body}
+        cta={overview.cta}
+        image={overview.image}
+      />
+      <GetStartedCard
+        heading={get_started.heading}
+        headingSlug={get_started.headingSlug}
+        body={get_started.body}
+        ctas={get_started.ctas}
+      />
+      <ProductLandingBlocks blocks={blocks} />
+    </>
   )
 }
 

--- a/src/views/product-landing/index.tsx
+++ b/src/views/product-landing/index.tsx
@@ -16,7 +16,7 @@ function ProductLandingView({
       <HeroHeadingVisual
         heading={hero.heading}
         image={hero.image}
-        productTheme={hero.productTheme}
+        productSlug={hero.productSlug}
       />
       <OverviewCta
         heading={overview.heading}

--- a/src/views/product-landing/types.ts
+++ b/src/views/product-landing/types.ts
@@ -1,0 +1,13 @@
+import { HeroHeadingVisualProps } from './components/hero-heading-visual/types'
+import { OverviewCtaProps } from './components/overview-cta/types'
+import { ProductLandingBlock } from './components/product-landing-blocks/types'
+import { GetStartedCardProps } from './components/get-started-card/types'
+
+export interface ProductLandingViewProps {
+  content: {
+    hero: HeroHeadingVisualProps
+    overview: OverviewCtaProps
+    get_started: GetStartedCardProps
+    blocks: ProductLandingBlock[]
+  }
+}


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][/waypoint] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Implements sidecar table-of-contents functionality for `views/product-landing`.

## 🤷 Why

To build out `views/product-landing`.

## 🛠️ How

- Adds a helper `transform-raw-content-to-prop`, which is hopefully clearly named.
    - This includes adding `headingSlug` elements where we need to include a heading in our table of contents.
    - This will later include fetching tutorial and collection data, and transforming it to card props
- Adds a helper `make-heading-slug-scope`, intent is to make it easy & clean to generate unique-on-the-page `headingSlug` values
- Adds all planned components as placeholders; this accounts for the majority of the lines-of-code
    - Adds prop types needed for the UI, which are referenced by `transform-raw-content-to-prop` (the collected component props types are the return type for that function!)
    - Some components & blocks (not all) render heading elements that get linked to from the table of contents

## 🧪 Testing

- [ ] Visit [/waypoint][/waypoint], and ensure the sidecar table-of-contents works as expected
- [ ] Visit [/vault][/vault], and ensure the sidecar table-of-contents works as expected

## 💭 Anything else?

Not at the moment! Excited to keep on truckin 🚂 

[task]: https://app.asana.com/0/1202097197789424/1202219063384067/f
[/waypoint]: https://dev-portal-git-zsproduct-landing-sidecar-hashicorp.vercel.app/waypoint
[/vault]: https://dev-portal-git-zsproduct-landing-sidecar-hashicorp.vercel.app/vault