### PR TITLE
fix: always run npm install on local preview start

### DIFF
--- a/scripts/content-repo-preview/start.sh
+++ b/scripts/content-repo-preview/start.sh
@@ -1,7 +1,5 @@
-# Install dependencies, if needed
-if [ ! -d "node_modules" ]; then
-    npm i --production=false
-fi
+# Install dependencies
+npm i --production=false
 # TODO set up watcher to sync all files
 # TODO under website/public into website/website-preview/public
 cp -R ../public/** ./public/


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
We got a report that local preview was regularly erroring for folks. This was because new packages weren't getting installed when they already had the `website-preview` directory locally. This adjustment should ensure that `npm install` always gets run, regardless of the local state.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
