### PR TITLE
chore: fix margin-bottom on alert component

### DIFF
--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -20,6 +20,7 @@
       border-radius: 6px;
       color: var(--token-color-palette-neutral-600);
       padding: 16px;
+      margin-bottom: 20px;
 
       & code {
         background-color: white;

--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -20,7 +20,7 @@
       border-radius: 6px;
       color: var(--token-color-palette-neutral-600);
       padding: 16px;
-      margin-bottom: 20px;
+      margin: 20px 0;
 
       & code {
         background-color: white;


### PR DESCRIPTION


## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-alert-bottom-margin-hashicorp.vercel.app/vault/docs/concepts/username-templating#examples) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202309283074066) 🎟️

## 🗒️ What

Fixes an issue where the alert component had no bottom margin. 

## 🧪 Testing

- Visit this PR and verify that the bottom margin is properly applied. See screenshot below for the previous view 
<img width="1034" alt="Screen Shot 2022-05-19 at 2 15 01 PM" src="https://user-images.githubusercontent.com/36613477/170351123-36c6222e-3262-4afe-b1d7-c0c53d77d9b8.png">
- Also click around a few more docs pages to verify that the alert spacing looks fine. 

