### PR TITLE
chore: hide TOC if only one heading

### DIFF
--- a/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
@@ -11,15 +11,13 @@ const TABLE_OF_CONTENTS_LABEL_ID = 'table-of-contents-label'
 const TableOfContents = ({ headings }: TableOfContentsProps): ReactElement => {
   const { isDesktop } = useDeviceSize()
   const hasOneHeading = headings.length === 1
+  const enableActiveSection = hasOneHeading ? false : isDesktop
 
   /**
    * @TODO (2022-5-17) update the second argument to useActiveSection. Sidecar
    * now goes away at 1280px rather than the isDesktop width.
    */
-  const activeSection = useActiveSection(
-    headings,
-    hasOneHeading ? false : isDesktop
-  )
+  const activeSection = useActiveSection(headings, enableActiveSection)
 
   // Don't render if only one item
   if (hasOneHeading) {

--- a/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
@@ -10,15 +10,19 @@ const TABLE_OF_CONTENTS_LABEL_ID = 'table-of-contents-label'
 
 const TableOfContents = ({ headings }: TableOfContentsProps): ReactElement => {
   const { isDesktop } = useDeviceSize()
+  const hasOneHeading = headings.length === 1
 
   /**
    * @TODO (2022-5-17) update the second argument to useActiveSection. Sidecar
    * now goes away at 1280px rather than the isDesktop width.
    */
-  const activeSection = useActiveSection(headings, isDesktop)
+  const activeSection = useActiveSection(
+    headings,
+    hasOneHeading ? false : isDesktop
+  )
 
   // Don't render if only one item
-  if (headings.length === 1) {
+  if (hasOneHeading) {
     return null
   }
 

--- a/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/index.tsx
@@ -17,6 +17,11 @@ const TableOfContents = ({ headings }: TableOfContentsProps): ReactElement => {
    */
   const activeSection = useActiveSection(headings, isDesktop)
 
+  // Don't render if only one item
+  if (headings.length === 1) {
+    return null
+  }
+
   return (
     <nav aria-labelledby={TABLE_OF_CONTENTS_LABEL_ID}>
       <p className={s.tableOfContentsLabel} id={TABLE_OF_CONTENTS_LABEL_ID}>


### PR DESCRIPTION


## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kshide-sidecar-one-item-hashicorp.vercel.app/http://localhost:3000/waypoint/tutorials/get-started-docker/get-started-intro) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202213086993158) 🎟️

## 🗒️ What
As per design's request this PR adds a check for the number of headings in the table of contents component (default for sidecar). If there's only one heading, the component doesn't render. 
