### PR TITLE
fix: tweak fullPath from relative href logic

### DIFF
--- a/src/layouts/sidebar-sidecar/utils/__tests__/prepare-nav-data-for-client.test.ts
+++ b/src/layouts/sidebar-sidecar/utils/__tests__/prepare-nav-data-for-client.test.ts
@@ -1,0 +1,31 @@
+import { fullPathFromRelativeHref } from '../prepare-nav-data-for-client'
+
+describe('fullPathFromRelativeHref', () => {
+	it('handles hrefs where the first path part is the current product', () => {
+		const basePaths = ['sentinel', 'docs']
+		const href = '/sentinel/something-else'
+		const expected = '/sentinel/something-else'
+		expect(fullPathFromRelativeHref(href, basePaths)).toEqual(expected)
+	})
+
+	it('handles hrefs where the first path part is not exactly the current product', () => {
+		const basePaths = ['vagrant', 'docs']
+		const href = '/vagrant-cloud'
+		const expected = '/vagrant/vagrant-cloud'
+		expect(fullPathFromRelativeHref(href, basePaths)).toEqual(expected)
+	})
+
+	it('handles hrefs that start a leading slash', () => {
+		const basePaths = ['vault', 'docs']
+		const href = '/something-else'
+		const expected = '/vault/something-else'
+		expect(fullPathFromRelativeHref(href, basePaths)).toEqual(expected)
+	})
+
+	it('handles hrefs that do not start with a leading slash', () => {
+		const basePaths = ['terraform', 'plugin']
+		const href = 'sdkv2'
+		const expected = '/terraform/plugin/sdkv2'
+		expect(fullPathFromRelativeHref(href, basePaths)).toEqual(expected)
+	})
+})

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -159,28 +159,7 @@ function prepareNavNodeForClient({
 			 * If we have a non-absolute NavDirectLink,
 			 * convert it to a NavLeaf node, and treat it similarly.
 			 */
-			let fullPath
-			if (node.href.startsWith(`/${basePaths[0]}/`)) {
-				/**
-				 * If the path already starts with the basePaths[0], the product slug,
-				 * we use the href as the fullPath directly.
-				 */
-				fullPath = node.href
-			} else if (node.href.startsWith('/')) {
-				/**
-				 * If the path starts with a slash, we treat it as relative
-				 * to the previous dot-io setup. We prefix it with basePaths[0],
-				 * which should be the product slug.
-				 */
-				fullPath = `/${path.join(basePaths[0], node.href)}`
-			} else {
-				/**
-				 * If the path does not start with a slash, we treat it as relative
-				 * to the combined current basePath.
-				 */
-				fullPath = `/${path.join(basePaths.join('/'), node.href)}`
-			}
-
+			const fullPath = fullPathFromRelativeHref(node.href, basePaths)
 			const preparedItem = {
 				...node,
 				fullPath,
@@ -202,4 +181,38 @@ function prepareNavNodeForClient({
 	}
 }
 
+/**
+ * Given a relative `href`, expected to be constructed for dot-io contexts,
+ * as well as the current `basePaths`,
+ * Return a `fullPath` for use with the Dev Dot URL structure.
+ *
+ * @param href A relative URL
+ * @param basePaths The current set of basePaths
+ */
+function fullPathFromRelativeHref(href: string, basePaths: string[]): string {
+	let fullPath
+	if (href.startsWith(`/${basePaths[0]}/`)) {
+		/**
+		 * If the path already starts with the basePaths[0], the product slug,
+		 * we use the href as the fullPath directly.
+		 */
+		fullPath = href
+	} else if (href.startsWith('/')) {
+		/**
+		 * If the path starts with a slash, we treat it as relative
+		 * to the previous dot-io setup. We prefix it with basePaths[0],
+		 * which should be the product slug.
+		 */
+		fullPath = `/${path.join(basePaths[0], href)}`
+	} else {
+		/**
+		 * If the path does not start with a slash, we treat it as relative
+		 * to the combined current basePath.
+		 */
+		fullPath = `/${path.join(basePaths.join('/'), href)}`
+	}
+	return fullPath
+}
+
+export { fullPathFromRelativeHref }
 export default prepareNavDataForClient

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -155,16 +155,31 @@ function prepareNavNodeForClient({
 		// and we want to use an internal rather than external link.
 		const hrefIsNotAbsolute = !isAbsoluteUrl(node.href)
 		if (hrefIsNotAbsolute) {
-			// If we have a non-absolute NavDirectLink,
-			// convert it to a NavLeaf node, and treat it similarly.
-			// Note that the `fullPath` added here differs from typical
-			// NavLeaf treatment, as we only use the first part of the `basePath`.
-			// (We expect this to be the product slug, eg "consul").
-
-			// If the path already starts with the base path (i.e. /vault), don't add it
-			const fullPath = node.href.startsWith(`/${basePaths.join('/')}`)
-				? node.href
-				: `/${path.join(basePaths.join('/'), node.href)}`
+			/**
+			 * If we have a non-absolute NavDirectLink,
+			 * convert it to a NavLeaf node, and treat it similarly.
+			 */
+			let fullPath
+			if (node.href.startsWith(`/${basePaths[0]}`)) {
+				/**
+				 * If the path already starts with the basePaths[0], the product slug,
+				 * we use the href as the fullPath directly.
+				 */
+				fullPath = node.href
+			} else if (node.href.startsWith('/')) {
+				/**
+				 * If the path starts with a slash, we treat it as relative
+				 * to the previous dot-io setup. We prefix it with basePaths[0],
+				 * which should be the product slug.
+				 */
+				fullPath = `/${path.join(basePaths[0], node.href)}`
+			} else {
+				/**
+				 * If the path does not start with a slash, we treat it as relative
+				 * to the combined current basePath.
+				 */
+				fullPath = `/${path.join(basePaths.join('/'), node.href)}`
+			}
 
 			const preparedItem = {
 				...node,

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -1,6 +1,7 @@
 import { NavNode } from '@hashicorp/react-docs-sidenav/types'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import { MenuItem } from 'components/sidebar'
+import path from 'path'
 
 // TODO: export NavBranch and NavLeaf
 // TODO: types from react-docs-sidenav.
@@ -161,9 +162,9 @@ function prepareNavNodeForClient({
 			// (We expect this to be the product slug, eg "consul").
 
 			// If the path already starts with the base path (i.e. /vault), don't add it
-			const fullPath = node.href.startsWith(`/${basePaths[0]}`)
+			const fullPath = node.href.startsWith(`/${basePaths.join('/')}`)
 				? node.href
-				: `/${basePaths[0]}${node.href}`
+				: `/${path.join(basePaths.join('/'), node.href)}`
 
 			const preparedItem = {
 				...node,

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -160,7 +160,7 @@ function prepareNavNodeForClient({
 			 * convert it to a NavLeaf node, and treat it similarly.
 			 */
 			let fullPath
-			if (node.href.startsWith(`/${basePaths[0]}`)) {
+			if (node.href.startsWith(`/${basePaths[0]}/`)) {
 				/**
 				 * If the path already starts with the basePaths[0], the product slug,
 				 * we use the href as the fullPath directly.


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][/terraform/plugin] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where some sidebar links on [/terraform/plugin][/terraform/plugin] did not function as expected.

## 🤷 Why

- We want to ensure sidebar links work as expected
- Our source `nav-data` may have relative `href` values without leading slashes
    - Example: [`plugins-nav-data.json` in `terraform-docs-common`](https://github.com/hashicorp/terraform-docs-common/blob/main/website/data/plugin-nav-data.json#L35)

## 🛠️ How

Tweaks `fullPath` construction when dealing with navNodes with relative `href` values. 

## 🧪 Testing

- [ ] Links under the `Plugin SDKs and Libraries` section of the sidebar on [/terraform/plugin][/terraform/plugin] page should work as expected
- [ ] Other non-absolute `href` links in sidebars should work as expected
    - Example: `Back to documentation` link on [/vagrant/vagrant-cloud][/vagrant/vagrant-cloud] uses non-absolute `href` ([source](https://github.com/hashicorp/vagrant/blob/main/website/data/vagrant-cloud-nav-data.json))
    - Example: many `Task Drivers / Community` links on [/nomad/docs][/nomad/docs] uses non-absolute `href` ([source](https://github.com/hashicorp/nomad/blob/main/website/data/docs-nav-data.json))

[task]: https://app.asana.com/0/1202097197789424/1202785022290157/f
[preview]: https://dev-portal-git-zsfix-terraform-sidebar-relative-hrefs-hashicorp.vercel.app
[/terraform/plugin]: https://dev-portal-git-zsfix-terraform-sidebar-relative-hrefs-hashicorp.vercel.app/terraform/plugin
[/vagrant/vagrant-cloud]: https://dev-portal-git-zsfix-terraform-sidebar-relative-hrefs-hashicorp.vercel.app/vagrant/vagrant-cloud
[/nomad/docs]: https://dev-portal-git-zsfix-terraform-sidebar-relative-hrefs-hashicorp.vercel.app/nomad/docs