### PR TITLE
Refactor ButtonProps and ButtonLinkProps

### DIFF
--- a/src/components/button-link/index.tsx
+++ b/src/components/button-link/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
-import s from './button-link.module.css'
-import { ButtonProps } from 'components/button/types'
 import classNames from 'classnames'
+import { ButtonLinkProps } from './types'
+import s from './button-link.module.css'
 
 /**
  * _Note WIP Component_
@@ -10,25 +10,16 @@ import classNames from 'classnames'
  * expanded upon. It currently renders a theme colors and sizes, with styles
  * copied from `Button`.
  **/
-interface ButtonLinkProps
-	extends Pick<
-		ButtonProps,
-		'color' | 'size' | 'text' | 'ariaLabel' | 'icon' | 'iconPosition'
-	> {
-	href: string
-	openInNewTab?: boolean
-}
-
-export default function ButtonLink({
+const ButtonLink = ({
+	'aria-label': ariaLabel,
 	color = 'primary',
-	size = 'medium',
 	href,
-	text,
-	ariaLabel,
 	icon,
 	iconPosition = 'leading',
 	openInNewTab = false,
-}: ButtonLinkProps) {
+	size = 'medium',
+	text,
+}: ButtonLinkProps) => {
 	const hasIcon = !!icon
 	const hasText = !!text
 	const hasLabel = !!ariaLabel
@@ -51,8 +42,8 @@ export default function ButtonLink({
 	return (
 		<Link href={href}>
 			<a
-				className={classNames(s.root, s[size], s[color])}
 				aria-label={ariaLabel}
+				className={classNames(s.root, s[size], s[color])}
 				rel={openInNewTab ? 'noreferrer noopener' : undefined}
 				target={openInNewTab ? '_blank' : '_self'}
 			>
@@ -63,3 +54,5 @@ export default function ButtonLink({
 		</Link>
 	)
 }
+
+export default ButtonLink

--- a/src/components/button-link/types.ts
+++ b/src/components/button-link/types.ts
@@ -1,0 +1,19 @@
+import { ButtonProps } from 'components/button'
+
+/**
+ * The inherited props from Button.
+ */
+type PickedButtonProps = Pick<
+	ButtonProps,
+	'aria-label' | 'color' | 'icon' | 'iconPosition' | 'size' | 'text'
+>
+
+/**
+ * The additional custom props for ButtonLink.
+ */
+interface ButtonLinkProps extends PickedButtonProps {
+	href: string
+	openInNewTab?: boolean
+}
+
+export type { ButtonLinkProps }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,82 +1,90 @@
+import { ForwardedRef, forwardRef } from 'react'
+import classNames from 'classnames'
 import { ButtonProps } from './types'
 import s from './button.module.css'
-import classNames from 'classnames'
 
-const Button = ({
-	'aria-controls': ariaControls,
-	'aria-describedby': ariaDescribedBy,
-	'aria-expanded': ariaExpanded,
-	'aria-label': ariaLabel,
-	'aria-labelledby': ariaLabelledBy,
-	className,
-	color = 'primary',
-	disabled,
-	form,
-	icon,
-	iconPosition = 'leading',
-	id,
-	isFullWidth,
-	name,
-	onClick,
-	size = 'medium',
-	text,
-	type = 'button',
-}: ButtonProps) => {
-	const classes = classNames(
-		s.root,
-		s[size],
-		s[color],
+// eslint-disable-next-line react/display-name
+const Button = forwardRef(
+	(
 		{
-			[s.fullWidth]: isFullWidth,
-		},
-		className
-	)
-	const hasIcon = !!icon
-	const hasText = !!text
-	const hasLabel = !!ariaLabel || !!ariaLabelledBy || !!ariaDescribedBy
-	const hasLeadingIcon = hasIcon && iconPosition === 'leading'
-	const hasTrailingIcon = hasIcon && iconPosition === 'trailing'
-	const isIconOnly = hasIcon && !hasText
+			'aria-controls': ariaControls,
+			'aria-describedby': ariaDescribedBy,
+			'aria-expanded': ariaExpanded,
+			'aria-label': ariaLabel,
+			'aria-labelledby': ariaLabelledBy,
+			className,
+			color = 'primary',
+			disabled,
+			form,
+			icon,
+			iconPosition = 'leading',
+			id,
+			isFullWidth,
+			name,
+			onClick,
+			size = 'medium',
+			text,
+			type = 'button',
+		}: ButtonProps,
+		ref: ForwardedRef<HTMLButtonElement>
+	) => {
+		const classes = classNames(
+			s.root,
+			s[size],
+			s[color],
+			{
+				[s.fullWidth]: isFullWidth,
+			},
+			className
+		)
+		const hasIcon = !!icon
+		const hasText = !!text
+		const hasLabel = !!ariaLabel || !!ariaLabelledBy || !!ariaDescribedBy
+		const hasLeadingIcon = hasIcon && iconPosition === 'leading'
+		const hasTrailingIcon = hasIcon && iconPosition === 'trailing'
+		const isIconOnly = hasIcon && !hasText
 
-	if (!hasIcon && !hasText) {
-		throw new Error(
-			'`Button` must have either `text` or an `icon` with accessible labels.'
+		if (!hasIcon && !hasText) {
+			throw new Error(
+				'`Button` must have either `text` or an `icon` with accessible labels.'
+			)
+		}
+
+		if (isIconOnly && !hasLabel) {
+			throw new Error(
+				'Icon-only `Button`s require an accessible label. Either provide the `text` prop or one of: `ariaLabel`, `ariaLabelledBy`, `ariaDescribedBy`.'
+			)
+		}
+
+		if (ariaLabel && ariaLabelledBy) {
+			throw new Error(
+				'`Button` does not accept both `ariaLabel` and `ariaLabelledBy`. Only provide one or the other.'
+			)
+		}
+
+		return (
+			<button
+				aria-controls={ariaControls}
+				aria-describedby={ariaDescribedBy}
+				aria-expanded={ariaExpanded}
+				aria-label={ariaLabel}
+				aria-labelledby={ariaLabelledBy}
+				className={classes}
+				disabled={disabled}
+				form={form}
+				id={id}
+				name={name}
+				onClick={onClick}
+				ref={ref}
+				type={type}
+			>
+				{hasLeadingIcon && icon}
+				{hasText && <span className={s.text}>{text}</span>}
+				{hasTrailingIcon && icon}
+			</button>
 		)
 	}
-
-	if (isIconOnly && !hasLabel) {
-		throw new Error(
-			'Icon-only `Button`s require an accessible label. Either provide the `text` prop or one of: `ariaLabel`, `ariaLabelledBy`, `ariaDescribedBy`.'
-		)
-	}
-
-	if (ariaLabel && ariaLabelledBy) {
-		throw new Error(
-			'`Button` does not accept both `ariaLabel` and `ariaLabelledBy`. Only provide one or the other.'
-		)
-	}
-
-	return (
-		<button
-			aria-controls={ariaControls}
-			aria-describedby={ariaDescribedBy}
-			aria-expanded={ariaExpanded}
-			aria-label={ariaLabel}
-			aria-labelledby={ariaLabelledBy}
-			className={classes}
-			disabled={disabled}
-			form={form}
-			id={id}
-			name={name}
-			onClick={onClick}
-			type={type}
-		>
-			{hasLeadingIcon && icon}
-			{hasText && <span className={s.text}>{text}</span>}
-			{hasTrailingIcon && icon}
-		</button>
-	)
-}
+)
 
 export type { ButtonProps }
 export default Button

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -3,22 +3,24 @@ import s from './button.module.css'
 import classNames from 'classnames'
 
 const Button = ({
-	ariaDescribedBy,
-	ariaLabel,
-	ariaLabelledBy,
+	'aria-controls': ariaControls,
+	'aria-describedby': ariaDescribedBy,
+	'aria-expanded': ariaExpanded,
+	'aria-label': ariaLabel,
+	'aria-labelledby': ariaLabelledBy,
 	className,
 	color = 'primary',
 	disabled,
+	form,
 	icon,
-	id,
 	iconPosition = 'leading',
+	id,
 	isFullWidth,
 	name,
 	onClick,
 	size = 'medium',
 	text,
 	type = 'button',
-	form,
 }: ButtonProps) => {
 	const classes = classNames(
 		s.root,
@@ -56,16 +58,18 @@ const Button = ({
 
 	return (
 		<button
+			aria-controls={ariaControls}
+			aria-describedby={ariaDescribedBy}
+			aria-expanded={ariaExpanded}
 			aria-label={ariaLabel}
 			aria-labelledby={ariaLabelledBy}
-			aria-describedby={ariaDescribedBy}
 			className={classes}
 			disabled={disabled}
+			form={form}
 			id={id}
 			name={name}
 			onClick={onClick}
 			type={type}
-			form={form}
 		>
 			{hasLeadingIcon && icon}
 			{hasText && <span className={s.text}>{text}</span>}

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,52 +1,38 @@
 import { ReactElement } from 'react'
 
+/**
+ * All props the native <button> HTML element accepts
+ */
 type NativeButtonProps = JSX.IntrinsicElements['button']
 
-export interface ButtonProps {
-	/**
-	 * The value of the `id` of the element that describes the action a button
-	 * allows a user to do. The describing element does not have to be visible. If
-	 * there are multiple labeling elements, this can be be a comma-separated list
-	 * of `id`s.
-	 *
-	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-describedby
-	 */
-	ariaDescribedBy?: NativeButtonProps['aria-describedby']
+/**
+ * The native button props the Button component accepts.
+ */
+type PickedNativeButtonProps = Pick<
+	NativeButtonProps,
+	| 'aria-controls'
+	| 'aria-describedby'
+	| 'aria-expanded'
+	| 'aria-label'
+	| 'aria-labelledby'
+	| 'className'
+	| 'disabled'
+	| 'form'
+	| 'id'
+	| 'name'
+	| 'onClick'
+	| 'type'
+>
 
-	/**
-	 * A non-visual label accessible and descriptive label for the action a button
-	 * allows the user to do.
-	 *
-	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-label
-	 */
-	ariaLabel?: NativeButtonProps['aria-label']
-
-	/**
-	 * The value of the `id` of the element that labels the button. The labeling
-	 * element does not have to be visible. If there are multiple labeling
-	 * elements, this can be be a comma-separated list of `id`s.
-	 *
-	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby
-	 */
-	ariaLabelledBy?: NativeButtonProps['aria-labelledby']
-
-	/**
-	 * A string of one or more classnames. Is appended last to list of classnames
-	 * passed to the button element.
-	 */
-	className?: NativeButtonProps['className']
-
+/**
+ * Additional custom props the Button component accepts.
+ */
+interface ButtonProps extends PickedNativeButtonProps {
 	/**
 	 * The name of the color to apply styles to the button. The default value is
 	 * "primary".
 	 */
 	color?: 'primary' | 'secondary' | 'tertiary' | 'critical'
-
-	/**
-	 * Whether or not the button should have all interaction disabled. Same as the
-	 * HTML `disabled` attribute.
-	 */
-	disabled?: NativeButtonProps['disabled']
 
 	/**
 	 * An icon from `@hashicorp/flight-icons` to render.
@@ -76,28 +62,10 @@ export interface ButtonProps {
 	iconPosition?: 'leading' | 'trailing'
 
 	/**
-	 * The string `id` to give the rendered `<button>` element. Same as the HTML
-	 * `id` attribute.
-	 */
-	id?: NativeButtonProps['id']
-
-	/**
 	 * Whether or not the button should take up the full width of its container.
 	 * Buttons do not take up their container's full width by default.
 	 */
 	isFullWidth?: boolean
-
-	/**
-	 * The string `name` to give the rendered `<button>` element. Same as the HTML
-	 * `name` attribute.
-	 */
-	name?: NativeButtonProps['name']
-
-	/**
-	 * The function invoked after the button is clicked. Passed directly to the
-	 * rendered `<button>` element. Same as the HTML `onClick` attribute.
-	 */
-	onClick?: NativeButtonProps['onClick']
 
 	/**
 	 * The size of the button, which mainly affects font size and padding.
@@ -110,12 +78,6 @@ export interface ButtonProps {
 	 * buttons.
 	 */
 	text?: string
-
-	/**
-	 * The `type` to give the rendered `<button>` element. Same as the HTML `type`
-	 * attribute for button elements.
-	 */
-	type?: NativeButtonProps['type']
-
-	form?: NativeButtonProps['form']
 }
+
+export type { ButtonProps }

--- a/src/components/navigation-header/components/give-feedback-button/index.tsx
+++ b/src/components/navigation-header/components/give-feedback-button/index.tsx
@@ -30,12 +30,12 @@ function GiveFeedbackButton(): ReactElement {
 			</span>
 			<span className={s.textButtonContainer}>
 				<ButtonLink
-					openInNewTab
-					href={FORM_URL}
-					text={LINK_TEXT}
 					aria-label={LINK_ARIA_LABEL}
+					href={FORM_URL}
 					icon={<IconExternalLink16 />}
 					iconPosition="trailing"
+					openInNewTab
+					text={LINK_TEXT}
 				/>
 			</span>
 		</>

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -44,9 +44,9 @@ export default function CollectionMeta({
 			<Text className={s.description}>{description}</Text>
 			<div className={s.cta}>
 				<ButtonLink
+					aria-label="Start first tutorial"
 					href={cta.href}
 					text="Start"
-					ariaLabel="Start first tutorial"
 				/>
 				<span className={s.ctaText}>
 					<IconCollections16 className={s.ctaIcon} />


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Refactors `ButtonProps` to inherit native `<button>` props without re-casing them (aka `aria-label` to `ariaLabel`)
- Wraps `Button` in `forwardRef` for future use
- Updates `ButtonLinkProps` with the refactored `ButtonProps` it references
- Updates `ButtonLink` references as needed

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Primarily, this makes it easier to spread props over `Button` or `<button>` in single component that chooses which element it needs to render.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

This PR is the first in creating the new `DropdownDisclosure` component. Some of these changes are needed in order for that component to use this one.