### PR TITLE
style: fix tutorial badge readtime

### DIFF
--- a/src/components/tutorial-meta/components/badges/badges.module.css
+++ b/src/components/tutorial-meta/components/badges/badges.module.css
@@ -21,3 +21,14 @@ ul.list {
   background-color: var(--token-color-highlight-background-faint);
   color: var(--token-color-palette-purple-300) !important;
 }
+
+.readTime {
+  composes: hds-font-weight-medium from global;
+  composes: hds-typography-display-100 from global;
+  color: var(--token-color-palette-neutral-600);
+  margin: 0 var(--badge-spacing) var(--badge-spacing) 0;
+  padding: 4px 0;
+  height: 24px;
+  display: flex;
+  align-items: center;
+}

--- a/src/components/tutorial-meta/components/badges/components/badge/badge.module.css
+++ b/src/components/tutorial-meta/components/badges/components/badge/badge.module.css
@@ -8,6 +8,7 @@
   height: 24px;
   display: flex;
   align-items: center;
+  color: var(--token-color-palette-neutral-600);
 }
 
 .icon {

--- a/src/components/tutorial-meta/components/badges/index.tsx
+++ b/src/components/tutorial-meta/components/badges/index.tsx
@@ -1,7 +1,7 @@
 import { Product as ClientProduct } from 'lib/learn-client/types'
 import { TutorialData } from 'views/tutorial-view'
 import { renderProductBadges, ProductDisplayOption } from './components/badge'
-import { generateBadges } from './helpers'
+import getReadableTime, { generateBadges } from './helpers'
 import s from './badges.module.css'
 
 export interface BadgesProps {
@@ -31,7 +31,7 @@ export function Badges({ options }: BadgesProps): React.ReactElement {
 
   return (
     <ul className={s.list}>
-      <Badge type="readTime" />
+      <p className={s.readTime}>{getReadableTime(readTime)}</p>
       {isBeta ? <Badge className={s.beta} type="isBeta" /> : null}
       {showEditionBadge ? <Badge type="edition" /> : null}
       {showProductBadges ? renderProductBadges(productBadgeOptions) : null}


### PR DESCRIPTION

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kstutorial-page-qa-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-intro) 🔎
- [Asana task](https://app.asana.com/0/1202001387788447/1202287572319161) 🎟️

## 🗒️ What

Addressing a QA ticket to update the readtime to no longer be a badge. See ticket for full context.
