### PR TITLE
fix: issue with toast route change detection

### DIFF
--- a/src/components/toast/index.tsx
+++ b/src/components/toast/index.tsx
@@ -51,14 +51,14 @@ function toast({
        */
       useEffect(() => {
         if (initialRoute == null) {
-          setInitialRoute(router.asPath)
+          setInitialRoute(router.pathname)
         } else {
-          const isRouteChanged = router.asPath !== initialRoute
+          const isRouteChanged = router.pathname !== initialRoute
           if (isRouteChanged && dismissOnRouteChange) {
             dismissSelf()
           }
         }
-      }, [router.asPath, initialRoute, setInitialRoute, dismissSelf])
+      }, [router.pathname, initialRoute, setInitialRoute, dismissSelf])
 
       return (
         <ToastDisplay

--- a/src/components/toast/index.tsx
+++ b/src/components/toast/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { default as reactHotToast, Toast } from 'react-hot-toast'
 import Toaster from './components/toaster'
 import ToastDisplay from './components/toast-display'
@@ -34,6 +34,7 @@ function toast({
   // Return a react-hot-toast
   return reactHotToast(
     (t: Toast) => {
+      const [initialRoute, setInitialRoute] = useState(null)
       const router = useRouter()
 
       // Allows the toast to dismiss itself
@@ -44,14 +45,15 @@ function toast({
 
       // If specified, when the route changes, we should dismiss the toast
       useEffect(() => {
-        if (dismissOnRouteChange) {
-          router.events.on('routeChangeComplete', dismissSelf)
+        if (initialRoute == null) {
+          setInitialRoute(router.asPath)
+        } else {
+          const isRouteChanged = router.asPath !== initialRoute
+          if (isRouteChanged && dismissOnRouteChange) {
+            dismissSelf()
+          }
         }
-        // Clean up
-        return () => {
-          router.events.off('routeChangeComplete', dismissSelf)
-        }
-      }, [router.events, dismissSelf])
+      }, [router.asPath, initialRoute, setInitialRoute, dismissSelf])
 
       return (
         <ToastDisplay

--- a/src/components/toast/index.tsx
+++ b/src/components/toast/index.tsx
@@ -43,7 +43,12 @@ function toast({
         reactHotToast.remove(t.id)
       }, [t.id])
 
-      // If specified, when the route changes, we should dismiss the toast
+      /**
+       * If specified, when the route changes, we should dismiss the toast.
+       * Note: there is a long-standing bug that prevents us from using
+       * the more expected routeChangComplete event from NextJS:
+       * https://github.com/vercel/next.js/issues/11639
+       */
       useEffect(() => {
         if (initialRoute == null) {
           setInitialRoute(router.asPath)


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202332432700512/f) 🎟️

## 🗒️ What

Ensures a welcome toast shows up when opting in to the dev-portal beta from docs sites.

## 🤷 Why

To display a welcome toast to visitors when they opt-in to the dev-portal beta. Specifically, ensure this toast appears when coming from docs sites.

## 🛠️ How

Replaces the existing `useEffect` which relied on `routeChangeComplete` with a new hook that relies on `router.asPath`. 

Monitoring the URL in this way seems to give a more accurate reflection of when the URL changes from the initial `router.asPath` to a new `router.asPath`. With `routeChangeComplete`, this detection did not seem to work as expected, and the toast would auto-dismiss as soon as the page mounted, resulting in the experience of not seeing the toast at all.

## 📸 Design Screenshots

<img width="2021" alt="CleanShot 2022-05-30 at 11 32 40@2x" src="https://user-images.githubusercontent.com/4624598/171024193-e990aea0-4ccb-4c75-b314-11a32d66dabc.png">

## 🧪 Testing

- [ ] Visit a docs page with an `optInFrom` parameter, such as [/waypoint/docs?optInFrom=waypoint-io][preview]
    - A welcome toast should appear in the lower left of the viewport, and be announced as an `aria-live="polite"` region
    - The welcome toast should auto-dismiss after 15 seconds
    - The welcome toast should be able to be manually dismissed with the `×` button
    - The `Leave Beta` button should appear at the top right of the main content area

## 💭 Anything else?

Not at the moment! Note that similar toasts for tutorials opt-ins were handled in #443 .

[preview]: https://dev-portal-git-zsdocs-opt-in-toast-hashicorp.vercel.app/waypoint/docs?optInFrom=waypoint-io