### PR TITLE
[install view] Fixing margin when IconTileLogo is hidden

### DIFF
--- a/src/views/product-downloads-view/components/page-header/index.tsx
+++ b/src/views/product-downloads-view/components/page-header/index.tsx
@@ -25,7 +25,7 @@ const PageHeader = (): ReactElement => {
           currentProduct.slug === 'sentinel' ? 'hcp' : currentProduct.slug
         }
       />
-      <div className={s.pageHeaderText}>
+      <div>
         <Heading
           className={s.pageHeaderTitle}
           level={1}

--- a/src/views/product-downloads-view/components/page-header/page-header.module.css
+++ b/src/views/product-downloads-view/components/page-header/page-header.module.css
@@ -9,11 +9,8 @@
 
   @media (--dev-dot-tablet-up) {
     display: block;
+    margin-right: 16px;
   }
-}
-
-.pageHeaderText {
-  margin-left: 16px;
 }
 
 .pageHeaderTitle {


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

When `IconTileLogo` is hidden (viewports <= `728px` wide), there is still a `margin-left` on the page header text container. This moves the margin from that element to the `IconTileLogo` element instead.

<table>
  <tr>
    <td>before<img src="https://user-images.githubusercontent.com/43934258/174689702-68fba631-c043-4b2b-934f-15e01c3bcb7c.png" /></td>
    <td>after<img src="https://user-images.githubusercontent.com/43934258/174689712-2d290195-01e6-4d4b-97d8-68eb8ec6ffbb.png" /></td>
  </tr>
</table>

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/waypoint/downloads](https://dev-portal-git-ambfix-downloads-hero-margin-hashicorp.vercel.app/waypoint/downloads)
- [ ] Set your viewport to be >= `729px` wide
- [ ] There should be `16px` of space between the header icon tile logo and the text
- [ ] Set your viewport to be <= `728px` wide
- [ ] The icon tile logo should still hide
- [ ] The header text should left-align with the rest of the page content
