### PR TITLE
chore: use product name for search placeholder

### DIFF
--- a/src/views/docs-view/components/product-docs-search/index.tsx
+++ b/src/views/docs-view/components/product-docs-search/index.tsx
@@ -37,7 +37,7 @@ export default function ProductDocsSearch() {
     <AlgoliaSearch
       className={s.root}
       openOnFocus={true}
-      placeholder={`Search ${currentProduct.slug} documentation`}
+      placeholder={`Search ${currentProduct.name} documentation`}
       ResultComponent={ProductSearchResult}
       getHitLinkProps={getHitLink}
       plugins={[algoliaInsightsPlugin]}


### PR DESCRIPTION


## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kscapitalize-product-search-hashicorp.vercel.app/vault/docs) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202309283074052) 🎟️

## 🗒️ What

This PR adjusts the search placeholder to use the product name, instead of the slug — this way the product is properly capitalized. 