### PR TITLE
fix: separate card sections on waypoint landing

### DIFF
--- a/src/data/vault-landing.json
+++ b/src/data/vault-landing.json
@@ -29,13 +29,19 @@
   "blocks": [
     {
       "type": "heading",
-      "heading": "Use Cases",
+      "heading": "Featured Tutorials",
       "level": 2,
       "size": 400
     },
     {
       "type": "tutorial_cards",
       "tutorialSlugs": ["vault/transform", "vault/static-secrets"]
+    },
+    {
+      "type": "heading",
+      "heading": "Featured Collections",
+      "level": 2,
+      "size": 400
     },
     {
       "type": "collection_cards",

--- a/src/data/waypoint-landing.json
+++ b/src/data/waypoint-landing.json
@@ -25,7 +25,7 @@
   "blocks": [
     {
       "type": "heading",
-      "heading": "Use Cases",
+      "heading": "Featured Collections",
       "level": 2,
       "size": 400
     },
@@ -36,6 +36,12 @@
         "waypoint/get-started-kubernetes",
         "waypoint/get-started-nomad"
       ]
+    },
+    {
+      "type": "heading",
+      "heading": "Featured Tutorials",
+      "level": 2,
+      "size": 400
     },
     {
       "type": "tutorial_cards",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link - /waypoint][preview] 🔎
- [Preview link - /vault][/vault] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adjusts content on `/waypoint` and `/vault` landing pages to create separate `Featured Tutorials` and `Featured Collections` sections.

## 🤷 Why

See [ticket][task], in some cases the layouts felt odd with these sections separated by card type, but not separated with headings.

## 🛠️ How

Modifies content to add a heading.

## 🧪 Testing

- [ ] Visit [/waypoint][preview] and ensure the page looks as expected
- [ ] Visit [/vault][/vault] and ensure the page looks as expected

[preview]: https://dev-portal-git-zsseparate-waypoint-land-card-sections-hashicorp.vercel.app/waypoint
[/vault]: https://dev-portal-git-zsseparate-waypoint-land-card-sections-hashicorp.vercel.app/vault
[task]: https://app.asana.com/0/1202114367927919/1202440154783258/f