### PR TITLE
feat: adds bookmark page empty state

### DIFF
--- a/src/components/button-link/index.tsx
+++ b/src/components/button-link/index.tsx
@@ -19,6 +19,7 @@ const ButtonLink = ({
 	openInNewTab = false,
 	size = 'medium',
 	text,
+	className,
 }: ButtonLinkProps) => {
 	const hasIcon = !!icon
 	const hasText = !!text
@@ -43,7 +44,7 @@ const ButtonLink = ({
 		<Link href={href}>
 			<a
 				aria-label={ariaLabel}
-				className={classNames(s.root, s[size], s[color])}
+				className={classNames(s.root, s[size], s[color], className)}
 				rel={openInNewTab ? 'noreferrer noopener' : undefined}
 				target={openInNewTab ? '_blank' : '_self'}
 			>

--- a/src/components/button-link/types.ts
+++ b/src/components/button-link/types.ts
@@ -5,7 +5,13 @@ import { ButtonProps } from 'components/button'
  */
 type PickedButtonProps = Pick<
 	ButtonProps,
-	'aria-label' | 'color' | 'icon' | 'iconPosition' | 'size' | 'text'
+	| 'aria-label'
+	| 'color'
+	| 'icon'
+	| 'iconPosition'
+	| 'size'
+	| 'text'
+	| 'className'
 >
 
 /**

--- a/src/views/profile/bookmarks-view/components/empty-state/empty-state.module.css
+++ b/src/views/profile/bookmarks-view/components/empty-state/empty-state.module.css
@@ -1,0 +1,22 @@
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	border: 1px dashed var(--token-color-neutral-border-strong);
+	padding: 24px;
+	text-align: center;
+}
+
+.heading {
+	margin-top: 8px;
+}
+
+.subheading {
+	color: var(--token-color-foreground-primary);
+	margin-top: 4px;
+}
+
+.buttonLink {
+	margin-top: 16px;
+}

--- a/src/views/profile/bookmarks-view/components/empty-state/index.tsx
+++ b/src/views/profile/bookmarks-view/components/empty-state/index.tsx
@@ -1,0 +1,28 @@
+import { IconBookmarkAdd16 } from '@hashicorp/flight-icons/svg-react/bookmark-add-16'
+import ButtonLink from 'components/button-link'
+import Heading from 'components/heading'
+import IconTile from 'components/icon-tile'
+import Text from 'components/text'
+import s from './empty-state.module.css'
+
+export default function BookmarksEmptyState() {
+	return (
+		<div className={s.wrapper}>
+			<IconTile size="small">
+				<IconBookmarkAdd16 />
+			</IconTile>
+			<Heading level={2} size={400} weight="semibold" className={s.heading}>
+				You have no saved bookmarks.
+			</Heading>
+			<Text className={s.subheading}>
+				You can select the bookmark icon on any tutorial card to save it for
+				future reference.
+			</Text>
+			<ButtonLink
+				href="/library"
+				text="Tutorial library"
+				className={s.buttonLink}
+			/>
+		</div>
+	)
+}

--- a/src/views/profile/bookmarks-view/components/empty-state/index.tsx
+++ b/src/views/profile/bookmarks-view/components/empty-state/index.tsx
@@ -19,7 +19,7 @@ export default function BookmarksEmptyState() {
 				future reference.
 			</Text>
 			<ButtonLink
-				href="/library"
+				href="/tutorials/library"
 				text="Tutorial library"
 				className={s.buttonLink}
 			/>

--- a/src/views/profile/bookmarks-view/components/empty-state/index.tsx
+++ b/src/views/profile/bookmarks-view/components/empty-state/index.tsx
@@ -11,7 +11,7 @@ export default function BookmarksEmptyState() {
 			<IconTile size="small">
 				<IconBookmarkAdd16 />
 			</IconTile>
-			<Heading level={2} size={400} weight="semibold" className={s.heading}>
+			<Heading level={2} size={300} weight="semibold" className={s.heading}>
 				You have no saved bookmarks.
 			</Heading>
 			<Text className={s.subheading}>

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -56,6 +56,8 @@ const ProfileBookmarksViewContent = () => {
 				) : (
 					<BookmarksEmptyState />
 				)}
+				<BookmarksEmptyState />
+				{/** Just for testing purposes, will refactor */}
 			</CardsGridList>
 		</div>
 	)

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -55,8 +55,6 @@ const ProfileBookmarksViewContent = () => {
 			) : (
 				<BookmarksEmptyState />
 			)}
