### PR TITLE
style-fix: move nav product logo margin

### DIFF
--- a/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
+++ b/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
@@ -6,7 +6,6 @@
 .activatorWrapper {
   padding-bottom: 16px;
   padding-top: 16px;
-  margin-right: 12px;
 }
 
 .activator {

--- a/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
+++ b/src/components/navigation-header/components/dropdown-menu/dropdown-menu.module.css
@@ -6,6 +6,7 @@
 .activatorWrapper {
   padding-bottom: 16px;
   padding-top: 16px;
+  margin-right: 12px;
 }
 
 .activator {

--- a/src/components/navigation-header/components/product-page-content/product-page-content.module.css
+++ b/src/components/navigation-header/components/product-page-content/product-page-content.module.css
@@ -22,4 +22,8 @@
 .productLogoLink {
   composes: g-focus-ring-from-box-shadow-dark from global;
   border-radius: 5px;
+
+  @media (--dev-dot-desktop) {
+    margin-left: 12px;
+  }
 }

--- a/src/components/navigation-header/components/product-page-content/product-page-content.module.css
+++ b/src/components/navigation-header/components/product-page-content/product-page-content.module.css
@@ -22,9 +22,4 @@
 .productLogoLink {
   composes: g-focus-ring-from-box-shadow-dark from global;
   border-radius: 5px;
-
-  /* On mobile/tablet, this element comes first */
-  &:not(:first-child) {
-    margin-left: 12px;
-  }
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-mobile-logo-position-hashicorp.vercel.app/vault/docs) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202292475408421) 🎟️

## 🗒️ What

This PR fixes a bug where left margin on the product logo was offsetting the product logo on mobile and tablet when the dropdown wasn't rendering. See the ticket for full context / screenshots. 

## 🧪 Testing

- [Visit a page](https://dev-portal-git-ksfix-mobile-logo-position-hashicorp.vercel.app/vault/docs) that renders the product logo and drop down. Ensure that the spacing is correct on both desktop and mobile. 

