### PR TITLE
fix: roll back subnanv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@hashicorp/react-search": "^6.4.0",
         "@hashicorp/react-section-header": "^5.0.4",
         "@hashicorp/react-sentinel-embedded": "^1.0.4",
-        "@hashicorp/react-subnav": "^9.3.5",
+        "@hashicorp/react-subnav": "9.3.3",
         "@hashicorp/react-tabs": "^7.1.2",
         "@hashicorp/react-text-input": "^5.0.1",
         "@hashicorp/react-text-split-with-image": "^4.3.0",
@@ -3735,13 +3735,13 @@
       }
     },
     "node_modules/@hashicorp/react-subnav": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-subnav/-/react-subnav-9.3.5.tgz",
-      "integrity": "sha512-eR9SOWgjA7X+3N2kqvDAA7yTdWpCF5pBtYxL8PSuBsC389N/4GbCaa/atLWKvz9sKcZ+gfu8O5sA7dX1o4X5zw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-subnav/-/react-subnav-9.3.3.tgz",
+      "integrity": "sha512-Q7P6TUbL+98rv3OuZXAyvoFel3ddO0nexHubL9y5ZnSgx9MKhZKKUltPTd2ic5/FQWOw2alUd4gofQT2nDKkOA==",
       "dependencies": {
-        "@hashicorp/mktg-logos": "^1.2.0",
+        "@hashicorp/mktg-logos": "^1.0.2",
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "@reach/visually-hidden": "^0.16.0",
@@ -36454,13 +36454,13 @@
       }
     },
     "@hashicorp/react-subnav": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-subnav/-/react-subnav-9.3.5.tgz",
-      "integrity": "sha512-eR9SOWgjA7X+3N2kqvDAA7yTdWpCF5pBtYxL8PSuBsC389N/4GbCaa/atLWKvz9sKcZ+gfu8O5sA7dX1o4X5zw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-subnav/-/react-subnav-9.3.3.tgz",
+      "integrity": "sha512-Q7P6TUbL+98rv3OuZXAyvoFel3ddO0nexHubL9y5ZnSgx9MKhZKKUltPTd2ic5/FQWOw2alUd4gofQT2nDKkOA==",
       "requires": {
-        "@hashicorp/mktg-logos": "^1.2.0",
+        "@hashicorp/mktg-logos": "^1.0.2",
         "@hashicorp/platform-product-meta": "^0.1.0",
-        "@hashicorp/react-button": "^6.0.4",
+        "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-link-wrap": "^3.0.3",
         "@reach/visually-hidden": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@hashicorp/react-search": "^6.4.0",
     "@hashicorp/react-section-header": "^5.0.4",
     "@hashicorp/react-sentinel-embedded": "^1.0.4",
-    "@hashicorp/react-subnav": "^9.3.5",
+    "@hashicorp/react-subnav": "9.3.3",
     "@hashicorp/react-tabs": "^7.1.2",
     "@hashicorp/react-text-input": "^5.0.1",
     "@hashicorp/react-text-split-with-image": "^4.3.0",


### PR DESCRIPTION
This PR fixes an issue where `@hashicorp/react-subnav`'s `overflow: hidden` means the mobile menu would not be visible.