### PR TITLE
Adding isOpen ability to SidebarNavSubmenuItem

### DIFF
--- a/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
@@ -157,7 +157,10 @@ const SidebarNavLinkItem = ({ item }: SidebarNavLinkItemProps) => {
 const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
 	const buttonRef = useRef<HTMLButtonElement>()
 	const [isOpen, setIsOpen] = useState(
-		item.hasActiveChild || item.hasChildrenMatchingFilter || item.matchesFilter
+		item.isOpen ||
+			item.hasActiveChild ||
+			item.hasChildrenMatchingFilter ||
+			item.matchesFilter
 	)
 	const hasBadge = !!(item as $TSFixMe).badge
 
@@ -168,11 +171,17 @@ const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
 	 */
 	useEffect(() => {
 		setIsOpen(
-			item.hasActiveChild ||
+			item.isOpen ||
+				item.hasActiveChild ||
 				item.hasChildrenMatchingFilter ||
 				item.matchesFilter
 		)
-	}, [item.hasActiveChild, item.hasChildrenMatchingFilter, item.matchesFilter])
+	}, [
+		item.isOpen,
+		item.hasActiveChild,
+		item.hasChildrenMatchingFilter,
+		item.matchesFilter,
+	])
 
 	const handleKeyDown: KeyboardEventHandler<HTMLUListElement> = (e) => {
 		if (e.key === 'Escape') {

--- a/src/components/sidebar/docs.mdx
+++ b/src/components/sidebar/docs.mdx
@@ -6,66 +6,66 @@ componentName: 'Sidebar'
 
 ## Default Sidebar with no props
 
-<LiveComponent>{`
-<Sidebar />
-`}</LiveComponent>
+<div style={{ border: '1px solid black', maxWidth: 320, padding: 24 }}>
+	<Sidebar />
+</div>
 
 ## Sidebar with Badges
 
 At the current time of writing, only the "highlight" and "neutral" [`Badge`](/swingset/components/badge) colors are supported. This is because other `Badge` colors are for used for indicating a status, and so they must also have an icon. See [Understanding Success Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) for further reading on the topic. Supporting icons in Sidebar Badges has not been designed at this time.
 
-<LiveComponent>{`
-<Sidebar
-  menuItems={[
-    {
-      title: 'Internal link item with a "highlight" Badge',
-      href: '/',
-      badge: {
-        text: 'Badge',
-        color: 'highlight',
-        type: 'filled'
-      }
-    },
-    {
-      title: 'Internal link item with a "neutral" Badge',
-      href: '/',
-      badge: {
-        text: 'Badge',
-        color: 'neutral',
-        type: 'outlined'
-      }
-    },
-    {
-      title: 'External link item with a Badge',
-      href: 'https://hashicorp.com',
-      badge: {
-        text: 'Badge',
-        color: 'highlight',
-        type: 'filled'
-      }
-    },
-    {
-      title: 'Submenu item with a Badge',
-      badge: {
-        text: 'Badge',
-        color: 'highlight',
-        type: 'filled'
-      },
-      routes: [
-        {
-          title: 'Child item 1',
-          href: '/'
-        },
-        {
-          title: 'Child item 2',
-          href: '/'
-        },
-        {
-          title: 'Child item 3',
-          href: '/'
-        },
-      ]
-    }
-  ]}
-/>
-`}</LiveComponent>
+<div style={{ border: '1px solid black', maxWidth: 320, padding: 24 }}>
+	<Sidebar
+		menuItems={[
+			{
+				title: 'Internal link item with a "highlight" Badge',
+				href: '/',
+				badge: {
+					text: 'Badge',
+					color: 'highlight',
+					type: 'filled',
+				},
+			},
+			{
+				title: 'Internal link item with a "neutral" Badge',
+				href: '/',
+				badge: {
+					text: 'Badge',
+					color: 'neutral',
+					type: 'outlined',
+				},
+			},
+			{
+				title: 'External link item with a Badge',
+				href: 'https://hashicorp.com',
+				badge: {
+					text: 'Badge',
+					color: 'highlight',
+					type: 'filled',
+				},
+			},
+			{
+				title: 'Submenu item with a Badge',
+				badge: {
+					text: 'Badge',
+					color: 'highlight',
+					type: 'filled',
+				},
+				routes: [
+					{
+						title: 'Child item 1',
+						href: '/',
+					},
+					{
+						title: 'Child item 2',
+						href: '/',
+					},
+					{
+						title: 'Child item 3',
+						href: '/',
+					},
+				],
+			},
+		]}
+	/>
+</div>

--- a/src/components/sidebar/docs.mdx
+++ b/src/components/sidebar/docs.mdx
@@ -10,6 +10,60 @@ componentName: 'Sidebar'
 	<Sidebar />
 </div>
 
+## Sidebar with some submenus open on load
+
+`SidebarNavSubmenuItem` elements can be rendered open on load if the `item` prop passed has an `isOpen` property set to `true`.
+
+<div style={{ border: '1px solid black', maxWidth: 320, padding: 24 }}>
+	<Sidebar
+		menuItems={[
+			{
+				title: 'Parent Menu 1',
+				isOpen: true,
+				routes: [
+					{
+						title: 'Child Item 1',
+						href: '#',
+					},
+					{
+						title: 'Child Item 1',
+						href: '#',
+					},
+					{
+						title: 'Child Item 2',
+						href: '#',
+					},
+				],
+			},
+			{
+				title: 'Parent Menu 2',
+				routes: [
+					{
+						title: 'Child Item 1',
+						href: '#',
+					},
+					{
+						title: 'Child Item 1',
+						href: '#',
+					},
+					{
+						title: 'Child Item 2',
+						href: '#',
+					},
+				],
+			},
+			{
+				title: 'Root Item 1',
+				href: '#',
+			},
+			{
+				title: 'Root Item 1',
+				href: '#',
+			},
+		]}
+	/>
+</div>
+
 ## Sidebar with Badges
 
 At the current time of writing, only the "highlight" and "neutral" [`Badge`](/swingset/components/badge) colors are supported. This is because other `Badge` colors are for used for indicating a status, and so they must also have an icon. See [Understanding Success Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) for further reading on the topic. Supporting icons in Sidebar Badges has not been designed at this time.

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -118,8 +118,8 @@ interface MenuItem {
 	path?: string
 	routes?: MenuItem[]
 	title?: string
-	/* Temporary solution to allow rendering of unlinked headings, as in designs */
 	heading?: string
+	isOpen?: boolean
 }
 
 interface SidebarBaseProps {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambenable-submenu-load-open-hashicorp.vercel.app/swingset/components/sidebar) 🔎
- [Asana task](https://app.asana.com/0/1202520168081556/1202710659957129/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds new `isOpen` property to `MenuItem`
- Handles `item.isOpen` in `SidebarNavSubmenuItem`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This is part of the request for nesting `rootDocsPaths` under a new `Documentation` submenu in Sidebar. See #762 for more context on the other part of this ask.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [the Sidebar Swingset page](https://dev-portal-git-ambenable-submenu-load-open-hashicorp.vercel.app/swingset/components/sidebar)
- [ ] Scroll to the "Sidebar with some submenus open on load" section
- [ ] Make sure the example behaves as you expect
