### PR TITLE
fix: only show version select for meaningful versions

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -88,6 +88,8 @@ const SidebarSidecarLayoutContent = ({
 		)
 	}
 
+	const hasMeaningfulVersions = versions && versions.length > 1
+
 	return (
 		<div className={s.root}>
 			<MobileMenuContainer className={s.mobileMenuContainer} ref={sidebarRef}>
@@ -95,7 +97,9 @@ const SidebarSidecarLayoutContent = ({
 					<MobileAuthenticationControls />
 					<SidebarContent />
 				</div>
-				{versions ? <DocsVersionSwitcher options={versions} /> : null}
+				{hasMeaningfulVersions ? (
+					<DocsVersionSwitcher options={versions} />
+				) : null}
 			</MobileMenuContainer>
 			<div className={s.contentWrapper}>
 				{currentlyViewedVersion && (

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -88,9 +88,6 @@ const SidebarSidecarLayoutContent = ({
 		)
 	}
 
-	const hasMeaningfulVersions =
-		versions && (versions.length > 1 || versions[0].version !== 'v0.0.x')
-
 	return (
 		<div className={s.root}>
 			<MobileMenuContainer className={s.mobileMenuContainer} ref={sidebarRef}>
@@ -98,9 +95,7 @@ const SidebarSidecarLayoutContent = ({
 					<MobileAuthenticationControls />
 					<SidebarContent />
 				</div>
-				{hasMeaningfulVersions ? (
-					<DocsVersionSwitcher options={versions} />
-				) : null}
+				{versions ? <DocsVersionSwitcher options={versions} /> : null}
 			</MobileMenuContainer>
 			<div className={s.contentWrapper}>
 				{currentlyViewedVersion && (

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -88,7 +88,8 @@ const SidebarSidecarLayoutContent = ({
 		)
 	}
 
-	const hasMeaningfulVersions = versions && versions.length > 1
+	const hasMeaningfulVersions =
+		versions && (versions.length > 1 || versions[0].version !== 'v0.0.x')
 
 	return (
 		<div className={s.root}>

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -94,7 +94,6 @@ export function getStaticGenerationFunctions<
 	getScope = async () => ({} as MdxScope),
 	mainBranch,
 	navDataPrefix,
-	showVersionSelect,
 }: {
 	product: ProductData
 	basePath: string
@@ -105,7 +104,6 @@ export function getStaticGenerationFunctions<
 	getScope?: () => Promise<MdxScope>
 	mainBranch?: string
 	navDataPrefix?: string
-	showVersionSelect?: boolean
 }): ReturnType<typeof _getStaticGenerationFunctions> {
 	/**
 	 * Beta products, defined in our config files, will source content from a
@@ -307,15 +305,21 @@ export function getStaticGenerationFunctions<
 
 			/**
 			 * Determine whether to show the version selector
+			 *
+			 * In most docs categories, we want to show the version selector if there
+			 * are multiple versions, or if the single version is not `v0.0.x`.
+			 * (We use `v0.0.x` as a placeholder version for un-versioned documentation)
 			 */
-			const shouldShowVersions = showVersionSelect === true
-			const shouldHideVersions = showVersionSelect === false
 			const hasMeaningfulVersions =
 				versions && (versions.length > 1 || versions[0].version !== 'v0.0.x')
-			if (
-				!shouldHideVersions &&
-				(shouldShowVersions || hasMeaningfulVersions)
-			) {
+			/**
+			 * For the /packer/plugins landing page, we want to hide the version selector,
+			 * even though we do have meaningful versions available
+			 */
+			const isPackerPlugins =
+				product.slug == 'packer' && currentRootDocsPath.path == 'plugins'
+
+			if (!isPackerPlugins && hasMeaningfulVersions) {
 				layoutProps.versions = versions
 			}
 

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -94,7 +94,7 @@ export function getStaticGenerationFunctions<
 	getScope = async () => ({} as MdxScope),
 	mainBranch,
 	navDataPrefix,
-	showVersionSelect = true,
+	showVersionSelect,
 }: {
 	product: ProductData
 	basePath: string
@@ -304,7 +304,18 @@ export function getStaticGenerationFunctions<
 				// TODO: need to adjust type for sidebarNavDataLevels here
 				sidebarNavDataLevels: sidebarNavDataLevels as $TSFixMe,
 			}
-			if (showVersionSelect) {
+
+			/**
+			 * Determine whether to show the version selector
+			 */
+			const shouldShowVersions = showVersionSelect === true
+			const shouldHideVersions = showVersionSelect === false
+			const hasMeaningfulVersions =
+				versions && (versions.length > 1 || versions[0].version !== 'v0.0.x')
+			if (
+				!shouldHideVersions &&
+				(shouldShowVersions || hasMeaningfulVersions)
+			) {
 				layoutProps.versions = versions
 			}
 

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -32,6 +32,7 @@ export function getRootDocsPathGenerationFunctions(
 		productSlugForLoader: rootDocsPath.productSlugForLoader,
 		basePathForLoader: rootDocsPath.basePathForLoader,
 		mainBranch: rootDocsPath.mainBranch,
+		showVersionSelect: getShowVersionSelect(productData, rootDocsPath),
 		additionalRemarkPlugins: getAdditionalRemarkPlugins(
 			productData,
 			rootDocsPath
@@ -98,4 +99,16 @@ function generateGetScope(
 	} else {
 		return undefined
 	}
+}
+
+/**
+ * On certain product paths, we do not want to show the version select.
+ */
+function getShowVersionSelect(
+	productData: ProductData,
+	rootDocsPath: RootDocsPath
+): boolean {
+	const isPackerPlugins =
+		productData.slug == 'packer' && rootDocsPath.path == 'plugins'
+	return !isPackerPlugins
 }

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -102,13 +102,20 @@ function generateGetScope(
 }
 
 /**
- * On certain product paths, we do not want to show the version select.
+ * On certain product paths, we want to hide the version selector.
  */
 function getShowVersionSelect(
 	productData: ProductData,
 	rootDocsPath: RootDocsPath
 ): boolean {
+	// For the /packer/plugins landing page, we want to hide the version selector,
+	// even though we do have meaningful versions available
 	const isPackerPlugins =
 		productData.slug == 'packer' && rootDocsPath.path == 'plugins'
-	return !isPackerPlugins
+	if (isPackerPlugins) {
+		return false
+	}
+	// For all other routes, return undefined so that we rely on logic
+	// within docs-view/server to only show meaningful versions.
+	return undefined
 }

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -32,7 +32,6 @@ export function getRootDocsPathGenerationFunctions(
 		productSlugForLoader: rootDocsPath.productSlugForLoader,
 		basePathForLoader: rootDocsPath.basePathForLoader,
 		mainBranch: rootDocsPath.mainBranch,
-		showVersionSelect: getShowVersionSelect(productData, rootDocsPath),
 		additionalRemarkPlugins: getAdditionalRemarkPlugins(
 			productData,
 			rootDocsPath
@@ -99,23 +98,4 @@ function generateGetScope(
 	} else {
 		return undefined
 	}
-}
-
-/**
- * On certain product paths, we want to hide the version selector.
- */
-function getShowVersionSelect(
-	productData: ProductData,
-	rootDocsPath: RootDocsPath
-): boolean {
-	// For the /packer/plugins landing page, we want to hide the version selector,
-	// even though we do have meaningful versions available
-	const isPackerPlugins =
-		productData.slug == 'packer' && rootDocsPath.path == 'plugins'
-	if (isPackerPlugins) {
-		return false
-	}
-	// For all other routes, return undefined so that we rely on logic
-	// within docs-view/server to only show meaningful versions.
-	return undefined
 }

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -32,7 +32,6 @@ export function getRootDocsPathGenerationFunctions(
 		productSlugForLoader: rootDocsPath.productSlugForLoader,
 		basePathForLoader: rootDocsPath.basePathForLoader,
 		mainBranch: rootDocsPath.mainBranch,
-		showVersionSelect: getShowVersionSelect(productData, rootDocsPath),
 		additionalRemarkPlugins: getAdditionalRemarkPlugins(
 			productData,
 			rootDocsPath
@@ -99,16 +98,4 @@ function generateGetScope(
 	} else {
 		return undefined
 	}
-}
-
-/**
- * On certain product paths, we do not want to show the version select.
- */
-function getShowVersionSelect(
-	productData: ProductData,
-	rootDocsPath: RootDocsPath
-): boolean {
-	const isPackerPlugins =
-		productData.slug == 'packer' && rootDocsPath.path == 'plugins'
-	return !isPackerPlugins
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR fixes an issue where the version select is shown unintentionally on pages.

## 🤷 Why

Showing a version select with a single `0.0.x` version is not our desired user experience.

## 🛠️ How

### Context

- Previously, in #817, we introduced a `getShowVersionSelect` function
- Currently, `showVersionSelect` defaults to `true` even if there is only one `0.0.x` version

### This PR

- This PR revises the approach in an attempt to simplify version select hiding for many cases
- If `showVersionSelect` has not explicitly been set, rather than default to `true`, we only show the version selector if:
    - there is more than one version
    - _or_ if the single version is any version other than `0.0.x`
- Note that we still retain `getShowVersionSelect`
    - For the Packer plugins case, we do have meaningful versions for the document, but we intentionally want to hide them. So the logic to show only meaningful version selectors is still not enough to match our intent.
    - Note as well that we do expect the Packer plugins use case to fade away once we have a dedicated integrations catalog, so we will likely eventually be able to get rid of `getShowVersionSelect` and rely instead on "meaningful versions" logic alone.

## 🧪 Testing

Ensure the Packer plugins docs category continues to hide the version selector:

- [/packer/plugins][/packer/plugins]
- [/packer/plugins/builders/oneandone][/packer/plugins/builders/oneandone]

Ensure all Waypoint and Vault docs categories continue to show the version selector:

- [/vault/api-docs][/vault/api-docs]
- [/vault/docs][/vault/docs]
- [/waypoint/docs][/waypoint/docs]
- [/waypoint/commands][/waypoint/commands]
- [/waypoint/plugins][/waypoint/plugins]

Visit Terraform docs categories show & hide the version selector where appropriate

- 👀 [/terraform/cdktf][/terraform/cdktf] - Should be visible
- 👀 [/terraform/cli][/terraform/cli] - Should be visible
- 🙈 [/terraform/cloud-docs][/terraform/cloud-docs] - Should be hidden
- 👀 [/terraform/cloud-docs/agents][/terraform/cloud-docs/agents] - Should be visible
- 🙈 [/terraform/docs][/terraform/docs] - Should be hidden
- 👀 [/terraform/enterprise][/terraform/enterprise] - Should be visible
- 👀 [/terraform/internals][/terraform/internals] - Should be visible
- 👀 [/terraform/intro][/terraform/intro] - Should be visible
- 👀 [/terraform/language][/terraform/language] - Should be visible
- 🙈 [/terraform/plugin][/terraform/plugin] - Should be hidden
- 👀 [/terraform/plugin/framework][/terraform/plugin/framework] - Should be visible
- 👀 [/terraform/plugin/log][/terraform/plugin/log] - Should be visible
- 👀 [/terraform/plugin/mux][/terraform/plugin/mux] - Should be visible
- 👀 [/terraform/plugin/sdkv2][/terraform/plugin/sdkv2] - Should be visible
- 🙈 [/terraform/registry][/terraform/registry] - Should be hidden

[task]: https://app.asana.com/0/1202097197789424/1202709883261301/f
[preview]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/
[/terraform/cdktf]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/cdktf
[/terraform/cli]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/cli
[/terraform/cloud-docs]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/cloud-docs
[/terraform/cloud-docs/agents]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/cloud-docs/agents
[/terraform/docs]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/docs
[/terraform/enterprise]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/enterprise
[/terraform/internals]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/internals
[/terraform/intro]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/intro
[/terraform/language]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/language
[/terraform/plugin]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/plugin
[/terraform/plugin/framework]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/plugin/framework
[/terraform/plugin/log]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/plugin/log
[/terraform/plugin/mux]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/plugin/mux
[/terraform/plugin/sdkv2]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/plugin/sdkv2
[/terraform/registry]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/terraform/registry
[/vault/api-docs]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/vault/api-docs
[/vault/docs]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/vault/docs
[/waypoint/docs]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/waypoint/docs
[/waypoint/commands]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/waypoint/commands
[/waypoint/plugins]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/waypoint/plugins
[/packer/plugins]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/packer/plugins
[/packer/plugins/builders/oneandone]: https://dev-portal-git-zsterraform-hide-versioning-whe-35808c-hashicorp.vercel.app/packer/plugins/builders/oneandone
