### PR TITLE
feat: all-product opt-in-out config

### DIFF
--- a/src/components/opt-in-out/helpers/get-io-redirect-path.ts
+++ b/src/components/opt-in-out/helpers/get-io-redirect-path.ts
@@ -2,3 +2,16 @@ export function getIoRedirectPath(path: string) {
 	// given /waypoint/docs/blah, return docs/blah
 	return path.split('/').slice(2).join('/')
 }
+
+export function generateGetIoRedirectPath(baseUrl) {
+	return function getRedirectPath(path) {
+		const url = new URL(getIoRedirectPath(path), baseUrl)
+
+		url.searchParams.set('betaOptOut', 'true')
+
+		// ensure we don't create a looping scenario if someone opts out immediately after opting-in
+		url.searchParams.delete('optInFrom')
+
+		return url.toString()
+	}
+}

--- a/src/components/opt-in-out/helpers/platform-options.ts
+++ b/src/components/opt-in-out/helpers/platform-options.ts
@@ -1,6 +1,41 @@
-import { PlatformOptionRedirectData } from '../types'
+import { PlatformOptionRedirectData, RedirectData } from '../types'
 import { getLearnRedirectPath } from './get-learn-redirect-path'
-import { getIoRedirectPath } from './get-io-redirect-path'
+import { generateGetIoRedirectPath } from './get-io-redirect-path'
+import { ProductSlug } from 'types/products'
+
+/**
+ * Map of productSlug to the product's dot-io domain.
+ *
+ * Note: somewhat duplicative of "proxyConfig" in "build-libs",
+ * but... HCP and Sentinel and Terraform are not yet served
+ * from here in dev-portal, so don't have proxy settings.
+ */
+const PRODUCT_IO_DOMAINS: Record<ProductSlug, string> = {
+	boundary: 'https://www.boundaryproject.io',
+	consul: 'https://www.consul.io',
+	hcp: 'https://cloud.hashicorp.com',
+	nomad: 'https://www.nomadproject.io',
+	packer: 'https://www.packer.io',
+	sentinel: 'https://docs.hashicorp.com',
+	terraform: 'https://www.terraform.io',
+	vault: 'https://www.vaultproject.io',
+	vagrant: 'https://www.vagrantup.com',
+	waypoint: 'https://www.waypointproject.io',
+}
+
+/**
+ * Given a productSlug,
+ * Return RedirectData for use with opt-in-out redirection work.
+ */
+function getDotIoRedirectData(productSlug: ProductSlug): RedirectData {
+	const domain = PRODUCT_IO_DOMAINS[productSlug]
+	return {
+		base_url: domain,
+		getRedirectPath: generateGetIoRedirectPath(domain),
+		cookieKey: `${productSlug}-io-beta-opt-in`,
+		cookieAnalyticsKey: `${productSlug}-io-beta-opt-in-tracked`,
+	}
+}
 
 export const PLATFORM_OPTIONS: PlatformOptionRedirectData = {
 	learn: {
@@ -9,34 +44,14 @@ export const PLATFORM_OPTIONS: PlatformOptionRedirectData = {
 		cookieKey: 'learn-beta-opt-in',
 		cookieAnalyticsKey: 'learn-beta-opt-in-tracked',
 	},
-	'waypoint-io': {
-		base_url: 'https://www.waypointproject.io/',
-		getRedirectPath(path) {
-			const url = new URL(getIoRedirectPath(path), this.base_url)
-
-			url.searchParams.set('betaOptOut', 'true')
-
-			// ensure we don't create a looping scenario if someone opts out immediately after opting-in
-			url.searchParams.delete('optInFrom')
-
-			return url.toString()
-		},
-		cookieKey: 'waypoint-io-beta-opt-in',
-		cookieAnalyticsKey: 'waypoint-io-beta-opt-in-tracked',
-	},
-	'vault-io': {
-		base_url: 'https://www.vaultproject.io/',
-		getRedirectPath(path) {
-			const url = new URL(getIoRedirectPath(path), this.base_url)
-
-			url.searchParams.set('betaOptOut', 'true')
-
-			// ensure we don't create a looping scenario if someone opts out immediately after opting-in
-			url.searchParams.delete('optInFrom')
-
-			return url.toString()
-		},
-		cookieKey: 'vault-io-beta-opt-in',
-		cookieAnalyticsKey: 'vault-io-beta-opt-in-tracked',
-	},
+	'boundary-io': getDotIoRedirectData('boundary'),
+	'consul-io': getDotIoRedirectData('consul'),
+	'hcp-io': getDotIoRedirectData('hcp'),
+	'nomad-io': getDotIoRedirectData('nomad'),
+	'packer-io': getDotIoRedirectData('packer'),
+	'sentinel-io': getDotIoRedirectData('sentinel'),
+	'terraform-io': getDotIoRedirectData('terraform'),
+	'vault-io': getDotIoRedirectData('vault'),
+	'vagrant-io': getDotIoRedirectData('vagrant'),
+	'waypoint-io': getDotIoRedirectData('waypoint'),
 }

--- a/src/components/opt-in-out/types.ts
+++ b/src/components/opt-in-out/types.ts
@@ -1,5 +1,13 @@
 export enum PlatformOptionTitles {
+	'boundary-io' = 'Boundary',
+	'consul-io' = 'Consul',
+	'hcp-io' = 'HashiCorp Cloud Platform',
+	'nomad-io' = 'Nomad',
+	'packer-io' = 'Packer',
+	'sentinel-io' = 'Sentinel',
+	'terraform-io' = 'Terraform',
 	'vault-io' = 'Vault',
+	'vagrant-io' = 'Vagrant',
 	'waypoint-io' = 'Waypoint',
 	learn = 'Learn',
 }
@@ -21,12 +29,14 @@ export interface OptInOutProps {
 	redirectPath?: string
 }
 
+export interface RedirectData {
+	base_url: string
+	getRedirectPath: (currentPath?: string) => string
+	cookieKey: string
+	cookieAnalyticsKey: string
+}
+
 export type PlatformOptionRedirectData = Record<
 	OptInPlatformOption,
-	{
-		base_url: string
-		getRedirectPath: (currentPath?: string) => string
-		cookieKey: string
-		cookieAnalyticsKey: string
-	}
+	RedirectData
 >

--- a/src/layouts/docs-view-layout/index.tsx
+++ b/src/layouts/docs-view-layout/index.tsx
@@ -15,7 +15,6 @@ const DocsViewLayout = (props: SidebarSidecarLayoutProps) => {
 	const isBetaProduct = useIsBetaProduct(currentProduct.slug)
 
 	const optInOutSlot = isBetaProduct ? (
-		// @ts-expect-error - the isBetaProduct check guarantees the platform property here will be valid
 		<OptInOut platform={`${currentProduct.slug}-io`} />
 	) : null
 


### PR DESCRIPTION
## 🔗 Relevant links


- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Builds out opt-in opt-out config for all remaining products.

## 🤷 Why

To reduce boilerplate needed when onboarding a new product to HashiCorp Developer.

## 🛠️ How

- Adds new function `generateGetIoRedirectPath`, which returns a `getRedirectPath` function for a given dot-io baseUrl.
- Uses `generateGetIoRedirectPath` to set up `PLATFORM_OPTIONS` for all remaining products

## 🧪 Testing

- [ ] Test the opt-in opt-out flow with an existing product already in Beta, such as [/vault][/vault] or [/waypoint][/waypoint]
    - Not sure this is really possible to fully test without this work being in production? 🤔 Open to ideas on how to best test this work.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1202606978405428/f
[preview]: https://dev-portal-git-zsopt-in-out-config-hashicorp.vercel.app/
[/vault]: https://dev-portal-git-zsopt-in-out-config-hashicorp.vercel.app/vault
[/waypoint]: https://dev-portal-git-zsopt-in-out-config-hashicorp.vercel.app/waypoint