### PR TITLE
fix: dev portal routes visible under io domains for same product

### DIFF
--- a/build-libs/proxy-settings.js
+++ b/build-libs/proxy-settings.js
@@ -105,7 +105,7 @@ function getDevPortalRoutesToProxy(product) {
     })
     .filter((ent) => ent.isDirectory() && ent.name !== '_proxied-dot-io')
     .map(({ name }) => ({
-      proxiedRoute: `/:path((?!${product})${name}.*)`,
+      proxiedRoute: `/:path(${name}.*)`,
       localRoute: `/_proxied-dot-io/${product}/:path`,
       skipRedirect: true,
     }))

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -14,8 +14,6 @@ const buildBetaProductOptInRedirect = require('./build-beta-opt-in-redirect')
 
 /** @typedef { import("next/dist/lib/load-custom-routes").Redirect } Redirect  */
 
-const DEV_PORTAL_DOMAIN = 'https://hashi-dev-portal.vercel.app'
-
 const PROXIED_PRODUCT = getProxiedProductSlug()
 
 // Redirect all proxied product pages
@@ -45,37 +43,6 @@ const devPortalToDotIoRedirects = isPreview()
         })
       return acc.concat(toDotIoRedirects)
     }, [])
-
-// Redirect dev-portal routes to the dev-portal domain,
-// if we're on the proxied domain.
-//
-// (Note: without these redirects, dev-portal routes will be visible and
-// indexed by search engines on our proxied .io domains, which seems
-// like it could cause problems)
-// TODO: this is a simple single route, we'd probably want to redirect all dev-portal routes
-// We could likely come up with a way to determine a full list automatically:
-// 1. list all dev routes, ie everything except what's in /_proxied-dot-io/*
-// 2. for each product domain, build a redirect so that when /some-dev-portal-route
-//    is visited on that product domain, it redirects to dev-portal
-const devPortalRoutes = ['/some-dev-portal-route']
-/** @type {Redirect[]} */
-const dotIoToDevPortalRedirects = productsToProxy.reduce((acc, productSlug) => {
-  const productHost = proxySettings[productSlug].host
-  const toDevPortalRedirects = devPortalRoutes.map((devPortalRoute) => {
-    return {
-      source: devPortalRoute,
-      destination: DEV_PORTAL_DOMAIN + devPortalRoute,
-      permanent: false,
-      has: [
-        {
-          type: 'host',
-          value: productHost,
-        },
-      ],
-    }
-  })
-  return acc.concat(toDevPortalRedirects)
-}, [])
 
 /**
  *
@@ -267,7 +234,6 @@ async function buildDotIoRedirects() {
   // TODO ... consolidate redirects for other products
   return [
     ...devPortalToDotIoRedirects,
-    ...dotIoToDevPortalRedirects,
     ...addHostCondition(boundaryIoRedirects, 'boundary'),
     ...addHostCondition(nomadIoRedirects, 'nomad'),
     ...addHostCondition(sentinelIoRedirects, 'sentinel'),

--- a/src/__tests__/e2e/rewrites.spec.ts
+++ b/src/__tests__/e2e/rewrites.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 
 // This test is primarily to ensure that known dev-portal routes aren't exposed via io sites
-test('should rewrite known dev-portal routes', async ({
+test('should rewrite known dev-portal routes - different product', async ({
   page,
   context,
   baseURL,
@@ -14,6 +14,25 @@ test('should rewrite known dev-portal routes', async ({
     },
   ])
   const response = await page.goto('/vault')
+  await expect(page.locator('head title')).toContainText(
+    'Waypoint by HashiCorp'
+  )
+  expect(response.status()).toEqual(404)
+})
+
+test('should rewrite known dev-portal routes - same product', async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  await context.addCookies([
+    {
+      name: 'io_preview',
+      value: 'waypoint',
+      url: baseURL,
+    },
+  ])
+  const response = await page.goto('/waypoint/docs')
   await expect(page.locator('head title')).toContainText(
     'Waypoint by HashiCorp'
   )


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Fixes this: https://www.vaultproject.io/vault

Exposing dev portal routes for the same product under its .io domain. Not something we want to do! Added a test case to validate that you can't hit a dev portal route for the same product. I also removed an unused block of redirect generation.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
