### PR TITLE
Add enable_auth flag

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -30,8 +30,9 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_product_docs_search": true,
+		"enable_auth": true,
+		"enable_datadog": true,
 		"enable_io_beta_cta": true,
-		"enable_datadog": true
+		"enable_product_docs_search": true
 	}
 }

--- a/config/base.json
+++ b/config/base.json
@@ -30,7 +30,7 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_auth": true,
+		"enable_auth": false,
 		"enable_datadog": true,
 		"enable_io_beta_cta": true,
 		"enable_product_docs_search": true

--- a/config/development.json
+++ b/config/development.json
@@ -8,5 +8,8 @@
 	},
 	"learn": {
 		"max_static_paths": 0
+	},
+	"flags": {
+		"enable_auth": true
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -3,5 +3,7 @@
 	"io_sites": {
 		"max_static_paths": 10
 	},
-	"flags": {}
+	"flags": {
+		"enable_auth": true
+	}
 }

--- a/config/production.json
+++ b/config/production.json
@@ -15,6 +15,7 @@
 		}
 	},
 	"flags": {
+		"enable_auth": false,
 		"enable_product_docs_search": true
 	}
 }

--- a/config/production.json
+++ b/config/production.json
@@ -15,7 +15,6 @@
 		}
 	},
 	"flags": {
-		"enable_auth": false,
 		"enable_product_docs_search": true
 	}
 }

--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -2,6 +2,7 @@ import { useSession, signIn, signOut, SignOutParams } from 'next-auth/react'
 import { SessionData, UserData, ValidAuthProviderId } from 'types/auth'
 
 const DEFAULT_PROVIDER_ID = ValidAuthProviderId.CloudIdp
+const AUTH_ENABLED = __config.flags.enable_auth
 
 /**
  * A minimal wrapper around next-auth/react's `signIn` function. Purpose is to
@@ -51,7 +52,7 @@ const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 
 	// Pull data and status from next-auth's hook, and pass options
 	const { data, status } = useSession({
-		required: isRequired,
+		required: AUTH_ENABLED && isRequired,
 		onUnauthenticated,
 	})
 
@@ -70,6 +71,7 @@ const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 	// Return everything packaged up in an object
 	return {
 		isAuthenticated,
+		isEnabled: AUTH_ENABLED,
 		isLoading,
 		session,
 		signIn: signInWrapper,

--- a/src/views/authenticated-view/index.tsx
+++ b/src/views/authenticated-view/index.tsx
@@ -1,4 +1,5 @@
 import useAuthentication from 'hooks/use-authentication'
+import ErrorView from 'views/error-view-switcher'
 import { AuthenticatedViewProps } from './types'
 
 /**
@@ -7,9 +8,14 @@ import { AuthenticatedViewProps } from './types'
  * authenticated.
  */
 const AuthenticatedView = ({ children }: AuthenticatedViewProps) => {
-	const { isAuthenticated } = useAuthentication({
+	const { isAuthenticated, isEnabled } = useAuthentication({
 		isRequired: true,
 	})
+
+	// Show the 404 error view if auth is not enabled
+	if (!isEnabled) {
+		return <ErrorView statusCode={404} isProxiedDotIo={false} />
+	}
 
 	// TODO - add a loading indicator?
 	if (!isAuthenticated) {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1202664135851182/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `enable_auth` flag to `base` and `production` configs
- Adds `isEnabled` derived boolean to our `useAuthentication` return value
- Updates `AuthenticationView` to return `ErrorView` if `isEnabled` is `false`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- The `enable_auth` flag is necessary for us to build authenticated user features in isolation without showing these features in production.
- The `isEnabled` boolean from `useAuthentication` will be really nice for conditionally rendering elements such as the Sign In and Sign Out buttons that will live in the navigation header / mobile sidebar.
- Updating `AuthenticationView` to return `ErrorView` if `isEnabled` is `false` is an easy test for checking if the flag is working as expected. And if any views are built on top of `AuthenticatedView`, they'll automatically behave the same without any extra work on the developer.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

We can't test the production environment until this branch is merged into `main` and a new deploy is created, but the local testing steps should help provide confidence that these changes will work in production.

- [ ] Check out this branch locally
- [ ] Run the server with `npm start`
- [ ] Go to the /profile page
- [ ] The page should behave as it was previously, because the `enable_auth` flag is set to `true`
- [ ] Set the `enable_auth` flag in `src/config/development.json` to `false`
- [ ] Go to the `/profile` page
- [ ] You should see the DevDot 404 view
