### PR TITLE
Moving non-product mobile menu to BaseNewLayout

### DIFF
--- a/src/layouts/base-new/base-new-layout.module.css
+++ b/src/layouts/base-new/base-new-layout.module.css
@@ -33,6 +33,18 @@ Asana task: https://app.asana.com/0/1202114367927919/1202316169578550/f
   z-index: 3;
 }
 
+.mobileMenuContainer {
+  padding: 24px;
+  z-index: 2;
+}
+
+.mobileMenuNavList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
 .contentArea {
   /* flex column gives consumers 
   flexibility in making their content either

--- a/src/layouts/base-new/index.tsx
+++ b/src/layouts/base-new/index.tsx
@@ -1,3 +1,5 @@
+// Third-party imports
+import { useRouter } from 'next/router'
 import classNames from 'classnames'
 
 // HashiCorp imports
@@ -5,10 +7,13 @@ import usePageviewAnalytics from '@hashicorp/platform-analytics'
 import createConsentManager from '@hashicorp/react-consent-manager/loader'
 
 // Global imports
+import { generateTopLevelSubNavItems } from 'lib/generate-top-level-sub-nav-items'
 import useScrollPercentageAnalytics from 'hooks/use-scroll-percentage-analytics'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
 import Footer from 'components/footer'
+import MobileMenuContainer from 'components/mobile-menu-container'
 import NavigationHeader from 'components/navigation-header'
+import { SidebarNavMenuItem } from 'components/sidebar/components'
 
 // Local imports
 import { BaseNewLayoutProps } from './types'
@@ -19,6 +24,24 @@ const { ConsentManager, openConsentManager } = createConsentManager({
 })
 
 /**
+ * The mobile menu that shows on non-product pages, or pages that do not use the
+ * SidebarSidecarLayout that usually handles the mobile menu.
+ */
+const NonProductPageMobileMenu = () => {
+  return (
+    <MobileMenuContainer className={s.mobileMenuContainer}>
+      <ul className={s.mobileMenuNavList}>
+        <SidebarNavMenuItem item={{ heading: 'Main Menu' }} />
+        {generateTopLevelSubNavItems().map((item: $TSFixMe, index: number) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <SidebarNavMenuItem item={item} key={index} />
+        ))}
+      </ul>
+    </MobileMenuContainer>
+  )
+}
+
+/**
  * TODO (future enhancement): rename and abstract `SidebarNavDataProvider` for
  * use here.
  */
@@ -26,12 +49,19 @@ const BaseNewLayout = ({
   children,
   showFooterTopBorder = false,
 }: BaseNewLayoutProps) => {
-  // hooks
+  const router = useRouter()
   usePageviewAnalytics({
     siteId: process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
     includedDomains: __config.dev_dot.analytics.included_domains,
   })
   useScrollPercentageAnalytics()
+
+  /**
+   * We only want to show this menu for certain routes. Other routes use
+   * SidebarSidecarLayout, which handles the mobile menu for those routes.
+   */
+  const shouldShowMobileMenu =
+    router.route === '/' || router.route === '/_error'
 
   return (
     <>
@@ -40,7 +70,10 @@ const BaseNewLayout = ({
           <div className={s.header}>
             <NavigationHeader />
           </div>
-          <div className={s.contentArea}>{children}</div>
+          <div className={s.contentArea}>
+            {shouldShowMobileMenu ? <NonProductPageMobileMenu /> : null}
+            {children}
+          </div>
           <div
             className={classNames(s.footer, {
               [s.showFooterTopBorder]: showFooterTopBorder,

--- a/src/views/homepage/homepage.module.css
+++ b/src/views/homepage/homepage.module.css
@@ -13,18 +13,6 @@
   }
 }
 
-.mobileMenuContainer {
-  padding: 24px;
-  z-index: 2;
-}
-
-.mobileMenuNavList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  width: 100%;
-}
-
 .homepageContent {
   z-index: 1;
 }

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -3,11 +3,8 @@ import { ReactElement } from 'react'
 
 // Global imports
 import { productSlugs } from 'lib/products'
-import { generateTopLevelSubNavItems } from 'lib/generate-top-level-sub-nav-items'
 import BaseNewLayout from 'layouts/base-new'
 import Text from 'components/text'
-import MobileMenuContainer from 'components/mobile-menu-container'
-import { SidebarNavMenuItem } from 'components/sidebar/components'
 
 // Local imports
 import { HomePageProps, HomePageContentProps } from './types'
@@ -23,20 +20,6 @@ import {
 import s from './homepage.module.css'
 
 const productNavSlugs = productSlugs.filter((slug) => slug !== 'sentinel')
-
-const HomePageMobileMenu = () => {
-  return (
-    <MobileMenuContainer className={s.mobileMenuContainer}>
-      <ul className={s.mobileMenuNavList}>
-        <SidebarNavMenuItem item={{ heading: 'Main Menu' }} />
-        {generateTopLevelSubNavItems().map((item: $TSFixMe, index: number) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <SidebarNavMenuItem item={item} key={index} />
-        ))}
-      </ul>
-    </MobileMenuContainer>
-  )
-}
 
 const HomePageContent = ({
   hero,
@@ -85,7 +68,6 @@ const HomePageContent = ({
 function HomePageView({ content }: HomePageProps): ReactElement {
   return (
     <div className={s.homepage}>
-      <HomePageMobileMenu />
       <HomePageContent {...content} />
     </div>
   )


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-amb404-mobile-menu-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202114367927919/1202474624444935/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Moves mobile menu previously in `src/views/homepage/index.tsx` to `src/layouts/base-new/index.tsx`, so it can be used for all pages that do not use `SidebarSidecarLayout`. Such as the error views.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Test the following pages at 2 viewport widths (`<= 728px` and `>= 729px`) and make sure the correct mobile menu appears when expected:

- [ ] https://dev-portal-git-amb404-mobile-menu-hashicorp.vercel.app/
- [ ] https://dev-portal-git-amb404-mobile-menu-hashicorp.vercel.app/vault
- [ ] https://dev-portal-git-amb404-mobile-menu-hashicorp.vercel.app/waypoint
- [ ] https://dev-portal-git-amb404-mobile-menu-hashicorp.vercel.app/this-page-should-404
