### PR TITLE
Add Create Account CTA to CollectionView and TutorialView

### DIFF
--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -22,8 +22,8 @@ export default function TutorialMeta({ heading, meta }: TutorialMetaProps) {
 	 * We only need to show the Create Account CTA if auth is enabled and there is
 	 * not already a user authenticated.
 	 */
-	const { isAuthenticated, isEnabled } = useAuthentication()
-	const showCreateAccountCta = isEnabled && isAuthenticated
+	const { isAuthenticated, isAuthEnabled } = useAuthentication()
+	const showCreateAccountCta = isAuthEnabled && isAuthenticated
 
 	return (
 		<header className={s.header}>

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -1,5 +1,8 @@
-import Heading from 'components/heading'
+import useAuthentication from 'hooks/use-authentication'
 import { TutorialData } from 'views/tutorial-view'
+import Heading from 'components/heading'
+import InlineLink from 'components/inline-link'
+import Text from 'components/text'
 import { Badges, getIsBeta } from './components'
 import InteractiveLabButton from './components/interactive-lab-button'
 import s from './tutorial-meta.module.css'
@@ -14,6 +17,14 @@ interface TutorialMetaProps {
 
 export default function TutorialMeta({ heading, meta }: TutorialMetaProps) {
 	const { isInteractive, hasVideo, edition, productsUsed, readTime } = meta
+
+	/**
+	 * We only need to show the Create Account CTA if auth is enabled and there is
+	 * not already a user authenticated.
+	 */
+	const { isAuthenticated, isEnabled } = useAuthentication()
+	const showCreateAccountCta = isEnabled && isAuthenticated
+
 	return (
 		<header className={s.header}>
 			<Heading
@@ -40,6 +51,13 @@ export default function TutorialMeta({ heading, meta }: TutorialMetaProps) {
 					}}
 				/>
 				<InteractiveLabButton />
+				{showCreateAccountCta ? (
+					<Text className={s.createAccountCta}>
+						Reference this often?{' '}
+						<InlineLink href="/sign-up">Create an account</InlineLink> to
+						bookmark tutorials.
+					</Text>
+				) : null}
 			</div>
 		</header>
 	)

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -22,8 +22,8 @@ export default function TutorialMeta({ heading, meta }: TutorialMetaProps) {
 	 * We only need to show the Create Account CTA if auth is enabled and there is
 	 * not already a user authenticated.
 	 */
-	const { isAuthenticated, isAuthEnabled } = useAuthentication()
-	const showCreateAccountCta = isAuthEnabled && !isAuthenticated
+	const { isAuthenticated, isAuthEnabled, isLoading } = useAuthentication()
+	const showCreateAccountCta = isAuthEnabled && !isLoading && !isAuthenticated
 
 	return (
 		<header className={s.header}>

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -23,7 +23,7 @@ export default function TutorialMeta({ heading, meta }: TutorialMetaProps) {
 	 * not already a user authenticated.
 	 */
 	const { isAuthenticated, isAuthEnabled } = useAuthentication()
-	const showCreateAccountCta = isAuthEnabled && isAuthenticated
+	const showCreateAccountCta = isAuthEnabled && !isAuthenticated
 
 	return (
 		<header className={s.header}>

--- a/src/components/tutorial-meta/tutorial-meta.module.css
+++ b/src/components/tutorial-meta/tutorial-meta.module.css
@@ -1,27 +1,32 @@
 .header {
-  --spacing-sml: 18px;
-  --spacing-med: 20px;
-  --spacing-lrg: 24px;
-  --spacing-xl: 32px;
+	--spacing-sml: 18px;
+	--spacing-med: 20px;
+	--spacing-lrg: 24px;
+	--spacing-xl: 32px;
 }
 
 .heading {
-  composes: g-offset-scroll-margin-top from global;
-  margin-bottom: var(--spacing-med);
+	composes: g-offset-scroll-margin-top from global;
+	margin-bottom: var(--spacing-med);
 
-  @media (--dev-dot-tablet-up) {
-    margin-bottom: var(--spacing-sml);
-  }
+	@media (--dev-dot-tablet-up) {
+		margin-bottom: var(--spacing-sml);
+	}
 
-  @media (--dev-dot-desktop) {
-    margin-bottom: var(--spacing-lrg);
-  }
+	@media (--dev-dot-desktop) {
+		margin-bottom: var(--spacing-lrg);
+	}
 }
 
 .meta {
-  margin-bottom: var(--spacing-lrg);
+	margin-bottom: var(--spacing-lrg);
 
-  @media (--dev-dot-tablet-up) {
-    margin-bottom: var(--spacing-xl);
-  }
+	@media (--dev-dot-tablet-up) {
+		margin-bottom: var(--spacing-xl);
+	}
+}
+
+.createAccountCta {
+	color: var(--token-color-foreground-primary);
+	margin-top: 32px;
 }

--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -71,7 +71,7 @@ const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 	// Return everything packaged up in an object
 	return {
 		isAuthenticated,
-		isEnabled: AUTH_ENABLED,
+		isAuthEnabled: AUTH_ENABLED,
 		isLoading,
 		session,
 		signIn: signInWrapper,

--- a/src/hooks/use-authentication.ts
+++ b/src/hooks/use-authentication.ts
@@ -70,8 +70,8 @@ const useAuthentication = (options: UseAuthenticationOptions = {}) => {
 
 	// Return everything packaged up in an object
 	return {
-		isAuthenticated,
 		isAuthEnabled: AUTH_ENABLED,
+		isAuthenticated,
 		isLoading,
 		session,
 		signIn: signInWrapper,

--- a/src/views/authenticated-view/index.tsx
+++ b/src/views/authenticated-view/index.tsx
@@ -8,12 +8,12 @@ import { AuthenticatedViewProps } from './types'
  * authenticated.
  */
 const AuthenticatedView = ({ children }: AuthenticatedViewProps) => {
-	const { isAuthenticated, isEnabled } = useAuthentication({
+	const { isAuthenticated, isAuthEnabled } = useAuthentication({
 		isRequired: true,
 	})
 
 	// Show the 404 error view if auth is not enabled
-	if (!isEnabled) {
+	if (!isAuthEnabled) {
 		return <ErrorView statusCode={404} isProxiedDotIo={false} />
 	}
 

--- a/src/views/collection-view/components/collection-meta/collection-meta.module.css
+++ b/src/views/collection-view/components/collection-meta/collection-meta.module.css
@@ -1,36 +1,41 @@
 .icon {
-  color: var(--token-color-foreground-primary);
+	color: var(--token-color-foreground-primary);
 }
 
 .heading {
-  margin-top: 12px;
+	margin-top: 12px;
 }
 
 .description {
-  margin-top: 8px;
-  color: var(--token-color-foreground-primary);
+	margin-top: 8px;
+	color: var(--token-color-foreground-primary);
+}
+
+.createAccountCta {
+	color: var(--token-color-foreground-primary);
+	margin-top: 12px;
 }
 
 .cta {
-  display: flex;
-  align-items: center;
-  margin-top: 24px;
-  margin-bottom: 16px;
+	display: flex;
+	align-items: center;
+	margin-top: 24px;
+	margin-bottom: 16px;
 
-  @media (--dev-dot-tablet-up) {
-    margin-top: 32px;
-    margin-bottom: 24px;
-  }
+	@media (--dev-dot-tablet-up) {
+		margin-top: 32px;
+		margin-bottom: 24px;
+	}
 }
 
 .ctaText {
-  color: var(--token-color-foreground-faint);
-  margin: 0 0 0 16px;
-  align-items: center;
-  justify-content: center;
-  display: flex;
+	color: var(--token-color-foreground-faint);
+	margin: 0 0 0 16px;
+	align-items: center;
+	justify-content: center;
+	display: flex;
 }
 
 .ctaIcon {
-  margin-right: 6px;
+	margin-right: 6px;
 }

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -1,10 +1,13 @@
-import { IconCollections24 } from '@hashicorp/flight-icons/svg-react/collections-24'
 import { IconCollections16 } from '@hashicorp/flight-icons/svg-react/collections-16'
-import Heading from 'components/heading'
-import Text from 'components/text'
-import IconTile from 'components/icon-tile'
-import s from './collection-meta.module.css'
+import { IconCollections24 } from '@hashicorp/flight-icons/svg-react/collections-24'
 import ButtonLink from 'components/button-link'
+import Heading from 'components/heading'
+import IconTile from 'components/icon-tile'
+import InlineLink from 'components/inline-link'
+import Text from 'components/text'
+import s from './collection-meta.module.css'
+
+const AUTH_ENABLED = __config.flags.enable_auth
 
 interface CollectionMetaProps {
 	heading: {
@@ -42,6 +45,12 @@ export default function CollectionMeta({
 				{heading.text}
 			</Heading>
 			<Text className={s.description}>{description}</Text>
+			{AUTH_ENABLED ? (
+				<Text className={s.createAccountCta}>
+					<InlineLink href="/sign-up">Create an account</InlineLink> to track
+					your progress.
+				</Text>
+			) : null}
 			<div className={s.cta}>
 				<ButtonLink
 					aria-label="Start first tutorial"

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -34,8 +34,8 @@ export default function CollectionMeta({
 	 * We only need to show the Create Account CTA if auth is enabled and there is
 	 * not already a user authenticated.
 	 */
-	const { isAuthenticated, isAuthEnabled } = useAuthentication()
-	const showCreateAccountCta = isAuthEnabled && !isAuthenticated
+	const { isAuthenticated, isAuthEnabled, isLoading } = useAuthentication()
+	const showCreateAccountCta = isAuthEnabled && !isLoading && !isAuthenticated
 
 	return (
 		<>

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -35,7 +35,7 @@ export default function CollectionMeta({
 	 * not already a user authenticated.
 	 */
 	const { isAuthenticated, isAuthEnabled } = useAuthentication()
-	const showCreateAccountCta = isAuthEnabled && isAuthenticated
+	const showCreateAccountCta = isAuthEnabled && !isAuthenticated
 
 	return (
 		<>

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -34,8 +34,8 @@ export default function CollectionMeta({
 	 * We only need to show the Create Account CTA if auth is enabled and there is
 	 * not already a user authenticated.
 	 */
-	const { isAuthenticated, isEnabled } = useAuthentication()
-	const showCreateAccountCta = isEnabled && isAuthenticated
+	const { isAuthenticated, isAuthEnabled } = useAuthentication()
+	const showCreateAccountCta = isAuthEnabled && isAuthenticated
 
 	return (
 		<>

--- a/src/views/collection-view/components/collection-meta/index.tsx
+++ b/src/views/collection-view/components/collection-meta/index.tsx
@@ -1,13 +1,12 @@
 import { IconCollections16 } from '@hashicorp/flight-icons/svg-react/collections-16'
 import { IconCollections24 } from '@hashicorp/flight-icons/svg-react/collections-24'
+import useAuthentication from 'hooks/use-authentication'
 import ButtonLink from 'components/button-link'
 import Heading from 'components/heading'
 import IconTile from 'components/icon-tile'
 import InlineLink from 'components/inline-link'
 import Text from 'components/text'
 import s from './collection-meta.module.css'
-
-const AUTH_ENABLED = __config.flags.enable_auth
 
 interface CollectionMetaProps {
 	heading: {
@@ -30,6 +29,14 @@ export default function CollectionMeta({
 	const ctaText = `${numTutorials} ${
 		numTutorials > 1 ? `tutorials` : `tutorial`
 	}`
+
+	/**
+	 * We only need to show the Create Account CTA if auth is enabled and there is
+	 * not already a user authenticated.
+	 */
+	const { isAuthenticated, isEnabled } = useAuthentication()
+	const showCreateAccountCta = isEnabled && isAuthenticated
+
 	return (
 		<>
 			<IconTile>
@@ -45,7 +52,7 @@ export default function CollectionMeta({
 				{heading.text}
 			</Heading>
 			<Text className={s.description}>{description}</Text>
-			{AUTH_ENABLED ? (
+			{showCreateAccountCta ? (
 				<Text className={s.createAccountCta}>
 					<InlineLink href="/sign-up">Create an account</InlineLink> to track
 					your progress.


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Asana Tasks 🎟️ 
  - [[CollectionView] Add "Create an account" CTA below collection description](https://app.asana.com/0/1202097197789424/1202661920988675/f)
  - [[TutorialView] Add "Create an account" CTA below badges and "Show Terminal" button](https://app.asana.com/0/1202097197789424/1202661920988679/f)

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renames `useAuthentication`'s `isEnabled` property in the returned object to `isAuthEnabled` for clarity
- Adds Create Account CTAs to both `CollectionView` and `TutorialView`

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- The `useAuthentication` `isAuthenticated` and `isAuthEnabled` properties were particularly useful here.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

<details>
  <summary>CollectionView CTA</summary>
  <a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=11440%3A114695">Figma link</a>
  <img src="https://user-images.githubusercontent.com/43934258/181135958-a8df4b71-dd4f-4f84-bdb9-f31d5109700a.png" />
</details>

<details>
  <summary>TutorialView CTA</summary>
  <a href="https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=11440%3A114496">Figma link</a>
  <img src="https://user-images.githubusercontent.com/43934258/181135984-d797a032-cb89-4c68-b65e-fd85e9a505cc.png" />
</details>

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out this branch locally (auth does not work in preview URLs yet)
- [ ] Set `auth_enabled` to `false` in `config/development.json`
- [ ] Go to a collection page
- [ ] You should not see the new CTA styled according to the designs
- [ ] Go to a tutorial page
- [ ] You should not see the new CTA styled according to the designs
- [ ] Set `auth_enabled` to `true` in `config/development.json`
- [ ] Go to a collection page
- [ ] You should see the new CTA styled according to the designs
- [ ] Go to a tutorial page
- [ ] You should see the new CTA styled according to the designs
- [ ] Go to /profile and sign in
- [ ] Go to a collection page
- [ ] You should no longer see the new CTA
- [ ] Go to a tutorial page
- [ ] You should no longer see the new CTA

## 💭 Anything else?

If auth is enabled and a user is not authenticated, these CTAs render after auth is finished loading and causes layout shift. I think we should resolve this outside of this PR so we can brainstorm the approach we want to take in Dev Dot. I'm guessing we'll want to create a loading skeleton like what Learn does, but I'm not familiar with that code yet.
