### PR TITLE
Replace HDS deprecated tokens with correct ones

### DIFF
--- a/src/components/algolia-search/algolia-search.module.css
+++ b/src/components/algolia-search/algolia-search.module.css
@@ -94,7 +94,7 @@
   width: 100%;
   max-height: 360px;
   position: absolute;
-  background: var(--token-color-neutral-background-base);
+  background: var(--token-color-surface-primary);
   border-radius: 5px;
   box-shadow: var(--token-surface-higher-box-shadow);
   margin-top: 4px;

--- a/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
+++ b/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
@@ -8,7 +8,7 @@
 
 .exitIcon {
   grid-area: icon;
-  color: var(--token-color-neutral-foreground-faint);
+  color: var(--token-color-foreground-faint);
   margin: 4px 2px;
   appearance: none;
   background: unset;
@@ -60,7 +60,7 @@
   background: url('~@hashicorp/flight-icons/svg/chevron-down-16.svg') no-repeat;
   background-position: calc(100% - 15px) center;
   background-color: var(--token-color-surface-faint);
-  border: 1px solid var(--token-color-neutral-border-strong);
+  border: 1px solid var(--token-color-border-strong);
   border-radius: 5px;
   padding: 10px 16px;
 

--- a/src/components/tabs/components/tab-dropdown-controls/tab-dropdown-controls.module.css
+++ b/src/components/tabs/components/tab-dropdown-controls/tab-dropdown-controls.module.css
@@ -36,6 +36,6 @@
   composes: hds-typography-body-200 from global;
 
   /* properties */
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   font-weight: var(--token-typography-font-weight-regular);
 }

--- a/src/components/tutorial-meta/components/badges/badges.module.css
+++ b/src/components/tutorial-meta/components/badges/badges.module.css
@@ -18,7 +18,7 @@ ul.list {
 }
 
 .beta {
-  background-color: var(--token-color-highlight-background-faint);
+  background-color: var(--token-color-surface-highlight);
   color: var(--token-color-palette-purple-300) !important;
 }
 

--- a/src/components/version-context-switcher/version-context-switcher.module.css
+++ b/src/components/version-context-switcher/version-context-switcher.module.css
@@ -45,6 +45,6 @@
   composes: hds-typography-body-200 from global;
 
   /* properties */
-  color: var(--token-color-neutral-foreground-primary);
+  color: var(--token-color-foreground-strong);
   font-weight: var(--token-typography-font-weight-regular);
 }

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -138,7 +138,7 @@ function Homepage(): ReactElement {
         actions={[
           {
             icon: (
-              <IconSupport24 color="var(--token-color-highlight-foreground-primary)" />
+              <IconSupport24 color="var(--token-color-foreground-highlight)" />
             ),
             heading: 'Support',
             description: 'Open a support ticket',


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

<!--
Check these items off in the GitHub PR UI as you complete them. If one of these items is not relevant to your PR, e.g. you do not have Asana ticket to go with them, you can remove them from the list.
-->

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [ ] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [ ] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1202008719910219/1202305194537473) 🎟️

## 🗒️ What

This PR replaces some old design tokens with the correct one (they were deprecated time ago).

## 🤷 Why

In https://github.com/hashicorp/design-system/pull/327 the HDS team has completely removed the deprecated tokens from the generated/released set of tokens.

## 🛠️ How

Search the codebase using this regex:
```
--token-color-(neutral|action|highlight|success|warning|critical)
```

## 🧪 Testing

This change should be completely seamless (the hex color values remain exactly the same).
