### PR TITLE
feat: conditionally render `ProductNav.notice`

### DIFF
--- a/src/views/homepage/components/product-nav/index.tsx
+++ b/src/views/homepage/components/product-nav/index.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import classNames from 'classnames'
 import type { ProductSlug } from 'types/products'
 import { productSlugsToNames } from 'lib/products'
-import getIsBetaProduct from 'lib/get-is-beta-product'
 import { IconHashicorp24 } from '@hashicorp/flight-icons/svg-react/hashicorp-24'
 import { IconHashicorpColor24 } from '@hashicorp/flight-icons/svg-react/hashicorp-color-24'
 import { IconTerraform24 } from '@hashicorp/flight-icons/svg-react/terraform-24'
@@ -75,13 +74,18 @@ const productIcons: {
 
 interface ProductNavProps {
 	notice?: string
-	products: Array<ProductSlug>
+	products: { slug: ProductSlug; isBeta: boolean }[]
 }
 
 export default function ProductNav({ notice, products }: ProductNavProps) {
+	// if at least one product is not in-beta, show the beta notice
+	// - This may need to be adjusted as Post-GA, products will be
+	//   promoted away from "beta", to "generally available", or something else.
+	const notAllInBeta = products.some(({ isBeta }) => !isBeta)
+
 	return (
 		<div className={s.productNav}>
-			{notice ? (
+			{notice && notAllInBeta ? (
 				<div className={s.notice}>
 					<Text size={200} className={s.noticeText}>
 						{notice}
@@ -90,12 +94,11 @@ export default function ProductNav({ notice, products }: ProductNavProps) {
 			) : null}
 			<nav className={s.nav}>
 				<ul className={s.list}>
-					{products.map((product, index) => {
-						const isBetaProduct = getIsBetaProduct(product)
+					{products.map(({ slug, isBeta }, index) => {
 						const productName =
-							product === 'hcp' ? 'HCP' : productSlugsToNames[product]
+							slug === 'hcp' ? 'HCP' : productSlugsToNames[slug]
 						const productBorderColor =
-							product === 'hcp' ? 'var(--black)' : `var(--${product})`
+							slug === 'hcp' ? 'var(--black)' : `var(--${slug})`
 						const productClassName = classNames(s.product, {
 							[s.isFirstChild]: index == 0,
 							[s.isLastChild]: index == products.length - 1,
@@ -103,17 +106,17 @@ export default function ProductNav({ notice, products }: ProductNavProps) {
 						return (
 							<li
 								className={s.listItem}
-								key={product}
+								key={slug}
 								style={
 									{
 										'--border-color': productBorderColor,
 									} as CSSProperties
 								}
 							>
-								{isBetaProduct ? (
-									<Link href={`/${product}/`}>
+								{isBeta ? (
+									<Link href={`/${slug}/`}>
 										<a className={productClassName}>
-											{productIcons[product].color}
+											{productIcons[slug].color}
 											<Text
 												weight="semibold"
 												size={200}
@@ -126,7 +129,7 @@ export default function ProductNav({ notice, products }: ProductNavProps) {
 									</Link>
 								) : (
 									<span className={productClassName}>
-										{productIcons[product].neutral}
+										{productIcons[slug].neutral}
 										<Text
 											weight="semibold"
 											size={200}

--- a/src/views/homepage/components/product-nav/product-nav.test.tsx
+++ b/src/views/homepage/components/product-nav/product-nav.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react'
+import { ProductSlug } from 'types/products'
+
+import ProductNav from '.'
+
+describe('ProductNav', () => {
+	describe('notice', () => {
+		let products: { slug: ProductSlug; isBeta: boolean }[]
+
+		it('should be displayed if not all products are in beta', () => {
+			products = [
+				{ slug: 'boundary', isBeta: true },
+				{ slug: 'waypoint', isBeta: false },
+			]
+
+			const { container } = render(
+				<ProductNav
+					notice="At least one product is not yet in-beta"
+					products={products}
+				/>
+			)
+
+			expect(container).toHaveTextContent(
+				'At least one product is not yet in-beta'
+			)
+		})
+
+		it('should not be displayed if all products are in beta', () => {
+			products = [
+				{ slug: 'boundary', isBeta: true },
+				{ slug: 'waypoint', isBeta: true },
+			]
+
+			const { container } = render(
+				<ProductNav
+					notice="At least one product is not yet in-beta"
+					products={products}
+				/>
+			)
+
+			expect(container).not.toHaveTextContent(
+				'At least one product is not yet in-beta'
+			)
+		})
+	})
+})

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -1,8 +1,9 @@
 // Third-party imports
-import { ReactElement } from 'react'
+import { ReactElement, useMemo } from 'react'
 
 // Global imports
 import { productSlugs } from 'lib/products'
+import getIsBetaProduct from 'lib/get-is-beta-product'
 import BaseNewLayout from 'layouts/base-new'
 import Text from 'components/text'
 
@@ -19,8 +20,6 @@ import {
 } from './components/merchandising-slots/slots'
 import s from './homepage.module.css'
 
-const productNavSlugs = productSlugs.filter((slug) => slug !== 'sentinel')
-
 const HomePageContent = ({
 	hero,
 	merchandising,
@@ -28,6 +27,17 @@ const HomePageContent = ({
 	preFooter,
 	navNotice,
 }: HomePageContentProps) => {
+	const products = useMemo(
+		() =>
+			productSlugs
+				.filter((slug) => slug !== 'sentinel')
+				.map((slug) => ({
+					slug,
+					isBeta: getIsBetaProduct(slug),
+				})),
+		[]
+	)
+
 	return (
 		<div className={s.homepageContent}>
 			<HeroWithVideo
@@ -37,7 +47,7 @@ const HomePageContent = ({
 				videoUrl="https://hashicorp.wistia.com/medias/031h9iogzx"
 				videoImageUrl="https://embed-ssl.wistia.com/deliveries/b65febe71ccfb5ded8d3958b1cf1ec61.jpg?image_crop_resized=960x540"
 			/>
-			<ProductNav notice={navNotice} products={productNavSlugs} />
+			<ProductNav notice={navNotice} products={products} />
 			<MerchandisingSlots>
 				<VaultSlot
 					url={merchandising.vault.url}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kevin-conditionally-render-prod-7da094-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202772453379361/f) 🎟️

## 🗒️ What

This adds logic to conditionally render the `ProductNav.notice` 

<img width="918" alt="CleanShot 2022-09-02 at 14 27 43@2x" src="https://user-images.githubusercontent.com/26389321/188215654-65af6d71-a328-4265-b000-579e307a5d90.png">


## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- View the deploy preview, and validate that the notice is **not** present (because all products are _in beta_ in preview environments)


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
