### PR TITLE
fix: dev-dot-content alert letter-spacing

### DIFF
--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -17,38 +17,38 @@
       display: none;
     }
 
-    /* Alert overrides. Note that alert classes are applied at content
+    /* Note on alert overrides: alert classes are applied at content
        extraction time, so it is currently difficult to remove or modify these
-       classes and their associated styles rather than override them */
-    & .alert {
-      /* Override letter-spacing, which in global styles is tracked out */
-      &.g-type-body {
-        letter-spacing: 0;
+       classes and their associated styles rather than override them.
+       https://app.asana.com/0/1100423001970639/1202448738938137/f */
+
+    /* Alert override:  letter-spacing, which in global styles is tracked out */
+    & .alert.g-type-body {
+      letter-spacing: 0;
+    }
+
+    /* Alert override: blue info alert appearance */
+    & .alert.alert-info {
+      background-color: #f2f8ff;
+      border: 1px solid #cce3f3;
+      border-radius: 6px;
+      color: var(--token-color-palette-neutral-600);
+      padding: 16px;
+      margin: 20px 0;
+
+      & code {
+        background-color: white;
+        border: 1px solid #cce3fe;
+        border-radius: 5px;
       }
 
-      /* Override default alert-info appearance, for dev-dot appearance */
-      &.alert-info {
-        background-color: #f2f8ff;
-        border: 1px solid #cce3f3;
-        border-radius: 6px;
-        color: var(--token-color-palette-neutral-600);
-        padding: 16px;
-        margin: 20px 0;
-
-        & code {
-          background-color: white;
-          border: 1px solid #cce3fe;
-          border-radius: 5px;
+      & p {
+        &:first-child {
+          margin-top: 0;
         }
 
-        & p {
-          &:first-child {
-            margin-top: 0;
-          }
-
-          &:last-child {
-            margin-bottom: 0;
-          }
+        &:last-child {
+          margin-bottom: 0;
         }
       }
     }
@@ -102,14 +102,16 @@
   }
 
   & table {
+    background-color: transparent;
     border-collapse: collapse;
+    border-right: 0;
     border-spacing: 0;
     border: 1px solid #ddd;
-    border-right: 0;
-    background-color: transparent;
-    width: 100%;
-    max-width: 100%;
+    display: block;
     margin-bottom: 20px;
+    max-width: 100%;
+    overflow-x: auto; /* TODO: find alternative solution */
+    width: max-content;
 
     & th {
       text-align: left;

--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -17,27 +17,38 @@
       display: none;
     }
 
-    & .alert.alert-info {
-      background-color: #f2f8ff;
-      border: 1px solid #cce3f3;
-      border-radius: 6px;
-      color: var(--token-color-palette-neutral-600);
-      padding: 16px;
-      margin: 20px 0;
-
-      & code {
-        background-color: white;
-        border: 1px solid #cce3fe;
-        border-radius: 5px;
+    /* Alert overrides. Note that alert classes are applied at content
+       extraction time, so it is currently difficult to remove or modify these
+       classes and their associated styles rather than override them */
+    & .alert {
+      /* Override letter-spacing, which in global styles is tracked out */
+      &.g-type-body {
+        letter-spacing: 0;
       }
 
-      & p {
-        &:first-child {
-          margin-top: 0;
+      /* Override default alert-info appearance, for dev-dot appearance */
+      &.alert-info {
+        background-color: #f2f8ff;
+        border: 1px solid #cce3f3;
+        border-radius: 6px;
+        color: var(--token-color-palette-neutral-600);
+        padding: 16px;
+        margin: 20px 0;
+
+        & code {
+          background-color: white;
+          border: 1px solid #cce3fe;
+          border-radius: 5px;
         }
 
-        &:last-child {
-          margin-bottom: 0;
+        & p {
+          &:first-child {
+            margin-top: 0;
+          }
+
+          &:last-child {
+            margin-bottom: 0;
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue with `letter-spacing` in custom alert boxes in `docs` and `tutorial` content.

## 🤷 Why

To match design spec - we don't want tracked out letter-spacing when using system fonts.

## 🛠️ How

Adds CSS override with high specificity.

## 📸 Design Screenshots

### Before

<img width="769" alt="before" src="https://user-images.githubusercontent.com/4624598/173728750-31d2276f-077b-4a5d-892d-de484280bd91.png">

### After

<img width="769" alt="after" src="https://user-images.githubusercontent.com/4624598/173728737-28884629-2bb5-42c2-86a7-5f5a903a1c71.png">


## 🧪 Testing

- [ ] Visit a page with paragraph custom alerts, such as [/vault/tutorials/getting-started/getting-started-install][preview], and confirm that letter-spacing is as expected
    - Also confirm the alerts look as expected otherwise

## 💭 Anything else?

Note: this is a relatively temporary fix. We have a broader platform task to move style transforms to content consumers: 🎟️ [[mktg-content] move style transforms such as paragraphCustomAlerts to load stage (rather than current extract stage)](https://app.asana.com/0/1100423001970639/1202448738938137/f)

[task]: https://app.asana.com/0/1202114367927919/1202439831418498/f
[preview]: https://dev-portal-git-zsfix-alert-box-letter-spacing-hashicorp.vercel.app/vault/tutorials/getting-started/getting-started-install