### PR TITLE
feat: adds bookmarks sort

### DIFF
--- a/src/components/dropdown-disclosure/components/activator/index.tsx
+++ b/src/components/dropdown-disclosure/components/activator/index.tsx
@@ -33,7 +33,11 @@ const DropdownDisclosureActivator = ({
 			<Button
 				{...buttonProps}
 				color={color}
-				icon={hideChevron ? null : <IconChevronDown16 />}
+				icon={
+					hideChevron ? null : (
+						<IconChevronDown16 className={s.chevronWrapper} />
+					)
+				}
 				iconPosition={hideChevron ? undefined : 'trailing'}
 				text={children}
 			/>

--- a/src/components/dropdown-disclosure/dropdown-disclosure.module.css
+++ b/src/components/dropdown-disclosure/dropdown-disclosure.module.css
@@ -23,7 +23,7 @@
 	padding-top: 4px;
 	position: absolute;
 	width: fit-content;
-	z-index: 1;
+	z-index: 2;
 }
 
 .list {

--- a/src/views/profile/bookmarks-view/bookmarks-view.module.css
+++ b/src/views/profile/bookmarks-view/bookmarks-view.module.css
@@ -8,5 +8,8 @@
 }
 
 .cardListHeading {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	margin-bottom: 20px;
 }

--- a/src/views/profile/bookmarks-view/helpers/card-sort-data.ts
+++ b/src/views/profile/bookmarks-view/helpers/card-sort-data.ts
@@ -4,13 +4,13 @@ export const SortData = {
 	newest: {
 		text: 'Newest',
 		sort: (a: ApiBookmark, b: ApiBookmark) => {
-			return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
 		},
 	},
 	oldest: {
 		text: 'Oldest',
 		sort: (a: ApiBookmark, b: ApiBookmark) => {
-			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+			return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
 		},
 	},
 }

--- a/src/views/profile/bookmarks-view/helpers/card-sort-data.ts
+++ b/src/views/profile/bookmarks-view/helpers/card-sort-data.ts
@@ -1,0 +1,16 @@
+import { ApiBookmark } from 'lib/learn-client/api/api-types'
+
+export const SortData = {
+	newest: {
+		text: 'Newest',
+		sort: (a: ApiBookmark, b: ApiBookmark) => {
+			return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+		},
+	},
+	oldest: {
+		text: 'Oldest',
+		sort: (a: ApiBookmark, b: ApiBookmark) => {
+			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+		},
+	},
+}

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -79,31 +79,27 @@ const ProfileBookmarksViewContent = () => {
 			</Text>
 			{bookmarks?.length > 0 ? (
 				<>
-					<Heading
-						level={2}
-						weight="semibold"
-						size={300}
-						className={s.cardListHeading}
-					>
-						Your Bookmarks
-					</Heading>
-					<DropdownDisclosure color="secondary" text={sortBy.text}>
-						<DropdownDisclosureButtonItem
-							onClick={() => {
-								setSortBy(SortData.newest)
-							}}
-						>
-							Newest
-						</DropdownDisclosureButtonItem>
-						<DropdownDisclosureButtonItem
-							onClick={() => {
-								setSortBy(SortData.oldest)
-							}}
-						>
-							Oldest
-						</DropdownDisclosureButtonItem>
-					</DropdownDisclosure>
-
+					<span className={s.cardListHeading}>
+						<Heading level={2} weight="semibold" size={300}>
+							Your Bookmarks
+						</Heading>
+						<DropdownDisclosure color="secondary" text={sortBy.text}>
+							<DropdownDisclosureButtonItem
+								onClick={() => {
+									setSortBy(SortData.newest)
+								}}
+							>
+								Newest
+							</DropdownDisclosureButtonItem>
+							<DropdownDisclosureButtonItem
+								onClick={() => {
+									setSortBy(SortData.oldest)
+								}}
+							>
+								Oldest
+							</DropdownDisclosureButtonItem>
+						</DropdownDisclosure>
+					</span>
 					<CardsGridList fixedColumns={2}>
 						{bookmarks.sort(sortBy.sort).map(renderBookmarkCard)}
 					</CardsGridList>

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -70,18 +70,14 @@ const ProfileBookmarksViewContent = () => {
 						</Heading>
 						<DropdownDisclosure color="secondary" text={sortBy.text}>
 							<DropdownDisclosureButtonItem
-								onClick={() => {
-									setSortBy(SortData.newest)
-								}}
+								onClick={() => setSortBy(SortData.newest)}
 							>
-								Newest
+								{SortData.newest.text}
 							</DropdownDisclosureButtonItem>
 							<DropdownDisclosureButtonItem
-								onClick={() => {
-									setSortBy(SortData.oldest)
-								}}
+								onClick={() => setSortBy(SortData.oldest)}
 							>
-								Oldest
+								{SortData.oldest.text}
 							</DropdownDisclosureButtonItem>
 						</DropdownDisclosure>
 					</span>

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -2,17 +2,17 @@ import { useState } from 'react'
 import { useAllBookmarks } from 'hooks/bookmarks'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import AuthenticatedView from 'views/authenticated-view'
-import { ApiBookmark } from 'lib/learn-client/api/api-types'
 import CardsGridList from 'components/cards-grid-list'
 import Text from 'components/text'
 import Heading from 'components/heading'
-import BookmarksEmptyState from './components/empty-state'
-import { ProfileBookmarksSidebar } from './components/sidebar'
-import renderBookmarkCard from './helpers/render-bookmark-cards'
-import s from './bookmarks-view.module.css'
 import DropdownDisclosure, {
 	DropdownDisclosureButtonItem,
 } from 'components/dropdown-disclosure'
+import BookmarksEmptyState from './components/empty-state'
+import { ProfileBookmarksSidebar } from './components/sidebar'
+import renderBookmarkCard from './helpers/render-bookmark-cards'
+import { SortData } from './helpers/card-sort-data'
+import s from './bookmarks-view.module.css'
 
 /**
  * The exported view component that handles wrapping the view content in
@@ -38,21 +38,6 @@ const ProfileBookmarksView = () => {
 			</SidebarSidecarLayout>
 		</AuthenticatedView>
 	)
-}
-
-const SortData = {
-	newest: {
-		text: 'Newest',
-		sort: (a: ApiBookmark, b: ApiBookmark) => {
-			return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-		},
-	},
-	oldest: {
-		text: 'Oldest',
-		sort: (a: ApiBookmark, b: ApiBookmark) => {
-			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-		},
-	},
 }
 
 /**

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -68,7 +68,11 @@ const ProfileBookmarksViewContent = () => {
 						<Heading level={2} weight="semibold" size={300}>
 							Your Bookmarks
 						</Heading>
-						<DropdownDisclosure color="secondary" text={sortBy.text}>
+						<DropdownDisclosure
+							color="secondary"
+							text={sortBy.text}
+							aria-label={`Sort by ${sortBy.text}`}
+						>
 							<DropdownDisclosureButtonItem
 								onClick={() => setSortBy(SortData.newest)}
 							>

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { useAllBookmarks } from 'hooks/bookmarks'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import AuthenticatedView from 'views/authenticated-view'
+import { ApiBookmark } from 'lib/learn-client/api/api-types'
 import CardsGridList from 'components/cards-grid-list'
 import Text from 'components/text'
 import Heading from 'components/heading'
@@ -8,6 +10,9 @@ import BookmarksEmptyState from './components/empty-state'
 import { ProfileBookmarksSidebar } from './components/sidebar'
 import renderBookmarkCard from './helpers/render-bookmark-cards'
 import s from './bookmarks-view.module.css'
+import DropdownDisclosure, {
+	DropdownDisclosureButtonItem,
+} from 'components/dropdown-disclosure'
 
 /**
  * The exported view component that handles wrapping the view content in
@@ -35,6 +40,21 @@ const ProfileBookmarksView = () => {
 	)
 }
 
+const SortData = {
+	newest: {
+		text: 'Newest',
+		sort: (a: ApiBookmark, b: ApiBookmark) => {
+			return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+		},
+	},
+	oldest: {
+		text: 'Oldest',
+		sort: (a: ApiBookmark, b: ApiBookmark) => {
+			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+		},
+	},
+}
+
 /**
  * The content of the ProfileView that is gated behind authentication.
  */
@@ -42,6 +62,7 @@ const ProfileBookmarksViewContent = () => {
 	const { bookmarks, isLoading } = useAllBookmarks({
 		enabled: true,
 	})
+	const [sortBy, setSortBy] = useState(SortData.newest)
 
 	if (isLoading) {
 		return null // TODO return loading skeleton
@@ -66,8 +87,25 @@ const ProfileBookmarksViewContent = () => {
 					>
 						Your Bookmarks
 					</Heading>
+					<DropdownDisclosure color="secondary" text={sortBy.text}>
+						<DropdownDisclosureButtonItem
+							onClick={() => {
+								setSortBy(SortData.newest)
+							}}
+						>
+							Newest
+						</DropdownDisclosureButtonItem>
+						<DropdownDisclosureButtonItem
+							onClick={() => {
+								setSortBy(SortData.oldest)
+							}}
+						>
+							Oldest
+						</DropdownDisclosureButtonItem>
+					</DropdownDisclosure>
+
 					<CardsGridList fixedColumns={2}>
-						{bookmarks.map(renderBookmarkCard)}
+						{bookmarks.sort(sortBy.sort).map(renderBookmarkCard)}
 					</CardsGridList>
 				</>
 			) : (

--- a/src/views/profile/bookmarks-view/index.tsx
+++ b/src/views/profile/bookmarks-view/index.tsx
@@ -72,6 +72,7 @@ const ProfileBookmarksViewContent = () => {
 							color="secondary"
 							text={sortBy.text}
 							aria-label={`Sort by ${sortBy.text}`}
+							listPosition="right"
 						>
 							<DropdownDisclosureButtonItem
 								onClick={() => setSortBy(SortData.newest)}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-bookmarks-sort-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202832753754546) 🎟️

## 🗒️ What

This PR adds a sort feature to the tutorial card view. This sort occurs based on `created_date` for the bookmark. 

## 📸 Design Screenshots

<img width="1464" alt="Screen Shot 2022-08-25 at 1 05 03 PM" src="https://user-images.githubusercontent.com/36613477/186758343-8bb4dce2-d207-4ddf-b23d-60e266f475ee.png">


## 🧪 Testing

- [ ] pull down this branch, run things locally and navigate to /profile/bookmarks
- [ ] test the sort dropdown, verify that the card order reverses. 
