### PR TITLE
Remove Tutorials links from Vault and Waypoint sidecar marketing cards

### DIFF
--- a/src/content/vault/install-landing.json
+++ b/src/content/vault/install-landing.json
@@ -41,10 +41,6 @@
 		"learnMoreLink": "https://www.vaultproject.io/",
 		"featuredDocsLinks": [
 			{
-				"href": "/vault/tutorials",
-				"text": "Tutorials"
-			},
-			{
 				"href": "/vault/docs/what-is-vault",
 				"text": "What is Vault?"
 			},

--- a/src/content/waypoint/install-landing.json
+++ b/src/content/waypoint/install-landing.json
@@ -41,10 +41,6 @@
 		"learnMoreLink": "https://www.waypointproject.io/",
 		"featuredDocsLinks": [
 			{
-				"href": "/waypoint/tutorials",
-				"text": "Tutorials"
-			},
-			{
 				"href": "/waypoint/docs/projects",
 				"text": "Projects"
 			},


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Removes Tutorials links from both Vault and Waypoint's /downloads sidecar marketing cards.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The Tutorials links were listed under "Featured docs", and the link is not a featured doc.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /vault/downloads
- [ ] There should **not** be a Tutorials link in the sidecar marketing card
- [ ] Go to /waypoint/downloads
- [ ] There should **not** be a Tutorials link in the sidecar marketing card
