### PR TITLE
chore: bump react-error-view to fix contrast issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^16.2.0",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
-        "@hashicorp/react-error-view": "^0.0.1",
+        "@hashicorp/react-error-view": "^0.0.2",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.2.0",
@@ -3408,9 +3408,9 @@
       }
     },
     "node_modules/@hashicorp/react-error-view": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-error-view/-/react-error-view-0.0.1.tgz",
-      "integrity": "sha512-PuGaGscHZmDPqhz4PvMP+smmAHisynesbrYGOte5qO1YaWKdljjtetYYizkhxvURNobJPs0crCONuG9L/Vzp6w==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-error-view/-/react-error-view-0.0.2.tgz",
+      "integrity": "sha512-HICgxFTdZrKjVMWknHiWgkuGnO/53Ukogw/kJwz+6tDxKXBZwzkvAdr9bHzhymv/fa9Tjbs6ZpFZJr6LZFhWRg==",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "next": ">=11.x",
@@ -36485,9 +36485,9 @@
       }
     },
     "@hashicorp/react-error-view": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-error-view/-/react-error-view-0.0.1.tgz",
-      "integrity": "sha512-PuGaGscHZmDPqhz4PvMP+smmAHisynesbrYGOte5qO1YaWKdljjtetYYizkhxvURNobJPs0crCONuG9L/Vzp6w==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-error-view/-/react-error-view-0.0.2.tgz",
+      "integrity": "sha512-HICgxFTdZrKjVMWknHiWgkuGnO/53Ukogw/kJwz+6tDxKXBZwzkvAdr9bHzhymv/fa9Tjbs6ZpFZJr6LZFhWRg==",
       "requires": {}
     },
     "@hashicorp/react-featured-slider": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^16.2.0",
     "@hashicorp/react-enterprise-alert": "^6.0.1",
-    "@hashicorp/react-error-view": "^0.0.1",
+    "@hashicorp/react-error-view": "^0.0.2",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.2.0",


### PR DESCRIPTION
## ✅ "Ready for Review" checklist

- [x] The Vercel preview link has been added to this PR's description
- [x] The Asana task has been added to this PR's description
- [x] This PR's link has been added to the "📐 Pull Request" field on the Asana task
- [x] This Vercel preview link has been added to the "🔍 Preview" field on the Asana task
- [x] The description template has been filled in below

---

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Bumps `@hashicorp/react-error-view`.

## 🤷 Why

To fix contrast issue.

## 📸 Design Screenshots

### Before

<img width="1384" alt="CleanShot 2022-05-31 at 12 32 59@2x" src="https://user-images.githubusercontent.com/4624598/171226741-328aa707-bc60-4739-ac6c-cc45f96acd1e.png">

### After

<img width="1384" alt="CleanShot 2022-05-31 at 12 46 54@2x" src="https://user-images.githubusercontent.com/4624598/171229172-af7d9fe6-c73b-4573-af5b-606953dcebbb.png">

## 🧪 Testing

- [ ] Visit [the preview link][preview], switch to Vault, visit a page that 404s, and confirm link colour has sufficient contrast

[task]: https://app.asana.com/0/1100423001970639/1202349999400572/f
[preview]: https://dev-portal-git-zsfix-dot-io-404-contrast-hashicorp.vercel.app/yeehaw