### PR TITLE
Track product download analytics

### DIFF
--- a/analytics/spec/events/product_downloaded.yaml
+++ b/analytics/spec/events/product_downloaded.yaml
@@ -1,4 +1,4 @@
-name: Product Downloaded
+name: Download
 description: User has downloaded a product
 rules:
   '$schema': http://json-schema.org/draft-04/schema#

--- a/src/components/download-standalone-link/index.tsx
+++ b/src/components/download-standalone-link/index.tsx
@@ -6,6 +6,7 @@ import { DownloadStandaloneLinkProps } from './types'
 const DownloadStandaloneLink = ({
   ariaLabel,
   href,
+  onClick,
 }: DownloadStandaloneLinkProps): ReactElement => (
   <StandaloneLink
     ariaLabel={ariaLabel}
@@ -13,6 +14,7 @@ const DownloadStandaloneLink = ({
     href={href}
     icon={<IconDownload16 />}
     iconPosition="trailing"
+    onClick={onClick}
     text="Download"
   />
 )

--- a/src/components/download-standalone-link/types.ts
+++ b/src/components/download-standalone-link/types.ts
@@ -11,4 +11,9 @@ export interface DownloadStandaloneLinkProps {
    * rendered `StandaloneLink`.
    */
   href: StandaloneLinkProps['href']
+
+  /**
+   * A callback function to invoke when the `<a>` element  clicked.
+   */
+  onClick?: StandaloneLinkProps['onClick']
 }

--- a/src/components/download-standalone-link/types.ts
+++ b/src/components/download-standalone-link/types.ts
@@ -4,7 +4,7 @@ export interface DownloadStandaloneLinkProps {
   /**
    * A non-visual accessible and descriptive label for what's being downloaded.
    */
-  ariaLabel: string
+  ariaLabel: StandaloneLinkProps['ariaLabel']
 
   /**
    * The location of the file to download. Passedd directly to the internally

--- a/src/components/standalone-link/index.tsx
+++ b/src/components/standalone-link/index.tsx
@@ -12,6 +12,7 @@ const StandaloneLink = ({
   href,
   icon,
   iconPosition,
+  onClick,
   openInNewTab = false,
   size = 'medium',
   text,
@@ -24,8 +25,9 @@ const StandaloneLink = ({
       className={classes}
       download={download}
       href={href}
-      target={openInNewTab ? '_blank' : '_self'}
+      onClick={onClick}
       rel={openInNewTab ? 'noreferrer noopener' : undefined}
+      target={openInNewTab ? '_blank' : '_self'}
     >
       {iconPosition === 'leading' && icon}
       <span className={s.text}>{text}</span>

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -1,5 +1,7 @@
 import { ReactElement } from 'react'
 
+type AnchorElementProps = JSX.IntrinsicElements['a']
+
 export interface StandaloneLinkProps {
   /**
    * A non-visible label presented by screen readers. Passed directly to the
@@ -7,13 +9,13 @@ export interface StandaloneLinkProps {
    *
    * ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
    */
-  ariaLabel?: string
+  ariaLabel?: AnchorElementProps['aria-label']
 
   /**
    * A string of one or more class names. Applied last to the rendered `<a>`
    * element.
    */
-  className?: string
+  className?: AnchorElementProps['className']
 
   /**
    * Determines the set of colors to use for various states of the component.
@@ -26,12 +28,12 @@ export interface StandaloneLinkProps {
    *
    * ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
    */
-  download?: boolean | string
+  download?: AnchorElementProps['download']
 
   /**
    * The destination of the link.
    */
-  href: string
+  href: AnchorElementProps['href']
 
   /**
    * An icon from `@hashicorp/flight-icons` to render.
@@ -63,7 +65,7 @@ export interface StandaloneLinkProps {
   /**
    * A callback function to invoke when the `<a>` element  clicked.
    */
-  onClick?: () => void
+  onClick?: AnchorElementProps['onClick']
 
   /**
    * Whether or not the link should open in a new tab. Affects the `target` and

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -61,6 +61,11 @@ export interface StandaloneLinkProps {
   iconPosition: 'leading' | 'trailing'
 
   /**
+   * A callback function to invoke when the `<a>` element  clicked.
+   */
+  onClick?: () => void
+
+  /**
    * Whether or not the link should open in a new tab. Affects the `target` and
    * `rel` props passed to the internally rendered `<a>` element.
    */

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,3 +1,6 @@
+import { ProductSlug } from 'types/products'
+import { Version } from './fetch-release-data'
+
 /**
  * Determines whether or not `window.analytics.track` can be invokved.
  */
@@ -22,4 +25,43 @@ const safeAnalyticsTrack = (
   }
 }
 
-export { safeAnalyticsTrack }
+/**
+ * Handles tracking the Download event in the same format it was tracked
+ * previously on .io sites (excluding the `category` and `label` properties).
+ *
+ * Important notes:
+ *  - Properties are defined in `analytics/spec/events/product_downloaded.yaml`
+ *  - `prettyOSName` examples: "macOS", "Windows", "Linux", "FreeBSD", "NetBSD",
+ *    "OpenBSD", "Solaris"
+ *  - `architecture` will have it's first character capitalized automatically
+ *
+ * Based off `@hashicorp/react-product-downloads-page`'s `trackDownload`:
+ * https://github.com/hashicorp/react-components/blob/d6eba7971bbbf7c58cf3cc110f5b7b423e3cd27c/packages/product-download-page/utils/downloader.ts#L115-L134
+ */
+const trackProductDownload = ({
+  architecture,
+  prettyOSName,
+  productSlug,
+  version,
+}: {
+  architecture: string
+  prettyOSName: string
+  productSlug: Exclude<ProductSlug, 'hcp'>
+  version: Version
+}) => {
+  // Ensure the `architecture` property has the correct casing
+  const lowercasedArchitectureName = architecture.toLowerCase()
+  const casedArchitectureName =
+    lowercasedArchitectureName.charAt(0).toUpperCase() +
+    lowercasedArchitectureName.slice(1)
+
+  // Track the Download event
+  safeAnalyticsTrack('Download', {
+    architecture: casedArchitectureName,
+    operating_system: prettyOSName,
+    product: productSlug,
+    version,
+  })
+}
+
+export { safeAnalyticsTrack, trackProductDownload }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,25 @@
+/**
+ * Determines whether or not `window.analytics.track` can be invokved.
+ */
+const canTrackAnalytics = (): boolean => {
+  return (
+    typeof window !== undefined &&
+    window.analytics &&
+    window.analytics.track &&
+    typeof window.analytics.track === 'function'
+  )
+}
+
+/**
+ * Invokes `window.analytics.track` if it is able to be invokved.
+ */
+const safeAnalyticsTrack = (
+  eventName: string,
+  properties: Record<string, unknown>
+): void => {
+  if (canTrackAnalytics()) {
+    window.analytics.track(eventName, properties)
+  }
+}
+
+export { safeAnalyticsTrack }

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -108,6 +108,20 @@ const BinaryDownloadsSection = ({
           <DownloadStandaloneLink
             ariaLabel={`download ${name} version ${version} for ${prettyOSName}, architecture ${arch}`}
             href={downloadsByOS[os][arch]}
+            onClick={() => {
+              if (
+                typeof window !== 'undefined' &&
+                window.analytics &&
+                window.analytics.track
+              ) {
+                window.analytics.track('Product Downloaded', {
+                  product: name,
+                  version: version,
+                  operating_system: os,
+                  architecture: arch,
+                })
+              }
+            }}
           />
         </Card>
       ))}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -1,8 +1,14 @@
+// Third-party imports
 import { ReactElement, useMemo } from 'react'
 import classNames from 'classnames'
+
+// HashiCorp imports
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import CodeBlock from '@hashicorp/react-code-block'
 import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
+
+// Global imports
+import { safeAnalyticsTrack } from 'lib/analytics'
 import { useCurrentProduct } from 'contexts'
 import { prettyOs } from 'views/product-downloads-view/helpers'
 import { useCurrentVersion } from 'views/product-downloads-view/contexts'
@@ -14,6 +20,8 @@ import StandaloneLink from 'components/standalone-link'
 import Tabs, { Tab } from 'components/tabs'
 import Text from 'components/text'
 import VersionContextSwitcher from 'components/version-context-switcher'
+
+// Local imports
 import { DownloadsSectionProps } from './types'
 import {
   generateCodePropFromCommands,
@@ -109,18 +117,12 @@ const BinaryDownloadsSection = ({
             ariaLabel={`download ${name} version ${version} for ${prettyOSName}, architecture ${arch}`}
             href={downloadsByOS[os][arch]}
             onClick={() => {
-              if (
-                typeof window !== 'undefined' &&
-                window.analytics &&
-                window.analytics.track
-              ) {
-                window.analytics.track('Product Downloaded', {
-                  product: name,
-                  version: version,
-                  operating_system: os,
-                  architecture: arch,
-                })
-              }
+              safeAnalyticsTrack('Product Downloaded', {
+                product: name,
+                version: version,
+                operating_system: os,
+                architecture: arch,
+              })
             }}
           />
         </Card>

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -8,7 +8,7 @@ import CodeBlock from '@hashicorp/react-code-block'
 import CodeTabs from '@hashicorp/react-code-block/partials/code-tabs'
 
 // Global imports
-import { safeAnalyticsTrack } from 'lib/analytics'
+import { trackProductDownload } from 'lib/analytics'
 import { useCurrentProduct } from 'contexts'
 import { prettyOs } from 'views/product-downloads-view/helpers'
 import { useCurrentVersion } from 'views/product-downloads-view/contexts'
@@ -117,10 +117,10 @@ const BinaryDownloadsSection = ({
             ariaLabel={`download ${name} version ${version} for ${prettyOSName}, architecture ${arch}`}
             href={downloadsByOS[os][arch]}
             onClick={() => {
-              safeAnalyticsTrack('Product Downloaded', {
-                product: name,
-                version: version,
-                operating_system: os,
+              trackProductDownload({
+                productSlug: name,
+                version,
+                prettyOSName,
                 architecture: arch,
               })
             }}


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them. If one of these items is not relevant to your PR, e.g. you do not have Asana ticket to go with them, you can remove them from the list.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambproduct-downloaded-analytics-hashicorp.vercel.app/waypoint/downloads) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202207336073931/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renamed `Product Downloaded` event name to `Download` in `analytics/spec/events/product_downloaded.yaml` to match the existing events we've tracked on .io sites.
- Adds `onClick` prop to both `StandaloneLink` and `DownloadStandaloneLink`
- Updates `DownloadStandaloneLinkProps['ariaLabel']` to reference `StandaloneLinkProps['ariaLabel']`
- Updates `StandaloneLinkProps` to reference `JSX.IntrinsicElements['a']` props for props that end up passed directly to the rendered `<a>` element
- Adds `src/lib/analytics.ts` with three functions:
  - `canTrackAnalytics` (not exported for wide reuse)
  - `safeAnalyticsTrack` (exported for wide reuse)
  - `trackProductDownload` (exported for wide reuse
- Updates `DownloadStandaloneLink`s in `src/views/product-downloads-view/components/downloads-section/index.tsx` to call `safeAnalyticsTrack` with the event name and properties specified in [`analytics/spec/events/product_downloaded.yaml`](https://github.com/hashicorp/dev-portal/blob/main/analytics/spec/events/product_downloaded.yaml)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- General reasoning behind this PR is that we want to track every time a user clicks a Download link in the install views. 😊
- An `onClick` handler was needed to call the tracking function in `DownloadStandaloneLink` which uses `StandaloneLink` under the hood, so an `onClick` handler was needed on that component as well.
- `safeAnalyticsTrack` was added because typing out the checks that have to happen before calling `window.analytics.track` is tedious and too long to memorize.
  - Those checks were separated out into `canTrackAnalytics` so it can be easily reused in future helpers defined next to `safeAnalyticsTrack` in `src/lib/analytics.ts`.
  - `canTrackAnalytics` is not currently exported in hopes of encouraging use of `safeTrackAnalytics` (and future similar helpers)
- `trackProductDownload` was added to automatically handle some formatting and also to document exactly how the event properties are expected to be formatted

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Followed the thoroughly detailed Asana ticket (thanks @BrandonRomano!!)
- Based `trackProductDownload` off of [`@hashicorp/react-product-downloads-page`'s `trackDownload`](https://github.com/hashicorp/react-components/blob/d6eba7971bbbf7c58cf3cc110f5b7b423e3cd27c/packages/product-download-page/utils/downloader.ts#L115-L134)
- Double-checked formatting of tracked data by looking at the tracking network requests made in waypointproject.io/downloads and vaultproject.io/downloads

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

N/A

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

### Waypoint

- [ ] Go to [/waypoint/downloads](https://dev-portal-git-ambproduct-downloaded-analytics-hashicorp.vercel.app/waypoint/downloads)
- [ ] Make sure you have the Network dev tools tab open
- [ ] Go to https://www.waypointproject.io/downloads in a separate tab
- [ ] Make sure you have the Network dev tools tab open for this tab as well
- [ ] For a few combinations of OSes and architectures:
  - [ ] Click the download links in each tab
  - [ ] Compare the analytics tracking network requests in each tab
  - [ ] Both requests should have the exact same values for these properties:
    - [ ] `architecture`
    - [ ] `prettyOSName`
    - [ ] `productSlug`
    - [ ] `version`

### Vault

- [ ] Go to [/vault/downloads](https://dev-portal-git-ambproduct-downloaded-analytics-hashicorp.vercel.app/vault/downloads)
- [ ] Make sure you have the Network dev tools tab open
- [ ] Go to https://www.vaultproject.io/downloads in a separate tab
- [ ] Make sure you have the Network dev tools tab open for this tab as well
- [ ] For a few combinations of OSes and architectures:
  - [ ] Click the download links in each tab
  - [ ] Compare the analytics tracking network requests in each tab
  - [ ] Both requests should have the exact same values for these properties:
    - [ ] `architecture`
    - [ ] `prettyOSName`
    - [ ] `productSlug`
    - [ ] `version`

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!