### PR TITLE
chore: fix onboarding link rewrites

### DIFF
--- a/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
@@ -89,7 +89,6 @@ export function rewriteTutorialsLink(
 		)
 		const product = match ? match[0] : null
 		const isExternalLearnLink = url.includes('learn.hashicorp.com')
-		console.log({ isExternalLearnLink }, { url })
 		const isBetaProduct = product
 			? getIsBetaProduct(product as ProductSlug)
 			: false

--- a/src/views/collection-view/helpers/get-slug.ts
+++ b/src/views/collection-view/helpers/get-slug.ts
@@ -19,7 +19,10 @@ export function getTutorialSlug(
 	const tutorialFilename = splitProductFromFilename(tutorialDbSlug)
 
 	// @TODO genericize this to use 'topic' or 'section' instead of 'product'
-	if (rawProductSlug === 'well-architected-framework') {
+	if (
+		rawProductSlug === 'well-architected-framework' ||
+		rawProductSlug === 'onboarding'
+	) {
 		return `/${collectionDbSlug}/${tutorialFilename}`
 	}
 
@@ -32,7 +35,10 @@ export function getCollectionSlug(collectionDbSlug: string): string {
 	const [rawProductSlug, collectionFilename] = collectionDbSlug.split('/')
 
 	// @TODO genericize this to use 'topic' or 'section' instead of 'product'
-	if (rawProductSlug === 'well-architected-framework') {
+	if (
+		rawProductSlug === 'well-architected-framework' ||
+		rawProductSlug === 'onboarding'
+	) {
 		return `/${collectionDbSlug}`
 	}
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

After #795, were getting a bunch of build log warnings because the onboarding tutorial paths are being rewritten in the tutorial map generation. This is a small fix for that warning.  

Also removed an accidental log that crept in.