-			<BookmarksEmptyState />
-			{/** Just for testing purposes, will refactor */}
 		</div>
 	)
 }

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -49,7 +49,9 @@ const ProfileBookmarksViewContent = () => {
 			>
 				Your Bookmarks
 			</Heading>
-			<CardsGridList>{bookmarks?.map(renderBookmarkCard)}</CardsGridList>
+			<CardsGridList>
+				{bookmarks?.map(renderBookmarkCard) || 'No bookmarks'}
+			</CardsGridList>
 		</div>
 	)
 }

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -50,15 +50,13 @@ const ProfileBookmarksViewContent = () => {
 			>
 				Your Bookmarks
 			</Heading>
-			<CardsGridList>
-				{bookmarks?.length > 0 ? (
-					bookmarks.map(renderBookmarkCard)
-				) : (
-					<BookmarksEmptyState />
-				)}
+			{bookmarks?.length > 0 ? (
+				<CardsGridList>{bookmarks.map(renderBookmarkCard)}</CardsGridList>
+			) : (
 				<BookmarksEmptyState />
-				{/** Just for testing purposes, will refactor */}
-			</CardsGridList>
+			)}
+			<BookmarksEmptyState />
+			{/** Just for testing purposes, will refactor */}
 		</div>
 	)
 }

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -42,16 +42,18 @@ const ProfileBookmarksViewContent = () => {
 				View and manage your personal bookmarks. Select the bookmark icon in
 				each card below to remove the bookmark.
 			</Text>
-			<Heading
-				level={2}
-				weight="semibold"
-				size={300}
-				className={s.cardListHeading}
-			>
-				Your Bookmarks
-			</Heading>
-			{bookmarks?.length > 0 ? (
-				<CardsGridList>{bookmarks.map(renderBookmarkCard)}</CardsGridList>
+			{bookmarks?.length === 0 ? (
+				<>
+					<Heading
+						level={2}
+						weight="semibold"
+						size={300}
+						className={s.cardListHeading}
+					>
+						Your Bookmarks
+					</Heading>
+					<CardsGridList>{bookmarks.map(renderBookmarkCard)}</CardsGridList>
+				</>
 			) : (
 				<BookmarksEmptyState />
 			)}

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -42,7 +42,7 @@ const ProfileBookmarksViewContent = () => {
 				View and manage your personal bookmarks. Select the bookmark icon in
 				each card below to remove the bookmark.
 			</Text>
-			{bookmarks?.length === 0 ? (
+			{bookmarks?.length > 0 ? (
 				<>
 					<Heading
 						level={2}

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -4,6 +4,7 @@ import AuthenticatedView from 'views/authenticated-view'
 import CardsGridList from 'components/cards-grid-list'
 import Text from 'components/text'
 import Heading from 'components/heading'
+import BookmarksEmptyState from './components/empty-state'
 import renderBookmarkCard from './helpers/render-bookmark-cards'
 import s from './bookmarks-view.module.css'
 
@@ -50,7 +51,11 @@ const ProfileBookmarksViewContent = () => {
 				Your Bookmarks
 			</Heading>
 			<CardsGridList>
-				{bookmarks?.map(renderBookmarkCard) || 'No bookmarks'}
+				{bookmarks?.length > 0 ? (
+					bookmarks.map(renderBookmarkCard)
+				) : (
+					<BookmarksEmptyState />
+				)}
 			</CardsGridList>
 		</div>
 	)


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-empty-state-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202702246158644/1202832753754548) 🎟️

## 🗒️ What

This PR adds a styled 'empty state' to the bookmarks profile view. 

## 📸 Design Screenshots

<img width="434" alt="Screen Shot 2022-08-22 at 4 31 22 PM" src="https://user-images.githubusercontent.com/36613477/186037419-ea30f8d0-1e5f-4467-a8ac-6f45fc57c415.png">


## 🧪 Testing

- Pull this branch down locally, start the dev server and sign in.
- Navigate to /profile/bookmarks
- You should see the test empty state below the card grid (if you already have bookmarks). 

## 💭 Anything else?

Since the bookmark cards don't let you remove them atm, I opted to stage the test component below the card grid. I guess I could add it to swingset but it is only used in one place so seems more suited nested under the /views structure. 
