### PR TITLE
Miscellaneous Sidebar adjustments/fixes

### DIFF
--- a/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
@@ -183,12 +183,15 @@ const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
     }
   }
 
+  const buttonId = `${item.id}-button`
+  const listId = `${item.id}-list`
   return (
     <>
       <button
-        aria-controls={item.id}
+        aria-controls={listId}
         aria-expanded={isOpen}
         className={s.sidebarNavMenuItem}
+        id={buttonId}
         onClick={() => setIsOpen((prevState: boolean) => !prevState)}
         ref={buttonRef}
       >
@@ -209,7 +212,7 @@ const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
         />
       </button>
       {isOpen && (
-        <ul id={item.id} onKeyDown={handleKeyDown}>
+        <ul id={listId} onKeyDown={handleKeyDown}>
           {item.routes.map((route: MenuItem) => (
             <SidebarNavMenuItem key={route.id} item={route} />
           ))}

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -86,7 +86,7 @@ const Sidebar = ({
   }
 
   let overviewItem
-  if (overviewItemHref) {
+  if (overviewItemHref && !filterValue) {
     overviewItem = (
       <SidebarNavLinkItem
         item={{

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -108,11 +108,8 @@ const Sidebar = ({
     )
     sidebarContent = (
       <ul className={s.navList}>
-        {filteredMenuItems.map((item: FilteredNavItem, index) => (
-          <SidebarNavMenuItem
-            item={item}
-            key={item.id ?? item.title ?? index}
-          />
+        {filteredMenuItems.map((item: FilteredNavItem) => (
+          <SidebarNavMenuItem item={item} key={item.id} />
         ))}
       </ul>
     )

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -77,7 +77,7 @@ const Sidebar = ({
     sidebarFilterInput = (
       <div
         className={classNames(s.filterInputWrapper, {
-          [s['filerInputWrapper--mobile']]: shouldRenderMobileControls,
+          [s['filterInputWrapper--mobile']]: shouldRenderMobileControls,
         })}
       >
         <SidebarFilterInput value={filterValue} onChange={setFilterValue} />

--- a/src/components/sidebar/sidebar.module.css
+++ b/src/components/sidebar/sidebar.module.css
@@ -41,6 +41,6 @@
   margin-top: 16px;
 }
 
-.filerInputWrapper--mobile {
+.filterInputWrapper--mobile {
   margin-top: 12px;
 }

--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -187,13 +187,13 @@ export function getStaticGenerationFunctions<
         }
       })
 
-      const fullNavData = [...navData]
-
-      // Add fullPaths and ids to navData
-      const navDataWithFullPaths = prepareNavDataForClient(fullNavData, [
-        product.slug,
-        basePath,
-      ])
+      /**
+       * Add fullPaths and auto-generated ids to navData
+       */
+      const { preparedItems: navDataWithFullPaths } = prepareNavDataForClient({
+        basePaths: [product.slug, basePath],
+        nodes: navData,
+      })
 
       /**
        * Figure out of a specific docs version is being viewed

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -1,7 +1,6 @@
-import slugify from 'slugify'
 import { NavNode } from '@hashicorp/react-docs-sidenav/types'
-import { MenuItem } from 'components/sidebar'
 import isAbsoluteUrl from 'lib/is-absolute-url'
+import { MenuItem } from 'components/sidebar'
 
 // TODO: export NavBranch and NavLeaf
 // TODO: types from react-docs-sidenav.
@@ -47,16 +46,66 @@ function isNavDirectLink(value: NavNode): value is NavDirectLink {
   return value.hasOwnProperty('href')
 }
 
-function prepareNavDataForClient(
-  nodes: NavNode[],
+/**
+ * Prepares all sidebar nav items for client-side rendering. Keeps track of the
+ * index of each node using `startingIndex` and the `traversedNodes` property
+ * returned from `prepareNavNodeForClient`. Also returns its own
+ * `traversedNodes` since it is recursively called in `prepareNavDataForClient`.
+ */
+function prepareNavDataForClient({
+  basePaths,
+  nodes,
+  startingIndex = 0,
+}: {
   basePaths: string[]
-): MenuItem[] {
-  return nodes
-    .map((n) => prepareNavNodeForClient(n, basePaths))
-    .filter((node) => node)
+  nodes: NavNode[]
+  startingIndex?: number
+}): { preparedItems: MenuItem[]; traversedNodes: number } {
+  const preparedNodes = []
+
+  let count = 0
+  nodes.forEach((node) => {
+    const result = prepareNavNodeForClient({
+      basePaths,
+      node,
+      nodeIndex: startingIndex + count,
+    })
+    if (result) {
+      const { preparedItem, traversedNodes } = result
+      preparedNodes.push(preparedItem)
+      count += traversedNodes
+    }
+  })
+
+  return { preparedItems: preparedNodes, traversedNodes: count }
 }
 
-function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
+/**
+ * Prepares a single sidebar nav item for client-side rendering. All items will
+ * have an auto-generated `id` added to them based on `nodeIndex` (which is the
+ * index of the current node being prepared) unless they have the "hidden"
+ * property set to TRUE. Returns the number of nodes it has traversed
+ * (`traversedNodes`) to help `prepareNavDataForClient` keep track of node
+ * indices.
+ *
+ * How different types of items are prepared:
+ *  - If the item is a submenu, its child items will be prepared as well.
+ *  - If the item is a link with the `path` property, then its `fullPath`
+ *    property will be generated from `basePaths` and `path`.
+ *  - If the item is a link with the `href` property and the `href` is an
+ *    internal path, then the object is "reset" to have the `path` and
+ *    `fullPath` properties.
+ *  - Otherwise, nothing is added to an item but a unique `id`.
+ */
+function prepareNavNodeForClient({
+  basePaths,
+  node,
+  nodeIndex,
+}: {
+  node: NavNode
+  basePaths: string[]
+  nodeIndex: number
+}): { preparedItem: MenuItem; traversedNodes: number } {
   /**
    * TODO: we need aligned types that will work here. NavNode (external import)
    * does not allow the `hidden` property.
@@ -67,22 +116,34 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
     return null
   }
 
+  // Generate a unique ID from `nodeIndex`
+  const id = `sidebar-nav-item-${nodeIndex}`
+
   if (isNavBranch(node)) {
     // For nodes with routes, add fullPaths to all routes, and `id`
-    return {
+    const { preparedItems, traversedNodes } = prepareNavDataForClient({
+      basePaths,
+      nodes: node.routes,
+      startingIndex: nodeIndex + 1,
+    })
+    const preparedItem = {
       ...node,
-      routes: prepareNavDataForClient(node.routes, basePaths),
-      id: slugify(`submenu-${node.title}`, { lower: true }),
+      id,
+      routes: preparedItems,
+    }
+    return {
+      preparedItem,
+      traversedNodes: traversedNodes + 1,
     }
   } else if (isNavLeaf(node)) {
     // For nodes with paths, add fullPath to the node, and `id`
-    return {
+    const preparedItem = {
       ...node,
       fullPath: `/${basePaths.join('/')}/${node.path}`,
-      id: slugify(`menu-item-${node.path}`, { lower: true }),
+      id,
     }
+    return { preparedItem, traversedNodes: 1 }
   } else if (isNavDirectLink(node)) {
-    const id = slugify(`external-url-${node.title}`, { lower: true })
     // Check if there is data that disagrees with DevDot's assumptions.
     // This can happen because in the context of dot-io domains,
     // authors may write NavDirectLinks with href values that are
@@ -104,21 +165,24 @@ function prepareNavNodeForClient(node: NavNode, basePaths: string[]): MenuItem {
         ? node.href
         : `/${basePaths[0]}${node.href}`
 
-      return {
+      const preparedItem = {
         ...node,
         fullPath,
         href: null,
         id,
         path: node.href,
       }
+      return { preparedItem, traversedNodes: 1 }
     } else {
       // Otherwise, this is a genuinely external NavDirectLink,
       // so we only need to add an `id` to it.
-      return { ...node, id }
+      const preparedItem = { ...node, id }
+      return { preparedItem, traversedNodes: 1 }
     }
   } else {
     // Otherwise return the node unmodified
-    return node
+    const preparedItem = { ...node, id }
+    return { preparedItem, traversedNodes: 1 }
   }
 }
 


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `prepareNavDataForClient` to generate unique IDs for each item (including dividers and headings) so we don't have `React` unique `key` warnings and so that we don't have to rely on an array `index` (which breaks rendering when a user is searching the sidebar)
- Updates reference to `prepareNavDataForClient` in `sidebar-sidecar`'s `server` code
- Adds suffixes to the `<button>` and `<ul>` element `id`s in `SidebarNavSubmenuItem` for more verbose/clear `id` names
- Updates `Sidebar` to not render the `Overview` menu item if the search input has a search value since this item won't be searched for
- Fixes a typo I noticed in the `filerInputWrapper` class name (was missing a `t`)

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

From #329, where I originally did the work for generating unique IDs:

> There are block comments above `prepareNavDataForClient` and `prepareNavNodeForClient` that give more detail, but the gist is that they were updated help each other keep track of how many nodes have been prepared so that IDs could be generated based on an index as if the nested data had been flattened and traversed.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to a docs page
- [ ] Make sure there are no key warnings for Sidebar in the console
- [ ] Make sure Sidebar searching still works as expected
- [ ] Make sure Sidebar submenus still work as expected
