### PR TITLE
chore: bump head

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@hashicorp/react-error-view": "^0.0.3",
         "@hashicorp/react-featured-slider": "^5.0.1",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
-        "@hashicorp/react-head": "^3.2.0",
+        "@hashicorp/react-head": "^3.3.0",
         "@hashicorp/react-hero": "^8.0.3",
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/react-learn-callout": "^2.0.1",
@@ -3469,9 +3469,9 @@
       }
     },
     "node_modules/@hashicorp/react-head": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.2.0.tgz",
-      "integrity": "sha512-uuF1lV2VzvdrLKkhdX/vhg2p1WHf78inM9L4RK8SajLd3NiMqgRzhp39dOQsRTmZAUgM5abObz3DtAy8G+Mnbw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.3.0.tgz",
+      "integrity": "sha512-kE6fEFyzYLDQl6DBuC8t70tvfqhyXAqXL7HonN+yb0G3bZ7Quf5Wkwe5LEPdxnZX2+iiOHEpo5MRCje9gWhxGg==",
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
@@ -36034,9 +36034,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.2.0.tgz",
-      "integrity": "sha512-uuF1lV2VzvdrLKkhdX/vhg2p1WHf78inM9L4RK8SajLd3NiMqgRzhp39dOQsRTmZAUgM5abObz3DtAy8G+Mnbw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.3.0.tgz",
+      "integrity": "sha512-kE6fEFyzYLDQl6DBuC8t70tvfqhyXAqXL7HonN+yb0G3bZ7Quf5Wkwe5LEPdxnZX2+iiOHEpo5MRCje9gWhxGg==",
       "requires": {}
     },
     "@hashicorp/react-hero": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@hashicorp/react-error-view": "^0.0.3",
     "@hashicorp/react-featured-slider": "^5.0.1",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
-    "@hashicorp/react-head": "^3.2.0",
+    "@hashicorp/react-head": "^3.3.0",
     "@hashicorp/react-hero": "^8.0.3",
     "@hashicorp/react-inline-svg": "^6.0.3",
     "@hashicorp/react-learn-callout": "^2.0.1",

--- a/src/__tests__/e2e/seo.spec.ts
+++ b/src/__tests__/e2e/seo.spec.ts
@@ -15,11 +15,11 @@ test('should render the proper page title and description', async ({
     await page.locator('head meta[name="description"]').getAttribute('content')
   ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
 
-  expect(
-    await page
-      .locator('head meta[name="twitter:description"]')
-      .getAttribute('content')
-  ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
+  // expect(
+  //   await page
+  //     .locator('head meta[name="twitter:description"]')
+  //     .getAttribute('content')
+  // ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
 
   expect(
     await page.locator('head meta[property="og:image"]').getAttribute('content')
@@ -44,11 +44,12 @@ test('product landing page should render the metadata', async ({
   expect(
     await page.locator('head meta[name="description"]').getAttribute('content')
   ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
-  expect(
-    await page
-      .locator('head meta[name="twitter:description"]')
-      .getAttribute('content')
-  ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
+
+  // expect(
+  //   await page
+  //     .locator('head meta[name="twitter:description"]')
+  //     .getAttribute('content')
+  // ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
 
   expect(
     await page.locator('head meta[property="og:image"]').getAttribute('content')

--- a/src/__tests__/e2e/seo.spec.ts
+++ b/src/__tests__/e2e/seo.spec.ts
@@ -15,11 +15,11 @@ test('should render the proper page title and description', async ({
     await page.locator('head meta[name="description"]').getAttribute('content')
   ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
 
-  // expect(
-  //   await page
-  //     .locator('head meta[name="twitter:description"]')
-  //     .getAttribute('content')
-  // ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
+  expect(
+    await page
+      .locator('head meta[name="twitter:description"]')
+      .getAttribute('content')
+  ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'HashiCorp'))
 
   expect(
     await page.locator('head meta[property="og:image"]').getAttribute('content')
@@ -45,11 +45,11 @@ test('product landing page should render the metadata', async ({
     await page.locator('head meta[name="description"]').getAttribute('content')
   ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
 
-  // expect(
-  //   await page
-  //     .locator('head meta[name="twitter:description"]')
-  //     .getAttribute('content')
-  // ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
+  expect(
+    await page
+      .locator('head meta[name="twitter:description"]')
+      .getAttribute('content')
+  ).toEqual(__config.dev_dot.meta.description.replace('{product}', 'Waypoint'))
 
   expect(
     await page.locator('head meta[property="og:image"]').getAttribute('content')

--- a/src/components/head-metadata/index.tsx
+++ b/src/components/head-metadata/index.tsx
@@ -59,11 +59,6 @@ export default function HeadMetadata(props: HeadMetadataProps) {
 
       {/* Some og tags do not get picked up for twitter's share cards, so we need these tags as well */}
       <meta name="twitter:image" key="twitter:image" content={ogImageUrl} />
-      <meta
-        name="twitter:description"
-        key="twitter:description"
-        content={finalDescription}
-      />
     </HashiHead>
   )
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Bumps `@hashicorp/react-head` to pull in updates from:

- https://github.com/hashicorp/react-components/pull/623

## 🤷 Why

To ensure metadata for Twitter cards is correctly populated.

## 🧪 Testing

- [ ] Validate a URL on the site, such as [the preview][preview], in [Twitter's card validator][validator]

[task]: https://app.asana.com/0/1100423001970639/1202415308965256/f
[preview]: https://dev-portal-git-zsbump-head-hashicorp.vercel.app
[validator]: https://cards-dev.twitter.com/validator