### PR TITLE
Fix tablet width mobile menu

### DIFF
--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -23,7 +23,7 @@
 	position: relative;
 	width: 100%;
 
-	@media (--nav-header-is-mobile) {
+	@media (--dev-dot-show-mobile-menu) {
 		padding-bottom: 14px;
 		padding-top: 14px;
 	}
@@ -36,7 +36,7 @@
 }
 
 .leftSideDesktopOnlyContent {
-	@media (--nav-header-is-mobile) {
+	@media (--dev-dot-show-mobile-menu) {
 		display: none;
 	}
 }
@@ -78,7 +78,7 @@
 	display: flex;
 	justify-content: left;
 
-	@media (--nav-header-is-desktop) {
+	@media (--dev-dot-hide-mobile-menu) {
 		width: calc(
 			var(--dev-dot-sidebar-width) + var(--main-area-padding-left) -
 				var(--header-padding-left-right) -
@@ -109,7 +109,7 @@
 		border: 1px solid var(--token-color-palette-neutral-200);
 	}
 
-	@media (--nav-header-is-desktop) {
+	@media (--dev-dot-hide-mobile-menu) {
 		display: none;
 	}
 }
@@ -120,7 +120,7 @@
 	display: flex;
 	gap: 16px;
 
-	@media (--nav-header-is-mobile) {
+	@media (--dev-dot-show-mobile-menu) {
 		display: none;
 	}
 }

--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -1,6 +1,3 @@
-@custom-media --nav-header-is-mobile (max-width: 1200px);
-@custom-media --nav-header-is-desktop (min-width: 1201px);
-
 /*
 ***
 * Class for the main container.

--- a/src/contexts/mobile-menu.tsx
+++ b/src/contexts/mobile-menu.tsx
@@ -15,7 +15,7 @@ const DEFAULT_NAV_HEADER_DESKTOP_WIDTH = 1201
 
 interface MobileMenuContextState {
 	/**
-	 * Indicates whether or not the screen size indicates that we should be rendering the mobile menu
+	 * Whether or not the screen size indicates that we should be rendering the mobile menu
 	 */
 	isMobileMenuRendered: boolean
 	mobileMenuIsOpen: boolean

--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -12,7 +12,7 @@
 	/* General mobile and tablet breakpoints */
 	--mobile-width-breakpoint: 728px;
 	--tablet-width-breakpoint: 1000px;
-	--nav-header-mobile-width-breakpoint: 1200px;
+	--mobile-menu-breakpoint: 1200px;
 
 	/* Font overwrites */
 	--font-body: var(--token-typography-font-stack-text);

--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -12,11 +12,7 @@
 	/* General mobile and tablet breakpoints */
 	--mobile-width-breakpoint: 728px;
 	--tablet-width-breakpoint: 1000px;
-
-	/* Nav header moblie breakpoint */
 	--nav-header-mobile-width-breakpoint: 1200px;
-	@custom-media --nav-header-is-mobile (max-width: 1200px);
-	@custom-media --nav-header-is-desktop (min-width: 1201px);
 
 	/* Font overwrites */
 	--font-body: var(--token-typography-font-stack-text);

--- a/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
+++ b/src/layouts/core-dev-dot-layout/core-dev-dot-layout.module.css
@@ -1,51 +1,56 @@
 .root {
-  /* Widths/spacing needed in multiple stylesheets */
-  --dev-dot-sidebar-width: 320px;
+	/* Widths/spacing needed in multiple stylesheets */
+	--dev-dot-sidebar-width: 320px;
 
-  /* Note: "right" value is not used in multiple stylesheets,
+	/* Note: "right" value is not used in multiple stylesheets,
      so is declared in sidebar-sidecar-layout.module.css */
-  --main-area-padding-left: 24px;
-  @media (--dev-dot-sidecar-up) {
-    --main-area-padding-left: 48px;
-  }
+	--main-area-padding-left: 24px;
+	@media (--dev-dot-sidecar-up) {
+		--main-area-padding-left: 48px;
+	}
 
-  /* Mobile and tablet breakpoints */
-  --mobile-width-breakpoint: 728px;
-  --tablet-width-breakpoint: 1000px;
+	/* General mobile and tablet breakpoints */
+	--mobile-width-breakpoint: 728px;
+	--tablet-width-breakpoint: 1000px;
 
-  /* Font overwrites */
-  --font-body: var(--token-typography-font-stack-text);
-  --font-display: var(--token-typography-font-stack-display);
-  --font-monospace: var(--token-typography-font-stack-code);
+	/* Nav header moblie breakpoint */
+	--nav-header-mobile-width-breakpoint: 1200px;
+	@custom-media --nav-header-is-mobile (max-width: 1200px);
+	@custom-media --nav-header-is-desktop (min-width: 1201px);
 
-  /* Custom tokens that aren't in the design system, but may be in the future */
-  --custom-token-color-focus-action-internal-dark: var(
-    --token-color-foreground-action-hover
-  );
-  --custom-token-color-focus-action-external-light: #5fbcff;
-  --custom-token-focus-ring-action-box-shadow-dark: 0 0 0 1px
-      var(--custom-token-color-focus-action-internal-dark),
-    0 0 0 3px var(--custom-token-color-focus-action-external-light);
+	/* Font overwrites */
+	--font-body: var(--token-typography-font-stack-text);
+	--font-display: var(--token-typography-font-stack-display);
+	--font-monospace: var(--token-typography-font-stack-code);
 
-  /* Custom properties are calculated before they're inherited, so the
+	/* Custom tokens that aren't in the design system, but may be in the future */
+	--custom-token-color-focus-action-internal-dark: var(
+		--token-color-foreground-action-hover
+	);
+	--custom-token-color-focus-action-external-light: #5fbcff;
+	--custom-token-focus-ring-action-box-shadow-dark: 0 0 0 1px
+			var(--custom-token-color-focus-action-internal-dark),
+		0 0 0 3px var(--custom-token-color-focus-action-external-light);
+
+	/* Custom properties are calculated before they're inherited, so the
   font-family: var(--font-body) we set on our `body` element needs to be
   re-declared here, so that our "system-ui" font stack cascades as expected. */
-  font-family: var(--font-body);
+	font-family: var(--font-body);
 
-  & input {
-    font-family: var(--font-body);
-  }
+	& input {
+		font-family: var(--font-body);
+	}
 
-  /* TODO: not sure where else to put this yet */
-  & button {
-    font-family: var(--font-body);
+	/* TODO: not sure where else to put this yet */
+	& button {
+		font-family: var(--font-body);
 
-    &:not(:disabled) {
-      cursor: pointer;
-    }
+		&:not(:disabled) {
+			cursor: pointer;
+		}
 
-    &:disabled {
-      cursor: not-allowed;
-    }
-  }
+		&:disabled {
+			cursor: not-allowed;
+		}
+	}
 }

--- a/src/layouts/sidebar-sidecar/contexts/sidebar-nav-data.tsx
+++ b/src/layouts/sidebar-sidecar/contexts/sidebar-nav-data.tsx
@@ -7,7 +7,7 @@ import {
 	useEffect,
 	useState,
 } from 'react'
-import { useDeviceSize, useMobileMenu } from 'contexts'
+import { useMobileMenu } from 'contexts'
 import { SidebarProps } from 'components/sidebar'
 
 interface State {
@@ -32,8 +32,8 @@ const SidebarNavDataProvider = ({
 	children,
 	navDataLevels,
 }: SidebarNavDataProviderProps) => {
-	const { isDesktop } = useDeviceSize()
-	const { mobileMenuIsOpen, setMobileMenuIsOpen } = useMobileMenu()
+	const { mobileMenuIsOpen, setMobileMenuIsOpen, isMobileMenuRendered } =
+		useMobileMenu()
 	const numberOfLevels = navDataLevels.length
 	const [currentLevel, setCurrentLevel] = useState<number>(numberOfLevels - 1)
 
@@ -55,7 +55,7 @@ const SidebarNavDataProvider = ({
 	const hasManyLevels = numberOfLevels > 1
 	const isFirstLevel = currentLevel === 0
 	const isLastLevel = currentLevel === numberOfLevels - 1
-	const shouldRenderMobileControls = hasManyLevels && !isDesktop
+	const shouldRenderMobileControls = hasManyLevels && isMobileMenuRendered
 
 	// Create state object to pass to the Provider
 	const state: State = {

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -9,7 +9,7 @@ import { getVersionFromPath } from 'lib/get-version-from-path'
 import { removeVersionFromPath } from 'lib/remove-version-from-path'
 import useOnFocusOutside from 'hooks/use-on-focus-outside'
 import useCurrentPath from 'hooks/use-current-path'
-import { useDeviceSize, useMobileMenu } from 'contexts'
+import { useMobileMenu } from 'contexts'
 import BaseLayout from 'layouts/base-new'
 import TableOfContents from 'layouts/sidebar-sidecar/components/table-of-contents'
 import BreadcrumbBar from 'components/breadcrumb-bar'
@@ -52,20 +52,20 @@ const SidebarSidecarLayoutContent = ({
 	sidebarNavDataLevels,
 	versions,
 }: SidebarSidecarLayoutProps) => {
-	const { isDesktop } = useDeviceSize()
-	const { mobileMenuIsOpen, setMobileMenuIsOpen } = useMobileMenu()
+	const { isMobileMenuRendered, mobileMenuIsOpen, setMobileMenuIsOpen } =
+		useMobileMenu()
 	const { currentLevel } = useSidebarNavData()
 	const sidebarRef = useRef<HTMLDivElement>()
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 	const currentlyViewedVersion = getVersionFromPath(currentPath)
 	const sidebarProps = sidebarNavDataLevels[currentLevel]
-	const sidebarIsVisible = isDesktop || mobileMenuIsOpen
+	const sidebarIsVisible = !isMobileMenuRendered || mobileMenuIsOpen
 
 	// Handles closing the sidebar if focus moves outside of it and it is open.
 	useOnFocusOutside(
 		[sidebarRef],
 		() => setMobileMenuIsOpen(false),
-		!isDesktop && sidebarIsVisible
+		isMobileMenuRendered && sidebarIsVisible
 	)
 
 	const SidebarContent = (): ReactElement => {

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -7,25 +7,25 @@ for further details.
 */
 
 .root {
-  display: flex;
-  flex-grow: 1;
+	display: flex;
+	flex-grow: 1;
 
-  /* For a coherent visual effect, the top padding value
+	/* For a coherent visual effect, the top padding value
   must be used for sticky positioning in addition to
   padding the content area. So, we create a CSS var
   to make it reusable and express this intent. */
-  --main-area-padding-top: 32px;
+	--main-area-padding-top: 32px;
 
-  /* When the sidecar is hidden, then --main-area-padding-right must adjust.
+	/* When the sidecar is hidden, then --main-area-padding-right must adjust.
   Note that the "left" value, --main-area-padding-left, is declared in 
   core-dev-dot-layout.module.css, as the left value  must be shared with the
   navigation-header component, in order to match alignment in design specs. */
-  --main-area-padding-right: 24px;
-  @media (--dev-dot-sidecar-up) {
-    --main-area-padding-right: 48px;
-  }
+	--main-area-padding-right: 24px;
+	@media (--dev-dot-sidecar-up) {
+		--main-area-padding-right: 48px;
+	}
 
-  /*
+	/*
   We want our footer to have a top border which spans
   across both the main content and sidecar.
   We also want our footer content to be aligned with our main content,
@@ -47,8 +47,8 @@ for further details.
   But, it sidesteps issues in mixing overflow: hidden with position: sticky.
   Details: https://css-tricks.com/dealing-with-overflow-and-position-sticky/
   */
-  --main-element-max-width: 896px;
-  --sidecar-width: 220px;
+	--main-element-max-width: 896px;
+	--sidecar-width: 220px;
 }
 
 /**
@@ -56,78 +56,78 @@ for further details.
  */
 
 .mobileMenuContainer {
-  @media (--dev-dot-desktop) {
-    display: flex !important; /* always want this value on desktop here */
-    left: 0 !important; /* always want this value on desktop here */
-    position: sticky; /* fixed does not take up horiz. space the same */
-    width: var(--dev-dot-sidebar-width); /* custom width overwrite */
-  }
+	@media (--dev-dot-hide-mobile-menu) {
+		display: flex !important; /* always want this value on desktop here */
+		left: 0 !important; /* always want this value on desktop here */
+		position: sticky; /* fixed does not take up horiz. space the same */
+		width: var(--dev-dot-sidebar-width); /* custom width overwrite */
+	}
 }
 
 /* Note: container is components/mobile-menu-container */
 .sidebarContentWrapper {
-  flex-shrink: 1;
-  flex-grow: 1;
-  overflow-y: auto;
-  padding-bottom: 48px;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 24px;
-  position: relative;
+	flex-shrink: 1;
+	flex-grow: 1;
+	overflow-y: auto;
+	padding-bottom: 48px;
+	padding-left: 24px;
+	padding-right: 24px;
+	padding-top: 24px;
+	position: relative;
 }
 
 .contentWrapper {
-  width: 100%;
+	width: 100%;
 
-  @media (--dev-dot-desktop) {
-    max-width: calc(100vw - var(--dev-dot-sidebar-width));
-  }
+	@media (--dev-dot-hide-mobile-menu) {
+		max-width: calc(100vw - var(--dev-dot-sidebar-width));
+	}
 }
 
 .main {
-  width: 100%;
+	width: 100%;
 
-  @media (--dev-dot-sidecar-up) {
-    max-width: var(--main-element-max-width);
-    min-width: 0;
-  }
+	@media (--dev-dot-sidecar-up) {
+		max-width: var(--main-element-max-width);
+		min-width: 0;
+	}
 }
 
 .editOnGithubLink {
-  margin-top: 64px;
+	margin-top: 64px;
 }
 
 .mainAreaWrapper {
-  display: flex;
-  justify-content: center;
-  padding-left: var(--main-area-padding-left);
-  padding-right: var(--main-area-padding-right);
-  padding-top: var(--main-area-padding-top);
-  padding-bottom: 128px;
+	display: flex;
+	justify-content: center;
+	padding-left: var(--main-area-padding-left);
+	padding-right: var(--main-area-padding-right);
+	padding-top: var(--main-area-padding-top);
+	padding-bottom: 128px;
 }
 
 .breadcrumbOptOutGroup {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
 }
 
 .optInOutSlot {
-  flex-shrink: 0;
+	flex-shrink: 0;
 }
 
 .sidecarWrapper {
-  display: none;
+	display: none;
 
-  @media (--dev-dot-sidecar-up) {
-    display: block;
-    flex-shrink: 0;
-    height: fit-content;
-    margin-left: 48px;
-    position: sticky;
-    top: calc(var(--sticky-bars-height) + var(--main-area-padding-top));
-    width: var(--sidecar-width);
-  }
+	@media (--dev-dot-sidecar-up) {
+		display: block;
+		flex-shrink: 0;
+		height: fit-content;
+		margin-left: 48px;
+		position: sticky;
+		top: calc(var(--sticky-bars-height) + var(--main-area-padding-top));
+		width: var(--sidecar-width);
+	}
 }
 
 /*
@@ -137,10 +137,10 @@ for further details.
 */
 
 .versionAlert {
-  padding-left: var(--main-area-padding-left);
-  padding-right: var(--main-area-padding-right);
+	padding-left: var(--main-area-padding-left);
+	padding-right: var(--main-area-padding-right);
 }
 
 .versionAlertLink {
-  color: var(--token-color-foreground-primary) !important;
+	color: var(--token-color-foreground-primary) !important;
 }

--- a/src/styles/custom-media.css
+++ b/src/styles/custom-media.css
@@ -13,6 +13,6 @@
 @custom-media --dev-dot-desktop only screen and (min-width: 1001px);
 @custom-media --dev-dot-sidecar-up only screen and (min-width: 1280px);
 
-/* See --nav-header-mobile-width-breakpoint */
-@custom-media --nav-header-is-mobile (max-width: 1200px);
-@custom-media --nav-header-is-desktop (min-width: 1201px);
+/* See --mobile-menu-breakpoint */
+@custom-media --dev-dot-show-mobile-menu (max-width: 1200px);
+@custom-media --dev-dot-hide-mobile-menu (min-width: 1201px);

--- a/src/styles/custom-media.css
+++ b/src/styles/custom-media.css
@@ -12,3 +12,7 @@
 @custom-media --dev-dot-tablet-up only screen and (min-width: 729px);
 @custom-media --dev-dot-desktop only screen and (min-width: 1001px);
 @custom-media --dev-dot-sidecar-up only screen and (min-width: 1280px);
+
+/* See --nav-header-mobile-width-breakpoint */
+@custom-media --nav-header-is-mobile (max-width: 1200px);
+@custom-media --nav-header-is-desktop (min-width: 1201px);


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the mobile menu on tablet viewports, with some custom logic pulled from `useDeviceSize`, since this is the only place where we have customized a special breakpoint.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- When we updated the nav header breakpoint recently, we did catch that we needed to update the breakpoint used by `MobileMenuProvider` as well.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check that the mobile menu shows at `1200px` or narrower
- [ ] Make sure the mobile menu closes when:
  - [ ] The menu is open and a page navigation occurs
  - [ ] The menu is open and the viewport is changed to `>= 1201px`
