### PR TITLE
Stage Nomad opt-in banner on .io site

### DIFF
--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -1,8 +1,10 @@
 import { IconAlertCircleFill16 } from '@hashicorp/flight-icons/svg-react/alert-circle-fill-16'
 import useProductMeta from '@hashicorp/platform-product-meta'
 import Cookies from 'js-cookie'
+import { isContentDeployPreview } from 'lib/env-checks'
+import getIsBetaProduct from 'lib/get-is-beta-product'
 import { useRouter } from 'next/router'
-import { ProductData } from 'types/products'
+import { ProductData, ProductSlug } from 'types/products'
 import s from './dev-dot-opt-in.module.css'
 
 const DAYS_UNTIL_EXPIRE = 180
@@ -30,6 +32,17 @@ export default function DevDotOptIn({ product }: { product?: ProductData }) {
 	// Prefer `product` prop over `productMeta`
 	const productName = product?.name || productMeta.name
 	const productSlug = product?.slug || productMeta.slug
+
+	// Based on our config values, decide whether or not we should render the CTA
+	const shouldRenderOptInCTA =
+		!isContentDeployPreview(productSlug) &&
+		getIsBetaProduct(productSlug as ProductSlug) &&
+		__config.flags.enable_io_beta_cta
+
+	// Return `null` if the CTA should not be rendered
+	if (!shouldRenderOptInCTA) {
+		return null
+	}
 
 	function handleOptIn() {
 		// Set a cookie to ensure any future navigation will send them to dev dot

--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -1,10 +1,10 @@
+import { useRouter } from 'next/router'
+import Cookies from 'js-cookie'
 import { IconAlertCircleFill16 } from '@hashicorp/flight-icons/svg-react/alert-circle-fill-16'
 import useProductMeta from '@hashicorp/platform-product-meta'
-import Cookies from 'js-cookie'
+import { ProductData, ProductSlug } from 'types/products'
 import { isContentDeployPreview } from 'lib/env-checks'
 import getIsBetaProduct from 'lib/get-is-beta-product'
-import { useRouter } from 'next/router'
-import { ProductData, ProductSlug } from 'types/products'
 import s from './dev-dot-opt-in.module.css'
 
 const DAYS_UNTIL_EXPIRE = 180

--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
 import { IconAlertCircleFill16 } from '@hashicorp/flight-icons/svg-react/alert-circle-fill-16'
 import useProductMeta from '@hashicorp/platform-product-meta'
-import { ProductData, ProductSlug } from 'types/products'
+import { ProductSlug } from 'types/products'
 import { isContentDeployPreview } from 'lib/env-checks'
 import getIsBetaProduct from 'lib/get-is-beta-product'
 import s from './dev-dot-opt-in.module.css'
@@ -25,18 +25,14 @@ const getDevDotLink = (product, path) => {
 /**
  * Largely copied from: https://github.com/hashicorp/learn/pull/4480
  */
-export default function DevDotOptIn({ product }: { product?: ProductData }) {
+export default function DevDotOptIn() {
 	const { asPath } = useRouter()
-	const productMeta = useProductMeta()
-
-	// Prefer `product` prop over `productMeta`
-	const productName = product?.name || productMeta.name
-	const productSlug = product?.slug || productMeta.slug
+	const { name, slug } = useProductMeta()
 
 	// Based on our config values, decide whether or not we should render the CTA
 	const shouldRenderOptInCTA =
-		!isContentDeployPreview(productSlug) &&
-		getIsBetaProduct(productSlug as ProductSlug) &&
+		!isContentDeployPreview(slug) &&
+		getIsBetaProduct(slug as ProductSlug) &&
 		__config.flags.enable_io_beta_cta
 
 	// Return `null` if the CTA should not be rendered
@@ -46,7 +42,7 @@ export default function DevDotOptIn({ product }: { product?: ProductData }) {
 
 	function handleOptIn() {
 		// Set a cookie to ensure any future navigation will send them to dev dot
-		Cookies.set(`${productSlug}-io-beta-opt-in`, true, {
+		Cookies.set(`${slug}-io-beta-opt-in`, true, {
 			expires: DAYS_UNTIL_EXPIRE,
 		})
 	}
@@ -55,11 +51,11 @@ export default function DevDotOptIn({ product }: { product?: ProductData }) {
 		<div className={s.container}>
 			<IconAlertCircleFill16 className={s.icon} />
 			<p className={s.alert}>
-				The {productName} website is being redesigned to help you find what you
-				are looking for more effectively.
+				The {name} website is being redesigned to help you find what you are
+				looking for more effectively.
 				<a
 					className={s.optInLink}
-					href={getDevDotLink(productSlug, asPath)}
+					href={getDevDotLink(slug, asPath)}
 					onClick={handleOptIn}
 				>
 					Join the Beta

--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -2,6 +2,7 @@ import { IconAlertCircleFill16 } from '@hashicorp/flight-icons/svg-react/alert-c
 import useProductMeta from '@hashicorp/platform-product-meta'
 import Cookies from 'js-cookie'
 import { useRouter } from 'next/router'
+import { ProductData } from 'types/products'
 import s from './dev-dot-opt-in.module.css'
 
 const DAYS_UNTIL_EXPIRE = 180
@@ -22,13 +23,17 @@ const getDevDotLink = (product, path) => {
 /**
  * Largely copied from: https://github.com/hashicorp/learn/pull/4480
  */
-export default function DevDotOptIn() {
-	const { name, slug } = useProductMeta()
+export default function DevDotOptIn({ product }: { product?: ProductData }) {
 	const { asPath } = useRouter()
+	const productMeta = useProductMeta()
+
+	// Prefer `product` prop over `productMeta`
+	const productName = product?.name || productMeta.name
+	const productSlug = product?.slug || productMeta.slug
 
 	function handleOptIn() {
 		// Set a cookie to ensure any future navigation will send them to dev dot
-		Cookies.set(`${slug}-io-beta-opt-in`, true, {
+		Cookies.set(`${productSlug}-io-beta-opt-in`, true, {
 			expires: DAYS_UNTIL_EXPIRE,
 		})
 	}
@@ -37,11 +42,11 @@ export default function DevDotOptIn() {
 		<div className={s.container}>
 			<IconAlertCircleFill16 className={s.icon} />
 			<p className={s.alert}>
-				The {name} website is being redesigned to help you find what you are
-				looking for more effectively.
+				The {productName} website is being redesigned to help you find what you
+				are looking for more effectively.
 				<a
 					className={s.optInLink}
-					href={getDevDotLink(slug, asPath)}
+					href={getDevDotLink(productSlug, asPath)}
 					onClick={handleOptIn}
 				>
 					Join the Beta

--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -30,7 +30,7 @@ export default function DevDotOptIn() {
 		const newURL = getDevDotLink(slug, asPath)
 
 		// Set a cookie to ensure any future navigation will send them to dev dot
-		Cookies.set('waypoint-io-beta-opt-in', true, {
+		Cookies.set(`${slug}-io-beta-opt-in`, true, {
 			expires: DAYS_UNTIL_EXPIRE,
 		})
 
@@ -43,9 +43,9 @@ export default function DevDotOptIn() {
 			<p className={s.alert}>
 				The {name} website is being redesigned to help you find what you are
 				looking for more effectively.
-				<button className={s.optInLink} onClick={handleOptIn}>
+				<a className={s.optInLink} onClick={handleOptIn}>
 					Join the Beta
-				</button>
+				</a>
 			</p>
 		</div>
 	)

--- a/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
+++ b/src/components/_proxied-dot-io/common/dev-dot-opt-in/index.tsx
@@ -27,14 +27,10 @@ export default function DevDotOptIn() {
 	const { asPath } = useRouter()
 
 	function handleOptIn() {
-		const newURL = getDevDotLink(slug, asPath)
-
 		// Set a cookie to ensure any future navigation will send them to dev dot
 		Cookies.set(`${slug}-io-beta-opt-in`, true, {
 			expires: DAYS_UNTIL_EXPIRE,
 		})
-
-		window.location.assign(newURL)
 	}
 
 	return (
@@ -43,7 +39,11 @@ export default function DevDotOptIn() {
 			<p className={s.alert}>
 				The {name} website is being redesigned to help you find what you are
 				looking for more effectively.
-				<a className={s.optInLink} onClick={handleOptIn}>
+				<a
+					className={s.optInLink}
+					href={getDevDotLink(slug, asPath)}
+					onClick={handleOptIn}
+				>
 					Join the Beta
 				</a>
 			</p>

--- a/src/components/_proxied-dot-io/common/docs-page/index.tsx
+++ b/src/components/_proxied-dot-io/common/docs-page/index.tsx
@@ -1,10 +1,6 @@
-import useProductMeta from '@hashicorp/platform-product-meta'
 import ReactDocsPage, { DocsPageProps } from '@hashicorp/react-docs-page'
 import ImageConfigBase from 'components/image-config'
 import { ImageConfigProps } from 'components/image-config/types'
-import { isContentDeployPreview } from 'lib/env-checks'
-import getIsBetaProduct from 'lib/get-is-beta-product'
-import { ProductSlug } from 'types/products'
 import DevDotOptIn from '../dev-dot-opt-in'
 
 const ioComponents = {
@@ -20,18 +16,10 @@ export default function DocsPage({
 	additionalComponents,
 	...props
 }: DocsPageProps) {
-	const { slug: productSlug } = useProductMeta()
-
-	// Based on our config values, decide whether or not we should render the dev portal beta CTA.
-	const shouldRenderOptInCTA =
-		!isContentDeployPreview(productSlug) &&
-		getIsBetaProduct(productSlug as ProductSlug) &&
-		__config.flags.enable_io_beta_cta
-
 	return (
 		<ReactDocsPage
 			additionalComponents={{ ...ioComponents, ...additionalComponents }}
-			optInBanner={shouldRenderOptInCTA ? <DevDotOptIn /> : null}
+			optInBanner={<DevDotOptIn />}
 			{...props}
 		/>
 	)

--- a/src/layouts/_proxied-dot-io/nomad/index.tsx
+++ b/src/layouts/_proxied-dot-io/nomad/index.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import HashiHead from '@hashicorp/react-head'
 import AlertBanner from '@hashicorp/react-alert-banner'
 import Min100Layout from '@hashicorp/react-min-100-layout'
-import useProductMeta, { Products } from '@hashicorp/platform-product-meta'
+import useProductMeta, {
+	ProductMetaProvider,
+	Products,
+} from '@hashicorp/platform-product-meta'
 import usePageviewAnalytics from '@hashicorp/platform-analytics'
 import createConsentManager from '@hashicorp/react-consent-manager/loader'
 import localConsentManagerServices from 'lib/consent-manager-services/io-sites'
@@ -49,66 +52,68 @@ function NomadIoLayout({ children, data }: Props): React.ReactElement {
 			/>
 
 			<Min100Layout footer={<Footer openConsentManager={openConsentManager} />}>
-				{productData.alertBannerActive && (
-					<AlertBanner
-						{...productData.alertBanner}
-						product={productData.slug as Products}
-						hideOnMobile
+				<ProductMetaProvider product={productData.slug as Products}>
+					{productData.alertBannerActive && (
+						<AlertBanner
+							{...productData.alertBanner}
+							product={productData.slug as Products}
+							hideOnMobile
+						/>
+					)}
+					<ProductSubnav
+						menuItems={[
+							{ text: 'Overview', url: '/', type: 'inbound' },
+							{
+								text: 'Use Cases',
+								submenu: [
+									...useCaseNavItems.map((item) => {
+										return {
+											text: item.text,
+											url: `/use-cases/${item.url}`,
+										}
+									}),
+								].sort((a, b) => a.text.localeCompare(b.text)),
+							},
+							{
+								text: 'Enterprise',
+								url: 'https://www.hashicorp.com/products/nomad/',
+								type: 'outbound',
+							},
+							'divider',
+							{
+								text: 'Tutorials',
+								url: 'https://learn.hashicorp.com/nomad',
+								type: 'outbound',
+							},
+							{
+								text: 'Docs',
+								url: '/docs',
+								type: 'inbound',
+							},
+							{
+								text: 'API',
+								url: '/api-docs',
+								type: 'inbound',
+							},
+							{
+								text: 'Plugins',
+								url: '/plugins',
+								type: 'inbound',
+							},
+							{
+								text: 'Tools',
+								url: '/tools',
+								type: 'inbound',
+							},
+							{
+								text: 'Community',
+								url: '/community',
+								type: 'inbound',
+							},
+						]}
 					/>
-				)}
-				<ProductSubnav
-					menuItems={[
-						{ text: 'Overview', url: '/', type: 'inbound' },
-						{
-							text: 'Use Cases',
-							submenu: [
-								...useCaseNavItems.map((item) => {
-									return {
-										text: item.text,
-										url: `/use-cases/${item.url}`,
-									}
-								}),
-							].sort((a, b) => a.text.localeCompare(b.text)),
-						},
-						{
-							text: 'Enterprise',
-							url: 'https://www.hashicorp.com/products/nomad/',
-							type: 'outbound',
-						},
-						'divider',
-						{
-							text: 'Tutorials',
-							url: 'https://learn.hashicorp.com/nomad',
-							type: 'outbound',
-						},
-						{
-							text: 'Docs',
-							url: '/docs',
-							type: 'inbound',
-						},
-						{
-							text: 'API',
-							url: '/api-docs',
-							type: 'inbound',
-						},
-						{
-							text: 'Plugins',
-							url: '/plugins',
-							type: 'inbound',
-						},
-						{
-							text: 'Tools',
-							url: '/tools',
-							type: 'inbound',
-						},
-						{
-							text: 'Community',
-							url: '/community',
-							type: 'inbound',
-						},
-					]}
-				/>
-				<div className={themeClass}>{children}</div>
+					<div className={themeClass}>{children}</div>
+				</ProductMetaProvider>
 			</Min100Layout>
 			<ConsentManager />
 		</>

--- a/src/pages/_proxied-dot-io/nomad/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/nomad/docs/index.tsx
@@ -51,7 +51,7 @@ function NomadDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
-			optInBanner={<DevDotOptIn product={productData as ProductData} />}
+			optInBanner={<DevDotOptIn />}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>

--- a/src/pages/_proxied-dot-io/nomad/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/nomad/docs/index.tsx
@@ -11,6 +11,8 @@ import PAGE_CONTENT from './content.json'
 // Imports below are used in getStatic functions only
 import { getStaticGenerationFunctions } from 'lib/_proxied-dot-io/get-static-generation-functions'
 import { GetStaticProps } from 'next'
+import DevDotOptIn from 'components/_proxied-dot-io/common/dev-dot-opt-in'
+import { ProductData } from 'types/products'
 
 const product = { name: productData.name, slug: productData.slug as Products }
 const basePath = 'docs'
@@ -28,7 +30,7 @@ const enableVersionedDocs = isVersionedDocsEnabled(productData.slug)
  * conflicting page files.
  * ref: https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes
  */
-function ConsulDocsLandingPage({
+function NomadDocsLandingPage({
 	frontMatter,
 	currentPath,
 	navData,
@@ -49,6 +51,11 @@ function ConsulDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
+			optInBanner={
+				__config.flags.enable_io_beta_cta ? (
+					<DevDotOptIn product={productData as ProductData} />
+				) : null
+			}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>
@@ -82,5 +89,5 @@ const getStaticProps: GetStaticProps = async (context) => {
 export { getStaticProps }
 
 // Export view with layout
-ConsulDocsLandingPage.layout = NomadIoLayout
-export default ConsulDocsLandingPage
+NomadDocsLandingPage.layout = NomadIoLayout
+export default NomadDocsLandingPage

--- a/src/pages/_proxied-dot-io/nomad/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/nomad/docs/index.tsx
@@ -51,11 +51,7 @@ function NomadDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
-			optInBanner={
-				__config.flags.enable_io_beta_cta ? (
-					<DevDotOptIn product={productData as ProductData} />
-				) : null
-			}
+			optInBanner={<DevDotOptIn product={productData as ProductData} />}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>

--- a/src/pages/_proxied-dot-io/vault/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/vault/docs/index.tsx
@@ -51,7 +51,7 @@ function VaultDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
-			optInBanner={<DevDotOptIn product={productData as ProductData} />}
+			optInBanner={<DevDotOptIn />}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>

--- a/src/pages/_proxied-dot-io/vault/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/vault/docs/index.tsx
@@ -51,11 +51,7 @@ function VaultDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
-			optInBanner={
-				__config.flags.enable_io_beta_cta ? (
-					<DevDotOptIn product={productData as ProductData} />
-				) : null
-			}
+			optInBanner={<DevDotOptIn product={productData as ProductData} />}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>

--- a/src/pages/_proxied-dot-io/vault/docs/index.tsx
+++ b/src/pages/_proxied-dot-io/vault/docs/index.tsx
@@ -12,6 +12,7 @@ import PAGE_CONTENT from './content.json'
 import { getStaticGenerationFunctions } from 'lib/_proxied-dot-io/get-static-generation-functions'
 import { GetStaticProps } from 'next'
 import DevDotOptIn from 'components/_proxied-dot-io/common/dev-dot-opt-in'
+import { ProductData } from 'types/products'
 
 const product = { name: productData.name, slug: productData.slug as Products }
 const basePath = 'docs'
@@ -50,7 +51,11 @@ function VaultDocsLandingPage({
 			baseRoute={basePath}
 			versions={versions}
 			algoliaConfig={productData.algoliaConfig}
-			optInBanner={__config.flags.enable_io_beta_cta ? <DevDotOptIn /> : null}
+			optInBanner={
+				__config.flags.enable_io_beta_cta ? (
+					<DevDotOptIn product={productData as ProductData} />
+				) : null
+			}
 		>
 			<ProductDocsLanding content={PAGE_CONTENT} />
 		</DocsPageInner>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Asana tasks 🎟️ 
  - [Stage adding "nomad" production beta_product_slugs array](https://app.asana.com/0/1202097197789424/1202632199481601/f)
  - [[DevDotOptIn] Cookie is not correctly set on VaultProject.io](https://app.asana.com/0/1202097197789424/1202699829872281/f)

## 🗒️ What

- Adds `ProductMetaProvider` to `NomadIoLayout`
- Adds `optInBanner` prop passed to `DocsPageInner` by `NomadDocsLandingPage`
- Delegates rendering logic of `DevDotOptIn` to the body of the component since the logic is always the same
- Updates `DevDotOptIn` to use a `<a>` instead of a `<button>` since clicking the element causes navigation
- Fixes the cookie set by `DevDotOptIn` to no longer be hardcoded to `"waypoint"` (this is a bug)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

### Vault

- [ ] Go to [the preview URL](https://dev-portal-git-ambstage-nomad-io-banner-hashicorp.vercel.app/)
- [ ] Choose Vault from the product switcher at the bottom left
- [ ] For the /docs, /api-docs routes:
  - [ ] Go to the page
  - [ ] Make sure there is no "vault-io-beta-opt-in" cookie set
  - [ ] Make sure there is no "waypoint-io-beta-opt-in" cookie set
  - [ ] Make sure the location of the "Join the beta" link is correct
  - [ ] Click the "Join the beta" link
  - [ ] You should be taken to the corresponding developer.hashicorp.com page with the `?optInFrom=vault-io` search query
  - [ ] Go back to the .io preview page you were on
  - [ ] Make sure the "vault-io-beta-opt-in" cookie is set
  - [ ] Make sure there is no "waypoint-io-beta-opt-in" cookie set

### Waypoint

- [ ] Go to [the preview URL](https://dev-portal-git-ambstage-nomad-io-banner-hashicorp.vercel.app/)
- [ ] Choose Waypoint from the product switcher at the bottom left
- [ ] For the /docs, /commands, /plugins routes:
  - [ ] Go to the page
  - [ ] Make sure there is no "waypoint-io-beta-opt-in" cookie set
  - [ ] Make sure the location of the "Join the beta" link is correct
  - [ ] Click the "Join the beta" link
  - [ ] You should be taken to the corresponding developer.hashicorp.com page with the `?optInFrom=waypoint-io` search query
  - [ ] Go back to the .io preview page you were on
  - [ ] Make sure the "waypoint-io-beta-opt-in" cookie is set

### Nomad

- [ ] Go to [the preview URL](https://dev-portal-git-ambstage-nomad-io-banner-hashicorp.vercel.app/)
- [ ] Choose Nomad from the product switcher at the bottom left
- [ ] For the /docs, /api-docs, /plugins, /tools routes:
  - [ ] Go to the page
  - [ ] Make sure there is no "nomad-io-beta-opt-in" cookie set
  - [ ] Make sure the location of the "Join the beta" link is correct
  - [ ] Click the "Join the beta" link
  - [ ] You should be taken to the corresponding developer.hashicorp.com page with the `?optInFrom=nomad-io` search query
    - NOTE: the 404 error will show but that's OK since Nomad isn't in production beta yet 
  - [ ] Go back to the /docs page
  - [ ] Make sure the "nomad-io-beta-opt-in" cookie is set

## 💭 Anything else?

The approach I've taken here allows us to merge this PR to fix bugs without affecting the production NomadProject.io website. We'll want to create a separate PR just for adding `"nomad"` to the beta product slugs array.
