### PR TITLE
fix: code-block dropdown alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-checkbox-input": "^5.0.1",
-        "@hashicorp/react-code-block": "^5.2.0",
+        "@hashicorp/react-code-block": "6.0.1-canary-20220614172337",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^17.0.0",
@@ -3251,9 +3251,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.2.0.tgz",
-      "integrity": "sha512-FkvOZ+7fbbKgVUYpZT4eom7IZb36oJqq6Qle7zo68kC9l2eRgVU8IXGEpjAvQWVGRkDlqcp/ISwZO04tZ3d+Tw==",
+      "version": "6.0.1-canary-20220614172337",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1-canary-20220614172337.tgz",
+      "integrity": "sha512-DkPhM+HfMlTx72FslmAMPQiwBDCo12b+7Wgcr8QxOQ4mdyOpRy8XUBWnCo5bJr1gAcLkcIs8GYEBe4I4LcrExg==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -35874,9 +35874,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-5.2.0.tgz",
-      "integrity": "sha512-FkvOZ+7fbbKgVUYpZT4eom7IZb36oJqq6Qle7zo68kC9l2eRgVU8IXGEpjAvQWVGRkDlqcp/ISwZO04tZ3d+Tw==",
+      "version": "6.0.1-canary-20220614172337",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1-canary-20220614172337.tgz",
+      "integrity": "sha512-DkPhM+HfMlTx72FslmAMPQiwBDCo12b+7Wgcr8QxOQ4mdyOpRy8XUBWnCo5bJr1gAcLkcIs8GYEBe4I4LcrExg==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@hashicorp/react-button": "^6.0.3",
         "@hashicorp/react-call-to-action": "^4.1.1",
         "@hashicorp/react-checkbox-input": "^5.0.1",
-        "@hashicorp/react-code-block": "6.0.1-canary-20220614172337",
+        "@hashicorp/react-code-block": "^6.0.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.2.0",
         "@hashicorp/react-docs-page": "^17.0.0",
@@ -3251,9 +3251,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "6.0.1-canary-20220614172337",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1-canary-20220614172337.tgz",
-      "integrity": "sha512-DkPhM+HfMlTx72FslmAMPQiwBDCo12b+7Wgcr8QxOQ4mdyOpRy8XUBWnCo5bJr1gAcLkcIs8GYEBe4I4LcrExg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1.tgz",
+      "integrity": "sha512-X2B/4craAdLfQNB9IpEtL7XOWvHKTNbsTUtUrgSK/FECYevVuktPQ00JWIoLtAXgT7jkFq4jxK4pDIF62AE8fg==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -35874,9 +35874,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "6.0.1-canary-20220614172337",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1-canary-20220614172337.tgz",
-      "integrity": "sha512-DkPhM+HfMlTx72FslmAMPQiwBDCo12b+7Wgcr8QxOQ4mdyOpRy8XUBWnCo5bJr1gAcLkcIs8GYEBe4I4LcrExg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.0.1.tgz",
+      "integrity": "sha512-X2B/4craAdLfQNB9IpEtL7XOWvHKTNbsTUtUrgSK/FECYevVuktPQ00JWIoLtAXgT7jkFq4jxK4pDIF62AE8fg==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-checkbox-input": "^5.0.1",
-    "@hashicorp/react-code-block": "6.0.1-canary-20220614172337",
+    "@hashicorp/react-code-block": "^6.0.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@hashicorp/react-button": "^6.0.3",
     "@hashicorp/react-call-to-action": "^4.1.1",
     "@hashicorp/react-checkbox-input": "^5.0.1",
-    "@hashicorp/react-code-block": "^5.2.0",
+    "@hashicorp/react-code-block": "6.0.1-canary-20220614172337",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.2.0",
     "@hashicorp/react-docs-page": "^17.0.0",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Pulls in a fix from https://github.com/hashicorp/react-components/pull/612 to adjust `<CodeTabs />` alignment when code tabs are in dropdown form _and_ there is no title for the code tabs.

## 🤷 Why

Previously, alignment was not correct - the dropdown should be left-aligned, but was right aligned.

## 📸 Design Screenshots

### Before

<img width="357" alt="code-tabs-before" src="https://user-images.githubusercontent.com/4624598/173733610-75c18108-efa7-4332-bc60-395cda213303.png">

### After

<img width="346" alt="code-tabs-after" src="https://user-images.githubusercontent.com/4624598/173733604-917d8341-8936-448f-952d-6ec08896daea.png">

## 🧪 Testing

- [ ] Visit a page with code tabs that go to dropdown on mobile, such as [/vault/downloads][preview]
    - Ensure alignment of the dropdown matches on which side the dropdown is aligned (the dropdown should NOT extend outside the boundaries of the code block)
    - Ensure the code block is otherwise the same

## 💭 Anything else?

We never bumped to [@hashicorp/react-code-block@6.0.0](https://github.com/hashicorp/react-components/releases/tag/%40hashicorp%2Freact-code-block%406.0.0). I think this is okay, I don't believe there are any uses of the affected `onCopyCallback` prop in that release 👍

[task]: https://app.asana.com/0/1202114367927919/1202439831418533/f
[preview]: https://dev-portal-git-zsbump-code-block-hashicorp.vercel.app/vault/downloads