### PR TITLE
chore: adds link to 'HashiCorp Developer' nav icon

### DIFF
--- a/src/components/navigation-header/components/home-page-content/index.tsx
+++ b/src/components/navigation-header/components/home-page-content/index.tsx
@@ -6,6 +6,7 @@ import { NavigationHeaderDropdownMenu } from '..'
 import sharedNavStyles from '../../navigation-header.module.css'
 import s from './home-page-content.module.css'
 import { NavigationHeaderItemGroup } from 'components/navigation-header/types'
+import Link from 'next/link'
 
 const HomePageHeaderContent = () => {
 	const betaProductItems = []
@@ -48,12 +49,17 @@ const HomePageHeaderContent = () => {
 
 	return (
 		<div className={sharedNavStyles.leftSide}>
-			<div className={sharedNavStyles.contentBeforeNav}>
-				<InlineSvg
-					className={s.siteLogo}
-					src={require('../../img/logo-white.svg?include')}
-				/>
-			</div>
+			<Link href="/">
+				<a
+					aria-label="HashiCorp Developer Home"
+					className={sharedNavStyles.contentBeforeNav}
+				>
+					<InlineSvg
+						className={s.siteLogo}
+						src={require('../../img/logo-white.svg?include')}
+					/>
+				</a>
+			</Link>
 			<div className={sharedNavStyles.leftSideDesktopOnlyContent}>
 				<nav className={sharedNavStyles.nav}>
 					<ul className={sharedNavStyles.navList}>

--- a/src/components/navigation-header/components/home-page-content/index.tsx
+++ b/src/components/navigation-header/components/home-page-content/index.tsx
@@ -49,17 +49,16 @@ const HomePageHeaderContent = () => {
 
 	return (
 		<div className={sharedNavStyles.leftSide}>
-			<Link href="/">
-				<a
-					aria-label="HashiCorp Developer Home"
-					className={sharedNavStyles.contentBeforeNav}
-				>
-					<InlineSvg
-						className={s.siteLogo}
-						src={require('../../img/logo-white.svg?include')}
-					/>
-				</a>
-			</Link>
+			<div className={sharedNavStyles.contentBeforeNav}>
+				<Link href="/">
+					<a aria-label="HashiCorp Developer Home">
+						<InlineSvg
+							className={s.siteLogo}
+							src={require('../../img/logo-white.svg?include')}
+						/>
+					</a>
+				</Link>
+			</div>
 			<div className={sharedNavStyles.leftSideDesktopOnlyContent}>
 				<nav className={sharedNavStyles.nav}>
 					<ul className={sharedNavStyles.navList}>

--- a/src/components/navigation-header/components/home-page-content/index.tsx
+++ b/src/components/navigation-header/components/home-page-content/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import InlineSvg from '@hashicorp/react-inline-svg'
 import { ProductSlug } from 'types/products'
 import { productSlugsToNames } from 'lib/products'
@@ -6,7 +7,6 @@ import { NavigationHeaderDropdownMenu } from '..'
 import sharedNavStyles from '../../navigation-header.module.css'
 import s from './home-page-content.module.css'
 import { NavigationHeaderItemGroup } from 'components/navigation-header/types'
-import Link from 'next/link'
 
 const HomePageHeaderContent = () => {
 	const betaProductItems = []

--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -46,7 +46,6 @@ export default function WellArchitectedFrameworkTutorialView({
 		SectionOption['well-architected-framework']
 	)
 	const canonicalUrl = generateCanonicalUrl(canonicalCollectionSlug, slug)
-	console.log(canonicalUrl)
 
 	return (
 		<>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksupdate-nav-hashicorp.vercel.app/well-architected-framework) 🔎
- [Asana task](https://app.asana.com/0/1202702246158644/1202863899279051) 🎟️

## 🗒️ What

To improve the UX for the waf pages, this link needed to be added to the base nav header. 

## 🤷 Why

To allow for ease of navigation between the waf views and the home page. 

## 🧪 Testing

- visit the [waf page](https://dev-portal-git-ksupdate-nav-hashicorp.vercel.app/well-architected-framework), click the link to the home page
- no styles should be affected


