### PR TITLE
feat: onboarding collection pages

### DIFF
--- a/src/__tests__/remove-non-beta-product-pages.test.ts
+++ b/src/__tests__/remove-non-beta-product-pages.test.ts
@@ -32,6 +32,7 @@ describe('remove-non-beta-product-pages', () => {
 		🧹 removing pages at /terraform
 		🧹 removing pages at /vagrant
 		🧹 removing pages at /well-architected-framework
+		🧹 removing pages at /onboarding
 		"
 	`)
 	})

--- a/src/__tests__/remove-non-beta-product-pages.test.ts
+++ b/src/__tests__/remove-non-beta-product-pages.test.ts
@@ -26,13 +26,13 @@ describe('remove-non-beta-product-pages', () => {
 		🧹 removing pages at /docs
 		🧹 removing pages at /hcp
 		🧹 removing pages at /nomad
+		🧹 removing pages at /onboarding
 		🧹 removing pages at /packer
 		🧹 removing pages at /profile
 		🧹 removing pages at /sentinel
 		🧹 removing pages at /terraform
 		🧹 removing pages at /vagrant
 		🧹 removing pages at /well-architected-framework
-		🧹 removing pages at /onboarding
 		"
 	`)
 	})

--- a/src/data/onboarding.json
+++ b/src/data/onboarding.json
@@ -1,0 +1,4 @@
+{
+	"slug": "onboarding",
+	"name": "Onboarding"
+}

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -5,11 +5,12 @@ import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import OnboardingCollectionView from 'views/onboarding/collection-view'
 import onboardingData from 'data/onboarding.json'
