### PR TITLE
[hotfix] Fixing IconCardLink urls on /docs

### DIFF
--- a/src/views/product-root-docs-path-landing/components/icon-card-link-grid/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/icon-card-link-grid/index.tsx
@@ -25,7 +25,7 @@ const ProductRootDocsPathLandingIconCardLinkGrid = () => {
 							icon={SUPPORTED_ICONS[iconName]}
 							productSlug={currentProduct.slug}
 							text={name}
-							url={path}
+							url={`/${currentProduct.slug}/${path}`}
 						/>
 					</li>
 				)


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Fixes the `IconCardLink` components in the hero of the `/docs` pages

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /waypoint/docs
- [ ] Make sure the `IconCardLink` components go to the right links
