### PR TITLE
fix: missing li with CardsGridList uses

### DIFF
--- a/src/components/cards-grid-list/docs.mdx
+++ b/src/components/cards-grid-list/docs.mdx
@@ -17,18 +17,18 @@ The layout for this component is driven by minimum width settings on card childr
 
 <LiveComponent>{`
 <CardsGridList isOrdered={false}>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
+  </li>
 </CardsGridList>
 `}</LiveComponent>
 
@@ -38,37 +38,37 @@ The layout for this component is driven by minimum width settings on card childr
 
 <LiveComponent>{`
 <CardsGridList>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
+  </li>
 </CardsGridList>
 `}</LiveComponent>
 
 <LiveComponent>{`
 <CardsGridList>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
-  <div style={{ border: '1px solid magenta', padding: '16px' }}>
+  </li>
+  <li style={{ border: '1px solid magenta', padding: '16px' }}>
       I am a fake card.
-  </div>
+  </li>
 </CardsGridList>
 `}</LiveComponent>

--- a/src/views/error-views/dev-dot-404/index.tsx
+++ b/src/views/error-views/dev-dot-404/index.tsx
@@ -3,8 +3,6 @@ import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-
 import { IconVaultColor16 } from '@hashicorp/flight-icons/svg-react/vault-color-16'
 import { IconHome16 } from '@hashicorp/flight-icons/svg-react/home-16'
 import { useErrorPageAnalytics } from '@hashicorp/react-error-view'
-import CardsGridList from 'components/cards-grid-list'
-import IconCardLink, { IconCardLinkProps } from 'components/icon-card-link'
 import {
   ErrorViewContainer,
   ErrorViewH1,

--- a/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
@@ -29,9 +29,17 @@ const FeaturedTutorialsSection = ({
           {featuredLearnCards.map((cardProps: FeaturedLearnCard) => {
             const { id, type } = cardProps
             if (type == 'collection') {
-              return <CollectionCard key={id} {...cardProps} />
+              return (
+                <li key={id}>
+                  <CollectionCard {...cardProps} />
+                </li>
+              )
             } else if (type == 'tutorial') {
-              return <TutorialCard key={id} {...cardProps} />
+              return (
+                <li key={id}>
+                  <TutorialCard {...cardProps} />
+                </li>
+              )
             }
           })}
         </CardsGridList>

--- a/src/views/product-landing/components/product-landing-blocks/blocks/collection-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/collection-cards/index.tsx
@@ -9,7 +9,11 @@ function CollectionCards({ collectionCards }: CollectionCardsProps) {
     <CardsGridList>
       {collectionCards.map((cardPropsWithId: CollectionCardPropsWithId) => {
         const { id, ...cardProps } = cardPropsWithId
-        return <CollectionCard key={id} {...cardProps} />
+        return (
+          <li key={id}>
+            <CollectionCard {...cardProps} />
+          </li>
+        )
       })}
     </CardsGridList>
   )

--- a/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/linked-cards/index.tsx
@@ -8,10 +8,12 @@ function LinkedCards({ cards }: LinkedCardsProps) {
     <CardsGridList>
       {cards.map((card: LinkedCard, idx: number) => {
         return (
-          <CardLink key={idx} href={card.url}>
-            <CardHeading level={3} text={card.heading} />
-            <CardBody text={card.body} />
-          </CardLink>
+          <li key={idx}>
+            <CardLink href={card.url}>
+              <CardHeading level={3} text={card.heading} />
+              <CardBody text={card.body} />
+            </CardLink>
+          </li>
         )
       })}
     </CardsGridList>

--- a/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
@@ -7,7 +7,11 @@ function TutorialCards({ tutorialCards }: TutorialCardsProps) {
     <CardsGridList>
       {tutorialCards.map((cardPropsWithId: TutorialCardPropsWithId) => {
         const { id, ...cardProps } = cardPropsWithId
-        return <TutorialCard key={id} {...cardProps} />
+        return (
+          <li key={id}>
+            <TutorialCard {...cardProps} />
+          </li>
+        )
       })}
     </CardsGridList>
   )

--- a/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/collections-stack/index.tsx
@@ -32,7 +32,11 @@ function CollectionsStack({
       <CardsGridList>
         {collectionCards.map((cardPropsWithId: CollectionCardPropsWithId) => {
           const { id, ...cardProps } = cardPropsWithId
-          return <CollectionCard key={id} {...cardProps} />
+          return (
+            <li key={id}>
+              <CollectionCard {...cardProps} />
+            </li>
+          )
         })}
       </CardsGridList>
     </FeaturedStack>

--- a/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/logo-card-list/index.tsx
@@ -22,7 +22,11 @@ function LogoCardList({ items }: LogoCardListProps): JSX.Element {
     <CardsGridList>
       {collectionCards.map((cardPropsWithId: CollectionCardPropsWithId) => {
         const { id, ...cardProps } = cardPropsWithId
-        return <CollectionCard key={id} {...cardProps} />
+        return (
+          <li key={id}>
+            <CollectionCard {...cardProps} />
+          </li>
+        )
       })}
     </CardsGridList>
   )

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
@@ -33,7 +33,11 @@ function TutorialsStack({
       <CardsGridList>
         {tutorialCards.map((cardPropsWithId: TutorialCardPropsWithId) => {
           const { id, ...cardProps } = cardPropsWithId
-          return <TutorialCard key={id} {...cardProps} />
+          return (
+            <li key={id}>
+              <TutorialCard {...cardProps} />
+            </li>
+          )
         })}
       </CardsGridList>
     </FeaturedStack>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview - product landing][/waypoint] 🔎
- [Preview - downloads view][/waypoint/downloads] 🔎
- [Preview - product tutorials view][/waypoint/tutorials] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where `<CardsGridList />` had children which were not `<li />`, resulting in incorrect HTML structure (since `<CardsGridList />` renders a `<ul />` or `<ol />`.

## 🧪 Testing

- [ ] Visit each of the preview links at the top of this PR description
    - [ ] Ensure the correct `<li />` elements are now in place
    - [ ] Ensure all grids of cards still look and behave as expected

[preview]: https://dev-portal-git-zsfix-missing-card-grid-li-hashicorp.vercel.app
[task]: https://app.asana.com/0/1202097197789424/1202368770478995/f
[/waypoint]: https://dev-portal-git-zsfix-missing-card-grid-li-hashicorp.vercel.app/waypoint
[/waypoint/downloads]: https://dev-portal-git-zsfix-missing-card-grid-li-hashicorp.vercel.app/waypoint/downloads
[/waypoint/tutorials]: https://dev-portal-git-zsfix-missing-card-grid-li-hashicorp.vercel.app/waypoint/tutorials