### PR TITLE
chore: test twitter:description fallback to og:description

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -59,7 +59,7 @@ export default function App({ Component, pageProps, layoutProps }) {
             <AllProductDataProvider>
               <CurrentProductProvider currentProduct={currentProduct}>
                 <CodeTabsProvider>
-                  <HeadMetadata {...pageProps.metadata} />
+                  {/* <HeadMetadata {...pageProps.metadata} /> */}
                   <LazyMotion
                     features={() =>
                       import('lib/framer-motion-features').then(

--- a/src/pages/test-with-twitter-description.tsx
+++ b/src/pages/test-with-twitter-description.tsx
@@ -16,6 +16,10 @@ function TestPageWithTwitterDescription() {
           name="twitter:description"
           content="This is the twitter:description for a test page with twitter description."
         />
+        <meta
+          property="og:image"
+          content="https://www.datocms-assets.com/2885/1655303762-16_9-social-image-homepage.jpg?fit=max&amp;fm=jpg&amp;w=1000"
+        ></meta>
       </Head>
       <p>
         Hello! This page has <code>twitter:description</code>, as well as an{' '}

--- a/src/pages/test-with-twitter-description.tsx
+++ b/src/pages/test-with-twitter-description.tsx
@@ -4,14 +4,17 @@ function TestPageWithTwitterDescription() {
   return (
     <>
       <Head>
+        <meta property="twitter:card" content="summary_large_image" />
+        <meta property="og:title" content="Test With Twitter Description" />
+        <meta property="og:type" content="website" />
         <meta
           name="description"
           property="og:description"
-          content="This is the og:description for a test page."
+          content="This is the og:description for a test page with twitter description."
         />
         <meta
           name="twitter:description"
-          content="This is the twitter:description for a test page."
+          content="This is the twitter:description for a test page with twitter description."
         />
       </Head>
       <p>

--- a/src/pages/test-with-twitter-description.tsx
+++ b/src/pages/test-with-twitter-description.tsx
@@ -1,0 +1,25 @@
+import Head from 'next/head'
+
+function TestPageWithTwitterDescription() {
+  return (
+    <>
+      <Head>
+        <meta
+          name="description"
+          property="og:description"
+          content="This is the og:description for a test page."
+        />
+        <meta
+          name="twitter:description"
+          content="This is the twitter:description for a test page."
+        />
+      </Head>
+      <p>
+        Hello! This page has <code>twitter:description</code>, as well as an{' '}
+        <code>og:description</code>. They have unique text.
+      </p>
+    </>
+  )
+}
+
+export default TestPageWithTwitterDescription

--- a/src/pages/test-without-twitter-description.tsx
+++ b/src/pages/test-without-twitter-description.tsx
@@ -4,10 +4,13 @@ function TestPageWithoutTwitterDescription() {
   return (
     <>
       <Head>
+        <meta property="twitter:card" content="summary_large_image" />
+        <meta property="og:title" content="Test Without Twitter Description" />
+        <meta property="og:type" content="website" />
         <meta
           name="description"
           property="og:description"
-          content="This is the og:description for a test page."
+          content="This is the og:description for a test page without twitter description."
         />
       </Head>
       <p>

--- a/src/pages/test-without-twitter-description.tsx
+++ b/src/pages/test-without-twitter-description.tsx
@@ -1,0 +1,20 @@
+import Head from 'next/head'
+
+function TestPageWithoutTwitterDescription() {
+  return (
+    <>
+      <Head>
+        <meta
+          name="description"
+          property="og:description"
+          content="This is the og:description for a test page."
+        />
+      </Head>
+      <p>
+        Hello! This page only has an <code>og:description</code>.
+      </p>
+    </>
+  )
+}
+
+export default TestPageWithoutTwitterDescription

--- a/src/pages/test-without-twitter-description.tsx
+++ b/src/pages/test-without-twitter-description.tsx
@@ -12,6 +12,10 @@ function TestPageWithoutTwitterDescription() {
           property="og:description"
           content="This is the og:description for a test page without twitter description."
         />
+        <meta
+          property="og:image"
+          content="https://www.datocms-assets.com/2885/1655303762-16_9-social-image-homepage.jpg?fit=max&amp;fm=jpg&amp;w=1000"
+        ></meta>
       </Head>
       <p>
         Hello! This page only has an <code>og:description</code>.


### PR DESCRIPTION
- [Preview link - with `twitter:description`](https://dev-portal-git-zstest-twitter-description-hashicorp.vercel.app/test-with-twitter-description) 🔎
- [Preview link - with `og:description` only](https://dev-portal-git-zstest-twitter-description-hashicorp.vercel.app/test-without-twitter-description) 🔎