+import { OnboardingCollectionViewProps } from 'views/onboarding/types'
 
 export async function getStaticProps({
 	params,
 }: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
-	props: any
+	props: OnboardingCollectionViewProps
 }> {
 	const allWafCollections = await getCollectionsBySection(onboardingData.slug)
 	const currentCollection = allWafCollections.find(
@@ -26,11 +27,19 @@ export async function getStaticProps({
 			isCurrentPage: true,
 		},
 	]
+	const sidebarSections = currentCollection.tutorials.map((tutorial) => ({
+		title: tutorial.name,
+		isActive: false,
+		fullPath: `/${currentCollection.slug}/${splitProductFromFilename(
+			tutorial.slug
+		)}`,
+		id: tutorial.id,
+	}))
 
 	return {
 		props: stripUndefinedProperties({
 			collection: currentCollection,
-			layoutProps: { breadcrumbLinks },
+			layoutProps: { breadcrumbLinks, sidebarSections },
 			metadata: {
 				onboardingName: onboardingData.name,
 				onboardingSlug: onboardingData.slug,
@@ -42,7 +51,6 @@ export async function getStaticProps({
 export async function getStaticPaths() {
 	const allCollections = await getCollectionsBySection(onboardingData.slug)
 	const paths = allCollections.map((c: ApiCollection) => {
-		console.log('collection slug', c.slug)
 		return {
 			params: { collectionSlug: splitProductFromFilename(c.slug) },
 		}

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -12,8 +12,8 @@ export async function getStaticProps({
 }: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
 	props: OnboardingCollectionViewProps
 }> {
-	const allWafCollections = await getCollectionsBySection(onboardingData.slug)
-	const currentCollection = allWafCollections.find(
+	const allOnboardingCollections = await getCollectionsBySection(onboardingData.slug)
+	const currentCollection = allOnboardingCollections.find(
 		(collection: ApiCollection) =>
 			collection.slug === `${onboardingData.slug}/${params.collectionSlug}`
 	)

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -20,7 +20,6 @@ export async function getStaticProps({
 
 	const breadcrumbLinks = [
 		{ title: 'Developer', url: '/' },
-		{ title: onboardingData.name },
 		{
 			title: currentCollection.name,
 			url: `/${currentCollection.slug}`,

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -1,0 +1,50 @@
+import { GetStaticPropsContext } from 'next'
+import { getCollectionsBySection } from 'lib/learn-client/api/collection'
+import { Collection as ApiCollection } from 'lib/learn-client/types'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import OnboardingCollectionView from 'views/onboarding/collection-view'
+import onboardingData from 'data/onboarding.json'
+
+export async function getStaticProps({
+	params,
+}: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
+	props: any
+}> {
+	const allWafCollections = await getCollectionsBySection(onboardingData.slug)
+	const currentCollection = allWafCollections.find(
+		(collection: ApiCollection) =>
+			collection.slug === `${onboardingData.slug}/${params.collectionSlug}`
+	)
+
+	const breadcrumbLinks = [
+		{ title: 'Developer', url: '/' },
+		{ title: onboardingData.name },
+		{
+			title: currentCollection.name,
+			url: `/${currentCollection.slug}`,
+			isCurrentPage: true,
+		},
+	]
+
+	return {
+		props: stripUndefinedProperties({
+			collection: currentCollection,
+			layoutProps: { breadcrumbLinks },
+		}),
+	}
+}
+
+export async function getStaticPaths() {
+	const allCollections = await getCollectionsBySection(onboardingData.slug)
+	const paths = allCollections.map((c: ApiCollection) => {
+		console.log('collection slug', c.slug)
+		return {
+			params: { collectionSlug: splitProductFromFilename(c.slug) },
+		}
+	})
+
+	return { paths, fallback: false }
+}
+
+export default OnboardingCollectionView

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -31,6 +31,10 @@ export async function getStaticProps({
 		props: stripUndefinedProperties({
 			collection: currentCollection,
 			layoutProps: { breadcrumbLinks },
+			metadata: {
+				onboardingName: onboardingData.name,
+				onboardingSlug: onboardingData.slug,
+			},
 		}),
 	}
 }

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -1,6 +1,9 @@
 import { GetStaticPropsContext } from 'next'
 import { getCollectionsBySection } from 'lib/learn-client/api/collection'
-import { Collection as ApiCollection } from 'lib/learn-client/types'
+import {
+	Collection as ClientCollection,
+	TutorialLite as ClientTutorialLite,
+} from 'lib/learn-client/types'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import OnboardingCollectionView from 'views/onboarding/collection-view'
@@ -12,9 +15,11 @@ export async function getStaticProps({
 }: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
 	props: OnboardingCollectionViewProps
 }> {
-	const allOnboardingCollections = await getCollectionsBySection(onboardingData.slug)
+	const allOnboardingCollections = await getCollectionsBySection(
+		onboardingData.slug
+	)
 	const currentCollection = allOnboardingCollections.find(
-		(collection: ApiCollection) =>
+		(collection: ClientCollection) =>
 			collection.slug === `${onboardingData.slug}/${params.collectionSlug}`
 	)
 
@@ -26,14 +31,16 @@ export async function getStaticProps({
 			isCurrentPage: true,
 		},
 	]
-	const sidebarSections = currentCollection.tutorials.map((tutorial) => ({
-		title: tutorial.name,
-		isActive: false,
-		fullPath: `/${currentCollection.slug}/${splitProductFromFilename(
-			tutorial.slug
-		)}`,
-		id: tutorial.id,
-	}))
+	const sidebarSections = currentCollection.tutorials.map(
+		(tutorial: ClientTutorialLite) => ({
+			title: tutorial.name,
+			isActive: false,
+			fullPath: `/${currentCollection.slug}/${splitProductFromFilename(
+				tutorial.slug
+			)}`,
+			id: tutorial.id,
+		})
+	)
 
 	return {
 		props: stripUndefinedProperties({
@@ -49,7 +56,7 @@ export async function getStaticProps({
 
 export async function getStaticPaths() {
 	const allCollections = await getCollectionsBySection(onboardingData.slug)
-	const paths = allCollections.map((c: ApiCollection) => {
+	const paths = allCollections.map((c: ClientCollection) => {
 		return {
 			params: { collectionSlug: splitProductFromFilename(c.slug) },
 		}

--- a/src/views/onboarding/collection-view/index.tsx
+++ b/src/views/onboarding/collection-view/index.tsx
@@ -1,3 +1,4 @@
+import HashiHead from '@hashicorp/react-head'
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import { splitProductFromFilename } from 'views/tutorial-view/utils'
 import getReadableTime from 'components/tutorial-meta/components/badges/helpers'
@@ -6,61 +7,62 @@ import CollectionTutorialList from 'views/collection-view/components/collection-
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
 import { SidebarProps } from 'components/sidebar'
+import { OnboardingCollectionViewProps } from '../types'
 
 export default function OnboardingCollectionView({
 	collection,
 	layoutProps,
 	metadata,
-}) {
+}: OnboardingCollectionViewProps) {
 	const { name, id, description, tutorials, ordered, slug } = collection
 	const startTutorialSlug = `/${slug}/${splitProductFromFilename(
 		tutorials[0].slug
 	)}`
 
 	return (
-		<SidebarSidecarLayout
-			sidecarSlot={null}
-			breadcrumbLinks={layoutProps.breadcrumbLinks}
-			sidebarNavDataLevels={[
-				generateTopLevelSidebarNavData(metadata.onboardingName) as SidebarProps,
-				{
-					title: metadata.onboardingName,
-					levelButtonProps: {
-						levelUpButtonText: `Main Menu`,
-						levelDownButtonText: 'Previous',
-					},
-					showFilterInput: false,
+		<>
+			<HashiHead>
+				<meta name="robots" content="noindex" />
+			</HashiHead>
+			<SidebarSidecarLayout
+				sidecarSlot={null}
+				breadcrumbLinks={layoutProps.breadcrumbLinks}
+				sidebarNavDataLevels={[
+					generateTopLevelSidebarNavData(
+						metadata.onboardingName
+					) as SidebarProps,
+					{
+						title: metadata.onboardingName,
+						levelButtonProps: {
+							levelUpButtonText: `Main Menu`,
+							levelDownButtonText: 'Previous',
+						},
+						showFilterInput: false,
 
-					menuItems: tutorials.map((tutorial) => ({
-						title: tutorial.name,
-						isActive: false,
-						fullPath: `/${collection.slug}/${splitProductFromFilename(
-							tutorial.slug
-						)}`,
-						id: tutorial.id,
-					})),
-				},
-			]}
-		>
-			<CollectionMeta
-				heading={{ text: name, id }}
-				description={description}
-				cta={{ href: startTutorialSlug }}
-				numTutorials={tutorials.length}
-			/>
-			<CollectionTutorialList
-				isOrdered={ordered}
-				tutorials={tutorials.map((t: ClientTutorialLite) => ({
-					id: t.id,
-					description: t.description,
-					duration: getReadableTime(t.readTime),
-					hasInteractiveLab: Boolean(t.handsOnLab),
-					hasVideo: Boolean(t.video),
-					heading: t.name,
-					url: `/${slug}/${splitProductFromFilename(t.slug)}`,
-					productsUsed: t.productsUsed.map((p) => p.product.slug),
-				}))}
-			/>
-		</SidebarSidecarLayout>
+						menuItems: layoutProps.sidebarSections,
+					},
+				]}
+			>
+				<CollectionMeta
+					heading={{ text: name, id }}
+					description={description}
+					cta={{ href: startTutorialSlug }}
+					numTutorials={tutorials.length}
+				/>
+				<CollectionTutorialList
+					isOrdered={ordered}
+					tutorials={tutorials.map((t: ClientTutorialLite) => ({
+						id: t.id,
+						description: t.description,
+						duration: getReadableTime(t.readTime),
+						hasInteractiveLab: Boolean(t.handsOnLab),
+						hasVideo: Boolean(t.video),
+						heading: t.name,
+						url: `/${slug}/${splitProductFromFilename(t.slug)}`,
+						productsUsed: t.productsUsed.map((p) => p.product.slug),
+					}))}
+				/>
+			</SidebarSidecarLayout>
+		</>
 	)
 }

--- a/src/views/onboarding/collection-view/index.tsx
+++ b/src/views/onboarding/collection-view/index.tsx
@@ -1,0 +1,41 @@
+import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import getReadableTime from 'components/tutorial-meta/components/badges/helpers'
+import CollectionMeta from 'views/collection-view/components/collection-meta'
+import CollectionTutorialList from 'views/collection-view/components/collection-tutorial-list'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+
+export default function OnboardingCollectionView({ collection, layoutProps }) {
+	const { name, id, description, tutorials, ordered, slug } = collection
+	const startTutorialSlug = `/${slug}/${splitProductFromFilename(
+		tutorials[0].slug
+	)}`
+
+	return (
+		<SidebarSidecarLayout
+			sidecarSlot={null}
+			breadcrumbLinks={layoutProps.breadcrumbLinks}
+			sidebarNavDataLevels={[]}
+		>
+			<CollectionMeta
+				heading={{ text: name, id }}
+				description={description}
+				cta={{ href: startTutorialSlug }}
+				numTutorials={tutorials.length}
+			/>
+			<CollectionTutorialList
+				isOrdered={ordered}
+				tutorials={tutorials.map((t: ClientTutorialLite) => ({
+					id: t.id,
+					description: t.description,
+					duration: getReadableTime(t.readTime),
+					hasInteractiveLab: Boolean(t.handsOnLab),
+					hasVideo: Boolean(t.video),
+					heading: t.name,
+					url: `/${slug}/${splitProductFromFilename(t.slug)}`,
+					productsUsed: t.productsUsed.map((p) => p.product.slug),
+				}))}
+			/>
+		</SidebarSidecarLayout>
+	)
+}

--- a/src/views/onboarding/collection-view/index.tsx
+++ b/src/views/onboarding/collection-view/index.tsx
@@ -4,8 +4,14 @@ import getReadableTime from 'components/tutorial-meta/components/badges/helpers'
 import CollectionMeta from 'views/collection-view/components/collection-meta'
 import CollectionTutorialList from 'views/collection-view/components/collection-tutorial-list'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
+import { SidebarProps } from 'components/sidebar'
 
-export default function OnboardingCollectionView({ collection, layoutProps }) {
+export default function OnboardingCollectionView({
+	collection,
+	layoutProps,
+	metadata,
+}) {
 	const { name, id, description, tutorials, ordered, slug } = collection
 	const startTutorialSlug = `/${slug}/${splitProductFromFilename(
 		tutorials[0].slug
@@ -15,7 +21,26 @@ export default function OnboardingCollectionView({ collection, layoutProps }) {
 		<SidebarSidecarLayout
 			sidecarSlot={null}
 			breadcrumbLinks={layoutProps.breadcrumbLinks}
-			sidebarNavDataLevels={[]}
+			sidebarNavDataLevels={[
+				generateTopLevelSidebarNavData(metadata.onboardingName) as SidebarProps,
+				{
+					title: metadata.onboardingName,
+					levelButtonProps: {
+						levelUpButtonText: `Main Menu`,
+						levelDownButtonText: 'Previous',
+					},
+					showFilterInput: false,
+
+					menuItems: tutorials.map((tutorial) => ({
+						title: tutorial.name,
+						isActive: false,
+						fullPath: `/${collection.slug}/${splitProductFromFilename(
+							tutorial.slug
+						)}`,
+						id: tutorial.id,
+					})),
+				},
+			]}
 		>
 			<CollectionMeta
 				heading={{ text: name, id }}

--- a/src/views/onboarding/types.ts
+++ b/src/views/onboarding/types.ts
@@ -1,0 +1,15 @@
+import { Collection as ApiCollection } from 'lib/learn-client/types'
+import { EnrichedNavItem } from 'components/sidebar/types'
+import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
+
+export interface OnboardingCollectionViewProps {
+	metadata: {
+		onboardingName: string
+		onboardingSlug: string
+	}
+	collection: ApiCollection
+	layoutProps: {
+		breadcrumbLinks: SidebarSidecarLayoutProps['breadcrumbLinks']
+		sidebarSections: EnrichedNavItem[]
+	}
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksonboarding-pages-hashicorp.vercel.app/onboarding/terraform-enterprise-week-1) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202885494551261) 🎟️

## 🗒️ What

This PR adds all onboarding collections. 

## 🛠️ How

I reused a lot of code from the waf implementation. There's room to abstract to create a generic collection or tutorial view, I will note that for follow up work. 

## 🧪 Testing

- visit a few onboarding collection urls
- https://dev-portal-git-ksonboarding-pages-hashicorp.vercel.app/onboarding/terraform-enterprise-week-1
- https://dev-portal-git-ksonboarding-pages-hashicorp.vercel.app/onboarding/hcp-vault-week-1
- https://dev-portal-git-ksonboarding-pages-hashicorp.vercel.app/onboarding/tfcb-week-3
- https://dev-portal-git-ksonboarding-pages-hashicorp.vercel.app/onboarding/vault-enterprise-week-6
- The collection list should render as normal, link to the proper tutorials (will 404 currently)
- There should be a 'noindex' tag in the page meta
- The sidebar should populate with the same list of tutorials in the collection, to match current day learn. [See this ticket](https://app.asana.com/0/1199634971449915/1202557239529928) for more context on this decision. 

