### PR TITLE
Adjusting SidebarSidecarLayout spacing and sidecar breakpoint

### DIFF
--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -7,35 +7,15 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: 32px 0;
+  padding-bottom: 16px;
+  padding-top: 16px;
   position: relative;
-
-  /*
-  before element acts as full-width border, no matter the container size
-  */
-  &::before {
-    background: var(--token-color-border-primary);
-    content: '\200B';
-    height: 1px;
-    left: 0;
-    left: 50%;
-    overflow: hidden;
-    position: absolute;
-    top: 0;
-    transform: translateX(-50%);
-    width: 200vh;
-  }
 }
 
 .logo {
-  margin: 8px 40px 8px 0;
-  position: relative;
+  height: 28px;
 
   & svg {
-    /*
-    default inline display results in misalignment with footer links
-    */
-    display: block;
     height: 28px;
     width: auto;
   }

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -9,22 +9,6 @@
   justify-content: space-between;
   padding: 32px 0;
   position: relative;
-
-  /*
-  before element acts as full-width border, no matter the container size
-  */
-  &::before {
-    background: var(--token-color-border-primary);
-    content: '\200B';
-    height: 1px;
-    left: 0;
-    left: 50%;
-    overflow: hidden;
-    position: absolute;
-    top: 0;
-    transform: translateX(-50%);
-    width: 200vh;
-  }
 }
 
 .logo {

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -7,15 +7,35 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding-bottom: 16px;
-  padding-top: 16px;
+  padding: 32px 0;
   position: relative;
+
+  /*
+  before element acts as full-width border, no matter the container size
+  */
+  &::before {
+    background: var(--token-color-border-primary);
+    content: '\200B';
+    height: 1px;
+    left: 0;
+    left: 50%;
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    width: 200vh;
+  }
 }
 
 .logo {
-  height: 28px;
+  margin: 8px 40px 8px 0;
+  position: relative;
 
   & svg {
+    /*
+    default inline display results in misalignment with footer links
+    */
+    display: block;
     height: 28px;
     width: auto;
   }

--- a/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
@@ -10,6 +10,11 @@ const TABLE_OF_CONTENTS_LABEL_ID = 'table-of-contents-label'
 
 const TableOfContents = ({ headings }: TableOfContentsProps): ReactElement => {
   const { isDesktop } = useDeviceSize()
+
+  /**
+   * @TODO (2022-5-17) update the second argument to useActiveSection. Sidecar
+   * now goes away at 1280px rather than the isDesktop width.
+   */
   const activeSection = useActiveSection(headings, isDesktop)
 
   return (

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -110,7 +110,7 @@ const SidebarSidecarLayoutContent = ({
               <SidecarContent />
             </div>
           </div>
-          <div className={s.footerWrapper}>
+          <div className={s.footerAreaWrapper}>
             <Footer
               className={s.footer}
               openConsentManager={openConsentManager}

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -83,18 +83,18 @@ const SidebarSidecarLayoutContent = ({
 
   return (
     <BaseLayout showFooter={false}>
-      <div className={s.contentWrapper}>
+      <div className={s.root}>
         <motion.div
           animate={sidebarIsVisible ? 'visible' : 'hidden'}
-          className={s.sidebar}
+          className={s.sidebarWrapper}
           ref={sidebarRef}
           transition={{ duration: shouldReduceMotion ? 0 : 0.6 }}
           variants={sidebarMotion}
         >
           <SidebarContent />
         </motion.div>
-        <div className={s.mainAreaAndFooter}>
-          <div className={s.mainArea}>
+        <div className={s.contentWrapper}>
+          <div className={s.mainAreaWrapper}>
             <main id="main" className={s.main}>
               {breadcrumbLinks && <BreadcrumbBar links={breadcrumbLinks} />}
               {children}
@@ -106,7 +106,7 @@ const SidebarSidecarLayoutContent = ({
                 />
               )}
             </main>
-            <div className={s.sidecar}>
+            <div className={s.sidecarWrapper}>
               <SidecarContent />
             </div>
           </div>
@@ -115,6 +115,7 @@ const SidebarSidecarLayoutContent = ({
               className={s.footer}
               openConsentManager={openConsentManager}
             />
+            <div className={s.emptyDuplicateSidecarWrapper} />
           </div>
         </div>
       </div>

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -110,7 +110,7 @@ const SidebarSidecarLayoutContent = ({
               <SidecarContent />
             </div>
           </div>
-          <div className={s.footerArea}>
+          <div className={s.footerWrapper}>
             <Footer
               className={s.footer}
               openConsentManager={openConsentManager}

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -9,10 +9,6 @@ for further details.
 .contentWrapper {
   display: flex;
 
-  /* flex-grow ensures the content fills available
-  space in BaseNewLayout */
-  flex-grow: 1;
-
   /* For a coherent visual effect, the top padding value
   must be used for sticky positioning in addition to
   padding the content area. So, we create a CSS var
@@ -47,7 +43,7 @@ for further details.
   But, it sidesteps issues in mixing overflow: hidden with position: sticky.
   Details: https://css-tricks.com/dealing-with-overflow-and-position-sticky/
   */
-  --main-area-max-width: 780px;
+  --main-element-max-width: 804px;
   --sidecar-width: 220px;
   --sidecar-gap: 48px;
 }
@@ -87,9 +83,14 @@ for further details.
 }
 
 .mainAreaAndFooter {
-  display: flex;
-  flex-direction: column;
+  padding-top: 32px;
+  padding-right: 24px;
+  padding-left: 24px;
   width: 100%;
+
+  @media (--dev-dot-desktop) {
+    max-width: calc(100vw - var(--dev-dot-sidebar-width));
+  }
 }
 
 /**
@@ -98,27 +99,20 @@ for further details.
 
 .mainArea {
   display: flex;
-  flex-grow: 1;
-  gap: var(--sidecar-gap);
-  min-width: 0;
   justify-content: center;
-  padding-bottom: 32px;
-  padding-top: var(--main-area-top-padding);
-  padding-left: var(--main-area-padding-left);
-  padding-right: var(--main-area-padding-right);
 }
 
 .main {
-  align-self: flex-start;
-  flex-grow: 1;
-  min-width: 0;
+  /* Ensure all TableOfContents items have room to be jumped to */
 
-  /* 50vh padding-bottom ensures that all
-  jump-nav items have room to be jumped to */
-  padding-bottom: 50vh;
+  /* padding-bottom: 50vh; */
+}
 
+.main,
+.footerWrapper {
   @media (--dev-dot-desktop) {
-    max-width: var(--main-area-max-width);
+    max-width: var(--main-element-max-width);
+    min-width: 0;
   }
 }
 
@@ -139,29 +133,6 @@ for further details.
   }
 }
 
-/**
- * Footer area row
- */
-
-.footerArea {
-  display: flex;
-  flex-grow: 1;
-  gap: var(--sidecar-gap);
-  min-width: 0;
-  justify-content: center;
-  padding-left: var(--main-area-padding-left);
-  padding-right: var(--main-area-padding-right);
-  overflow: hidden;
-
-  /* Acts as a sidecar placeholder to ensure spacing is consistent */
-  &::after {
-    content: '';
-    display: block;
-    width: var(--sidecar-width);
-  }
-}
-
-.footer {
-  flex-grow: 1;
-  max-width: var(--main-area-max-width);
+.footerWrapper {
+  margin-top: 106px;
 }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -6,7 +6,7 @@ See comment in src/layouts/base-new/base-new-layout.module.css
 for further details.
 */
 
-.contentWrapper {
+.root {
   display: flex;
 
   /* For a coherent visual effect, the top padding value
@@ -43,16 +43,15 @@ for further details.
   But, it sidesteps issues in mixing overflow: hidden with position: sticky.
   Details: https://css-tricks.com/dealing-with-overflow-and-position-sticky/
   */
-  --main-element-max-width: 804px;
+  --main-element-max-width: 780px;
   --sidecar-width: 220px;
-  --sidecar-gap: 48px;
 }
 
 /**
  * Sidebar + main containers
  */
 
-.sidebar {
+.sidebarWrapper {
   background-color: white;
   box-shadow: 0 2px 3px rgba(101, 106, 118, 0.1),
     0 12px 28px rgba(101, 106, 118, 0.25);
@@ -82,10 +81,10 @@ for further details.
   }
 }
 
-.mainAreaAndFooter {
+.contentWrapper {
+  padding-left: var(--main-area-padding-left);
+  padding-right: var(--main-area-padding-right);
   padding-top: 32px;
-  padding-right: 24px;
-  padding-left: 24px;
   width: 100%;
 
   @media (--dev-dot-desktop) {
@@ -93,46 +92,52 @@ for further details.
   }
 }
 
-/**
- * Main area row
- */
-
-.mainArea {
-  display: flex;
-  justify-content: center;
-}
-
 .main {
   /* Ensure all TableOfContents items have room to be jumped to */
-
-  /* padding-bottom: 50vh; */
-}
-
-.main,
-.footerWrapper {
-  @media (--dev-dot-desktop) {
-    max-width: var(--main-element-max-width);
-    min-width: 0;
-  }
+  padding-bottom: 50vh;
 }
 
 .editOnGithubLink {
   margin-top: 64px;
 }
 
-.sidecar {
+.footerWrapper {
+  margin-top: 106px;
+}
+
+/*
+***
+* The following classes are grouped in a way that ensures the footer is always
+* left-aligned and the same width as the main content area.
+***
+*/
+
+.mainAreaWrapper,
+.footerWrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.main,
+.footer {
+  width: 100%;
+
+  @media (--dev-dot-sidecar-up) {
+    max-width: var(--main-element-max-width);
+    min-width: 0;
+  }
+}
+
+.sidecarWrapper,
+.emptyDuplicateSidecarWrapper {
   display: none;
 
-  @media (--dev-dot-desktop) {
-    align-self: flex-start;
+  @media (--dev-dot-sidecar-up) {
     display: block;
     flex-shrink: 0;
     position: sticky;
     top: calc(var(--sticky-bars-height) + var(--main-area-top-padding));
     width: var(--sidecar-width);
+    margin-left: 48px;
   }
-}
-
-.footerWrapper {
-  margin-top: 106px;
 }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -13,7 +13,7 @@ for further details.
   must be used for sticky positioning in addition to
   padding the content area. So, we create a CSS var
   to make it reusable and express this intent. */
-  --main-area-top-padding: 32px;
+  --main-area-padding-top: 32px;
 
   /* When the sidecar is hidden, then --main-area-padding-right must adjust.
   Note that the "left" value, --main-area-padding-left, is declared in 
@@ -84,7 +84,7 @@ for further details.
 .contentWrapper {
   padding-left: var(--main-area-padding-left);
   padding-right: var(--main-area-padding-right);
-  padding-top: 32px;
+  padding-top: var(--main-area-padding-top);
   width: 100%;
 
   @media (--dev-dot-desktop) {
@@ -136,7 +136,7 @@ for further details.
     display: block;
     flex-shrink: 0;
     position: sticky;
-    top: calc(var(--sticky-bars-height) + var(--main-area-top-padding));
+    top: calc(var(--sticky-bars-height) + var(--main-area-padding-top));
     width: var(--sidecar-width);
     margin-left: 48px;
   }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -101,7 +101,7 @@ for further details.
   margin-top: 64px;
 }
 
-.footerWrapper {
+.footerAreaWrapper {
   margin-top: 106px;
 }
 
@@ -113,7 +113,7 @@ for further details.
 */
 
 .mainAreaWrapper,
-.footerWrapper {
+.footerAreaWrapper {
   display: flex;
   justify-content: center;
 }

--- a/src/styles/custom-media.css
+++ b/src/styles/custom-media.css
@@ -11,3 +11,4 @@
 @custom-media --dev-dot-tablet-down only screen and (max-width: 1000px);
 @custom-media --dev-dot-tablet-up only screen and (min-width: 729px);
 @custom-media --dev-dot-desktop only screen and (min-width: 1001px);
+@custom-media --dev-dot-sidecar-up only screen and (min-width: 1280px);


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them. If one of these items is not relevant to your PR, e.g. you do not have Asana ticket to go with them, you can remove them from the list.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202001387788447/1202287572319130/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renamed a couple of CSS classes in `SidebarSidecarLayout` for extra clarity:
  - `contentWrapper` -> `root`
  - `sidebar` -> `sidebarWrapper`
  - `mainAreaAndFooter` -> `contentWrapper`
  - `mainArea` -> `mainAreaWrapper`
  - `sidecar` -> `sidecarWrapper`
  - `footerArea` -> `footerAreaWrapper`
- Replaced the `footer::after` pseudoelement with an empty `div`. I think something about the changes I made caused the pseudoelement approach to no longer work.
- Added `--dev-dot-sidecar-up` custom media and set it to the new `1280px` breakpoint. Sidecar styles are applied at this breakpoint and the `main` and `footer` classes also use this breakpoint for setting a `max-width` when the Sidecar should be present.
- In general, refined how margins, paddings, and widths are set to align with the latest Figma specification for this layout. Brayden created a video today clarifying some details, and it's attached in this Slack message: https://hashicorp.slack.com/archives/C01KCU4HDPY/p1652821970693979?thread_ts=1652796652.219419&cid=C01KCU4HDPY.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

<details>
<summary>1920px wide grid</summary>
<img src="https://user-images.githubusercontent.com/43934258/168941770-613ebcff-d690-4f05-9cde-946ab1e0205e.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9688%3A140703">Link to Figma frame</a>
</details>

<details>
<summary>1440px wide grid</summary>
<img src="https://user-images.githubusercontent.com/43934258/168941980-9828dec6-138f-45df-ac4f-3738b9a30084.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9688%3A139849">Link to Figma frame</a>
</details>

<details>
<summary>1280px wide grid (max width that shows Sidecar)</summary>
<img src="https://user-images.githubusercontent.com/43934258/168942081-52f2a86b-80cb-4e12-b5d8-33afca5edbec.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9688%3A139397">Link to Figma frame</a>
</details>

<details>
<summary>1279px wide grid</summary>
<img src="https://user-images.githubusercontent.com/43934258/168942167-c3a7f295-ae6b-4cd4-b1be-fcd087c5e19e.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9686%3A139967">Link to Figma frame</a>
</details>

<details>
<summary>1000px wide grid (max width that shows Sidebar)</summary>
<img src="https://user-images.githubusercontent.com/43934258/168942282-5074e9ad-a2f7-4e80-a9af-56bbe4ae1d4a.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9688%3A140678">Link to Figma frame</a>
</details>

<details>
<summary>999px wide grid</summary>
<img src="https://user-images.githubusercontent.com/43934258/168942406-5c3d9963-241b-4f4d-980d-df67f9fbba41.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9686%3A140101">Link to Figma frame</a>
</details>

<details>
<summary>768px, 441px, 320px wide grids</summary>
<img src="https://user-images.githubusercontent.com/43934258/168942449-6e69aaad-baf9-4a68-aba8-2bf310e063e9.png" />
<a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/?node-id=9688%3A140852">Link to Figma frame</a>
</details>

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

For the following pages, check that the rendered output matches what's specified in the design screenshots above (1920, 1440, 1280, 1279, 1000, 999, 768, 441, 320).

- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/docs
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/commands
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/plugins
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/tutorials
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/tutorials/get-started-docker
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-intro
- [ ] https://dev-portal-git-ambfix-sidecar-rendering-hashicorp.vercel.app/waypoint/downloads

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Added a TODO for this in `src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx`: we'll need to update the boolean argument passed to `useActiveSection`. The boolean is used to determine whether or not an `IntersectionObserver` should be instantiated for active headings in `TableOfContents`. It's currently based on the `1000px` breakpoint we have for `isDesktop`, which means that between the new breakpoint for Sidecar and the desktop breakpoint, `IntersectionObserver` will be instantiated unnecessarily. I'm not 100% sure how we should address this yet (could update `DeviceSizeContext`, could do a media query in the JS) so I'm saving it for a future PR to keep this one small and focused.