### PR TITLE
fix: nav bar height mismatch

### DIFF
--- a/src/components/navigation-header/components/home-page-content/home-page-content.module.css
+++ b/src/components/navigation-header/components/home-page-content/home-page-content.module.css
@@ -3,11 +3,11 @@
 
   /* Note: padding here necessary to match height of .productLogo
      in navigation-header.module.css */
-  padding-top: 2px;
-  padding-bottom: 2px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 
   & svg {
-    height: 36px;
+    height: 32px;
     width: auto;
   }
 }

--- a/src/components/navigation-header/components/home-page-content/home-page-content.module.css
+++ b/src/components/navigation-header/components/home-page-content/home-page-content.module.css
@@ -1,3 +1,13 @@
 .siteLogo {
   display: flex;
+
+  /* Note: padding here necessary to match height of .productLogo
+     in navigation-header.module.css */
+  padding-top: 2px;
+  padding-bottom: 2px;
+
+  & svg {
+    height: 36px;
+    width: auto;
+  }
 }

--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -22,8 +22,8 @@
   width: 100%;
 
   @media (--dev-dot-tablet-down) {
-    padding-bottom: 16px;
-    padding-top: 16px;
+    padding-bottom: 14px;
+    padding-top: 14px;
   }
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes minor issues in the top nav bar that caused it to have an unexpected height on certain viewport sizes and on certain pages.

## 🤷 Why

To fix issues related to layouts that rely on the sticky top nav bar being a known, consistent height.

## 🛠️ How

- adjusts top nav padding so that height is accurate
- adjusts home page logo padding so nav height is consistent between product-specific and home pages

## 📸 Design Screenshots

<img width="3135" alt="Nav bar" src="https://user-images.githubusercontent.com/4624598/172171786-38c13745-1263-4838-baae-faac628f7d91.png">

## 🧪 Testing

- [ ] Visit the [home page][preview], and ensure the top nav-bar height is consistently `68px` across all viewports
- [ ] Visit a [product page][/waypoint], and ensure the top nav-bar height is consistently `68px` across all viewports

[task]: https://app.asana.com/0/1202114367927919/1202316169578550/f
[preview]: https://dev-portal-git-zsfix-top-bar-height-hashicorp.vercel.app
[/waypoint]: https://dev-portal-git-zsfix-top-bar-height-hashicorp.vercel.app/waypoint
