### PR TITLE
fix(beta opt-out): add betaOptOut query param to io site opt-out

### DIFF
--- a/src/components/opt-in-out/helpers/platform-options.ts
+++ b/src/components/opt-in-out/helpers/platform-options.ts
@@ -14,6 +14,8 @@ export const PLATFORM_OPTIONS: PlatformOptionRedirectData = {
     getRedirectPath(path) {
       const url = new URL(getIoRedirectPath(path), this.base_url)
 
+      url.searchParams.set('betaOptOut', 'true')
+
       // ensure we don't create a looping scenario if someone opts out immediately after opting-in
       url.searchParams.delete('optInFrom')
 
@@ -26,6 +28,8 @@ export const PLATFORM_OPTIONS: PlatformOptionRedirectData = {
     base_url: 'https://www.vaultproject.io/',
     getRedirectPath(path) {
       const url = new URL(getIoRedirectPath(path), this.base_url)
+
+      url.searchParams.set('betaOptOut', 'true')
 
       // ensure we don't create a looping scenario if someone opts out immediately after opting-in
       url.searchParams.delete('optInFrom')


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
We need the `betaOptOut=true` query parameter set when redirecting back to an .io site from the opt-out flow, otherwise a user would just get redirected back to Hashi Developer on opt-out

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
