### PR TITLE
fix: z-index on mobile-menu

### DIFF
--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -9,6 +9,7 @@
   position: sticky;
   top: var(--sticky-bars-height);
   width: var(--dev-dot-sidebar-width);
+  z-index: 1;
 
   @media (--dev-dot-tablet-down) {
     height: 100%;
@@ -16,6 +17,5 @@
     position: fixed;
     top: unset; /* make top relative to the parent */
     width: 100vw;
-    z-index: 1;
   }
 }

--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -16,5 +16,6 @@
     position: fixed;
     top: unset; /* make top relative to the parent */
     width: 100vw;
+    z-index: 1;
   }
 }

--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -9,7 +9,6 @@
   position: sticky;
   top: var(--sticky-bars-height);
   width: var(--dev-dot-sidebar-width);
-  z-index: 1;
 
   @media (--dev-dot-tablet-down) {
     height: 100%;
@@ -17,5 +16,6 @@
     position: fixed;
     top: unset; /* make top relative to the parent */
     width: 100vw;
+    z-index: 1;
   }
 }

--- a/src/layouts/base-new/base-new-layout.module.css
+++ b/src/layouts/base-new/base-new-layout.module.css
@@ -65,7 +65,7 @@ Asana task: https://app.asana.com/0/1202114367927919/1202316169578550/f
   }
 
   /* On Desktop, footer should layer above sidebar */
-  @media (--dev-dot-tablet-up) {
+  @media (--dev-dot-desktop) {
     z-index: 2;
   }
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎

## 🗒️ What

Fixes an issue where mobile menu would appear below search input.

## 📸 Design Screenshots

### Before

<img width="852" alt="CleanShot 2022-06-10 at 12 11 56@2x" src="https://user-images.githubusercontent.com/4624598/173107696-48a3b3a7-629e-4f6e-982f-2c4aa93a7ff5.png">

### After

<img width="851" alt="CleanShot 2022-06-10 at 12 12 49@2x" src="https://user-images.githubusercontent.com/4624598/173107838-445a4db0-408f-4dd8-b228-ebacd3f313dd.png">

## 🧪 Testing

- [ ] Visit a docs page, such as [/waypoint/docs][preview], and ensure the mobile menu layers properly when open
    - Also ensure the footer still layers correctly with the sidebar on desktop, as the sidebar uses "mobileMenuContainer"

[preview]: https://dev-portal-git-zsfix-mobile-menu-z-index-hashicorp.vercel.app/waypoint/docs/