### PR TITLE
Add mobile UserDropdownDisclosure; render in mobile sidebar for authenticated users

### DIFF
--- a/src/components/mobile-menu-container/components/index.ts
+++ b/src/components/mobile-menu-container/components/index.ts
@@ -1,0 +1,3 @@
+import MobileUserDisclosure from './mobile-user-disclosure'
+
+export { MobileUserDisclosure }

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -8,6 +8,43 @@ import Disclosure, {
 import Text from 'components/text'
 import s from './mobile-user-disclosure.module.css'
 
+/**
+ * Handles rendering a list item for `MobileUserDisclosure`.
+ */
+const renderItem = ({ icon, label, href, onClick }, index) => {
+	if (!href && !onClick) {
+		return null
+	}
+
+	const labelElement = (
+		<Text asElement="span" size={200} weight="medium">
+			{label}
+		</Text>
+	)
+
+	let content
+	if (href) {
+		content = (
+			<Link href={href}>
+				<a className={s.link}>
+					{icon}
+					{labelElement}
+				</a>
+			</Link>
+		)
+	} else if (onClick) {
+		content = (
+			<button className={s.button} onClick={onClick}>
+				{icon}
+				{labelElement}
+			</button>
+		)
+	}
+
+	// eslint-disable-next-line react/no-array-index-key
+	return <li key={index}>{content}</li>
+}
+
 const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
 	const { icon, description } = getUserMeta(user)
 
@@ -25,41 +62,7 @@ const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
 				</span>
 			</DisclosureActivator>
 			<DisclosureContent className={s.content}>
-				<ul className={s.list}>
-					{items.map(({ icon, label, href, onClick }, index) => {
-						if (!href && !onClick) {
-							return null
-						}
-
-						const labelElement = (
-							<Text asElement="span" size={200} weight="medium">
-								{label}
-							</Text>
-						)
-
-						let content
-						if (href) {
-							content = (
-								<Link href={href}>
-									<a className={s.link}>
-										{icon}
-										{labelElement}
-									</a>
-								</Link>
-							)
-						} else if (onClick) {
-							content = (
-								<button className={s.button} onClick={onClick}>
-									{icon}
-									{labelElement}
-								</button>
-							)
-						}
-
-						// eslint-disable-next-line react/no-array-index-key
-						return <li key={index}>{content}</li>
-					})}
-				</ul>
+				<ul className={s.list}>{items.map(renderItem)}</ul>
 			</DisclosureContent>
 		</Disclosure>
 	)

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { IconChevronDown24 } from '@hashicorp/flight-icons/svg-react/chevron-down-24'
-import { IconUser16 } from '@hashicorp/flight-icons/svg-react/user-16'
+import { getUserMeta } from 'lib/auth/user'
 import Disclosure, {
 	DisclosureActivator,
 	DisclosureContent,
@@ -9,8 +9,7 @@ import Text from 'components/text'
 import s from './mobile-user-disclosure.module.css'
 
 const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
-	// eslint-disable-next-line @next/next/no-img-element
-	const icon = user.image ? <img alt="" src={user.image} /> : <IconUser16 />
+	const { icon, description } = getUserMeta(user)
 
 	return (
 		<Disclosure containerClassName={s.root}>
@@ -18,8 +17,7 @@ const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
 				<span className={s.iconAndTextWrapper}>
 					<span className={s.icon}>{icon}</span>
 					<Text asElement="span" className={s.text} size={200} weight="regular">
-						{/* TODO show nickname if github, email otherwise */}
-						{user.nickname}
+						{description}
 					</Text>
 				</span>
 				<span className={s.chevron}>

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -1,51 +1,59 @@
 import Link from 'next/link'
-import { IconChevronDown16 } from '@hashicorp/flight-icons/svg-react/chevron-down-16'
+import { IconChevronDown24 } from '@hashicorp/flight-icons/svg-react/chevron-down-24'
 import { IconUser16 } from '@hashicorp/flight-icons/svg-react/user-16'
 import Disclosure, {
 	DisclosureActivator,
 	DisclosureContent,
 } from 'components/disclosure'
 import Text from 'components/text'
+import s from './mobile-user-disclosure.module.css'
 
 const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
 	// eslint-disable-next-line @next/next/no-img-element
 	const icon = user.image ? <img alt="" src={user.image} /> : <IconUser16 />
 
 	return (
-		<Disclosure>
-			<DisclosureActivator>
-				<div>
-					{icon}
-					<Text size={200} weight="regular">
+		<Disclosure containerClassName={s.root}>
+			<DisclosureActivator className={s.activator}>
+				<span className={s.iconAndTextWrapper}>
+					<span className={s.icon}>{icon}</span>
+					<Text asElement="span" className={s.text} size={200} weight="regular">
 						{/* TODO show nickname if github, email otherwise */}
 						{user.nickname}
 					</Text>
-				</div>
-				{/* TODO rotate 180deg when open */}
-				<IconChevronDown16 />
+				</span>
+				<span className={s.chevron}>
+					<IconChevronDown24 />
+				</span>
 			</DisclosureActivator>
-			<DisclosureContent>
-				<ul>
+			<DisclosureContent className={s.content}>
+				<ul className={s.list}>
 					{items.map(({ icon, label, href, onClick }, index) => {
 						if (!href && !onClick) {
 							return null
 						}
 
+						const labelElement = (
+							<Text asElement="span" size={200} weight="medium">
+								{label}
+							</Text>
+						)
+
 						let content
 						if (href) {
 							content = (
 								<Link href={href}>
-									<a>
+									<a className={s.link}>
 										{icon}
-										{label}
+										{labelElement}
 									</a>
 								</Link>
 							)
 						} else if (onClick) {
 							content = (
-								<button onClick={onClick}>
+								<button className={s.button} onClick={onClick}>
 									{icon}
-									{label}
+									{labelElement}
 								</button>
 							)
 						}

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { IconChevronDown16 } from '@hashicorp/flight-icons/svg-react/chevron-down-16'
+import { IconUser16 } from '@hashicorp/flight-icons/svg-react/user-16'
+import Disclosure, {
+	DisclosureActivator,
+	DisclosureContent,
+} from 'components/disclosure'
+import Text from 'components/text'
+
+const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
+	// eslint-disable-next-line @next/next/no-img-element
+	const icon = user.image ? <img alt="" src={user.image} /> : <IconUser16 />
+
+	return (
+		<Disclosure>
+			<DisclosureActivator>
+				<div>
+					{icon}
+					<Text size={200} weight="regular">
+						{/* TODO show nickname if github, email otherwise */}
+						{user.nickname}
+					</Text>
+				</div>
+				{/* TODO rotate 180deg when open */}
+				<IconChevronDown16 />
+			</DisclosureActivator>
+			<DisclosureContent>
+				<ul>
+					{items.map(({ icon, label, href, onClick }, index) => {
+						if (!href && !onClick) {
+							return null
+						}
+
+						let content
+						if (href) {
+							content = (
+								<Link href={href}>
+									<a>
+										{icon}
+										{label}
+									</a>
+								</Link>
+							)
+						} else if (onClick) {
+							content = (
+								<button onClick={onClick}>
+									{icon}
+									{label}
+								</button>
+							)
+						}
+
+						// eslint-disable-next-line react/no-array-index-key
+						return <li key={index}>{content}</li>
+					})}
+				</ul>
+			</DisclosureContent>
+		</Disclosure>
+	)
+}
+
+export default MobileUserDisclosure

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -6,12 +6,17 @@ import Disclosure, {
 	DisclosureContent,
 } from 'components/disclosure'
 import Text from 'components/text'
+import { UserDropdownDisclosureItem } from 'components/user-dropdown-disclosure'
+import { MobileUserDisclosureProps } from './types'
 import s from './mobile-user-disclosure.module.css'
 
 /**
  * Handles rendering a list item for `MobileUserDisclosure`.
  */
-const renderItem = ({ icon, label, href, onClick }, index) => {
+const renderItem = (
+	{ icon, label, href, onClick }: UserDropdownDisclosureItem,
+	index: number
+) => {
 	if (!href && !onClick) {
 		return null
 	}
@@ -45,7 +50,7 @@ const renderItem = ({ icon, label, href, onClick }, index) => {
 	return <li key={index}>{content}</li>
 }
 
-const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
+const MobileUserDisclosure = ({ items, user }: MobileUserDisclosureProps) => {
 	const { icon, description } = getUserMeta(user)
 
 	return (
@@ -68,4 +73,5 @@ const MobileUserDisclosure = ({ items, user }: $TSFixMe) => {
 	)
 }
 
+export type { MobileUserDisclosureProps }
 export default MobileUserDisclosure

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
@@ -1,0 +1,92 @@
+.root {
+	/* composition */
+	composes: hds-surface-base from global;
+
+	/* properties */
+	background-color: var(--token-color-surface-faint);
+	border-radius: 6px;
+	margin-bottom: 24px;
+}
+
+.activator {
+	align-items: center;
+	background-color: transparent;
+	border-radius: 6px;
+	border: none;
+	display: flex;
+	gap: 8px;
+	justify-content: space-between;
+	padding: 16px;
+	outline: transparent;
+
+	/* aka disclosure is open */
+	&[aria-expanded='true'] {
+		padding-bottom: 12px;
+
+		& .chevron svg {
+			transform: rotate(-180deg);
+		}
+	}
+}
+
+.iconAndTextWrapper {
+	align-items: center;
+	display: flex;
+	gap: 6px;
+}
+
+.icon {
+	display: block;
+	border-radius: 5px;
+	height: 28px;
+	overflow: hidden;
+	width: 28px;
+
+	& img {
+		width: 100%;
+	}
+}
+
+.text {
+	color: var(--token-color-foreground-primary);
+}
+
+.chevron {
+	display: block;
+	height: 24px;
+	width: 24px;
+
+	& svg {
+		color: var(--token-color-foreground-primary);
+
+		/* Only enable animation if query is supported and value is no-preference */
+		@media (prefers-reduced-motion: no-preference) {
+			transition: transform 0.2s;
+		}
+	}
+}
+
+.content {
+	padding-bottom: 16px;
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.button,
+.link {
+	align-items: center;
+	background-color: transparent;
+	border: none;
+	color: var(--token-color-foreground-primary);
+	display: flex;
+	gap: 8px;
+	padding-bottom: 8px;
+	padding-left: 16px;
+	padding-right: 16px;
+	padding-top: 8px;
+	width: 100%;
+}

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
@@ -9,6 +9,10 @@
 }
 
 .activator {
+	/* composition */
+	composes: g-focus-ring-from-box-shadow from global;
+
+	/* properties */
 	align-items: center;
 	background-color: transparent;
 	border-radius: 6px;
@@ -21,8 +25,6 @@
 
 	/* aka disclosure is open */
 	&[aria-expanded='true'] {
-		padding-bottom: 12px;
-
 		& .chevron svg {
 			transform: rotate(-180deg);
 		}
@@ -78,9 +80,14 @@
 
 .button,
 .link {
+	/* composition */
+	composes: g-focus-ring-from-box-shadow from global;
+
+	/* properties */
 	align-items: center;
 	background-color: transparent;
 	border: none;
+	border-radius: 5px;
 	color: var(--token-color-foreground-primary);
 	display: flex;
 	gap: 8px;

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
@@ -5,7 +5,6 @@
 	/* properties */
 	background-color: var(--token-color-surface-faint);
 	border-radius: 6px;
-	margin-bottom: 24px;
 }
 
 .activator {

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/types.ts
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/types.ts
@@ -1,0 +1,9 @@
+import { UserData } from 'types/auth'
+import { UserDropdownDisclosureItem } from 'components/user-dropdown-disclosure'
+
+interface MobileUserDisclosureProps {
+	items: UserDropdownDisclosureItem[]
+	user: UserData
+}
+
+export type { MobileUserDisclosureProps }

--- a/src/components/mobile-menu-container/index.tsx
+++ b/src/components/mobile-menu-container/index.tsx
@@ -38,12 +38,8 @@ const MOBILE_MENU_MOTION = {
  * Intended to be used alongside `MobileMenuContainer`.
  */
 const MobileAuthenticationControls = () => {
-	const { isAuthEnabled, isAuthenticated, isLoading, signIn, signOut, user } =
+	const { showAuthenticatedUI, showUnauthenticatedUI, signIn, signOut, user } =
 		useAuthentication()
-
-	// TODO these will come from PR #746
-	const showAuthenticatedUI = isAuthenticated
-	const showUnauthenticatedUI = isAuthEnabled && !isLoading && !isAuthenticated
 
 	if (showUnauthenticatedUI) {
 		return (

--- a/src/components/mobile-menu-container/index.tsx
+++ b/src/components/mobile-menu-container/index.tsx
@@ -1,15 +1,27 @@
+// Third-party imports
 import { ForwardedRef, forwardRef } from 'react'
 import classNames from 'classnames'
 import { m, useReducedMotion } from 'framer-motion'
-import { IconUserPlus16 } from '@hashicorp/flight-icons/svg-react/user-plus-16'
+
+// HashiCorp imports
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
+import { IconBookmark16 } from '@hashicorp/flight-icons/svg-react/bookmark-16'
+import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
+import { IconSignOut16 } from '@hashicorp/flight-icons/svg-react/sign-out-16'
+import { IconUserPlus16 } from '@hashicorp/flight-icons/svg-react/user-plus-16'
+
+// Global imports
 import { useMobileMenu } from 'contexts'
 import useAuthentication from 'hooks/use-authentication'
 import Button from 'components/button'
 import ButtonLink from 'components/button-link'
+
+// Local imports
 import { MobileMenuContainerProps } from './types'
+import { MobileUserDisclosure } from './components'
 import s from './mobile-menu-container.module.css'
 
+// Constants
 const MOBILE_MENU_MOTION = {
 	visible: {
 		left: 0,
@@ -26,38 +38,63 @@ const MOBILE_MENU_MOTION = {
 /**
  * Handles rendering the Sign In and Sign Up UI elements in mobile viewports.
  * Intended to be used alongside `MobileMenuContainer`.
- *
- * @TODO Render user dropdown disclosure for authenticated users
- * ref: https://app.asana.com/0/1202097197789424/1202665629707469/f
  */
 const MobileAuthenticationControls = () => {
-	const { isAuthEnabled, isAuthenticated, isLoading, signIn } =
+	const { isAuthEnabled, isAuthenticated, isLoading, signIn, signOut, user } =
 		useAuthentication()
-	const shouldShowAuthButtons = isAuthEnabled && !isLoading && !isAuthenticated
 
-	if (!shouldShowAuthButtons) {
-		return null
+	// TODO these will come from PR #746
+	const showAuthenticatedUI = isAuthenticated
+	const showUnauthenticatedUI = isAuthEnabled && !isLoading && !isAuthenticated
+
+	if (showUnauthenticatedUI) {
+		return (
+			<div className={s.mobileAuthenticationControls}>
+				<ButtonLink
+					href="/sign-up"
+					icon={<IconUserPlus16 />}
+					iconPosition="trailing"
+					size="small"
+					text="Sign Up"
+				/>
+				<Button
+					color="secondary"
+					icon={<IconArrowRight16 />}
+					iconPosition="trailing"
+					onClick={() => signIn()}
+					size="small"
+					text="Sign In"
+				/>
+			</div>
+		)
 	}
 
-	return (
-		<div className={s.mobileAuthenticationControls}>
-			<ButtonLink
-				href="/sign-up"
-				icon={<IconUserPlus16 />}
-				iconPosition="trailing"
-				size="small"
-				text="Sign Up"
+	if (showAuthenticatedUI) {
+		return (
+			<MobileUserDisclosure
+				items={[
+					{
+						icon: <IconBookmark16 />,
+						label: 'Bookmarks',
+						href: '/bookmarks',
+					},
+					{
+						icon: <IconExternalLink16 />,
+						label: 'Account Settings',
+						href: 'https://portal.cloud.hashicorp.com/account-settings',
+					},
+					{
+						icon: <IconSignOut16 />,
+						label: 'Sign Out',
+						onClick: () => signOut(),
+					},
+				]}
+				user={user}
 			/>
-			<Button
-				color="secondary"
-				icon={<IconArrowRight16 />}
-				iconPosition="trailing"
-				onClick={() => signIn()}
-				size="small"
-				text="Sign In"
-			/>
-		</div>
-	)
+		)
+	}
+
+	return null
 }
 
 // eslint-disable-next-line react/display-name

--- a/src/components/mobile-menu-container/index.tsx
+++ b/src/components/mobile-menu-container/index.tsx
@@ -41,9 +41,14 @@ const MobileAuthenticationControls = () => {
 	const { showAuthenticatedUI, showUnauthenticatedUI, signIn, signOut, user } =
 		useAuthentication()
 
+	if (!showAuthenticatedUI && !showUnauthenticatedUI) {
+		return null
+	}
+
+	let content
 	if (showUnauthenticatedUI) {
-		return (
-			<div className={s.mobileAuthenticationControls}>
+		content = (
+			<>
 				<ButtonLink
 					href="/sign-up"
 					icon={<IconUserPlus16 />}
@@ -59,17 +64,15 @@ const MobileAuthenticationControls = () => {
 					size="small"
 					text="Sign In"
 				/>
-			</div>
+			</>
 		)
-	}
-
-	if (showAuthenticatedUI) {
-		return (
+	} else if (showAuthenticatedUI) {
+		content = (
 			<MobileUserDisclosure items={getUserMenuItems({ signOut })} user={user} />
 		)
 	}
 
-	return null
+	return <div className={s.mobileAuthenticationControls}>{content}</div>
 }
 
 // eslint-disable-next-line react/display-name

--- a/src/components/mobile-menu-container/index.tsx
+++ b/src/components/mobile-menu-container/index.tsx
@@ -5,12 +5,10 @@ import { m, useReducedMotion } from 'framer-motion'
 
 // HashiCorp imports
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
-import { IconBookmark16 } from '@hashicorp/flight-icons/svg-react/bookmark-16'
-import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
-import { IconSignOut16 } from '@hashicorp/flight-icons/svg-react/sign-out-16'
 import { IconUserPlus16 } from '@hashicorp/flight-icons/svg-react/user-plus-16'
 
 // Global imports
+import { getUserMenuItems } from 'lib/auth/user'
 import { useMobileMenu } from 'contexts'
 import useAuthentication from 'hooks/use-authentication'
 import Button from 'components/button'
@@ -71,26 +69,7 @@ const MobileAuthenticationControls = () => {
 
 	if (showAuthenticatedUI) {
 		return (
-			<MobileUserDisclosure
-				items={[
-					{
-						icon: <IconBookmark16 />,
-						label: 'Bookmarks',
-						href: '/bookmarks',
-					},
-					{
-						icon: <IconExternalLink16 />,
-						label: 'Account Settings',
-						href: 'https://portal.cloud.hashicorp.com/account-settings',
-					},
-					{
-						icon: <IconSignOut16 />,
-						label: 'Sign Out',
-						onClick: () => signOut(),
-					},
-				]}
-				user={user}
-			/>
+			<MobileUserDisclosure items={getUserMenuItems({ signOut })} user={user} />
 		)
 	}
 

--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -2,14 +2,12 @@
 import { useRouter } from 'next/router'
 
 // HashiCorp imports
-import { IconBookmark16 } from '@hashicorp/flight-icons/svg-react/bookmark-16'
-import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import { IconMenu24 } from '@hashicorp/flight-icons/svg-react/menu-24'
-import { IconSignOut16 } from '@hashicorp/flight-icons/svg-react/sign-out-16'
 import { IconUserPlus16 } from '@hashicorp/flight-icons/svg-react/user-plus-16'
 import { IconX24 } from '@hashicorp/flight-icons/svg-react/x-24'
 
 // Global imports
+import { getUserMenuItems } from 'lib/auth/user'
 import useAuthentication from 'hooks/use-authentication'
 import { useCurrentProduct, useMobileMenu } from 'contexts'
 import Button from 'components/button'
@@ -78,23 +76,7 @@ const AuthenticationControls = () => {
 			<UserDropdownDisclosure
 				className={s.userDropdownDisclosure}
 				listPosition="right"
-				items={[
-					{
-						href: '/bookmarks',
-						icon: <IconBookmark16 />,
-						label: 'Bookmarks',
-					},
-					{
-						href: 'https://portal.cloud.hashicorp.com/account-settings',
-						icon: <IconExternalLink16 />,
-						label: 'Account Settings',
-					},
-					{
-						icon: <IconSignOut16 />,
-						label: 'Sign Out',
-						onClick: () => signOut(),
-					},
-				]}
+				items={getUserMenuItems({ signOut })}
 				user={user}
 			/>
 		)

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
-import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
 import DropdownDisclosure, {
 	DropdownDisclosureButtonItem,
 	DropdownDisclosureDescriptionItem,
@@ -7,6 +5,7 @@ import DropdownDisclosure, {
 	DropdownDisclosureLinkItem,
 	DropdownDisclosureSeparatorItem,
 } from 'components/dropdown-disclosure'
+import { getUserMeta } from 'lib/auth/user'
 import {
 	UserDropdownDisclosureItem,
 	UserDropdownDisclosureProps,
@@ -48,10 +47,7 @@ const UserDropdownDisclosure = ({
 	listPosition,
 	user,
 }: UserDropdownDisclosureProps) => {
-	const icon = user.image ? <img alt="" src={user.image} /> : <IconUser24 />
-	const isSignedInWithGitHub = user.image?.includes('github')
-	const description = isSignedInWithGitHub ? user.nickname : user.email
-	const label = `Signed in with ${isSignedInWithGitHub ? 'GitHub' : 'Email'}`
+	const { icon, label, description } = getUserMeta(user)
 
 	return (
 		<DropdownDisclosure

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -67,5 +67,5 @@ const UserDropdownDisclosure = ({
 	)
 }
 
-export type { UserDropdownDisclosureProps }
+export type { UserDropdownDisclosureItem, UserDropdownDisclosureProps }
 export default UserDropdownDisclosure

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -67,4 +67,5 @@ const UserDropdownDisclosure = ({
 	)
 }
 
+export type { UserDropdownDisclosureProps }
 export default UserDropdownDisclosure

--- a/src/lib/auth/user.tsx
+++ b/src/lib/auth/user.tsx
@@ -1,3 +1,6 @@
+import { IconBookmark16 } from '@hashicorp/flight-icons/svg-react/bookmark-16'
+import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
+import { IconSignOut16 } from '@hashicorp/flight-icons/svg-react/sign-out-16'
 import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
 import { UserData } from 'types/auth'
 
@@ -18,6 +21,26 @@ const getDescription = (user: UserData, isSignedInWithGitHub: boolean) => {
 	return isSignedInWithGitHub ? user.nickname : user.email
 }
 
+const getUserMenuItems = ({ signOut }) => {
+	return [
+		{
+			icon: <IconBookmark16 />,
+			label: 'Bookmarks',
+			href: '/bookmarks',
+		},
+		{
+			icon: <IconExternalLink16 />,
+			label: 'Account Settings',
+			href: 'https://portal.cloud.hashicorp.com/account-settings',
+		},
+		{
+			icon: <IconSignOut16 />,
+			label: 'Sign Out',
+			onClick: () => signOut(),
+		},
+	]
+}
+
 const getUserMeta = (user: UserData) => {
 	const icon = getIcon(user)
 	const isSignedInWithGitHub = getIsSignedInWithGitHub(user)
@@ -32,4 +55,4 @@ const getUserMeta = (user: UserData) => {
 	}
 }
 
-export { getUserMeta }
+export { getUserMenuItems, getUserMeta }

--- a/src/lib/auth/user.tsx
+++ b/src/lib/auth/user.tsx
@@ -3,6 +3,8 @@ import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-l
 import { IconSignOut16 } from '@hashicorp/flight-icons/svg-react/sign-out-16'
 import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
 import { UserData } from 'types/auth'
+import useAuthentication from 'hooks/use-authentication'
+import { UserDropdownDisclosureProps } from 'components/user-dropdown-disclosure'
 
 const getIcon = (user: UserData) => {
 	// eslint-disable-next-line @next/next/no-img-element
@@ -21,7 +23,11 @@ const getDescription = (user: UserData, isSignedInWithGitHub: boolean) => {
 	return isSignedInWithGitHub ? user.nickname : user.email
 }
 
-const getUserMenuItems = ({ signOut }) => {
+const getUserMenuItems = ({
+	signOut,
+}: {
+	signOut: ReturnType<typeof useAuthentication>['signOut']
+}): UserDropdownDisclosureProps['items'] => {
 	return [
 		{
 			icon: <IconBookmark16 />,

--- a/src/lib/auth/user.tsx
+++ b/src/lib/auth/user.tsx
@@ -1,0 +1,35 @@
+import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
+import { UserData } from 'types/auth'
+
+const getIcon = (user: UserData) => {
+	// eslint-disable-next-line @next/next/no-img-element
+	return user.image ? <img alt="" src={user.image} /> : <IconUser24 />
+}
+
+const getIsSignedInWithGitHub = (user: UserData) => {
+	return user.image?.includes('github')
+}
+
+const getLabel = (isSignedInWithGitHub: boolean) => {
+	return `Signed in with ${isSignedInWithGitHub ? 'GitHub' : 'Email'}`
+}
+
+const getDescription = (user: UserData, isSignedInWithGitHub: boolean) => {
+	return isSignedInWithGitHub ? user.nickname : user.email
+}
+
+const getUserMeta = (user: UserData) => {
+	const icon = getIcon(user)
+	const isSignedInWithGitHub = getIsSignedInWithGitHub(user)
+	const label = getLabel(isSignedInWithGitHub)
+	const description = getDescription(user, isSignedInWithGitHub)
+
+	return {
+		icon,
+		isSignedInWithGitHub,
+		label,
+		description,
+	}
+}
+
+export { getUserMeta }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Asana tasks 🎟️
  - [Build mobile version of UserDropdown (attempt just CSS changes)](https://app.asana.com/0/1202097197789424/1202665629707465/f)
  - [[Mobile Sidebar] Render mobile UserDropdown (behind enable_auth flag) on narrow viewports when a user is authenticated](https://app.asana.com/0/1202097197789424/1202665629707469/f)

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds several helpers in `src/lib/auth/user.tsx` that provide a content source of truth for consistent rendering between `MobileUserDisclosure` and `UserDropdownDisclosure`
- Adds new `MobileUserDisclosure` under `MobileMenuContainer`
- Updates `MobileMenuContainer` to show `MobileUserDisclosure` for authenticated users
- Updates `NavigationHeader` to source `UserDropdownDisclosure` items from new `getUserMenuItems` helper
- Updates `UserDropdownDisclosure` to leverage new `getUserMeta` helper

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=11619%3A114923)

<img width="900" alt="CleanShot 2022-07-29 at 13 04 19@2x" src="https://user-images.githubusercontent.com/43934258/181809167-189bde89-b921-4a6c-b010-570eeb91dd14.png">

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out this code locally (auth doesn't work in preview URLs yet)
- [ ] Make sure you're authenticated
- [ ] Go to a page with a Sidebar, such as /waypoint
- [ ] Make sure the `MobileUserDisclosure` on renders in the sidebar on narrow viewports
- [ ] Make sure the content of the `MobileUserDisclosure` matches the designs
