### PR TITLE
Fixing scroll-margin-top on /vault/docs and /waypoint/docs

### DIFF
--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -31,6 +31,7 @@ const AutosizedHeading = ({
   }
   const classes = classNames(
     devDotStyles[`h${level}`],
+    s.heading,
     s[`h${level}`],
     className
   )

--- a/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
@@ -4,6 +4,10 @@
 ***
 */
 
+.heading {
+  composes: g-offset-scroll-margin-top from global;
+}
+
 .h2 {
   margin-bottom: 24px;
   margin-top: 0;


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the `scroll-margin-top` on the headings in the marketing section of the root docs path landing pages

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Composes the handy dandy `g-offset-scroll-margin-top` global helper. 😊

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /vault/docs
- [ ] Make sure clicking each Sidecar heading jumps to the correct location on the page
- [ ] Go to /waypoint/docs
- [ ] Make sure clicking each Sidecar heading jumps to the correct location on the page

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Nope!