### PR TITLE
fix: clean up more duplicate CoreDevDotLayouts

### DIFF
--- a/src/pages/boundary/downloads/index.tsx
+++ b/src/pages/boundary/downloads/index.tsx
@@ -4,7 +4,6 @@ import boundaryData from 'data/boundary.json'
 import installData from 'data/boundary-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const BoundaryDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-BoundaryDownloadsPage.layout = CoreDevDotLayout
 
 export default BoundaryDownloadsPage

--- a/src/pages/consul/downloads/index.tsx
+++ b/src/pages/consul/downloads/index.tsx
@@ -4,7 +4,6 @@ import consulData from 'data/consul.json'
 import installData from 'data/consul-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const ConsulDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-ConsulDownloadsPage.layout = CoreDevDotLayout
 
 export default ConsulDownloadsPage

--- a/src/pages/nomad/downloads/index.tsx
+++ b/src/pages/nomad/downloads/index.tsx
@@ -4,7 +4,6 @@ import nomadData from 'data/nomad.json'
 import installData from 'data/nomad-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const NomadDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-NomadDownloadsPage.layout = CoreDevDotLayout
 
 export default NomadDownloadsPage

--- a/src/pages/packer/downloads/index.tsx
+++ b/src/pages/packer/downloads/index.tsx
@@ -4,7 +4,6 @@ import packerData from 'data/packer.json'
 import installData from 'data/packer-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const PackerDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-PackerDownloadsPage.layout = CoreDevDotLayout
 
 export default PackerDownloadsPage

--- a/src/pages/sentinel/downloads/index.tsx
+++ b/src/pages/sentinel/downloads/index.tsx
@@ -4,7 +4,6 @@ import sentinelData from 'data/sentinel.json'
 import installData from 'data/sentinel-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const SentinelDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-SentinelDownloadsPage.layout = CoreDevDotLayout
 
 export default SentinelDownloadsPage

--- a/src/pages/terraform/downloads/index.tsx
+++ b/src/pages/terraform/downloads/index.tsx
@@ -12,7 +12,6 @@ import {
   generateStaticProps,
   ReleasesAPIResponse,
 } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const VERSION_DOWNLOAD_CUTOFF = '>=1.0.11'
@@ -93,7 +92,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generatedProps
 }
-
-TerraformDownloadsPage.layout = CoreDevDotLayout
 
 export default TerraformDownloadsPage

--- a/src/pages/vagrant/downloads/index.tsx
+++ b/src/pages/vagrant/downloads/index.tsx
@@ -4,7 +4,6 @@ import vagrantData from 'data/vagrant.json'
 import installData from 'data/vagrant-install.json'
 import { ProductData } from 'types/products'
 import { generateStaticProps, GeneratedProps } from 'lib/fetch-release-data'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import ProductDownloadsView from 'views/product-downloads-view'
 
 const VagrantDownloadsPage = (props: GeneratedProps): ReactElement => {
@@ -23,7 +22,5 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return generateStaticProps(product)
 }
-
-VagrantDownloadsPage.layout = CoreDevDotLayout
 
 export default VagrantDownloadsPage

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -1,7 +1,6 @@
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import { useOptInAnalyticsTracking } from 'hooks/use-opt-in-analytics-tracking'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import {
   generateProductLandingSidebarNavData,
   generateTopLevelSidebarNavData,
@@ -77,5 +76,4 @@ function CollectionView({
   )
 }
 
-CollectionView.layout = CoreDevDotLayout
 export default CollectionView

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -1,6 +1,5 @@
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import Heading from 'components/heading'
-import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import {
   generateProductLandingSidebarNavData,
   generateTopLevelSidebarNavData,
@@ -93,5 +92,4 @@ function ProductTutorialsView({
   )
 }
 
-ProductTutorialsView.layout = CoreDevDotLayout
 export default ProductTutorialsView


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where buttons in ConsentManager would stack and break.

## 🤷 Why

To prevent unexpected layout in `ConsentManager`

## 🛠️ How

Removes duplicate `CoreDevDotLayout`. Already used in `SidebarSidecarLayout`, so no need to set twice - and doing so wraps `ConsentManager` in font-family settings which alter layout and cause button stacking.

## 🧪 Testing

- [ ] Visit a tutorial landing page, such as [/vault/tutorials][preview], and ensure ConsentManager buttons are not stacking

[task]: https://app.asana.com/0/1202114367927919/1202448714497715/f
[preview]: https://dev-portal-git-zsfixup-layout-again-hashicorp.vercel.app/vault/tutorials