### PR TITLE
fix: terraform nested docs backToLinkProps

### DIFF
--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -153,7 +153,7 @@
 		},
 		{
 			"iconName": "docs",
-			"name": "Plugin",
+			"name": "Plugin Development",
 			"path": "plugin",
 			"productSlugForLoader": "terraform-docs-common"
 		},

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -23,6 +23,7 @@ import {
 
 // Local imports
 import { getProductUrlAdjuster } from './utils/product-url-adjusters'
+import { getBackToLink } from './utils/get-back-to-link'
 
 /**
  * Given a productSlugForLoader (which generally corresponds to a repo name),
@@ -266,21 +267,8 @@ export function getStaticGenerationFunctions<
 			const sidebarNavDataLevels = [
 				generateTopLevelSidebarNavData(product.name),
 				generateProductLandingSidebarNavData(product),
-				/**
-				 * TODO: for nested rootDocsPaths, the backToLink props should
-				 * lead the previous rootDocsPath.
-				 *
-				 * A rootDocsPath is considered "nested" if its path contains a slash.
-				 * If we have a "nested" rootDocsPath, we should try to find the parent
-				 * rootDocsPath. If we can't find a "parent" rootDocsPath,
-				 * or if this is not a "nested" rootDocsPath, then we should use
-				 * a back-to "<product> Home" link.
-				 */
 				{
-					backToLinkProps: {
-						text: `${product.name} Home`,
-						href: `/${product.slug}`,
-					},
+					backToLinkProps: getBackToLink(currentRootDocsPath, product),
 					levelButtonProps: {
 						levelUpButtonText: `${product.name} Home`,
 					},

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -266,6 +266,16 @@ export function getStaticGenerationFunctions<
 			const sidebarNavDataLevels = [
 				generateTopLevelSidebarNavData(product.name),
 				generateProductLandingSidebarNavData(product),
+				/**
+				 * TODO: for nested rootDocsPaths, the backToLink props should
+				 * lead the previous rootDocsPath.
+				 *
+				 * A rootDocsPath is considered "nested" if its path contains a slash.
+				 * If we have a "nested" rootDocsPath, we should try to find the parent
+				 * rootDocsPath. If we can't find a "parent" rootDocsPath,
+				 * or if this is not a "nested" rootDocsPath, then we should use
+				 * a back-to "<product> Home" link.
+				 */
 				{
 					backToLinkProps: {
 						text: `${product.name} Home`,

--- a/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
+++ b/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
@@ -32,10 +32,7 @@ describe('fullPathFromRelativeHref', () => {
 		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)
 	})
 
-	/**
-	 * TODO: implement so that this doesn't fail when not skipped.
-	 */
-	it.skip('generates a level-up backToLink for a nested currentRootDocsPath', () => {
+	it('generates a level-up backToLink for a nested currentRootDocsPath', () => {
 		// Construct arguments for this test case
 		const currentRootDocsPath = {
 			name: 'Plugin Framework',
@@ -70,10 +67,7 @@ describe('fullPathFromRelativeHref', () => {
 		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)
 	})
 
-	/**
-	 * TODO: implement so that this doesn't fail when not skipped.
-	 */
-	it.skip('generates a generic backToLink for a nested currentRootDocsPath without a parent rootDocsPath', () => {
+	it('generates a generic backToLink for a nested currentRootDocsPath without a parent rootDocsPath', () => {
 		// Construct arguments for this test case
 		const currentRootDocsPath = {
 			name: 'Plugin Framework',

--- a/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
+++ b/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
@@ -61,7 +61,7 @@ describe('fullPathFromRelativeHref', () => {
 		}
 		// Assert the expected result
 		const expected = {
-			text: 'Terraform Plugin',
+			text: 'Plugin',
 			href: '/terraform/plugin',
 		}
 		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)

--- a/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
+++ b/src/views/docs-view/utils/__tests__/get-back-to-link.test.ts
@@ -1,0 +1,105 @@
+import { ProductName, ProductSlug } from 'types/products'
+import { getBackToLink } from '../get-back-to-link'
+
+describe('fullPathFromRelativeHref', () => {
+	it('generates a generic backToLink for a non-nested currentRootDocsPath', () => {
+		// Construct arguments for this test case
+		const currentRootDocsPath = {
+			name: 'Documentation',
+			path: 'docs',
+		}
+		const productData = {
+			name: 'Vault' as ProductName,
+			slug: 'vault' as ProductSlug,
+			rootDocsPaths: [
+				{
+					iconName: 'docs',
+					name: 'Documentation',
+					path: 'docs',
+				},
+				{
+					iconName: 'docs',
+					name: 'API',
+					path: 'api-docs',
+				},
+			],
+		}
+		// Assert the expected result
+		const expected = {
+			text: 'Vault Home',
+			href: '/vault',
+		}
+		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)
+	})
+
+	/**
+	 * TODO: implement so that this doesn't fail when not skipped.
+	 */
+	it.skip('generates a level-up backToLink for a nested currentRootDocsPath', () => {
+		// Construct arguments for this test case
+		const currentRootDocsPath = {
+			name: 'Plugin Framework',
+			path: 'plugin/framework',
+		}
+		const productData = {
+			name: 'Terraform' as ProductName,
+			slug: 'terraform' as ProductSlug,
+			rootDocsPaths: [
+				{
+					iconName: 'docs',
+					name: 'Documentation',
+					path: 'docs',
+				},
+				{
+					iconName: 'docs',
+					name: 'Plugin',
+					path: 'plugin',
+				},
+				{
+					iconName: 'docs',
+					name: 'Plugin Framework',
+					path: 'plugin/framework',
+				},
+			],
+		}
+		// Assert the expected result
+		const expected = {
+			text: 'Terraform Plugin',
+			href: '/terraform/plugin',
+		}
+		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)
+	})
+
+	/**
+	 * TODO: implement so that this doesn't fail when not skipped.
+	 */
+	it.skip('generates a generic backToLink for a nested currentRootDocsPath without a parent rootDocsPath', () => {
+		// Construct arguments for this test case
+		const currentRootDocsPath = {
+			name: 'Plugin Framework',
+			path: 'plugin/framework',
+		}
+		const productData = {
+			name: 'Terraform' as ProductName,
+			slug: 'terraform' as ProductSlug,
+			rootDocsPaths: [
+				{
+					iconName: 'docs',
+					name: 'Documentation',
+					path: 'docs',
+				},
+				{
+					iconName: 'docs',
+					name: 'Plugin Framework',
+					path: 'plugin/framework',
+				},
+			],
+		}
+		// Assert the expected result
+		const expected = {
+			text: 'Terraform Home',
+			href: '/terraform',
+		}
+		expect(getBackToLink(currentRootDocsPath, productData)).toEqual(expected)
+	})
+})

--- a/src/views/docs-view/utils/get-back-to-link.ts
+++ b/src/views/docs-view/utils/get-back-to-link.ts
@@ -1,0 +1,25 @@
+import { SidebarBackToLinkProps } from 'components/sidebar/components/sidebar-back-to-link'
+import { ProductData, RootDocsPath } from 'types/products'
+
+/**
+ * Generate `backToLinkProps` for the current `rootDocsPath`,
+ * for use with `DocsView`.
+ *
+ * TODO: for nested rootDocsPaths, the backToLink props should
+ * lead the previous rootDocsPath.
+ *
+ * A rootDocsPath is considered "nested" if its path contains a slash.
+ * If we have a "nested" rootDocsPath, we should try to find the parent
+ * rootDocsPath. If we can't find a "parent" rootDocsPath,
+ * or if this is not a "nested" rootDocsPath, then we should use
+ * a back-to "<product> Home" link.
+ */
+export function getBackToLink(
+	currentRootDocsPath: Pick<RootDocsPath, 'name' | 'path'>,
+	product: Pick<ProductData, 'name' | 'slug' | 'rootDocsPaths'>
+): SidebarBackToLinkProps {
+	return {
+		text: `${product.name} Home`,
+		href: `/${product.slug}`,
+	}
+}

--- a/src/views/docs-view/utils/get-back-to-link.ts
+++ b/src/views/docs-view/utils/get-back-to-link.ts
@@ -37,7 +37,7 @@ export function getBackToLink(
 		if (parentMatches.length > 0) {
 			const parentDocsPath = parentMatches[0]
 			return {
-				text: `${product.name} ${parentDocsPath.name}`,
+				text: parentDocsPath.name,
 				href: `/${product.slug}/${parentDocsPath.path}`,
 			}
 		}

--- a/src/views/docs-view/utils/get-back-to-link.ts
+++ b/src/views/docs-view/utils/get-back-to-link.ts
@@ -5,8 +5,10 @@ import { ProductData, RootDocsPath } from 'types/products'
  * Generate `backToLinkProps` for the current `rootDocsPath`,
  * for use with `DocsView`.
  *
- * TODO: for nested rootDocsPaths, the backToLink props should
- * lead the previous rootDocsPath.
+ * For nested rootDocsPaths, the `backToLinkProps` will
+ * lead to the "parent" rootDocsPath if there is one.
+ *
+ * For other cases, the `backToLinkProps` will lead to the product home page.
  *
  * A rootDocsPath is considered "nested" if its path contains a slash.
  * If we have a "nested" rootDocsPath, we should try to find the parent
@@ -18,6 +20,33 @@ export function getBackToLink(
 	currentRootDocsPath: Pick<RootDocsPath, 'name' | 'path'>,
 	product: Pick<ProductData, 'name' | 'slug' | 'rootDocsPaths'>
 ): SidebarBackToLinkProps {
+	/**
+	 * A rootDocsPath is considered "nested" if it has multiple path parts.
+	 */
+	const pathParts = currentRootDocsPath.path.split('/')
+	const isNestedPath = pathParts.length > 1
+	/**
+	 * If we have a nested path, we try to find the parent rootDocsPath.
+	 * Note that we may not find a match.
+	 */
+	if (isNestedPath) {
+		const parentPath = pathParts.slice(0, pathParts.length - 1).join('/')
+		const parentMatches = product.rootDocsPaths.filter((rootDocsPath) => {
+			return rootDocsPath.path == parentPath
+		})
+		if (parentMatches.length > 0) {
+			const parentDocsPath = parentMatches[0]
+			return {
+				text: `${product.name} ${parentDocsPath.name}`,
+				href: `/${product.slug}/${parentDocsPath.path}`,
+			}
+		}
+	}
+	/**
+	 * If we can't find a "parent" rootDocsPath,
+	 * or if this is not a "nested" rootDocsPath, then we should use
+	 * a generic back-to "<product> Home" link.
+	 */
 	return {
 		text: `${product.name} Home`,
 		href: `/${product.slug}`,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates "nested" docs categories to have a "back to" link in the sidebar that leads to the parent category, rather than the product home page.

## 🤷 Why

To match designs.

## 🛠️ How

- Splits out a new utility `get-back-to-link` under `views/docs-view/utils` to handle some revised logic
- In `get-back-to-link`, if the current `rootDocsPath` is "nested", looks for the parent `rootDocsPath`, and if it can find one, uses it to build the `backToLinkProps`

## 📸 Design Screenshots

### Context

![terraform-plugins-sdkv2  update backToLinkProps for plugins-sdkv2](https://user-images.githubusercontent.com/4624598/184964507-910b427d-ef68-4cad-a5c8-5269ed677d7d.png)

### Preview from this PR

> **Note**: the scope of this PR is to address the "back to" link only. There are other changes we need to make to match designs, these are list as subtasks of 🎟️  [Implement design updates for Terraform](https://app.asana.com/0/1202097197789424/1202663176963860/f) and will be handled separately.

<img width="1435" alt="CleanShot 2022-08-16 at 15 33 15@2x" src="https://user-images.githubusercontent.com/4624598/184966388-2615d44d-c300-4d96-9f48-d99a6a2e612c.png">


## 🧪 Testing

Confirm that this PR fixes the issue:

- [ ] Visit a "nested" docs category and confirm that the "back to" link leads to the "parent" category
    - For example, on [/terraform/plugin/framework][/terraform/plugin/framework], the "back to" link should lead to [/terraform/plugin][/terraform/plugin]

And ensure that existing back-to links have not been affected:

- [ ] Visit a non-"nested" docs category, and confirm that the "back to" link works as previously
    - For example, on [/vault/docs][/vault/docs], the "back to" link should lead to [/vault][/vault]

[task]: https://app.asana.com/0/1202097197789424/1202785022290151/f
[preview]: https://dev-portal-git-zsfix-terraform-nested-back-to-78210c-hashicorp.vercel.app
[/terraform/plugin]: https://dev-portal-git-zsfix-terraform-nested-back-to-78210c-hashicorp.vercel.app/terraform/plugin
[/terraform/plugin/framework]: https://dev-portal-git-zsfix-terraform-nested-back-to-78210c-hashicorp.vercel.app/terraform/plugin/framework
[/vault]: https://dev-portal-git-zsfix-terraform-nested-back-to-78210c-hashicorp.vercel.app/vault
[/vault/docs]: https://dev-portal-git-zsfix-terraform-nested-back-to-78210c-hashicorp.vercel.app/vault/docs