### PR TITLE
Add signOutWrapper in useAuthentication

### DIFF
--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -41,6 +41,8 @@ interface UseAuthenticationOptions {
 /**
  * Hook for consuming user, session, and authentication state. Sources all data
  * from next-auth/react's `useSession` hook.
+ *
+ * https://next-auth.js.org/getting-started/client#usesession
  */
 const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 	// Get option properties from `options` parameter

--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -1,4 +1,4 @@
-import { useSession, signIn, signOut } from 'next-auth/react'
+import { useSession, signIn, signOut, SignOutParams } from 'next-auth/react'
 import { SessionData, UserData, ValidAuthProviderId } from 'types/auth'
 
 const DEFAULT_PROVIDER_ID = ValidAuthProviderId.CloudIdp
@@ -6,9 +6,22 @@ const DEFAULT_PROVIDER_ID = ValidAuthProviderId.CloudIdp
 /**
  * A minimal wrapper around next-auth/react's `signIn` function. Purpose is to
  * handle invoking the wrapped function with a default value.
+ *
+ * https://next-auth.js.org/getting-started/client#signin
  */
 const signInWrapper = (provider: ValidAuthProviderId = DEFAULT_PROVIDER_ID) => {
 	return signIn(provider)
+}
+
+/**
+ * A minimal wrapper around next-auth/react's `signOut` function. Purpose is to
+ * handle invoking the wrapped function with a default value.
+ *
+ * https://next-auth.js.org/getting-started/client#signout
+ */
+const signOutWrapper = (options: SignOutParams = {}) => {
+	const { callbackUrl = '/', redirect = true } = options
+	return signOut({ callbackUrl, redirect })
 }
 
 interface UseAuthenticationOptions {
@@ -58,7 +71,7 @@ const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 		isLoading,
 		session,
 		signIn: signInWrapper,
-		signOut,
+		signOut: signOutWrapper,
 		status,
 		user,
 	}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1201147515801429/1202651576734176/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `signOutWrapper`, similar to `signInWrapper`
- Sets default `callbackUrl` for `signOut` to be the home page

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- On SignOut, we currently get re-logged back in because the `/profile` page gets reloaded
- The `signOutWrapper` makes it possible for us to easily customize this experience (Not sure if `/` is the longterm place to redirect to, but it's a good temporary place)

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- The [`signOut` docs](https://next-auth.js.org/getting-started/client#specifying-a-callbackurl-1) were particularly helpful

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out and run the code locally
- [ ] Go to `/profile`
- [ ] If needed, sign in
- [ ] Click the Sign Out button
- [ ] You should be logged out and redirected to the home page
