### PR TITLE
fix: change name of cache job

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,7 +1,7 @@
 name: Cache .io Sites
 on: [deployment_status]
 jobs:
-  test:
+  cache:
     if: github.event.deployment_status.state == 'success' && github.event.deployment.environment == 'production' && github.event.sender.id == 35613825
     timeout-minutes: 60
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the name of the .io cache job from `test` to `cache`.