### PR TITLE
fix: move content_preview_branch config to function

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -14,7 +14,6 @@
 		"canonical_base_url": "https://developer.hashicorp.com",
 		"max_static_paths": 10,
 		"revalidate": 360,
-		"content_preview_branch": "dev-portal",
 		"beta_product_slugs": ["waypoint", "vault"],
 		"datadog_config": {
 			"scriptUrl": "https://www.datadoghq-browser-agent.com/datadog-rum-v4.js",

--- a/src/layouts/sidebar-sidecar/server.ts
+++ b/src/layouts/sidebar-sidecar/server.ts
@@ -21,6 +21,27 @@ import {
 } from 'components/sidebar/helpers'
 
 /**
+ * Given a productSlugForLoader (which generally corresponds to a repo name),
+ * Return the ref to use for remote content when the product is marked "beta".
+ *
+ * Note: for products where we intend to use the latest ref according
+ * to the marketing content API, we return undefined.
+ *
+ * TODO: this is not intended as a permanent solution.
+ * At present, it seems likely we'll transition away from using "dev-portal"
+ * branches, and instead focus on backwards-compatible content changes
+ * until each product is generally available on developer.hashicorp.com.
+ *
+ * Once we've moved away from "dev-portal" branches, this function
+ * will no longer be necessary, and we will no longer pass the
+ * "latestVersionRef" to the remote content loader config.
+ */
+function getBetaLatestVersionRef(slug: string): string | undefined {
+	const hasDevPortalBranch = slug == 'vault' || slug == 'waypoint'
+	return hasDevPortalBranch ? 'dev-portal' : undefined
+}
+
+/**
  * @TODO update the basePaths inside of `src/data/${productSLug}.json` files to
  * be arrays of objects that look like:
  *
@@ -97,8 +118,13 @@ export function getStaticGenerationFunctions<
 		product: productSlugForLoader,
 		basePath: basePathForLoader,
 		enabledVersionedDocs: true,
+		/**
+		 * Note: not all products in "beta" are expected to have a specific
+		 * "content_preview_branch", so even for products marked "beta",
+		 * "latestVersionRef" may end up being undefined.
+		 */
 		latestVersionRef: isBetaProduct
-			? __config.dev_dot.content_preview_branch
+			? getBetaLatestVersionRef(productSlugForLoader)
 			: undefined,
 	}
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Moves `content_preview_branch` out of config, and into a function in the one area where `content_preview_branch` config was previously used. 

## 🤷 Why

We intend to onboard further products to "beta" mode, but we do not intend to add `dev-portal` branches for these products.

## 🧪 Testing

- [ ] Content on [/vault][/vault] and [/waypoint][/waypoint] routes should still look as expected
    - [ ] Should render correctly
    - [ ] Should be coming from the `dev-portal` branch in the content source repos

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1202594381568855/f
[preview]: https://dev-portal-git-zscontent-branch-config-hashicorp.vercel.app
[/vault]: https://dev-portal-git-zscontent-branch-config-hashicorp.vercel.app/vault
[/waypoint]: https://dev-portal-git-zscontent-branch-config-hashicorp.vercel.app/waypoint