### PR TITLE
Rendering generic nav header on /_error

### DIFF
--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { IconMenu24 } from '@hashicorp/flight-icons/svg-react/menu-24'
 import { IconX24 } from '@hashicorp/flight-icons/svg-react/x-24'
 import { useCurrentProduct, useMobileMenu } from 'contexts'
@@ -36,10 +37,14 @@ const MobileMenuButton = () => {
  * `/{productSlug}.`
  */
 const NavigationHeader = () => {
+	const router = useRouter()
 	const currentProduct = useCurrentProduct()
-	const LeftSideHeaderContent = currentProduct
-		? ProductPageHeaderContent
-		: HomePageHeaderContent
+
+	const shouldRenderGenericHeaderContent =
+		currentProduct === undefined || router.route === '/_error'
+	const LeftSideHeaderContent = shouldRenderGenericHeaderContent
+		? HomePageHeaderContent
+		: ProductPageHeaderContent
 
 	return (
 		<header className={s.root}>

--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -41,7 +41,7 @@ const NavigationHeader = () => {
 	const currentProduct = useCurrentProduct()
 
 	const shouldRenderGenericHeaderContent =
-		currentProduct === undefined || router.route === '/_error'
+		!currentProduct || router.route === '/_error'
 	const LeftSideHeaderContent = shouldRenderGenericHeaderContent
 		? HomePageHeaderContent
 		: ProductPageHeaderContent


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates the main navigation header to render the non-product header on `/_error` routes (such as 404)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- When we updated `PRODUCT_SLUGS_TO_LOGOS` in #699, it made non-beta product logos start showing up on 404 routes nested under non-beta product slugs (example: https://developer.hashicorp.com/boundary/not-a-page)

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Just updated the logic of when the non-product header is rendered, to include a check for `router.route === '/_error'`

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to a page under a non-beta product, such as /boundary/not-a-page
- [ ] You should see the same navigation header that you see on the home page

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

This might just be a bandaid until we've released all products in beta / GA. I figured it's better overall to not show non-beta product slugs on 404 pages until we've confirmed a long term plan.
