### PR TITLE
fix: tweak install view mobile styles

### DIFF
--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -1,3 +1,7 @@
+/* This custom-media is for .cardHeader contents only,
+   to wrap version-select at smaller viewport sizes */
+@custom-media --same-row-version-select only screen and (min-width: 400px);
+
 .root {
   margin-bottom: 48px;
 }
@@ -10,25 +14,35 @@
   justify-content: space-between;
   padding-bottom: 12px;
 
-  & > h2 {
-    /* Flex-grow as much as possible to keep .versionSwitcherWrapper small */
-    flex-grow: 100;
-
-    /* Margin reset is necessary to override styles from dev-dot-content */
-    margin-bottom: 0;
+  @media (--same-row-version-select) {
+    flex-wrap: nowrap;
   }
 }
 
 .versionSwitcherWrapper {
-  /* Flex-grow to fill space when wrapped to new row */
+  /* Flex-grow to fill space when in separate row */
   flex-grow: 1;
   flex-shrink: 1;
   width: max-content;
+
+  @media (--same-row-version-select) {
+    flex-grow: 0;
+
+    /* Note: logical order is Vault version, then OS.
+       But in flex layout, we want Vault version after OS heading,
+       so that it appears in the top left of the downloads section box */
+    order: 2;
+  }
 }
 
 .operatingSystemTitle {
   color: var(--token-color-foreground-strong);
-  margin-bottom: 12px;
+  width: 100%;
+
+  @media (--same-row-version-select) {
+    order: 1;
+    width: auto;
+  }
 }
 
 .tabContent {

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -5,7 +5,25 @@
 .cardHeader {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   justify-content: space-between;
+  padding-bottom: 12px;
+
+  & > h2 {
+    /* Flex-grow as much as possible to keep .versionSwitcherWrapper small */
+    flex-grow: 100;
+
+    /* Margin reset is necessary to override styles from dev-dot-content */
+    margin-bottom: 0;
+  }
+}
+
+.versionSwitcherWrapper {
+  /* Flex-grow to fill space when wrapped to new row */
+  flex-grow: 1;
+  flex-shrink: 1;
+  width: max-content;
 }
 
 .operatingSystemTitle {

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -1,7 +1,3 @@
-/* This custom-media is for .cardHeader contents only,
-   to wrap version-select at smaller viewport sizes */
-@custom-media --same-row-version-select only screen and (min-width: 400px);
-
 .root {
   margin-bottom: 48px;
 }
@@ -9,14 +5,15 @@
 .cardHeader {
   align-items: center;
   display: flex;
+
+  /* Note: logical order is Vault version, then OS.
+     But in flex layout, we want Vault version after OS heading,
+     so that it appears in the top left of the downloads section box */
+  flex-direction: row-reverse;
   flex-wrap: wrap;
   gap: 12px;
   justify-content: space-between;
   padding-bottom: 12px;
-
-  @media (--same-row-version-select) {
-    flex-wrap: nowrap;
-  }
 }
 
 .versionSwitcherWrapper {
@@ -24,25 +21,13 @@
   flex-grow: 1;
   flex-shrink: 1;
   width: max-content;
-
-  @media (--same-row-version-select) {
-    flex-grow: 0;
-
-    /* Note: logical order is Vault version, then OS.
-       But in flex layout, we want Vault version after OS heading,
-       so that it appears in the top left of the downloads section box */
-    order: 2;
-  }
 }
 
 .operatingSystemTitle {
   color: var(--token-color-foreground-strong);
-  width: 100%;
 
-  @media (--same-row-version-select) {
-    order: 1;
-    width: auto;
-  }
+  /* Flex-grow as much as possible to keep .versionSwitcherWrapper small */
+  flex-grow: 100;
 }
 
 .tabContent {

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -19,7 +19,6 @@
 .versionSwitcherWrapper {
   /* Flex-grow to fill space when in separate row */
   flex-grow: 1;
-  flex-shrink: 1;
   width: max-content;
 }
 

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -226,12 +226,6 @@ const DownloadsSection = ({
     <div className={s.root}>
       <Card elevation="base">
         <div className={s.cardHeader}>
-          {/*
-          NOTE: This wrapper `<div>` shrinks `VersionContextSwitcher` to only
-          take up as much space as needed for its content, an effect of using
-          flexbox to render the `Heading` and `VersionContextSwitcher` in the
-          same line.
-          */}
           <div className={s.versionSwitcherWrapper}>
             <VersionContextSwitcher
               onChange={(e) => setCurrentVersion(e.target.value)}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -241,7 +241,7 @@ const DownloadsSection = ({
           flexbox to render the `Heading` and `VersionContextSwitcher` in the
           same line.
           */}
-          <div>
+          <div className={s.versionSwitcherWrapper}>
             <VersionContextSwitcher
               onChange={(e) => setCurrentVersion(e.target.value)}
               options={versionSwitcherOptions}

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -226,15 +226,6 @@ const DownloadsSection = ({
     <div className={s.root}>
       <Card elevation="base">
         <div className={s.cardHeader}>
-          <Heading
-            className={s.operatingSystemTitle}
-            level={2}
-            size={300}
-            id="operating-system"
-            weight="bold"
-          >
-            Operating System
-          </Heading>
           {/*
           NOTE: This wrapper `<div>` shrinks `VersionContextSwitcher` to only
           take up as much space as needed for its content, an effect of using
@@ -247,6 +238,15 @@ const DownloadsSection = ({
               options={versionSwitcherOptions}
             />
           </div>
+          <Heading
+            className={s.operatingSystemTitle}
+            level={2}
+            size={300}
+            id="operating-system"
+            weight="bold"
+          >
+            Operating System
+          </Heading>
         </div>
         <Tabs showAnchorLine>
           {Object.keys(downloadsByOS).map((os) => {

--- a/src/views/product-downloads-view/components/page-header/index.tsx
+++ b/src/views/product-downloads-view/components/page-header/index.tsx
@@ -20,6 +20,7 @@ const PageHeader = (): ReactElement => {
   return (
     <div className={s.root}>
       <IconTileLogo
+        className={s.iconTileLogo}
         productSlug={
           currentProduct.slug === 'sentinel' ? 'hcp' : currentProduct.slug
         }

--- a/src/views/product-downloads-view/components/page-header/page-header.module.css
+++ b/src/views/product-downloads-view/components/page-header/page-header.module.css
@@ -4,6 +4,14 @@
   margin-bottom: 48px;
 }
 
+.iconTileLogo {
+  display: none;
+
+  @media (--dev-dot-tablet-up) {
+    display: block;
+  }
+}
+
 .pageHeaderText {
   margin-left: 16px;
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR refines mobile styling for the top section of our install views.

## 🛠️ How

- Removes product icon on mobile, for topmost area
- Refactors version-select + heading layout, to avoid cut-off version select text

## 📸 Design Screenshots

### Before & After Responsive Behaviour

https://user-images.githubusercontent.com/4624598/173732880-275adcb2-61ca-4ded-a82a-48fc131e8336.mp4

## 🧪 Testing

- [ ] Visit the install views, namely [/waypoint/downloads][preview] and [/vault/downloads][/vault/downloads], and ensure the mobile behaviour is as expected
    - Desktop appearance should be unchanged, apart from a minor spacing tweak

[task]: https://app.asana.com/0/1202114367927919/1202439831418522/f
[preview]: https://dev-portal-git-zsinstall-view-mobile-tweaks-hashicorp.vercel.app/waypoint/downloads