### PR TITLE
Nesting rootDocsPaths under new Documentation sidebar item

### DIFF
--- a/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
@@ -25,6 +25,7 @@ export const generateProductLandingSidebarMenuItems = (
 		})
 		const documentationSubmenu = {
 			title: 'Documentation',
+			isOpen: true,
 			routes: [...rootDocsNavItems],
 		}
 		menuItems = [

--- a/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
@@ -20,11 +20,15 @@ export const generateProductLandingSidebarMenuItems = (
 
 	if (product.rootDocsPaths) {
 		const rootDocsNavItems = product.rootDocsPaths.map((rootDocsPath) => {
-			const { shortName, name, path } = rootDocsPath
-			return { title: shortName || name, fullPath: `/${product.slug}/${path}` }
+			const { name, path } = rootDocsPath
+			return { title: name, fullPath: `/${product.slug}/${path}` }
 		})
+		const documentationSubmenu = {
+			title: 'Documentation',
+			routes: [...rootDocsNavItems],
+		}
 		menuItems = [
-			...rootDocsNavItems,
+			documentationSubmenu,
 			{
 				title: 'Tutorials',
 				fullPath: `/${product.slug}/tutorials`,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1202710659957128/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `generateProductLandingSidebarMenuItems` to nest `rootDocsPaths` items under a new `Documentation` submenu, rather than list each item as an item at the root level

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This is an update in our designs

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

| Nomad  | Terraform |
| - | - |
| [Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=11227%3A114199)  | [Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=11253%3A106817) |
| <img width="458" alt="CleanShot 2022-08-03 at 11 31 05@2x" src="https://user-images.githubusercontent.com/43934258/182648297-c961c4cc-b94b-4da6-b43e-da66c4044082.png"> | <img width="286" alt="CleanShot 2022-08-03 at 11 32 13@2x" src="https://user-images.githubusercontent.com/43934258/182648543-664b3d11-4f6a-44fb-8d5d-67487bb85453.png"> |

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

For the following links, make sure that the `rootDocsPaths` items are now nested under a `Documentation` menu item in the **desktop sidebar** and second-to-top level of the **mobile sidebar**:

- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/hcp
- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/terraform
- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/consul
- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/vault
- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/nomad
- [ ] https://dev-portal-git-ambadd-documentation-sidebar-item-hashicorp.vercel.app/waypoint
