### PR TITLE
chore(packer.io): removes beta badge from HCP packer section

### DIFF
--- a/src/components/_proxied-dot-io/packer/section-break-cta/index.tsx
+++ b/src/components/_proxied-dot-io/packer/section-break-cta/index.tsx
@@ -18,7 +18,7 @@ export default function SectionBreakCta({
             className={s.logo}
             src={require('./hcp-packer.svg?include')}
           />
-          <span className={s.badge}>{badge}</span>
+          {badge ? <span className={s.badge}>{badge}</span> : null}
         </div>
         <h2 className={s.heading}>{heading}</h2>
         <p className={s.description}>{description}</p>

--- a/src/pages/_proxied-dot-io/packer/index.jsx
+++ b/src/pages/_proxied-dot-io/packer/index.jsx
@@ -119,7 +119,6 @@ function HomePage() {
       </section>
       <section className={s.sectionGridContainer}>
         <SectionBreakCta
-          badge="Beta"
           heading="Automate build configuration across cloud providers."
           description="Set up HCP Packer in minutes to start tracking Packer images across your provisioning pipeline."
           link={{


### PR DESCRIPTION
Removes beta badge from HCP packer section.

![CleanShot 2022-05-25 at 18 41 58@2x](https://user-images.githubusercontent.com/825855/170381502-2a99a89a-fc5d-46e8-86f4-254c74c92d0c.png)

Preview (switch to packer homepage via product select): https://dev-portal-git-acpacker-remove-beta-badge-hashicorp.vercel.app/ 