### PR TITLE
fix: tweak heading > code font-size

### DIFF
--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -72,7 +72,7 @@
     background-color: var(--token-color-palette-neutral-50);
     border-radius: 5px;
     border: 1px solid rgba(101, 106, 118, 0.2);
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 400;
     line-height: 16px;
     padding: 2px 4px;

--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -217,7 +217,7 @@
   less jarring.
   */
   & code {
-    font-size: 0.6em;
+    font-size: 0.8em;
     font-weight: 500;
   }
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Tweaks font size of inline code within content headings.

## 🛠️ How

Adjusts font-size for inline `<code />` in content headings from `0.6em` to `0.8em`.

## 📸 Design Screenshots

### Before

<img width="785" alt="inline-code-before" src="https://user-images.githubusercontent.com/4624598/173726588-a0398cc7-359a-46af-a6a1-c8c9ac577d48.png">

### After

<img width="780" alt="inline-code-after" src="https://user-images.githubusercontent.com/4624598/173726582-72d08d1f-14e2-4db4-bc7e-ebf084c17e2c.png">


## 🧪 Testing

- [ ] Visit a docs page with inline code in a heading, such as [/vault/docs/configuration/listener/tcp][preview], and ensure it looks as expected

[task]: https://app.asana.com/0/1202114367927919/1202439831418480/f
[preview]: https://dev-portal-git-zstweak-inline-code-hashicorp.vercel.app/vault/docs/configuration/listener/tcp