### PR TITLE
chore: don't add base path if its present

### DIFF
--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -98,9 +98,15 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
       // Note that the `fullPath` added here differs from typical
       // NavLeaf treatment, as we only use the first part of the `basePath`.
       // (We expect this to be the product slug, eg "consul").
+
+      // If the path already starts with the base path (i.e. /vault), don't add it
+      const fullPath = node.href.startsWith(`/${basePaths[0]}`)
+        ? node.href
+        : `/${basePaths[0]}${node.href}`
+
       return {
         ...node,
-        fullPath: `/${basePaths[0]}${node.href}`,
+        fullPath,
         href: null,
         id,
         path: node.href,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-vault-tutorial-links-hashicorp.vercel.app/vault/docs) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202394505015462) 🎟️

## 🗒️ What

Adjusting the docs nav item paths to be more resilient if the data already contains the expected base path. Such as with [tutorial links](https://github.com/hashicorp/vault/blob/dev-portal/website/data/docs-nav-data.json#L14-L19)

## 🧪 Testing

- Visit the [docs page](https://dev-portal-git-ksfix-vault-tutorial-links-hashicorp.vercel.app/vault/docs), open the Getting Started dropdown, click one of those tutorial links. It should link to the proper tutorial within dev dot (previously it was 404'ing). 


