### PR TITLE
fix: use host in get-deployed-url

### DIFF
--- a/src/components/head-metadata/index.tsx
+++ b/src/components/head-metadata/index.tsx
@@ -38,7 +38,9 @@ export default function HeadMetadata(props: HeadMetadataProps) {
 		productName ?? 'HashiCorp'
 	)
 
-	const ogImageUrl = `${getDeployedUrl()}/og-image/${productSlug ?? 'base'}.jpg`
+	const ogImageUrl = `${getDeployedUrl(props.host)}/og-image/${
+		productSlug ?? 'base'
+	}.jpg`
 
 	return (
 		// TODO: OpenGraph image to be passed as the image prop here

--- a/src/components/head-metadata/types.ts
+++ b/src/components/head-metadata/types.ts
@@ -8,4 +8,9 @@ export interface HeadMetadataProps {
 	 * Description of the current page, render in the meta description tag. Defaults to the value in config
 	 */
 	description?: string
+
+	/**
+	 * Optional host value, such as 'localhost:3000', used during development
+	 */
+	host?: string
 }

--- a/src/lib/get-deployed-url.ts
+++ b/src/lib/get-deployed-url.ts
@@ -4,14 +4,14 @@
  *
  * Returns an empty string in development.
  */
-export default function getDeployedUrl() {
+export default function getDeployedUrl(host?: string) {
 	// preview deployments should derive the url from Vercel's env var
 	if (process.env.HASHI_ENV === 'preview') {
 		return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
 	}
 
 	if (process.env.HASHI_ENV === 'development') {
-		return ''
+		return host ? `http://${host}` : ''
 	}
 
 	// use our canonical URL for production

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,7 +35,7 @@ if (typeof window !== 'undefined' && process.env.AXE_ENABLED) {
 	axe(React, ReactDOM, 1000)
 }
 
-export default function App({ Component, pageProps, layoutProps }) {
+export default function App({ Component, pageProps, layoutProps, host }) {
 	useAnchorLinkAnalytics()
 	useEffect(() => makeDevAnalyticsLogger(), [])
 
@@ -59,7 +59,7 @@ export default function App({ Component, pageProps, layoutProps }) {
 						<AllProductDataProvider>
 							<CurrentProductProvider currentProduct={currentProduct}>
 								<CodeTabsProvider>
-									<HeadMetadata {...pageProps.metadata} />
+									<HeadMetadata {...pageProps.metadata} host={host} />
 									<LazyMotion
 										features={() =>
 											import('lib/framer-motion-features').then(
@@ -102,8 +102,14 @@ App.getInitialProps = async ({ Component, ctx }) => {
 		pageProps = await Component.getInitialProps(ctx)
 	}
 
+	let host
+	if (ctx.req) {
+		host = ctx.req.headers.host
+	}
+
 	return {
 		pageProps,
 		layoutProps,
+		host,
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-zspatch-local-dev-img-url-issue-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202555939973908/f) 🎟️

## 🗒️ What

Fixes an issue related to `@hashicorp/react-head`, where aggressive validation of image URLs passed to the component would cause errors in local development.

## 🛠️ How

Gets the `host` value in `_app.tsx` `getInitialProps`.

An alternate solution might be to hard-code the `PORT` and read that from `process.env`, as suggested [here](https://github.com/hashicorp/dev-portal/pull/664#discussion_r911359822). However, that would mean we'd sacrifice NextJS's dynamic port selection (which automatically chooses a port other than `3000` if that port is already in use).
