### PR TITLE
Return 404 page if error loading static props for docs pages

### DIFF
--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -110,8 +110,22 @@ export function getStaticGenerationFunctions<
         scope: await getScope(),
       })
 
+      /**
+       * Try to load the static props for the given context. If there is a
+       * ContentApiError with a 404 status, return a 404 status and page.
+       * https://nextjs.org/docs/api-reference/data-fetching/get-static-props#notfound
+       */
+      let loadStaticPropsResult
+      try {
+        loadStaticPropsResult = await loader.loadStaticProps(ctx)
+      } catch (error) {
+        if (error.status === 404) {
+          return { notFound: true }
+        }
+      }
+
       const { navData, mdxSource, githubFileUrl, versions } =
-        await loader.loadStaticProps(ctx)
+        loadStaticPropsResult
 
       /**
        * NOTE: we've encountered empty headings on at least one page:

--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -119,9 +119,13 @@ export function getStaticGenerationFunctions<
       try {
         loadStaticPropsResult = await loader.loadStaticProps(ctx)
       } catch (error) {
+        // Catch 404 errors, return a 404 status page
         if (error.status === 404) {
           return { notFound: true }
         }
+
+        // Throw non-404 errors
+        throw error
       }
 
       const { navData, mdxSource, githubFileUrl, versions } =


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them. If one of these items is not relevant to your PR, e.g. you do not have Asana ticket to go with them, you can remove them from the list.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202286782903644/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Wraps the `loader.loadStaticProps` call in `src/layouts/sidebar-sidecar/server.ts` with a `try/catch`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- The server error we see when going to not-found routes under docs pages is happening inside of the `loader.loadStaticProps` call. Wrapping it in a try/catch enables us to check the status of the error to see if it's a 404 or not.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

The following pages should still work as expected (just tossing a few in here):

- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/vault/api-docs
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/vault/docs
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/docs
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/commands
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/plugins

The following pages should show the 404 page rather than the server error page:

- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/vault/api-docs/foo/bar
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/vault/docs/foo/bar
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/docs/foo/bar
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/commands/foo/bar
- [ ] https://dev-portal-git-ambreturn-not-found-on-docs-404-hashicorp.vercel.app/waypoint/plugins/foo/bar

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

I think we may need to update the current `if (error.status === 404) { ... }` to be an `if/else`?