### PR TITLE
Add useAuthentication hook

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -34,3 +34,10 @@ interface Window {
 	 */
 	DD_RUM: $TSFixMe
 }
+
+/**
+ * Custom utility that constructs a union of all possible property value types.
+ *
+ * ref: https://stackoverflow.com/a/49286056
+ */
+type ValueOf<T> = T[keyof T]

--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -1,0 +1,46 @@
+import { useSession, signIn, signOut } from 'next-auth/react'
+import { SessionData, UserData, ValidAuthProviderId } from 'types/auth'
+
+/**
+ * A minimal wrapper around next-auth/react's `signIn` function. Purpose is to
+ * handle invoking the wrapped function with a default value.
+ */
+const signInWrapper = (
+	provider: ValueOf<typeof ValidAuthProviderId> = ValidAuthProviderId.CloudIdp
+) => {
+	return signIn(provider)
+}
+
+/**
+ * Hook for consuming user, session, and authentication state. Sources all data
+ * from next-auth/react's `useSession` hook.
+ */
+const useAuthentication = () => {
+	// Pull data and status from next-auth's hook
+	const { data, status } = useSession()
+
+	// Deriving booleans about auth state
+	const isLoading = status === 'loading'
+	const isAuthenticated = status === 'authenticated'
+
+	// Separating user and session data
+	let session: SessionData, user: UserData
+	if (isAuthenticated) {
+		session = { ...data }
+		user = data.user
+		delete session.user
+	}
+
+	// Return everything packaged up in an object
+	return {
+		isAuthenticated,
+		isLoading,
+		session,
+		signIn: signInWrapper,
+		signOut,
+		status,
+		user,
+	}
+}
+
+export default useAuthentication

--- a/src/lib/auth/cloud-idp-provider.ts
+++ b/src/lib/auth/cloud-idp-provider.ts
@@ -1,10 +1,11 @@
 import { Provider } from 'next-auth/providers'
+import { ValidAuthProviderId } from 'types/auth'
 
 /**
  * A custom next-auth provider to authenticate via HashiCorp's Cloud IDP service
  */
 const CloudIdpProvider: Provider = {
-	id: 'cloud-idp',
+	id: ValidAuthProviderId.CloudIdp,
 	name: 'Cloud IDP',
 	type: 'oauth',
 	wellKnown:

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,15 +1,12 @@
-import { useSession, signIn, signOut } from 'next-auth/react'
-
-// 1. useAuthentication hook?
-// exposes pre-configured signIn method
+import useAuthentication from 'hooks/use-authentication'
 
 export default function AuthPage() {
-	const { data: session } = useSession()
-	if (session) {
+	const { isAuthenticated, signIn, signOut, user } = useAuthentication()
+	if (isAuthenticated) {
 		return (
 			<>
-				Signed in as {session.user.email} <br />
-				<img src={session.user.image} alt={`${session.user.name} picture`} />
+				Signed in as {user.email} <br />
+				<img src={user.image} alt={`${user.name} picture`} />
 				<button onClick={() => signOut()}>Sign out</button>
 			</>
 		)
@@ -17,7 +14,7 @@ export default function AuthPage() {
 	return (
 		<>
 			Not signed in <br />
-			<button onClick={() => signIn('cloud-idp')}>Sign in</button>
+			<button onClick={() => signIn()}>Sign in</button>
 		</>
 	)
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,25 @@
+import { Session } from 'next-auth'
+
+/**
+ * Object representing an authentication session.
+ */
+type SessionData = Omit<Session, 'user'> & {
+	id?: 'string'
+}
+
+/**
+ * Object representing an authenticated user.
+ */
+type UserData = Session['user'] & {
+	nickname?: string | null
+}
+
+/**
+ * Enumeration of supported auth provider IDs.
+ */
+const ValidAuthProviderId = {
+	CloudIdp: 'cloud-idp',
+} as const
+
+export type { SessionData, UserData }
+export { ValidAuthProviderId }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,9 +17,10 @@ type UserData = Session['user'] & {
 /**
  * Enumeration of supported auth provider IDs.
  */
-const ValidAuthProviderId = {
-	CloudIdp: 'cloud-idp',
-} as const
+enum ValidAuthProviderId {
+	CloudIdp = 'cloud-idp',
+	Test = 'test-123',
+}
 
 export type { SessionData, UserData }
 export { ValidAuthProviderId }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-auth-abstractions-hashicorp.vercel.app/auth) 🔎
- [Asana task](https://app.asana.com/0/1201147515801429/1202621516737909/f) 🎟️

## 🗒️ What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `ValueOf` global utility type (in `global.d.ts`)
- Adds high-level types for auth (in `src/types/auth.ts`)
  - `SessionData`: similar to next-auth's `Session` object, but we remove `user` from and add `id`
  - `UserData`: similar to next-auth's `Session['user']` object, but we add `nickname` to it
  - `ValidAuthProviderId`: an readonly object of valid auth provider IDs, useful in the `signInWrapper` signature
- Adds `useAuthentication` hook with a few derived values, re-organized data, and helpers
  - `isAuthenticated`: prevents needing to type out `status === 'authenticated'`
  - `isLoading`: prevents needing to type out `status === 'loading'`
  - `session`: same as next-auth's `useSession` `data` property, minus the `user` property
  - `signIn`: invokes `signInWrapper`, which uses Cloud IDP as the default provider
  - `signOut`: no wrapper needed, so this is just next-auth's `signOut`
  - `status`: the `status` property that comes from `useSession`
  - `user`: same as `next-auth`'s `useSession` `data.user` property, lifted up as a property so we don't have to type out `data.user` every time we want the user object
- Updates `CloudIdpProvider` to use the new `ValidAuthProviderId`, so there is one source of truth for that ID
- Updates `src/pages/auth.tsx` to use the new hook

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] There should be no functionality changes to the [/auth](https://dev-portal-git-ambadd-auth-abstractions-hashicorp.vercel.app/auth) page

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- Coming up next: [Create stubbed profile page](https://app.asana.com/0/1201147515801429/1202621516737909/f)
