### PR TITLE
refactor: renaming bookmark components

### DIFF
--- a/src/components/bookmark-button/helpers/connected-bookmark-button.tsx
+++ b/src/components/bookmark-button/helpers/connected-bookmark-button.tsx
@@ -10,9 +10,11 @@ import makeBookmarkToast from '../toast/make-bookmark-toast'
 /**
  * This HOC serves as a 'controller'
  * for rendering the various state of bookmark
- * interaction. It accepts a UI component to render,
- * and renders a dialog if unauthenticated, and
- * updates data when authenticated.
+ * interaction. It accepts a UI component to render and
+ * fetches the tutorial bookmark state.
+ *
+ * When clicked, it renders a dialog if unauthenticated,
+ * and updates data when authenticated.
  */
 
 export function Connected(BookmarkComponent: React.FC<BookmarkButtonProps>) {

--- a/src/components/bookmark-button/helpers/connected-bookmark-button.tsx
+++ b/src/components/bookmark-button/helpers/connected-bookmark-button.tsx
@@ -11,11 +11,12 @@ import makeBookmarkToast from '../toast/make-bookmark-toast'
  * This HOC serves as a 'controller'
  * for rendering the various state of bookmark
  * interaction. It accepts a UI component to render,
- * and renders a dialog if unauthenticated.
+ * and renders a dialog if unauthenticated, and
+ * updates data when authenticated.
  */
 
-export function withDialog(BookmarkComponent: React.FC<BookmarkButtonProps>) {
-	return function BookmarkComponentWithDialog({
+export function Connected(BookmarkComponent: React.FC<BookmarkButtonProps>) {
+	return function ConnectedBookmarkComponent({
 		tutorialId,
 	}: {
 		tutorialId: Tutorial['id']

--- a/src/components/bookmark-button/index.tsx
+++ b/src/components/bookmark-button/index.tsx
@@ -1,7 +1,7 @@
 import { IconBookmarkAdd16 } from '@hashicorp/flight-icons/svg-react/bookmark-add-16'
 import { IconBookmarkRemove16 } from '@hashicorp/flight-icons/svg-react/bookmark-remove-16'
 import Button from 'components/button'
-import { withDialog } from './helpers/with-dialog'
+import { Connected } from './helpers/connected-bookmark-button'
 import { RemoveBookmarkIcon, AddBookmarkIcon } from './icons'
 import { BookmarkButtonConfigType, BookmarkButtonProps } from './types'
 import s from './bookmark-button.module.css'
@@ -70,5 +70,5 @@ function BookmarkButtonTextAndIcon({
  * Eventually this HOC may also handle the API requests to manage data.
  * and trigger toasts based on the result.
  */
-export const TutorialCardBookmarkButton = withDialog(BookmarkButtonIconOnly)
-export const TutorialMetaBookmarkButton = withDialog(BookmarkButtonTextAndIcon)
+export const TutorialCardBookmarkButton = Connected(BookmarkButtonIconOnly)
+export const TutorialMetaBookmarkButton = Connected(BookmarkButtonTextAndIcon)

--- a/src/components/bookmark-button/index.tsx
+++ b/src/components/bookmark-button/index.tsx
@@ -67,8 +67,8 @@ function BookmarkButtonTextAndIcon({
  * which passes the `handleOnClick` logic, checks for authentication,
  * and opens a dialog to prompt authentication.
  *
- * Eventually this HOC may also handle the API requests to manage data.
- * and trigger toasts based on the result.
+ * It also fetches the bookmark state and updates the API
+ * upon user interaction, if authenticated.
  */
 export const TutorialCardBookmarkButton = Connected(BookmarkButtonIconOnly)
 export const TutorialMetaBookmarkButton = Connected(BookmarkButtonTextAndIcon)

--- a/src/components/tutorial-card/helpers/index.ts
+++ b/src/components/tutorial-card/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './build-aria-label'
 export * from './format-tutorial-card'
+export * from './with-bookmark'

--- a/src/components/tutorial-card/helpers/with-bookmark.tsx
+++ b/src/components/tutorial-card/helpers/with-bookmark.tsx
@@ -1,9 +1,9 @@
 import { AUTH_ENABLED } from 'hooks/use-authentication'
 import { TutorialCardBookmarkButton } from 'components/bookmark-button'
-import TutorialCard from '.'
-import { TutorialCardPropsWithId } from '.'
+import TutorialCard from '..'
+import { TutorialCardPropsWithId } from '..'
 
-export function ConnectedTutorialCard(props: TutorialCardPropsWithId) {
+export function TutorialCardWithBookmark(props: TutorialCardPropsWithId) {
 	const { id: tutorialId, ...rest } = props
 
 	return (

--- a/src/components/tutorial-card/index.tsx
+++ b/src/components/tutorial-card/index.tsx
@@ -6,9 +6,8 @@ import {
 	CardBadges,
 	CardBadgeOption,
 } from 'components/tutorial-collection-cards'
-import { buildAriaLabel } from './helpers'
+import { buildAriaLabel, TutorialCardWithBookmark } from './helpers'
 import { TutorialCardProps, TutorialCardPropsWithId } from './types'
-import { TutorialCardWithBookmark } from './helpers'
 import s from './tutorial-card.module.css'
 
 /**

--- a/src/components/tutorial-card/index.tsx
+++ b/src/components/tutorial-card/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'components/tutorial-collection-cards'
 import { buildAriaLabel } from './helpers'
 import { TutorialCardProps, TutorialCardPropsWithId } from './types'
-import { ConnectedTutorialCard } from './connected-tutorial-card'
+import { TutorialCardWithBookmark } from './helpers'
 import s from './tutorial-card.module.css'
 
 /**
@@ -55,5 +55,5 @@ function TutorialCard({
 }
 
 export type { TutorialCardProps, TutorialCardPropsWithId }
-export { ConnectedTutorialCard }
+export { TutorialCardWithBookmark }
 export default TutorialCard

--- a/src/views/collection-view/components/collection-tutorial-list/index.tsx
+++ b/src/views/collection-view/components/collection-tutorial-list/index.tsx
@@ -1,6 +1,6 @@
 import CardsGridList from 'components/cards-grid-list'
 import { TutorialCardPropsWithId } from 'components/tutorial-card/types'
-import { ConnectedTutorialCard } from 'components/tutorial-card/connected-tutorial-card'
+import { TutorialCardWithBookmark } from 'components/tutorial-card'
 import { CollectionTutorialListProps } from './types'
 import s from './collection-tutorial-list.module.css'
 
@@ -14,7 +14,7 @@ function CollectionTutorialList({
 				{tutorials.map((tutorial: TutorialCardPropsWithId) => {
 					return (
 						<li key={tutorial.id}>
-							<ConnectedTutorialCard {...tutorial} />
+							<TutorialCardWithBookmark {...tutorial} />
 						</li>
 					)
 				})}

--- a/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-tutorials-section/index.tsx
@@ -3,7 +3,7 @@ import { FeaturedLearnCard } from 'views/product-downloads-view/types'
 import Heading from 'components/heading'
 import CardsGridList from 'components/cards-grid-list'
 import CollectionCard from 'components/collection-card'
-import { ConnectedTutorialCard } from 'components/tutorial-card'
+import { TutorialCardWithBookmark } from 'components/tutorial-card'
 import viewStyles from 'views/product-downloads-view/product-downloads-view.module.css'
 
 interface FeaturedTutorialsSectionProps {
@@ -36,7 +36,7 @@ const FeaturedTutorialsSection = ({
 					} else if (type == 'tutorial') {
 						return (
 							<li key={id}>
-								<ConnectedTutorialCard {...cardProps} />
+								<TutorialCardWithBookmark {...cardProps} />
 							</li>
 						)
 					}

--- a/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
+++ b/src/views/product-landing/components/product-landing-blocks/blocks/tutorial-cards/index.tsx
@@ -1,7 +1,7 @@
 import { TutorialCardsProps } from './types'
 import CardsGridList from 'components/cards-grid-list'
 import {
-	ConnectedTutorialCard,
+	TutorialCardWithBookmark,
 	TutorialCardPropsWithId,
 } from 'components/tutorial-card'
 
@@ -11,7 +11,7 @@ function TutorialCards({ tutorialCards }: TutorialCardsProps) {
 			{tutorialCards.map((cardPropsWithId: TutorialCardPropsWithId) => {
 				return (
 					<li key={cardPropsWithId.id}>
-						<ConnectedTutorialCard {...cardPropsWithId} />
+						<TutorialCardWithBookmark {...cardPropsWithId} />
 					</li>
 				)
 			})}

--- a/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
+++ b/src/views/product-tutorials-view/components/product-view-content/components/tutorials-stack/index.tsx
@@ -1,7 +1,7 @@
 import { Tutorial as ClientTutorial } from 'lib/learn-client/types'
 import CardsGridList from 'components/cards-grid-list'
 import {
-	ConnectedTutorialCard,
+	TutorialCardWithBookmark,
 	TutorialCardPropsWithId,
 } from 'components/tutorial-card'
 import { formatTutorialCard } from 'components/tutorial-card/helpers'
@@ -37,7 +37,7 @@ function TutorialsStack({
 				{tutorialCards.map((cardPropsWithId: TutorialCardPropsWithId) => {
 					return (
 						<li key={cardPropsWithId.id}>
-							<ConnectedTutorialCard {...cardPropsWithId} />
+							<TutorialCardWithBookmark {...cardPropsWithId} />
 						</li>
 					)
 				})}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadjust-bookmark-controller-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Renamed the `withDialog` component to be `ConnectedBookmarkComponent` to reflect that it controls state, along with the dialog rendering. 

Renamed `ConnectedTutorialCard` to `TutorialCardWithBookmark` since it doesn't manage state, and just renders the bookmark in the eyebrow slot. 

