### PR TITLE
Small polishing fixes

### DIFF
--- a/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
+++ b/src/components/breadcrumb-bar/utils/get-docs-breadcrumbs.ts
@@ -207,12 +207,22 @@ function getDocsBreadcrumbs({
     filteredPathParts = pathParts
   }
 
+  /**
+   * Generate the root docs path item's url
+   */
+  let rootDocsPathUrl
+  if (version) {
+    rootDocsPathUrl = `/${productPath}/${basePath}/${version}`
+  } else {
+    rootDocsPathUrl = `/${productPath}/${basePath}`
+  }
+
   return [
     { title: 'Developer', url: '/' },
     { title: productName, url: `/${productPath}` },
     {
       title: generatedBaseName,
-      url: `/${productPath}/${basePath}`,
+      url: rootDocsPathUrl,
       isCurrentPage: pathParts.length == 0,
     },
     ...getPathBreadcrumbs({

--- a/src/components/mobile-standalone-link/mobile-standalone-link.module.css
+++ b/src/components/mobile-standalone-link/mobile-standalone-link.module.css
@@ -7,7 +7,8 @@
 }
 
 .mobileIcon {
-  display: block;
+  align-items: center;
+  display: flex;
 
   @media (--dev-dot-tablet-up) {
     display: none;

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -73,7 +73,6 @@ for further details.
   @media (--dev-dot-tablet-down) {
     left: -150vw;
     width: 100vw;
-    padding-bottom: 70px;
     height: 100%;
     position: fixed;
     top: unset; /** We want to pull the top relative to the parent on mobile */
@@ -84,7 +83,10 @@ for further details.
   height: 100%; /* for positioning the version switcher */
   overflow-y: auto; /* for positioning the version switcher */
   position: relative;
-  padding: 24px;
+  padding-bottom: 150px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 24px;
 }
 
 .docsVersionSwitcherWrapper {


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes old `70px` padding for mobile sidebar since that's fixed
- Adds `150px` padding to the bottom of sidebar content
  - This makes it so the version switcher doesn't cut off the content anymore
  - This is also nice so that sidebar content isn't always at the bottom of a window/screen
- Fixes the link of the third docs breadcrumb item when a past version is selected

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /waypoint/docs
- [ ] On desktop, make sure the end of sidebar content isn't cut off by the version switcher
- [ ] On mobile, make sure everything is placed correctly
- [ ] Make sure the sidebar looks correct on mobile/desktop on these pages:
  - [ ] /waypoint
  - [ ] /waypoint/tutorials
  - [ ] /waypoint/tutorials/get-started-docker
  - [ ] /waypoint/tutorials/get-started-docker/get-started-intro
