### PR TITLE
disable waypoint alert banner

### DIFF
--- a/src/data/waypoint.json
+++ b/src/data/waypoint.json
@@ -19,7 +19,7 @@
 			}
 		]
 	},
-	"alertBannerActive": true,
+	"alertBannerActive": false,
 	"alertBanner": {
 		"tag": "New",
 		"url": "https://hashi.co/waypoint-beta",


### PR DESCRIPTION
Turns off waypointproject.io alert banner. Confirmed with PMM that they have enough sign-ups for the private beta program.