### PR TITLE
fix: support all products on 404 page

### DIFF
--- a/src/views/error-views/dev-dot-404/index.tsx
+++ b/src/views/error-views/dev-dot-404/index.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react'
-import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
-import { IconVaultColor16 } from '@hashicorp/flight-icons/svg-react/vault-color-16'
+import { ProductSlug } from 'types/products'
 import { IconHome16 } from '@hashicorp/flight-icons/svg-react/home-16'
 import { useErrorPageAnalytics } from '@hashicorp/react-error-view'
+import ProductIcon from 'components/product-icon'
+import { productSlugs, productSlugsToNames } from 'lib/products'
 import {
 	ErrorViewContainer,
 	ErrorViewH1,
@@ -11,6 +12,25 @@ import {
 
 import s from './dev-dot-404.module.css'
 import IconCardLinkGridList from 'components/icon-card-link-grid-list'
+import getIsBetaProduct from 'lib/get-is-beta-product'
+
+/**
+ * Build an array of link cards for each beta product
+ */
+const PRODUCT_LINK_CARDS = productSlugs
+	// We only want to show beta product links on the 404 view
+	.filter(getIsBetaProduct)
+	// Even once Sentinel is in beta, we won't show it, since it has no icon
+	.filter((productSlug: ProductSlug) => productSlug !== 'sentinel')
+	// Map remaining products
+	.map((productSlug: ProductSlug) => {
+		return {
+			url: `/${productSlug}/`,
+			text: productSlugsToNames[productSlug],
+			productSlug: productSlug,
+			icon: <ProductIcon productSlug={productSlug} />,
+		}
+	})
 
 /**
  * Generic 404 error view content for use in dev-dot.
@@ -30,18 +50,7 @@ export function DevDot404(): ReactElement {
 			<div className={s.cards}>
 				<IconCardLinkGridList
 					cards={[
-						{
-							url: '/vault',
-							text: 'Vault',
-							productSlug: 'vault',
-							icon: <IconVaultColor16 />,
-						},
-						{
-							url: '/waypoint',
-							text: 'Waypoint',
-							productSlug: 'waypoint',
-							icon: <IconWaypointColor16 />,
-						},
+						...PRODUCT_LINK_CARDS,
 						{
 							url: '/',
 							text: 'HashiCorp Developer',


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes up the 404 page to support any and all products that are marked as in `"beta"`.

## 🤷 Why

To ensure the 404 page will automatically work as expected as new products are added to the beta.

## 🛠️ How

- Imports `ProductIcon` to allow any product icon to be rendered
- Uses `getIsBetaProduct` to filter products list
- Maps all products to necessary data for the `IconCardLinkGridList` "ViewModel"-ish component

## 🧪 Testing

- Visit [the preview of a 404 page][preview], and ensure it looks as expected
- Review the analogous work in #686, which makes identical changes but also flags Nomad as `"beta"`, and confirm the [404 preview from that PR][nomad-beta-preview] looks as expected (with Nomad added)

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1202587270508503/f
[preview]: https://dev-portal-git-zssupport-all-products-in-404-hashicorp.vercel.app/foo-bar-this-is-a-404
[nomad-beta-preview]: https://dev-portal-git-zsspike-nomad-rollout-hashicorp.vercel.app/this-is-a-404