### PR TITLE
ubuntu: pipe to dd when downloading gpg key

### DIFF
--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -31,7 +31,7 @@ export const generateDefaultPackageManagers = (
 		{
 			label: 'Ubuntu/Debian',
 			commands: [
-				`wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
+				`wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo dd of=/usr/share/keyrings/hashicorp-archive-keyring.gpg`,
 				`echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list`,
 				`sudo apt update && sudo apt install ${productSlug}`,
 			],


### PR DESCRIPTION
This PR swaps the use of `tee` for `dd` when creating the gpg key file
for setting up the apt repository on Debian/Ubuntu systems.

Using `tee` causes binary output to be displayed on the terminal, which
is not desireable (see  https://github.com/hashicorp/nomad/issues/14047)

