### PR TITLE
turn off generic hashiconf alert banners

### DIFF
--- a/src/data/nomad.json
+++ b/src/data/nomad.json
@@ -20,7 +20,7 @@
       }
     ]
   },
-  "alertBannerActive": true,
+  "alertBannerActive": false,
   "alertBanner": {
     "tag": "June 21-22",
     "url": "https://hashiconf.com/europe?utm_source=Banner",

--- a/src/data/packer.json
+++ b/src/data/packer.json
@@ -19,7 +19,7 @@
       }
     ]
   },
-  "alertBannerActive": true,
+  "alertBannerActive": false,
   "alertBanner": {
     "tag": "June 21-22",
     "url": "https://hashiconf.com/europe?utm_source=Banner",

--- a/src/data/sentinel.json
+++ b/src/data/sentinel.json
@@ -32,7 +32,7 @@
       }
     ]
   },
-  "alertBannerActive": true,
+  "alertBannerActive": false,
   "alertBanner": {
     "tag": "June 21-22",
     "url": "https://hashiconf.com/europe?utm_source=Banner",

--- a/src/data/vagrant.json
+++ b/src/data/vagrant.json
@@ -19,7 +19,7 @@
       }
     ]
   },
-  "alertBannerActive": true,
+  "alertBannerActive": false,
   "alertBanner": {
     "tag": "June 21-22",
     "url": "https://hashiconf.com/europe?utm_source=Banner",

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -39,7 +39,7 @@
       }
     ]
   },
-  "alertBannerActive": true,
+  "alertBannerActive": false,
   "alertBanner": {
     "tag": "June 21-22",
     "url": "https://hashiconf.com/europe?utm_source=Banner",


### PR DESCRIPTION
HashiConf is no longer live, so this turns off the generic alert banners (leaving Boundary, Waypoint & Consul as they're promoting specific announcements)