### PR TITLE
[mobile Sidebar] Right aligning lonely level down button

### DIFF
--- a/src/components/sidebar/components/sidebar-mobile-controls/index.tsx
+++ b/src/components/sidebar/components/sidebar-mobile-controls/index.tsx
@@ -1,6 +1,6 @@
+import classNames from 'classnames'
 import { IconChevronLeft16 } from '@hashicorp/flight-icons/svg-react/chevron-left-16'
 import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
-import { useCurrentProduct } from 'contexts'
 import { useSidebarNavData } from 'layouts/sidebar-sidecar/contexts/sidebar-nav-data'
 import Button, { ButtonProps } from 'components/button'
 import s from './sidebar-mobile-controls.module.css'
@@ -109,8 +109,9 @@ const SidebarMobileControls = ({
     )
   }
 
+  const atTopLevel = !levelUpButton && !!levelDownButton
   return (
-    <div className={s.root}>
+    <div className={classNames(s.root, { [s.rightAlign]: atTopLevel })}>
       {levelUpButton}
       {levelDownButton}
     </div>

--- a/src/components/sidebar/components/sidebar-mobile-controls/sidebar-mobile-controls.module.css
+++ b/src/components/sidebar/components/sidebar-mobile-controls/sidebar-mobile-controls.module.css
@@ -5,6 +5,10 @@
   margin-bottom: 12px;
 }
 
+.rightAlign {
+  justify-content: flex-end;
+}
+
 .levelUpButton {
   padding-bottom: 7px;
   padding-left: 3px;


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202022787106817/1202307248480199/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Updates `LevelDownButton` to be right-aligned at the top-level mobile sidebar.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to a page like /waypoint/docs
- [ ] Narrow your viewport until the sidebar goes away
- [ ] Use the sidebar level buttons to go up to the top level
- [ ] The level down button should be right-aligned
