### PR TITLE
Reduce ProductLandingView boilerplate

### DIFF
--- a/src/pages/boundary/index.tsx
+++ b/src/pages/boundary/index.tsx
@@ -1,16 +1,9 @@
 import boundaryData from 'data/boundary.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/boundary-landing.json'
-	const product = boundaryData as ProductData
+const getStaticProps = generateGetStaticProps(boundaryData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/consul/index.tsx
+++ b/src/pages/consul/index.tsx
@@ -1,16 +1,9 @@
 import consulData from 'data/consul.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/consul-landing.json'
-	const product = consulData as ProductData
+const getStaticProps = generateGetStaticProps(consulData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/hcp/index.tsx
+++ b/src/pages/hcp/index.tsx
@@ -1,16 +1,9 @@
 import hcpData from 'data/hcp.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/hcp-landing.json'
-	const product = hcpData as ProductData
+const getStaticProps = generateGetStaticProps(hcpData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/nomad/index.tsx
+++ b/src/pages/nomad/index.tsx
@@ -1,16 +1,9 @@
 import nomadData from 'data/nomad.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/nomad-landing.json'
-	const product = nomadData as ProductData
+const getStaticProps = generateGetStaticProps(nomadData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/packer/index.tsx
+++ b/src/pages/packer/index.tsx
@@ -1,16 +1,9 @@
 import packerData from 'data/packer.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/packer-landing.json'
-	const product = packerData as ProductData
+const getStaticProps = generateGetStaticProps(packerData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/sentinel/index.tsx
+++ b/src/pages/sentinel/index.tsx
@@ -1,16 +1,9 @@
 import sentinelData from 'data/sentinel.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/sentinel-landing.json'
-	const product = sentinelData as ProductData
+const getStaticProps = generateGetStaticProps(sentinelData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/terraform/index.tsx
+++ b/src/pages/terraform/index.tsx
@@ -1,16 +1,9 @@
 import terraformData from 'data/terraform.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/terraform-landing.json'
-	const product = terraformData as ProductData
+const getStaticProps = generateGetStaticProps(terraformData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/vagrant/index.tsx
+++ b/src/pages/vagrant/index.tsx
@@ -1,16 +1,9 @@
 import vagrantData from 'data/vagrant.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/vagrant-landing.json'
-	const product = vagrantData as ProductData
+const getStaticProps = generateGetStaticProps(vagrantData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		revalidate: 10,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/vault/index.tsx
+++ b/src/pages/vault/index.tsx
@@ -1,18 +1,9 @@
 import vaultData from 'data/vault.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/vault-landing.json'
-	const product = vaultData as ProductData
+const getStaticProps = generateGetStaticProps(vaultData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		// as this reads from the file system, we don't want to revalidate at all as the files
-		// will not be available at runtime
-		revalidate: false,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/pages/waypoint/index.tsx
+++ b/src/pages/waypoint/index.tsx
@@ -1,18 +1,9 @@
 import waypointData from 'data/waypoint.json'
-import ProductLandingView from 'views/product-landing'
-import { generateStaticProps } from 'views/product-landing/server'
 import { ProductData } from 'types/products'
+import ProductLandingView from 'views/product-landing'
+import { generateGetStaticProps } from 'views/product-landing/server'
 
-export async function getStaticProps() {
-	const contentJsonFile = 'src/data/waypoint-landing.json'
-	const product = waypointData as ProductData
+const getStaticProps = generateGetStaticProps(waypointData as ProductData)
 
-	return {
-		props: await generateStaticProps({ product, contentJsonFile }),
-		// as this reads from the file system, we don't want to revalidate at all as the files
-		// will not be available at runtime
-		revalidate: false,
-	}
-}
-
+export { getStaticProps }
 export default ProductLandingView

--- a/src/views/product-landing/index.tsx
+++ b/src/views/product-landing/index.tsx
@@ -1,12 +1,12 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import IconCardLinkGridList from 'components/icon-card-link-grid-list'
 import { ProductLandingViewProps } from './types'
 import { getIconCards } from './helpers'
-import ProductLandingBlocks from './components/product-landing-blocks'
+import GetStartedCard from './components/get-started-card'
 import HeroHeadingVisual from './components/hero-heading-visual'
 import OverviewCta from './components/overview-cta'
-import GetStartedCard from './components/get-started-card'
+import ProductLandingBlocks from './components/product-landing-blocks'
 import s from './product-landing.module.css'
 
 function ProductLandingView({

--- a/src/views/product-landing/index.tsx
+++ b/src/views/product-landing/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 import React, { ReactElement } from 'react'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import IconCardLinkGridList from 'components/icon-card-link-grid-list'

--- a/src/views/product-landing/server.ts
+++ b/src/views/product-landing/server.ts
@@ -1,86 +1,90 @@
+import { GetStaticPropsResult } from 'next'
 import fs from 'fs'
 import path from 'path'
 import { ProductData } from 'types/products'
+import { validateAgainstSchema } from 'lib/validate-against-schema'
+import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { SidebarProps } from 'components/sidebar'
-// import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
 import {
 	generateProductLandingSidebarNavData,
 	generateTopLevelSidebarNavData,
 } from 'components/sidebar/helpers'
-import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
 import { ProductLandingContent, ProductLandingContentSchema } from './schema'
-import { validateAgainstSchema } from 'lib/validate-against-schema'
 import { transformRawContentToProp, extractHeadings } from './helpers'
 import { ProductLandingViewProps } from './types'
 
-async function generateStaticProps({
-	product,
-	contentJsonFile,
-}: {
-	product: ProductData
-	contentJsonFile: string
-}): Promise<
-	ProductLandingViewProps & {
-		layoutProps: {
-			headings: TableOfContentsHeading[]
-			breadcrumbLinks: BreadcrumbLink[]
-			sidebarNavDataLevels: SidebarProps[]
+const generateGetStaticProps = (product: ProductData) => {
+	return async (): Promise<
+		GetStaticPropsResult<
+			ProductLandingViewProps & {
+				layoutProps: {
+					headings: TableOfContentsHeading[]
+					breadcrumbLinks: BreadcrumbLink[]
+					sidebarNavDataLevels: SidebarProps[]
+				}
+				product: ProductData
+			}
+		>
+	> => {
+		/**
+		 * Note: could consider other content sources. For now, JSON.
+		 * Asana task: https://app.asana.com/0/1100423001970639/1201631159784193/f
+		 */
+		const jsonFilePath = path.join(
+			process.cwd(),
+			`src/data/${product.slug}-landing.json`
+		)
+		const CONTENT = JSON.parse(fs.readFileSync(jsonFilePath, 'utf8'))
+
+		/**
+		 * Validate that CONTENT matches our schema. This includes a type guard,
+		 * which asserts that CONTENT is ProductLandingContent.
+		 */
+		validateAgainstSchema<ProductLandingContent>(
+			CONTENT,
+			ProductLandingContentSchema,
+			jsonFilePath
+		)
+
+		/**
+		 * Transform content to props.
+		 * This includes filling in inline tutorials and collection content.
+		 */
+		const content = await transformRawContentToProp(CONTENT, product)
+
+		/**
+		 * Gather up our static props package & return it
+		 */
+		const props = {
+			content,
+			product,
+			layoutProps: {
+				headings: extractHeadings(content),
+				breadcrumbLinks: [
+					{ title: 'Developer', url: '/' },
+					{ title: product.name, url: `/${product.slug}`, isCurrentPage: true },
+				],
+				/**
+				 * @TODO remove casting to `any` (used $TSFixMe here for visibility).
+				 * This requires refactoring both `generateTopLevelSidebarNavData` and
+				 * `generateProductLandingSidebarNavData` to set up `menuItems` with the
+				 * correct types.
+				 * This is outside the scope of the product landing page content build,
+				 * so deferring to a sidebar-focused follow-up PR.
+				 */
+				sidebarNavDataLevels: [
+					generateTopLevelSidebarNavData(product.name),
+					generateProductLandingSidebarNavData(product),
+				] as $TSFixMe,
+			},
 		}
-		product: ProductData
-	}
-> {
-	/**
-	 * Note: could consider other content sources. For now, JSON.
-	 * Asana task: https://app.asana.com/0/1100423001970639/1201631159784193/f
-	 */
-	const jsonFilePath = path.join(process.cwd(), contentJsonFile)
-	const CONTENT = JSON.parse(fs.readFileSync(jsonFilePath, 'utf8'))
 
-	/**
-	 * Validate that CONTENT matches our schema. This includes a type guard,
-	 * which asserts that CONTENT is ProductLandingContent.
-	 */
-	validateAgainstSchema<ProductLandingContent>(
-		CONTENT,
-		ProductLandingContentSchema,
-		jsonFilePath
-	)
-
-	/**
-	 * Transform content to props.
-	 * This includes filling in inline tutorials and collection content.
-	 */
-	const content = await transformRawContentToProp(CONTENT, product)
-
-	/**
-	 * Gather up our static props package & return it
-	 */
-	return {
-		content,
-		product,
-		layoutProps: {
-			headings: extractHeadings(content),
-			breadcrumbLinks: [
-				{ title: 'Developer', url: '/' },
-				{ title: product.name, url: `/${product.slug}`, isCurrentPage: true },
-			],
-			/**
-			 * @TODO remove casting to `any` (used $TSFixMe here for visibility).
-			 * This requires refactoring both `generateTopLevelSidebarNavData` and
-			 * `generateProductLandingSidebarNavData` to set up `menuItems` with the
-			 * correct types.
-			 * This is outside the scope of the product landing page content build,
-			 * so deferring to a sidebar-focused follow-up PR.
-			 */
-			sidebarNavDataLevels: [
-				generateTopLevelSidebarNavData(product.name),
-				generateProductLandingSidebarNavData(product),
-			] as $TSFixMe,
-		},
+		return {
+			props,
+			revalidate: false,
+		}
 	}
 }
 
-export { generateStaticProps }
-// eslint-disable-next-line import/no-anonymous-default-export
-export default { generateStaticProps }
+export { generateGetStaticProps }

--- a/src/views/product-landing/server.ts
+++ b/src/views/product-landing/server.ts
@@ -54,7 +54,7 @@ const generateGetStaticProps = (product: ProductData) => {
 		const content = await transformRawContentToProp(CONTENT, product)
 
 		/**
-		 * Gather up our static props package & return it
+		 * Gather up our static props
 		 */
 		const props = {
 			content,


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- This is the first PR for breaking up #701 into smaller PRs.
- Adds a `generateGetStaticProps` to `ProductLandingView`'s server
- Updates the generated `getStaticProps` to generate the page content file path from the given `product.slug`
- Updates each page component that has `export default ProductLandingView` to use the new `generateGetStaticProps`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Overall, this reduces the boilerplate needed in each page component that renders `ProductLandingView`
- The generated `getStaticProps` was updated to generate the page content file path from the given `product.slug` to:
  - simplify the API of `generateGetStaticProps`
  - increase maintainability by having only one place to update the file path structure (rather than 1 for each product)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

The following pages should have no change in content or functionality:

- [ ] [/boundary](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/boundary)
- [ ] [/consul](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/consul)
- [ ] [/hcp](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/hcp)
- [ ] [/nomad](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/nomad)
- [ ] [/packer](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/packer)
- [ ] [/sentinel](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/sentinel)
- [ ] [/terraform](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/terraform)
- [ ] [/vagrant](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/vagrant)
- [ ] [/vault](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/vault)
- [ ] [/waypoint](https://dev-portal-git-ambrefactor-product-landing-view-hashicorp.vercel.app/waypoint)
