### PR TITLE
Closing NavigationHeaderDropdownMenu on navigation start

### DIFF
--- a/src/components/navigation-header/components/dropdown-menu/index.tsx
+++ b/src/components/navigation-header/components/dropdown-menu/index.tsx
@@ -1,5 +1,13 @@
 // Third-party imports
-import { Fragment, KeyboardEvent, ReactElement, useRef, useState } from 'react'
+import {
+  Fragment,
+  KeyboardEvent,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { useId } from '@react-aria/utils'
 import classNames from 'classnames'
@@ -54,6 +62,7 @@ const NavigationHeaderDropdownMenu = ({
   label,
   leadingIcon,
 }: NavigationHeaderDropdownMenuProps) => {
+  const router = useRouter()
   const uniqueId = useId()
   const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
   const menuRef = useRef<HTMLDivElement>()
@@ -75,6 +84,25 @@ const NavigationHeaderDropdownMenu = ({
       '`NavigationHeaderDropdownMenu` needs either the `label` or `leadingIcon` prop.'
     )
   }
+
+  // if the disclosure is open, handle closing it on `routeChangeStart`
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const handleRouteChangeStart = () => {
+      setIsOpen(false)
+    }
+
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+    }
+    // Only need to base this on `isOpen`
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
 
   // Check for an accesible label if there is a leading icon
   const accessibleLabel = ariaLabel || label


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.

When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambclose-navs-on-click-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202317183612770/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Closes the `NavigationHeaderDropdownMenu` when one of the links is clicked.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The disclosures would stay open after navigating to a new page, which is atypical of widgets used for navigation.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Added a `useEffect` based on `isOpen`.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to any page that isn't the home page
- [ ] Open one of the nav disclosures in the header
- [ ] Click a link from the list
- [ ] The disclosure should close
- [ ] You should be taken to the page you clicked

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

This'll be handled for us after leveraging the `NavigationDisclosure` component, but it's not quite ready to leverage yet because it doesn't handle some keyboard functionality.
