### PR TITLE
chore: fix search results on blur

### DIFF
--- a/src/components/algolia-search/index.tsx
+++ b/src/components/algolia-search/index.tsx
@@ -113,6 +113,9 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
   return (
     <div
       className={classNames(s.root, className)}
+      onBlur={() => {
+        autocomplete.setIsOpen(false)
+      }}
       {...autocomplete.getRootProps({})}
     >
       <form

--- a/src/components/algolia-search/index.tsx
+++ b/src/components/algolia-search/index.tsx
@@ -113,9 +113,6 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
   return (
     <div
       className={classNames(s.root, className)}
-      onBlur={() => {
-        autocomplete.setIsOpen(false)
-      }}
       {...autocomplete.getRootProps({})}
     >
       <form
@@ -135,6 +132,9 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
           className={s.input}
           ref={inputRef}
           {...autocomplete.getInputProps({ inputElement: inputRef.current })}
+          onBlur={() => {
+            autocomplete.setIsOpen(false)
+          }}
         />
         <div className={s.inputWrapperSuffix}>
           <button

--- a/src/components/algolia-search/index.tsx
+++ b/src/components/algolia-search/index.tsx
@@ -65,6 +65,10 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
     })
   }, [])
 
+  const inputProps = autocomplete.getInputProps({
+    inputElement: inputRef.current,
+  })
+
   /**
    * Clear the query input on route change
    */
@@ -131,9 +135,10 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
         <input
           className={s.input}
           ref={inputRef}
-          {...autocomplete.getInputProps({ inputElement: inputRef.current })}
+          {...inputProps}
           onBlur={() => {
             autocomplete.setIsOpen(false)
+            inputProps.onBlur()
           }}
         />
         <div className={s.inputWrapperSuffix}>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksclose-search-panel-on-blur-hashicorp.vercel.app/waypoint/docs) 🔎
- [Asana task](https://app.asana.com/0/1202276096167515/1202390857238416) 🎟️

## 🗒️ What

Fixes the issue where the search panel would stay open when the mobile sidebar menu is opened. The default `onBlur` is overridden for the `autocomplete` props so we should validate that this doesn't break other behavior. 

## 🧪 Testing

- Visit a docs page, enter some search input, open the hamburger menu. The search panel should close. 
