### PR TITLE
chore: bump code-block for use-overflow-ref fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-checkbox-input": "^5.0.1",
-        "@hashicorp/react-code-block": "5.1.1-canary-20220601222249",
+        "@hashicorp/react-code-block": "5.1.1-canary-20220601223106",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^16.2.0",
@@ -3254,9 +3254,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "5.1.1-canary-20220601222249",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601222249.tgz",
-      "integrity": "sha512-5Op1IN8BwOr7lCCZa0DnPSQLGgzIaUxht1cxl8eExhfhl4xooHewp/HGu4G2J7JZ41c368JxTAAO7M44pWIHOA==",
+      "version": "5.1.1-canary-20220601223106",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601223106.tgz",
+      "integrity": "sha512-qPjCMf/ktf5Ra8YiTywBX7ErY+n6uOnMZYqEJ4cD7E17qzWQ5ecEzoumtDvn34TEnCF2O0KcMrbpbgTeHNriVw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -36369,9 +36369,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "5.1.1-canary-20220601222249",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601222249.tgz",
-      "integrity": "sha512-5Op1IN8BwOr7lCCZa0DnPSQLGgzIaUxht1cxl8eExhfhl4xooHewp/HGu4G2J7JZ41c368JxTAAO7M44pWIHOA==",
+      "version": "5.1.1-canary-20220601223106",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601223106.tgz",
+      "integrity": "sha512-qPjCMf/ktf5Ra8YiTywBX7ErY+n6uOnMZYqEJ4cD7E17qzWQ5ecEzoumtDvn34TEnCF2O0KcMrbpbgTeHNriVw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-checkbox-input": "^5.0.1",
-        "@hashicorp/react-code-block": "5.1.1-canary-20220601223106",
+        "@hashicorp/react-code-block": "^5.1.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^16.2.0",
@@ -3254,9 +3254,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "5.1.1-canary-20220601223106",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601223106.tgz",
-      "integrity": "sha512-qPjCMf/ktf5Ra8YiTywBX7ErY+n6uOnMZYqEJ4cD7E17qzWQ5ecEzoumtDvn34TEnCF2O0KcMrbpbgTeHNriVw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1.tgz",
+      "integrity": "sha512-agUuLjMoMQQAAYKFBnfBuCGTe1I4qtvat4OTohq5Rx5AF50xHhEb5pZEMNKiAgsG/jLLfl2+wdXlk40FlWawfw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -36369,9 +36369,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "5.1.1-canary-20220601223106",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601223106.tgz",
-      "integrity": "sha512-qPjCMf/ktf5Ra8YiTywBX7ErY+n6uOnMZYqEJ4cD7E17qzWQ5ecEzoumtDvn34TEnCF2O0KcMrbpbgTeHNriVw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1.tgz",
+      "integrity": "sha512-agUuLjMoMQQAAYKFBnfBuCGTe1I4qtvat4OTohq5Rx5AF50xHhEb5pZEMNKiAgsG/jLLfl2+wdXlk40FlWawfw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-checkbox-input": "^5.0.1",
-        "@hashicorp/react-code-block": "^5.1.0",
+        "@hashicorp/react-code-block": "5.1.1-canary-20220601222249",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^16.2.0",
@@ -3254,9 +3254,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.0.tgz",
-      "integrity": "sha512-8jwcD+Q8YwGK4srB9UYVoTCqRVXkSL2wun4qu73Wbb02x1d1hL8M00h++AHW77pa6bCRaXXwDHn6pavFqJcgkg==",
+      "version": "5.1.1-canary-20220601222249",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601222249.tgz",
+      "integrity": "sha512-5Op1IN8BwOr7lCCZa0DnPSQLGgzIaUxht1cxl8eExhfhl4xooHewp/HGu4G2J7JZ41c368JxTAAO7M44pWIHOA==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -36369,9 +36369,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.0.tgz",
-      "integrity": "sha512-8jwcD+Q8YwGK4srB9UYVoTCqRVXkSL2wun4qu73Wbb02x1d1hL8M00h++AHW77pa6bCRaXXwDHn6pavFqJcgkg==",
+      "version": "5.1.1-canary-20220601222249",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.1.1-canary-20220601222249.tgz",
+      "integrity": "sha512-5Op1IN8BwOr7lCCZa0DnPSQLGgzIaUxht1cxl8eExhfhl4xooHewp/HGu4G2J7JZ41c368JxTAAO7M44pWIHOA==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-checkbox-input": "^5.0.1",
-    "@hashicorp/react-code-block": "5.1.1-canary-20220601223106",
+    "@hashicorp/react-code-block": "^5.1.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-checkbox-input": "^5.0.1",
-    "@hashicorp/react-code-block": "5.1.1-canary-20220601222249",
+    "@hashicorp/react-code-block": "5.1.1-canary-20220601223106",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-checkbox-input": "^5.0.1",
-    "@hashicorp/react-code-block": "^5.1.0",
+    "@hashicorp/react-code-block": "5.1.1-canary-20220601222249",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^16.2.0",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview - /waypoint/downloads][/waypoint/downloads] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Bumps `@hashicorp/react-code-block` to fix an issue with overflow detection when nested within tabs.

For details, see the `react-components` PR:
- https://github.com/hashicorp/react-components/pull/600

## 🧪 Testing

- [ ] Visit a page with code blocks nested in tabs, such as [/waypoint/downloads][/waypoint/downloads]

## 📼 Demo

### Before

![before](https://user-images.githubusercontent.com/4624598/171658034-79ed56d0-f760-46d5-a285-19368f32bcb4.gif)

### After

![after](https://user-images.githubusercontent.com/4624598/171658048-b4df3496-65b3-4d2c-8f56-027e8b1444b8.gif)

[/waypoint/downloads]: https://dev-portal-git-zsbump-code-block-fix-use-overflow-ref-hashicorp.vercel.app/waypoint/downloads
[task]: https://app.asana.com/0/1202114367927919/1202350092732470/f