### PR TITLE
fix: avoid 500 when Packer plugins navNode cannot be matched

### DIFF
--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -68,7 +68,7 @@ async function generateStaticProps({
 	try {
 		navNode = getNodeFromPath(currentPath, navData, localContentDir)
 	} catch (e) {
-		const isNotFound = e.indexOf('Missing resource') !== -1
+		const isNotFound = String(e).indexOf('Missing resource') !== -1
 		if (isNotFound) {
 			return null
 		} else {

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -68,7 +68,7 @@ async function generateStaticProps({
 	try {
 		navNode = getNodeFromPath(currentPath, navData, localContentDir)
 	} catch (e) {
-		const isNotFound = String(e).indexOf('Missing resource') !== -1
+		const isNotFound = String(e).includes('Missing resource')
 		if (isNotFound) {
 			return null
 		} else {

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -33,6 +33,11 @@ async function generateStaticPaths({ navDataFile, remotePluginsFile }) {
 	return paths
 }
 
+/**
+ * Given page params for a Packer plugins URL,
+ * Return static props for the plugin document in question,
+ * or `null` if a document cannot be found.
+ */
 async function generateStaticProps({
 	localContentDir,
 	mainBranch = 'main',
@@ -57,7 +62,19 @@ async function generateStaticProps({
 		remotePluginsFile,
 		currentPath,
 	})
-	const navNode = getNodeFromPath(currentPath, navData, localContentDir)
+	// Attempt to match a navNode for this path.
+	// Note that we may not be able to find a match, in which case we 404.
+	let navNode
+	try {
+		navNode = getNodeFromPath(currentPath, navData, localContentDir)
+	} catch (e) {
+		const isNotFound = e.indexOf('Missing resource') !== -1
+		if (isNotFound) {
+			return null
+		} else {
+			throw e
+		}
+	}
 	const { filePath, remoteFile, pluginData } = navNode
 	//  Fetch the MDX file content
 	const mdxString = remoteFile

--- a/src/pages/_proxied-dot-io/packer/plugins/[...page].tsx
+++ b/src/pages/_proxied-dot-io/packer/plugins/[...page].tsx
@@ -65,6 +65,9 @@ export async function getStaticProps({ params }) {
 		product,
 		remotePluginsFile,
 	})
+	if (!props) {
+		return { notFound: true }
+	}
 	return { props, revalidate: __config.io_sites.revalidate }
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where Packer `/plugin` routes that could not be resolved would 500, rather than produce a more expected 404 status.

## 🤷 Why

- It may be unexpected that a resource can't be resolved, but we should handle this more gracefully that the Vercel default 500 error page currently visible at URLs such as https://www.packer.io/plugins/builders/huaweicloud
- This fix will hopefully also get our `Cache io & tutorials path` check working again, which is [currently failing for reasons that seem related](https://github.com/hashicorp/dev-portal/runs/7662061150?check_suite_focus=true) to URLs such as https://www.packer.io/plugins/builders/huaweicloud
    - We currently [throw errors in CI for 500s](https://github.com/hashicorp/dev-portal/blob/28f9ad1600b1c76f6c5f533b53ce59eebb01d975/scripts/warm-dotio-cache.ts#L127), but only [warn for 404](https://github.com/hashicorp/dev-portal/blob/28f9ad1600b1c76f6c5f533b53ce59eebb01d975/scripts/warm-dotio-cache.ts#L125), intent here is to fix Packer plugins falsely triggering the former case

## 🛠️ How

Updates Packer plugin server functions to return `{ notFound: true }` when the relevant static props cannot be resolved as expected.

## 🧪 Testing

- Confirm that https://www.packer.io/plugins/builders/huaweicloud returns a 500 error page
- In [the preview][preview], switch to Packer dot-io mode using the product dropdown in the lower left
- Visit [/plugins/builders/huaweicloud][/plugins/builders/huaweicloud]. It should 404 rather than 500.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1100423001970639/1202722608014577/f
[preview]: https://dev-portal-git-zsfix-packer-plugins-500-hashicorp.vercel.app
[/plugins/builders/huaweicloud]: https://dev-portal-git-zsfix-packer-plugins-500-hashicorp.vercel.app/plugins/builders/huaweicloud