### PR TITLE
fix: adjust filter input box shadow

### DIFF
--- a/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
+++ b/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
@@ -18,8 +18,6 @@
   height: var(--input-height);
   margin-bottom: 16px;
   position: relative;
-  border-radius: 5px;
-  box-shadow: var(--token-surface-inset-box-shadow);
 }
 
 .filterIcon {
@@ -47,11 +45,14 @@
 }
 
 .filterInput {
+  appearance: none;
+  border-radius: 5px;
+  box-shadow: var(--token-surface-inset-box-shadow);
   composes: g-focus-ring-from-box-shadow from global;
   background-color: transparent;
   border: none;
   color: var(--token-color-palette-neutral-700);
-  font-size: 14px;
+  font-size: 16px;
   line-height: 18px;
   padding-bottom: 9px;
   padding-left: calc(var(--input-padding) * 2 + var(--input-icon-size));

--- a/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
+++ b/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
@@ -49,7 +49,7 @@
   background-color: transparent;
   border: none;
   border-radius: 5px;
-  box-shadow: inset 0 0 0 1px rgba(101, 106, 118, 0.3),
+  box-shadow: inset 0 0 1px 1px rgba(101, 106, 118, 0.3),
     inset 0 1px 2px 1px rgba(101, 106, 118, 0.1);
   color: var(--token-color-palette-neutral-700);
   font-size: 14px;

--- a/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
+++ b/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
@@ -45,12 +45,12 @@
 }
 
 .filterInput {
-  appearance: none;
-  border-radius: 5px;
-  box-shadow: var(--token-surface-inset-box-shadow);
   composes: g-focus-ring-from-box-shadow from global;
+  appearance: none;
   background-color: transparent;
   border: none;
+  border-radius: 5px;
+  box-shadow: var(--token-surface-inset-box-shadow);
   color: var(--token-color-palette-neutral-700);
   font-size: 16px;
   line-height: 18px;

--- a/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
+++ b/src/components/sidebar/components/sidebar-filter-input/sidebar-filter-input.module.css
@@ -18,6 +18,8 @@
   height: var(--input-height);
   margin-bottom: 16px;
   position: relative;
+  border-radius: 5px;
+  box-shadow: var(--token-surface-inset-box-shadow);
 }
 
 .filterIcon {
@@ -48,9 +50,6 @@
   composes: g-focus-ring-from-box-shadow from global;
   background-color: transparent;
   border: none;
-  border-radius: 5px;
-  box-shadow: inset 0 0 1px 1px rgba(101, 106, 118, 0.3),
-    inset 0 1px 2px 1px rgba(101, 106, 118, 0.1);
   color: var(--token-color-palette-neutral-700);
   font-size: 14px;
   line-height: 18px;

--- a/src/styles/sizing.css
+++ b/src/styles/sizing.css
@@ -1,5 +1,5 @@
 :root {
-  --input-height: 38px;
+  --input-height: 36px;
   --input-icon-size: 16px;
 
   /* NOTE: The --navigation-header-height may be brittle & inaccurate.


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-input-outline-hashicorp.vercel.app/waypoint/docs) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202317183612796) 🎟️

## 🗒️ What

Fixes an issue where the sidebar filter input box shadow wasn't rendering on iOS browsers.  

At first I thought it was related to this known issue. See this note from [can-i-use](https://caniuse.com/?search=box-shadow), apparently this is a known issue with iOS safari and we can't use the `blur-radius` as 0. I updated it to 1px and it didn't seem to fix the issue. 

<img width="884" alt="Screen Shot 2022-06-07 at 3 55 07 PM" src="https://user-images.githubusercontent.com/36613477/172496982-9bb664b9-3db9-49d3-a69e-b051f750fc48.png">

> [Also see this stack overflow discussion.](https://stackoverflow.com/questions/28245254/box-shadow-inset-doesnt-work-in-ios)

~~I ended up moving the box shadow up to the container div and that seems to solve it. Perhaps there some iOS input issue with box shadow. When I would inspect the input element, the `box-shadow` was computing to `none`. Visually this still seems consistent. Open to alternative fixes though!~~ Ended up using `appearance: none` and this solved it.

## 🧪 Testing

Fire up simulator and [visit the preview link](https://dev-portal-git-ksfix-input-outline-hashicorp.vercel.app/waypoint/docs). Hit the hamburger menu to open the sidebar and the filter input box shadow outline should render. 


