### PR TITLE
Fixing Dialog/Opt-out Dialog visual issues

### DIFF
--- a/src/components/dialog/dialog.module.css
+++ b/src/components/dialog/dialog.module.css
@@ -3,10 +3,24 @@
   z-index: 100;
 }
 
-.content {
-  box-shadow: var(--token-surface-overlay-box-shadow);
-  border-radius: 6px;
+.contentWrapper {
+  align-items: flex-start;
+  display: flex;
+  height: 100vh;
+  justify-content: center;
   padding: 24px;
+  width: 100vw;
+
+  @media (--dev-dot-tablet-up) {
+    padding-top: 10vh;
+  }
+}
+
+.content {
+  border-radius: 6px;
+  box-shadow: var(--token-surface-overlay-box-shadow);
+  margin: 0;
   max-width: 600px;
-  min-width: 300px;
+  padding: 24px;
+  width: 100%;
 }

--- a/src/components/dialog/dialog.module.css
+++ b/src/components/dialog/dialog.module.css
@@ -1,5 +1,18 @@
-.overlay {
-  background: var(--token-color-border-strong);
+/*
+***
+* This class is necessary so avoid issues with the layer behind the dialog
+* looking strange. Setting `background: none` on the `dialogOverlay` class does
+* not work.
+* 
+* ref: https://app.asana.com/0/1202114367927919/1202440311005416/f
+***
+*/
+.animatedDialogOverlay {
+  background: none;
+}
+
+.dialogOverlay {
+  background-color: var(--token-color-border-strong);
   z-index: 100;
 }
 

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -31,9 +31,11 @@ export default function Dialog({
               exit={{ y: 50 }}
               transition={{ min: 0, max: 100, bounceDamping: 8 }}
             >
-              <DialogContent className={s.content} aria-label={label}>
-                {children}
-              </DialogContent>
+              <div className={s.contentWrapper}>
+                <DialogContent className={s.content} aria-label={label}>
+                  {children}
+                </DialogContent>
+              </div>
             </m.div>
           </DialogOverlay>
         </AnimatedDialogOverlay>

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -14,14 +14,14 @@ export default function Dialog({
     <AnimatePresence>
       {isOpen && (
         <AnimatedDialogOverlay
-          className={s.dialogOverlay}
+          className={s.animatedDialogOverlay}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           onDismiss={onDismiss}
         >
           <DialogOverlay
-            className={s.overlay}
+            className={s.dialogOverlay}
             isOpen={isOpen}
             onDismiss={onDismiss}
           >

--- a/src/components/opt-in-out/components/opt-out-form/index.tsx
+++ b/src/components/opt-in-out/components/opt-out-form/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState, ChangeEvent, useRef } from 'react'
+import { FormEvent, useState, ChangeEvent } from 'react'
 import { IconX16 } from '@hashicorp/flight-icons/svg-react/x-16'
 import Button from 'components/button'
 import Text from 'components/text'

--- a/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
+++ b/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
@@ -74,6 +74,7 @@
 
 .optionalText {
   composes: hds-typography-body-200 hds-font-weight-regular from global;
+  appearance: none; /* resets iOS styles */
   border-radius: 5px;
   border: unset;
   box-shadow: var(--token-surface-base-box-shadow);

--- a/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
+++ b/src/components/opt-in-out/components/opt-out-form/opt-out-form.module.css
@@ -74,15 +74,15 @@
 
 .optionalText {
   composes: hds-typography-body-200 hds-font-weight-regular from global;
-  width: 100%;
-  height: 100px;
-  display: flex;
   border-radius: 5px;
-  color: var(--token-color-foreground-primary);
-  padding: 12px;
-  box-shadow: var(--token-surface-base-box-shadow);
   border: unset;
+  box-shadow: var(--token-surface-base-box-shadow);
+  color: var(--token-color-foreground-primary);
+  display: flex;
+  height: 100px;
+  padding: 12px;
   resize: none;
+  width: 100%;
 
   &::placeholder {
     color: var(--token-color-foreground-faint);


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambopt-out-dialog-hashicorp.vercel.app/waypoint/docs?optInFrom=waypoint-io) 🔎
- Asana tasks 🎟️
  - [[text area] Text area in opt-out dialog not showing border on iOS devices](https://app.asana.com/0/1202114367927919/1202440311005396/f)
  - [[dialog] Refine opt-out beta feedback at smaller viewports](https://app.asana.com/0/1202114367927919/1202440311005385/f)
  - [[dialog] background color visual bugs](https://app.asana.com/0/1202114367927919/1202440311005416/f)

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes "missing" border on opt-out dialog `textarea` for iOS devices
- Changes the placement of `Dialog`s on viewports <= `728px` wide
- Fixes the look of the `Dialog` background

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- The "missing" border was fixed by setting `appearance: none` on the `textarea`. We also had to do this for `input` elements. It will be very beneficial to create UI components soon that handle this for us. The Design Systems team is currently working on form elements, so I imagine we'll work on this soon. Especially since we'll be adding more form elements with the development of authentication and more.
- To update the placement of `Dialog` on various viewports, I added a wrapper `<div>` around the `DialogContent` element and updated styles for both elements. The approach I took was for the wrapper to have `padding` that restrains its contents, rather than add margins to the `DialogContent` element because that would require more math to calculate the width of the element.
- To fix the strange-looking background behind `Dialog`s, I set `background: none` on the `AnimatedDialogOverlay` element. Setting `background: none` on the `DialogOverlay` did nothing, and I made note of this in a comment in the CSS.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview link: [/waypoint/docs?optInFrom=waypoint-io](https://dev-portal-git-ambopt-out-dialog-hashicorp.vercel.app/waypoint/docs?optInFrom=waypoint-io)
- [ ] Click the "Leave Beta" button towards the top of the page
- [ ] With an iOS device, make sure the `textarea` border is visible
- [ ] Ensure the placing of the dialog is desirable in both narrow and wide viewports
- [ ] Ensure the background behind the dialog looks correct
