### PR TITLE
[TutorialView] Fixing next/previous at bottom of page

### DIFF
--- a/src/views/tutorial-view/components/next-previous/next-previous.module.css
+++ b/src/views/tutorial-view/components/next-previous/next-previous.module.css
@@ -1,24 +1,28 @@
 .linkBoxWrapper {
-  --gap: 24px;
-  --item-count: 2;
+	--gap: 24px;
+	--item-count: 2;
 
-  border-top: 1px solid var(--token-color-border-primary);
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--gap);
-  margin-top: 48px;
-  padding-top: 48px;
+	border-top: 1px solid var(--token-color-border-primary);
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gap);
+	margin-top: 48px;
+	padding-top: 48px;
 
-  & > * {
-    /* Items should grow and shrink, but should ideally take up their
+	& > * {
+		/* Items should grow and shrink, but should ideally take up their
        "auto" width, which is their size without text wrapping. */
-    flex: 1 1 auto;
+		flex: 1 1 auto;
 
-    /* With flex-basis: auto on both items, the one with longer text
+		/* With flex-basis: auto on both items, the one with longer text
        will take up more space by default. Setting min-width to the
        width of half the available space (minus gap) ensures that
        each item takes up an equal amount of space. This comes at the
        cost of going to a single-column layout slightly earlier */
-    min-width: calc(50% - (var(--gap) / var(--item-count)));
-  }
+		min-width: calc(50% - (var(--gap) / var(--item-count)));
+	}
+
+	@media (--dev-dot-tablet-up) {
+		flex-wrap: nowrap;
+	}
 }


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the alignment of the Next/Previous `CardLink` elements that show at the bottom of `TutorialView`s, which was introduced in #764 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /waypoint/tutorials/get-started-kubernetes/get-started-intro
- [ ] Scroll to the bottom of the content
- [ ] In tablet views and wider, the Next/Previous `CardLink`s should be inline with one another
- [ ] In mobile views and narrower, the Next/Previous `CardLink`s should be stacked on top of each other
