### PR TITLE
Fixing MobileMenuContainer scroll

### DIFF
--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -14,6 +14,7 @@
   flex-shrink: 0;
   height: calc(100vh - var(--sticky-bars-height));
   left: -150vw;
+  overflow-y: auto;
   position: fixed;
   top: var(--sticky-bars-height);
   width: 100%;


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Fixes scrolling of `MobileMenuContainer` when the viewport is too vertically short to show all the content.
## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Open the browser developer tools
- [ ] Toggle the mobile view of the page
- [ ] Rotate the mobile view device
- [ ] Open the mobile menu
- [ ] It should be scrollable
- [ ] Go to /waypoint/docs
- [ ] Check that the docs sidebar still renders correctly
- [ ] View the page at a desktop width
- [ ] Check that the docs sidebar still renders correctly