### PR TITLE
feat(test): test case for remove-non-beta-product-pages

### DIFF
--- a/scripts/remove-non-beta-product-pages.ts
+++ b/scripts/remove-non-beta-product-pages.ts
@@ -38,9 +38,11 @@ async function main() {
 			dir.name !== '[productSlug]'
 		) {
 			console.log(`🧹 removing pages at /${dir.name}`)
-			await fs.promises.rm(path.join(pagesDir, dir.name), {
-				recursive: true,
-			})
+			if (!process.env.DRY_RUN) {
+				await fs.promises.rm(path.join(pagesDir, dir.name), {
+					recursive: true,
+				})
+			}
 		}
 	}
 }

--- a/src/__tests__/remove-non-beta-product-pages.test.ts
+++ b/src/__tests__/remove-non-beta-product-pages.test.ts
@@ -17,6 +17,7 @@ describe('remove-non-beta-product-pages', () => {
 			)
 		)
 
+		// Ignore output that contains a machine-specific path
 		stdout = stdout.split('\n').slice(1).join('\n')
 
 		expect(stdout).toMatchInlineSnapshot(`

--- a/src/__tests__/remove-non-beta-product-pages.test.ts
+++ b/src/__tests__/remove-non-beta-product-pages.test.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from 'child_process'
+
+describe('remove-non-beta-product-pages', () => {
+	test('only removes expected page directories', () => {
+		let stdout = String(
+			execFileSync(
+				'npx',
+				['hc-tools', './scripts/remove-non-beta-product-pages.ts'],
+				{
+					env: {
+						...process.env,
+						HASHI_ENV: 'production',
+						CI: '1',
+						DRY_RUN: '1',
+					},
+				}
+			)
+		)
+
+		stdout = stdout.split('\n').slice(1).join('\n')
+
+		expect(stdout).toMatchInlineSnapshot(`
+		"🧹 removing pages at /boundary
+		🧹 removing pages at /consul
+		🧹 removing pages at /docs
+		🧹 removing pages at /hcp
+		🧹 removing pages at /nomad
+		🧹 removing pages at /packer
+		🧹 removing pages at /sentinel
+		🧹 removing pages at /terraform
+		🧹 removing pages at /vagrant
+		"
+	`)
+	})
+})


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Adds a short test case for `remove-non-beta-product-slugs` to ensure that any time the list of
removed directories changes we need to address it via a snapshot update, which should give us a signal as to whether or not the change is expected.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
We accidentally deleted the new dynamic tutorials routes, which didn't manifest until the production build.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
