### PR TITLE
fix: hide edit-on-github for HCP and Sentinel

### DIFF
--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -299,13 +299,22 @@ export function getStaticGenerationFunctions<
 			 */
 			const layoutProps: Omit<SidebarSidecarLayoutProps, 'children'> = {
 				breadcrumbLinks,
-				githubFileUrl,
 				headings: nonEmptyHeadings,
 				// TODO: need to adjust type for sidebarNavDataLevels here
 				sidebarNavDataLevels: sidebarNavDataLevels as $TSFixMe,
 			}
 			if (showVersionSelect) {
 				layoutProps.versions = versions
+			}
+			/**
+			 * We want to show "Edit on GitHub" links for public content repos only.
+			 * Currently, HCP and Sentinel docs are stored in private repositories.
+			 */
+			const isHcp = product.slug == 'hcp'
+			const isSentinel = product.slug == 'sentinel'
+			const isPublicContentRepo = !isHcp && !isSentinel
+			if (isPublicContentRepo) {
+				layoutProps.githubFileUrl = githubFileUrl
 			}
 
 			const finalProps = {

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -309,6 +309,9 @@ export function getStaticGenerationFunctions<
 			/**
 			 * We want to show "Edit on GitHub" links for public content repos only.
 			 * Currently, HCP and Sentinel docs are stored in private repositories.
+			 *
+			 * Note: If we need more granularity here, we could change this to be
+			 * part of `rootDocsPath` configuration in `src/data/<product>.json`.
 			 */
 			const isHcp = product.slug == 'hcp'
 			const isSentinel = product.slug == 'sentinel'


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where `Edit on GitHub` links are being displayed for HCP and Sentinel docs. The content repositories are private, so these links aren't of much use to the public.

## 🤷 Why

To only show useful, functioning `Edit on GitHub` links.

## 🛠️ How

Conditionally adds `layoutProps.githubFileUrl` only if the current product slug is not `hcp` or `sentinel`.

## 🧪 Testing

- [ ] Visit an HCP docs page
    - 🙈 The `Edit on GitHub` link should not be shown.
    - Example: [/hcp/docs/create-account][/hcp/docs/create-account]
- [ ] Visit a Sentinel docs page
    - 🙈 The `Edit on GitHub` link should not be shown.
    - Example: [/sentinel/docs/writing][/sentinel/docs/writing]
- [ ] Visit a docs page under another product
    - 👀 The `Edit on GitHub` link should still be visible.
    - Example: [/vault/docs/use-cases][/vault/docs/use-cases]

[preview]: https://dev-portal-git-zsfix-hcp-edit-on-github-hashicorp.vercel.app
[task]: https://app.asana.com/0/1202097197789424/1202678460952043/f
[/hcp/docs/create-account]: https://dev-portal-git-zsfix-hcp-edit-on-github-hashicorp.vercel.app/hcp/docs/hcp/create-account
[/sentinel/docs/writing]: https://dev-portal-git-zsfix-hcp-edit-on-github-hashicorp.vercel.app/sentinel/docs/writing
[/vault/docs/use-cases]: https://dev-portal-git-zsfix-hcp-edit-on-github-hashicorp.vercel.app/vault/docs/use-cases