### PR TITLE
fix: footer overflow issues

### DIFF
--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -69,7 +69,7 @@
   display: flex;
   justify-content: left;
   width: calc(
-    var(--dev-dot-sidebar-width) + 2 * var(--main-area-padding-left-right) -
+    var(--dev-dot-sidebar-width) + var(--main-area-padding-left) -
       var(--header-padding-left-right) -
       var(--header-dropdown-menu-padding-left-right)
   );

--- a/src/layouts/base-new/base-new-layout.module.css
+++ b/src/layouts/base-new/base-new-layout.module.css
@@ -54,6 +54,7 @@ for both --navigation-header-height and --alert-bar-height.
 
 .footer {
   margin-top: auto;
+  overflow: hidden;
   padding-left: 24px;
   padding-right: 24px;
 }

--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -1,7 +1,13 @@
 .root {
   /* Widths/spacing needed in multiple stylesheets */
   --dev-dot-sidebar-width: 320px;
-  --main-area-padding-left-right: 24px;
+
+  /* Note: "right" value is not used in multiple stylesheets,
+     so is declared in sidebar-sidecar-layout.module.css */
+  --main-area-padding-left: 24px;
+  @media (--dev-dot-desktop) {
+    --main-area-padding-left: 48px;
+  }
 
   /* Mobile and tablet breakpoints */
   --mobile-width-breakpoint: 728px;

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -93,9 +93,9 @@ const SidebarSidecarLayoutContent = ({
         >
           <SidebarContent />
         </motion.div>
-        <div className={s.mainArea}>
-          <div className={s.main}>
-            <main id="main">
+        <div className={s.mainAreaAndFooter}>
+          <div className={s.mainArea}>
+            <main id="main" className={s.mainContent}>
               {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
               {children}
               {githubFileUrl && (
@@ -106,13 +106,16 @@ const SidebarSidecarLayoutContent = ({
                 />
               )}
             </main>
+            <div className={s.sidecar}>
+              <SidecarContent />
+            </div>
+          </div>
+          <div className={s.footerArea}>
             <Footer
               className={s.footer}
               openConsentManager={openConsentManager}
             />
-          </div>
-          <div className={`${s.sidecar} g-hide-on-mobile g-hide-on-tablet`}>
-            <SidecarContent />
+            <div className={s.footerSpaceForSidecar}></div>
           </div>
         </div>
       </div>

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -95,7 +95,7 @@ const SidebarSidecarLayoutContent = ({
         </motion.div>
         <div className={s.mainAreaAndFooter}>
           <div className={s.mainArea}>
-            <main id="main" className={s.mainContent}>
+            <main id="main" className={s.main}>
               {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
               {children}
               {githubFileUrl && (

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -115,7 +115,6 @@ const SidebarSidecarLayoutContent = ({
               className={s.footer}
               openConsentManager={openConsentManager}
             />
-            <div className={s.footerSpaceForSidecar}></div>
           </div>
         </div>
       </div>

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -107,7 +107,7 @@ for further details.
   padding-right: var(--main-area-padding-right);
 }
 
-.mainContent {
+.main {
   align-self: flex-start;
   flex-grow: 1;
   min-width: 0;

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -130,7 +130,6 @@ for further details.
 
   @media (--dev-dot-desktop) {
     display: block;
-    border: 1px solid magenta;
     align-self: flex-start;
     flex-shrink: 0;
     margin-left: var(--sidecar-margin-left);
@@ -150,7 +149,7 @@ for further details.
   min-width: 0;
   justify-content: center;
   padding-left: var(--main-area-padding-left);
-  padding-right: var(--main-area-padding-left);
+  padding-right: var(--main-area-padding-right);
   overflow: hidden;
 }
 

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -39,7 +39,7 @@ for further details.
   which serves as the border, and which overflows the footer on both sides.
   
   The footer container ensures this border overflow does not cause scroll
-  using overflow hidden. We place an empty sidecar placeholder element
+  using overflow hidden. We place an empty sidecar placeholder pseudo-element
   within this container, next to the footer, to ensure spacing is consistent.
 
   This method requires two separate "rows" for the main content + sidecar area,
@@ -49,7 +49,7 @@ for further details.
   */
   --main-area-max-width: 780px;
   --sidecar-width: 220px;
-  --sidecar-margin-left: 48px;
+  --sidecar-gap: 48px;
 }
 
 /**
@@ -99,6 +99,7 @@ for further details.
 .mainArea {
   display: flex;
   flex-grow: 1;
+  gap: var(--sidecar-gap);
   min-width: 0;
   justify-content: center;
   padding-bottom: 32px;
@@ -129,10 +130,9 @@ for further details.
   display: none;
 
   @media (--dev-dot-desktop) {
-    display: block;
     align-self: flex-start;
+    display: block;
     flex-shrink: 0;
-    margin-left: var(--sidecar-margin-left);
     position: sticky;
     top: calc(var(--sticky-bars-height) + var(--main-area-top-padding));
     width: var(--sidecar-width);
@@ -146,21 +146,22 @@ for further details.
 .footerArea {
   display: flex;
   flex-grow: 1;
+  gap: var(--sidecar-gap);
   min-width: 0;
   justify-content: center;
   padding-left: var(--main-area-padding-left);
   padding-right: var(--main-area-padding-right);
   overflow: hidden;
+
+  /* Acts as a sidecar placeholder to ensure spacing is consistent */
+  &::after {
+    content: '';
+    display: block;
+    width: var(--sidecar-width);
+  }
 }
 
 .footer {
   flex-grow: 1;
   max-width: var(--main-area-max-width);
-}
-
-/* Acts as a sidecar placeholder to ensure spacing is consistent */
-.footerSpaceForSidecar {
-  flex-shrink: 0;
-  margin-left: var(--sidecar-margin-left);
-  width: var(--sidecar-width);
 }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -18,7 +18,43 @@ for further details.
   padding the content area. So, we create a CSS var
   to make it reusable and express this intent. */
   --main-area-top-padding: 32px;
+
+  /* When the sidecar is hidden, then --main-area-padding-right must adjust.
+  Note that the "left" value, --main-area-padding-left, is declared in 
+  core-dev-dot-layout.module.css, as the left value  must be shared with the
+  navigation-header component, in order to match alignment in design specs. */
+  --main-area-padding-right: 24px;
+
+  /*
+  We want our footer to have a top border which spans
+  across both the main content and sidecar.
+  We also want our footer content to be aligned with our main content,
+  taking on the same max width and left-right padding.
+
+  To achieve this, we set the main content max width,
+  main content padding, and sidecar width as CSS variables
+  to be used in the main content, sidecar, and footer containers.
+
+  The footer itself contains an absolutely positioned :before element
+  which serves as the border, and which overflows the footer on both sides.
+  
+  The footer container ensures this border overflow does not cause scroll
+  using overflow hidden. We place an empty sidecar placeholder element
+  within this container, next to the footer, to ensure spacing is consistent.
+
+  This method requires two separate "rows" for the main content + sidecar area,
+  and for the footer area. Having to share values between them is not ideal.
+  But, it sidesteps issues in mixing overflow: hidden with position: sticky.
+  Details: https://css-tricks.com/dealing-with-overflow-and-position-sticky/
+  */
+  --main-area-max-width: 780px;
+  --sidecar-width: 220px;
+  --sidecar-margin-left: 48px;
 }
+
+/**
+ * Sidebar + main containers
+ */
 
 .sidebar {
   background-color: white;
@@ -50,6 +86,16 @@ for further details.
   }
 }
 
+.mainAreaAndFooter {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/**
+ * Main area row
+ */
+
 .mainArea {
   display: flex;
   flex-grow: 1;
@@ -57,22 +103,21 @@ for further details.
   justify-content: center;
   padding-bottom: 32px;
   padding-top: var(--main-area-top-padding);
-  padding-left: var(--main-area-padding-left-right);
-  padding-right: var(--main-area-padding-left-right);
+  padding-left: var(--main-area-padding-left);
+  padding-right: var(--main-area-padding-right);
 }
 
-.main {
+.mainContent {
   align-self: flex-start;
   flex-grow: 1;
   min-width: 0;
-  max-width: calc(780px + (var(--main-area-padding-left-right) * 2));
-  padding-left: var(--main-area-padding-left-right);
-  padding-right: var(--main-area-padding-left-right);
 
-  @media (--dev-dot-tablet-down) {
-    padding-left: 0;
-    padding-right: 0;
-    max-width: none;
+  /* 50vh padding-bottom ensures that all
+  jump-nav items have room to be jumped to */
+  padding-bottom: 50vh;
+
+  @media (--dev-dot-desktop) {
+    max-width: var(--main-area-max-width);
   }
 }
 
@@ -80,17 +125,43 @@ for further details.
   margin-top: 64px;
 }
 
-.footer {
-  /* the 50vh margin-top on footer ensures that all
-  jump-nav items have room to be jumped to */
-  margin-top: 50vh;
+.sidecar {
+  display: none;
+
+  @media (--dev-dot-desktop) {
+    display: block;
+    border: 1px solid magenta;
+    align-self: flex-start;
+    flex-shrink: 0;
+    margin-left: var(--sidecar-margin-left);
+    position: sticky;
+    top: calc(var(--sticky-bars-height) + var(--main-area-top-padding));
+    width: var(--sidecar-width);
+  }
 }
 
-.sidecar {
-  align-self: flex-start;
+/**
+ * Footer area row
+ */
+
+.footerArea {
+  display: flex;
+  flex-grow: 1;
+  min-width: 0;
+  justify-content: center;
+  padding-left: var(--main-area-padding-left);
+  padding-right: var(--main-area-padding-left);
+  overflow: hidden;
+}
+
+.footer {
+  flex-grow: 1;
+  max-width: var(--main-area-max-width);
+}
+
+/* Acts as a sidecar placeholder to ensure spacing is consistent */
+.footerSpaceForSidecar {
   flex-shrink: 0;
-  margin-left: 24px;
-  position: sticky;
-  top: calc(var(--sticky-bars-height) + var(--main-area-top-padding));
-  width: 220px;
+  margin-left: var(--sidecar-margin-left);
+  width: var(--sidecar-width);
 }


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][preview-sidebar-sidecar] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where the top border of our `footer` component caused horizontal overflow and scroll in both our core layout, and in our sidebar-sidecar layout.

## 🤷 Why

Horizontal scroll is unintentional, unexpected to visitors, and quite janky.

## 🛠️ How

### Fix for sidebar-sidecar layout

#### Context on design needs

In our designs, the footer needs to be aligned with main content, but its top border needs to span all the way across the main content and sidecar area:

![CleanShot 2022-05-13 at 12 13 46@2x](https://user-images.githubusercontent.com/4624598/168324956-e0f48bfb-a967-4e32-8ddf-4a971bc15546.png)

#### Context on current situation

Various approaches were attempted without changing markup, and I hit dead ends in all of them. In brief, I think the fundamental challenge with the current implementation's markup is that `overflow: hidden` and `position: sticky` [don't work together](https://css-tricks.com/dealing-with-overflow-and-position-sticky/):

![CleanShot 2022-05-12 at 16 54 11@2x](https://user-images.githubusercontent.com/4624598/168181231-0f9861b8-85ee-4f7a-bccf-b298230472aa.png)

#### Proposed solution, implemented in this PR

To work around this, markup as well as styles have been changed. A new `.mainAreaAndFooter` element creates a flex "column" layout, with two rows:

- the first row, `.mainArea`, contains the main area and handles the sidecar stickiness. It cannot have `overflow: hidden` because this would mess with sidecar's `position: sticky`.
- the second row, `.footerArea`, handles the footer positioning and overflow issues. It contains the footer and a `footerSpaceForSidecar` element. This area _must_ have `overflow: hidden` to prevent footer top border from overflowing

![2022-05-12-sidebar-sidecar-footer-overflow-fix-summary](https://user-images.githubusercontent.com/4624598/168180335-76b511e7-fc21-46ea-b9ef-eac495e9b218.png)

This requires lifting some CSS custom properties in order to share things like the sidecar width and the main content area max-width between the now-separate `.mainArea` and `.footerArea`. But, it addresses the overflow issue without breaking the `sticky` behaviour of the sidecar.

### Fix for base layout (as on home page, for example)

- Sets `overflow: hidden` on the footer container
- This was the easy one, very much a footnote compared to the sidebar-sidecar fix


## 🧪 Testing

- [ ] Visit the [home page][preview-home], and ensure there is no horizontal overflow. As well, ensure the footer looks as expected.
- [ ] Visit a page with `sidebar-sidecar-layout`, such as [/waypoint/tutorials][preview-sidebar-sidecar]
    - [ ] On both desktop and mobile sized viewports...
        - [ ] Ensure there is no horizontal overflow
        - [ ] Ensure the footer looks and functions as expected
    - [ ] On desktop viewports...
        - [ ] Ensure the left boundary of items in the top-level navigation bar aligns with the left boundary of the content area within the layout
        - [ ] Ensure the footer's left and right boundaries align with the content area's left and right boundaries
        - [ ] Ensure the main content area and sidecar still look and function as expected, with a focus on correct alignment

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1202271065589112/f
[preview-home]: https://dev-portal-git-zsfix-footer-overflow-hashicorp.vercel.app
[preview-sidebar-sidecar]: https://dev-portal-git-zsfix-footer-overflow-hashicorp.vercel.app/waypoint/tutorials