### PR TITLE
fix: escape query selector to ensure it doesn't break

### DIFF
--- a/src/layouts/sidebar-sidecar/components/table-of-contents/use-active-section.ts
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/use-active-section.ts
@@ -131,7 +131,7 @@ export function useActiveSection(
     headings.forEach((section) => {
       const el = document
         .getElementById('main')
-        ?.querySelector(`#${section.slug}`)
+        ?.querySelector(`#${CSS.escape(section.slug)}`)
       if (el) {
         observer.observe(el)
       }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Fixing this error: https://developer.hashicorp.com/vault/docs/platform/k8s/helm/examples/standalone-tls

This is caused by a query selector which has a leading digit, which is not valid as a CSS selector. Using the built-in [`CSS.escape()`](https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape) method to properly escape the selector.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
