### PR TITLE
feat: expand PRODUCT_SLUGS_TO_LOGOS

### DIFF
--- a/src/components/navigation-header/components/product-page-content/index.tsx
+++ b/src/components/navigation-header/components/product-page-content/index.tsx
@@ -3,7 +3,13 @@ import Link from 'next/link'
 
 // HashiCorp Imports
 import InlineSvg from '@hashicorp/react-inline-svg'
+import BoundaryLogo from '@hashicorp/mktg-logos/product/boundary/primary-padding/colorwhite.svg?include'
+import ConsulLogo from '@hashicorp/mktg-logos/product/consul/primary-padding/colorwhite.svg?include'
 import HashiCorpLogo from '@hashicorp/mktg-logos/corporate/hashicorp/logomark/white.svg?include'
+import NomadLogo from '@hashicorp/mktg-logos/product/nomad/primary-padding/colorwhite.svg?include'
+import PackerLogo from '@hashicorp/mktg-logos/product/packer/primary-padding/colorwhite.svg?include'
+import TerraformLogo from '@hashicorp/mktg-logos/product/terraform/primary-padding/colorwhite.svg?include'
+import VagrantLogo from '@hashicorp/mktg-logos/product/vagrant/primary-padding/colorwhite.svg?include'
 import VaultLogo from '@hashicorp/mktg-logos/product/vault/primary-padding/colorwhite.svg?include'
 import WaypointLogo from '@hashicorp/mktg-logos/product/waypoint/primary-padding/colorwhite.svg?include'
 
@@ -39,7 +45,15 @@ const PRODUCT_PAGE_NAV_ITEMS = [
  * A mapping of Product slugs to their imported SVG colorwhite logos. Used for
  * the headers under `/{productSlug}` pages.
  */
-const PRODUCT_SLUGS_TO_LOGOS = {
+const PRODUCT_SLUGS_TO_LOGOS: Record<ProductSlug, string> = {
+	boundary: BoundaryLogo,
+	consul: ConsulLogo,
+	nomad: NomadLogo,
+	hcp: HashiCorpLogo,
+	packer: PackerLogo,
+	sentinel: HashiCorpLogo,
+	terraform: TerraformLogo,
+	vagrant: VagrantLogo,
 	vault: VaultLogo,
 	waypoint: WaypointLogo,
 }

--- a/src/components/navigation-header/components/product-page-content/index.tsx
+++ b/src/components/navigation-header/components/product-page-content/index.tsx
@@ -44,14 +44,18 @@ const PRODUCT_PAGE_NAV_ITEMS = [
 /**
  * A mapping of Product slugs to their imported SVG colorwhite logos. Used for
  * the headers under `/{productSlug}` pages.
+ *
+ * Note: Sentinel and HCP are excluded here,
+ * as we do not yet have a confirmed design treatment.
  */
-const PRODUCT_SLUGS_TO_LOGOS: Record<ProductSlug, string> = {
+const PRODUCT_SLUGS_TO_LOGOS: Record<
+	Exclude<ProductSlug, 'sentinel' | 'hcp'>,
+	string
+> = {
 	boundary: BoundaryLogo,
 	consul: ConsulLogo,
 	nomad: NomadLogo,
-	hcp: HashiCorpLogo,
 	packer: PackerLogo,
-	sentinel: HashiCorpLogo,
 	terraform: TerraformLogo,
 	vagrant: VagrantLogo,
 	vault: VaultLogo,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds in remaining product logos to the `product-page-content` portion of `navigation-header`.

## 🤷 Why

To ease onboarding of new products, one less place to edit as we add new products to the beta.

## 🧪 Testing

Visit each of the stubbed product routes, and ensure the logo in the top navigation looks as expected:

- [/boundary][/boundary]
- [/consul][/consul]
- [/nomad][/nomad]
- [/packer][/packer]
- [/terraform][/terraform]
- [/vagrant][/vagrant]
- [/vault][/vault]
- [/waypoint][/waypoint]

## 💭 Anything else?

Note that `sentinel` and `hcp` are excluded for now, as we do not yet have a clear design spec for the top navigation bar for those "products".

[task]: https://app.asana.com/0/1202097197789424/1202591099445242/f
[preview]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app
[/boundary]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/boundary
[/consul]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/consul
[/nomad]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/nomad
[/packer]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/packer
[/terraform]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/terraform
[/vagrant]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/vagrant
[/vault]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/vault
[/waypoint]: https://dev-portal-git-zsadd-nav-logos-hashicorp.vercel.app/waypoint