### PR TITLE
feat: tutorial progress toasts

### DIFF
--- a/src/components/toast/components/toast-display/toast-display.module.css
+++ b/src/components/toast/components/toast-display/toast-display.module.css
@@ -54,7 +54,6 @@
 
 .contentArea {
 	flex-grow: 1;
-	padding-top: 2px;
 }
 
 .title {

--- a/src/components/toast/components/toast-display/toast-display.module.css
+++ b/src/components/toast/components/toast-display/toast-display.module.css
@@ -1,84 +1,85 @@
 .root {
-  border-radius: 6px;
-  border: 1px solid;
-  box-shadow: var(--token-elevation-higher-box-shadow);
-  display: flex;
-  padding: 16px;
+	border-radius: 6px;
+	border: 1px solid;
+	box-shadow: var(--token-elevation-higher-box-shadow);
+	display: flex;
+	padding: 16px;
+	width: 100%;
 
-  &.color-neutral {
-    background: var(--token-color-surface-faint);
-    border-color: var(--token-color-border-strong);
+	&.color-neutral {
+		background: var(--token-color-surface-faint);
+		border-color: var(--token-color-border-strong);
 
-    --title-and-icon-color: var(--token-color-foreground-strong);
-  }
+		--title-and-icon-color: var(--token-color-foreground-strong);
+	}
 
-  &.color-highlight {
-    background: var(--token-color-surface-highlight);
-    border-color: var(--token-color-border-highlight);
+	&.color-highlight {
+		background: var(--token-color-surface-highlight);
+		border-color: var(--token-color-border-highlight);
 
-    --title-and-icon-color: var(--token-color-foreground-highlight-on-surface);
-  }
+		--title-and-icon-color: var(--token-color-foreground-highlight-on-surface);
+	}
 
-  &.color-warning {
-    background: var(--token-color-surface-warning);
-    border-color: var(--token-color-border-warning);
+	&.color-warning {
+		background: var(--token-color-surface-warning);
+		border-color: var(--token-color-border-warning);
 
-    --title-and-icon-color: var(--token-color-foreground-warning-on-surface);
-  }
+		--title-and-icon-color: var(--token-color-foreground-warning-on-surface);
+	}
 
-  &.color-success {
-    background: var(--token-color-surface-success);
-    border-color: var(--token-color-border-success);
+	&.color-success {
+		background: var(--token-color-surface-success);
+		border-color: var(--token-color-border-success);
 
-    --title-and-icon-color: var(--token-color-foreground-success-on-surface);
-  }
+		--title-and-icon-color: var(--token-color-foreground-success-on-surface);
+	}
 
-  &.color-critical {
-    background: var(--token-color-surface-critical);
-    border-color: var(--token-color-border-critical);
+	&.color-critical {
+		background: var(--token-color-surface-critical);
+		border-color: var(--token-color-border-critical);
 
-    --title-and-icon-color: var(--token-color-foreground-critical-on-surface);
-  }
+		--title-and-icon-color: var(--token-color-foreground-critical-on-surface);
+	}
 }
 
 .iconArea {
-  color: var(--title-and-icon-color);
-  flex-shrink: 0;
-  margin-right: 12px;
+	color: var(--title-and-icon-color);
+	flex-shrink: 0;
+	margin-right: 12px;
 
-  & svg {
-    display: block;
-  }
+	& svg {
+		display: block;
+	}
 }
 
 .contentArea {
-  flex-grow: 1;
-  padding-top: 2px;
+	flex-grow: 1;
+	padding-top: 2px;
 }
 
 .title {
-  composes: hds-typography-body-200 from global;
-  color: var(--title-and-icon-color);
-  font-weight: var(--token-typography-font-weight-semibold);
+	composes: hds-typography-body-200 from global;
+	color: var(--title-and-icon-color);
+	font-weight: var(--token-typography-font-weight-semibold);
 }
 
 .description {
-  composes: hds-typography-body-200 from global;
-  color: var(--token-color-foreground-primary);
+	composes: hds-typography-body-200 from global;
+	color: var(--token-color-foreground-primary);
 
-  &:not(:first-child) {
-    margin-top: 4px;
-  }
+	&:not(:first-child) {
+		margin-top: 4px;
+	}
 }
 
 .actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 16px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 16px;
 }
 
 .closeArea {
-  flex-shrink: 0;
-  margin-left: 16px;
+	flex-shrink: 0;
+	margin-left: 16px;
 }

--- a/src/hooks/progress/index.ts
+++ b/src/hooks/progress/index.ts
@@ -1,4 +1,5 @@
 export const TUTORIAL_PROGRESS_QUERY_ID = 'tutorialProgress'
+export { useCollectionProgress } from './use-collection-progress'
 export { useTutorialProgress } from './use-tutorial-progress'
 export { useTutorialProgressMutations } from './use-tutorial-progress-mutations'
 export type { TutorialProgressMutationArgs } from './use-tutorial-progress-mutations'

--- a/src/hooks/progress/use-collection-progress.ts
+++ b/src/hooks/progress/use-collection-progress.ts
@@ -1,0 +1,44 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query'
+import useAuthentication from 'hooks/use-authentication'
+import {
+	getAllProgress,
+	GetAllProgressResult,
+} from 'lib/learn-client/api/progress'
+import { Collection } from 'lib/learn-client/types'
+
+type QueryDataType = GetAllProgressResult
+
+interface UseCollectionProgressOptions {
+	collectionId: Collection['id']
+}
+
+interface UseCollectionProgressResult
+	extends Omit<UseQueryResult<QueryDataType>, 'data'> {
+	data: UseQueryResult<QueryDataType>['data']
+}
+
+/**
+ * Handles checking if there is progress for the given `collectionId`.
+ */
+function useCollectionProgress({
+	collectionId,
+}: UseCollectionProgressOptions): UseCollectionProgressResult {
+	// Get the current user's access token
+	const { session } = useAuthentication()
+	const accessToken = session?.accessToken
+
+	// Fetch progress records by `collectionId`
+	const { data, ...restQueryResult } = useQuery<QueryDataType>(
+		['collectionProgress', collectionId],
+		() => getAllProgress({ accessToken, collectionIds: [collectionId] }),
+		{ enabled: !!accessToken }
+	)
+
+	return {
+		data,
+		...restQueryResult,
+	}
+}
+
+export type { UseCollectionProgressOptions, UseCollectionProgressResult }
+export { useCollectionProgress }

--- a/src/hooks/progress/use-tutorial-progress-mutations/index.ts
+++ b/src/hooks/progress/use-tutorial-progress-mutations/index.ts
@@ -44,6 +44,9 @@ const useTutorialProgressMutations = (): UseTutorialProgressMutationsResult => {
 				[TUTORIAL_PROGRESS_QUERY_ID, tutorialId, collectionId],
 				data
 			)
+
+			// Invalidate related collection progress
+			queryClient.invalidateQueries(['collectionProgress', collectionId])
 		}
 	}
 

--- a/src/hooks/use-previous.ts
+++ b/src/hooks/use-previous.ts
@@ -1,0 +1,12 @@
+import { useRef, useEffect } from 'react'
+
+/**
+ * Keep track of the previous value of a variable
+ */
+export default function usePrevious<T = never>(value: T) {
+	const ref = useRef<T>()
+	useEffect(() => {
+		ref.current = value
+	}, [value])
+	return ref.current
+}

--- a/src/lib/learn-client/api/progress/formatting.ts
+++ b/src/lib/learn-client/api/progress/formatting.ts
@@ -2,7 +2,6 @@ import {
 	TutorialProgressStatus,
 	TutorialProgressPercent,
 } from 'lib/learn-client/types'
-import { ApiCollectionTutorialProgress } from '../api-types'
 
 /**
  * Convert from API's complete_percent to the TutorialProgressStatus enum.

--- a/src/lib/learn-client/api/progress/formatting.ts
+++ b/src/lib/learn-client/api/progress/formatting.ts
@@ -2,6 +2,7 @@ import {
 	TutorialProgressStatus,
 	TutorialProgressPercent,
 } from 'lib/learn-client/types'
+import { ApiCollectionTutorialProgress } from '../api-types'
 
 /**
  * Convert from API's complete_percent to the TutorialProgressStatus enum.
@@ -37,4 +38,19 @@ export function progressStatusToPercent(
 	} else {
 		return TutorialProgressPercent.Zero
 	}
+}
+
+/**
+ * Given an array of progress records,
+ * Return the best progress found for that tutorialId in any collection context.
+ */
+export function parseCollectionProgress(
+	data: ApiCollectionTutorialProgress[]
+): number {
+	// Filter for records associated with this collection
+	const completedTutorials = data.filter(
+		(record: ApiCollectionTutorialProgress) => record.complete_percent == '100'
+	)
+	// Return the count of completed tutorials
+	return completedTutorials.length
 }

--- a/src/lib/learn-client/api/progress/formatting.ts
+++ b/src/lib/learn-client/api/progress/formatting.ts
@@ -39,18 +39,3 @@ export function progressStatusToPercent(
 		return TutorialProgressPercent.Zero
 	}
 }
-
-/**
- * Given an array of progress records,
- * Return the best progress found for that tutorialId in any collection context.
- */
-export function parseCollectionProgress(
-	data: ApiCollectionTutorialProgress[]
-): number {
-	// Filter for records associated with this collection
-	const completedTutorials = data.filter(
-		(record: ApiCollectionTutorialProgress) => record.complete_percent == '100'
-	)
-	// Return the count of completed tutorials
-	return completedTutorials.length
-}

--- a/src/lib/learn-client/api/progress/get-all-progress.ts
+++ b/src/lib/learn-client/api/progress/get-all-progress.ts
@@ -1,4 +1,6 @@
 import { get, toError } from 'lib/learn-client'
+// TODO: use queryString for addQueryParams
+// import queryString from 'query-string'
 import { Collection, Tutorial } from 'lib/learn-client/types'
 import { SessionData } from 'types/auth'
 import { PROGRESS_API_ROUTE } from '.'
@@ -27,7 +29,6 @@ const getAllProgress = async ({
 	let url = PROGRESS_API_ROUTE
 	const addQueryParams = tutorialIds || collectionIds
 	if (addQueryParams) {
-		url += '?'
 		const params = []
 		if (tutorialIds) {
 			params.push(`tutorialIds=${tutorialIds.join(',')}`)

--- a/src/lib/learn-client/api/progress/get-all-progress.ts
+++ b/src/lib/learn-client/api/progress/get-all-progress.ts
@@ -1,0 +1,55 @@
+import { get, toError } from 'lib/learn-client'
+import { uuid } from 'lib/learn-client/types'
+import { SessionData } from 'types/auth'
+import { PROGRESS_API_ROUTE } from '.'
+import { ApiCollectionTutorialProgress } from '../api-types'
+
+interface GetAllProgressOptions {
+	accessToken: SessionData['accessToken']
+	tutorialIds?: uuid[]
+	collectionIds?: uuid[]
+}
+
+type GetAllProgressResult = ApiCollectionTutorialProgress[]
+
+/**
+ * Fetches all bookmarks for the current user. If successful, returns an array
+ * of bookmark objects. Otherwise throws an error.
+ *
+ * https://digital-api-specs.vercel.app/learn#tag/Bookmarks/paths/~1bookmarks/get
+ */
+const getAllProgress = async ({
+	accessToken,
+	tutorialIds,
+	collectionIds,
+}: GetAllProgressOptions): Promise<GetAllProgressResult> => {
+	// Add query params to the URL, if applicable
+	let url = PROGRESS_API_ROUTE
+	const addQueryParams = tutorialIds || collectionIds
+	if (addQueryParams) {
+		url += '?'
+		const params = []
+		if (tutorialIds) {
+			params.push(`tutorialIds=${tutorialIds.join(',')}`)
+		}
+		if (collectionIds) {
+			params.push(`collectionIds=${collectionIds.join(',')}`)
+		}
+		url += '?' + params.join('&')
+	}
+	// Make the GET request
+	const requestResult = await get(url, accessToken)
+
+	// Return data as JSON if result is OK
+	if (requestResult.ok) {
+		const { result } = await requestResult.json()
+		return result
+	}
+
+	// Throw an error if result is not OK
+	const error = await toError(requestResult)
+	throw error
+}
+
+export type { GetAllProgressOptions, GetAllProgressResult }
+export { getAllProgress }

--- a/src/lib/learn-client/api/progress/get-all-progress.ts
+++ b/src/lib/learn-client/api/progress/get-all-progress.ts
@@ -1,7 +1,6 @@
+import queryString from 'query-string'
 import { get, toError } from 'lib/learn-client'
-// TODO: use queryString for addQueryParams
-// import queryString from 'query-string'
-import { Collection, Tutorial } from 'lib/learn-client/types'
+import { Tutorial, Collection } from 'lib/learn-client/types'
 import { SessionData } from 'types/auth'
 import { PROGRESS_API_ROUTE } from '.'
 import { ApiCollectionTutorialProgress } from '../api-types'
@@ -15,10 +14,17 @@ interface GetAllProgressOptions {
 type GetAllProgressResult = ApiCollectionTutorialProgress[]
 
 /**
- * Fetches all bookmarks for the current user. If successful, returns an array
- * of bookmark objects. Otherwise throws an error.
+ * Fetches all tutorial progress records for the current user.
+ * If successful, returns an array of progress objects.
+ * Otherwise throws an error.
  *
- * https://digital-api-specs.vercel.app/learn#tag/Bookmarks/paths/~1bookmarks/get
+ * Accepts optional arrays of `tutorialIds` and `collectionIds`.
+ * When either of these are provided, we return all progress records
+ * that match either:
+ * - any one of the provided `tutorialIds`
+ * - any one of the provided `collectionIds`
+ *
+ * https://digital-api-specs.vercel.app/learn#tag/Progress/paths/~1progress/get
  */
 const getAllProgress = async ({
 	accessToken,
@@ -27,17 +33,11 @@ const getAllProgress = async ({
 }: GetAllProgressOptions): Promise<GetAllProgressResult> => {
 	// Add query params to the URL, if applicable
 	let url = PROGRESS_API_ROUTE
-	const addQueryParams = tutorialIds || collectionIds
-	if (addQueryParams) {
-		const params = []
-		if (tutorialIds) {
-			params.push(`tutorialIds=${tutorialIds.join(',')}`)
-		}
-		if (collectionIds) {
-			params.push(`collectionIds=${collectionIds.join(',')}`)
-		}
-		url += '?' + params.join('&')
+	const qs = queryString.stringify({ tutorialIds, collectionIds })
+	if (qs !== '') {
+		url += `?${qs}`
 	}
+
 	// Make the GET request
 	const requestResult = await get(url, accessToken)
 

--- a/src/lib/learn-client/api/progress/get-all-progress.ts
+++ b/src/lib/learn-client/api/progress/get-all-progress.ts
@@ -1,13 +1,13 @@
 import { get, toError } from 'lib/learn-client'
-import { uuid } from 'lib/learn-client/types'
+import { Collection, Tutorial } from 'lib/learn-client/types'
 import { SessionData } from 'types/auth'
 import { PROGRESS_API_ROUTE } from '.'
 import { ApiCollectionTutorialProgress } from '../api-types'
 
 interface GetAllProgressOptions {
 	accessToken: SessionData['accessToken']
-	tutorialIds?: uuid[]
-	collectionIds?: uuid[]
+	tutorialIds?: Tutorial['id'][]
+	collectionIds?: Collection['id'][]
 }
 
 type GetAllProgressResult = ApiCollectionTutorialProgress[]

--- a/src/lib/learn-client/api/progress/index.ts
+++ b/src/lib/learn-client/api/progress/index.ts
@@ -20,15 +20,18 @@ import { progressStatusToPercent, progressPercentToStatus } from './formatting'
  * Used in get-all-progress.
  */
 export const PROGRESS_API_ROUTE = '/progress'
+import { getAllProgress, GetAllProgressResult } from './get-all-progress'
 
 export type {
 	CreateTutorialProgressOptions,
+	GetAllProgressResult,
 	GetTutorialProgressResult,
 	UpdateTutorialProgressOptions,
 }
 
 export {
 	createTutorialProgress,
+	getAllProgress,
 	getTutorialProgress,
 	progressStatusToPercent,
 	progressPercentToStatus,

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head'
 import { MDXRemote } from 'next-mdx-remote'
 
 // Global imports
-import { useCollectionProgress, useTutorialProgressRefs } from 'hooks/progress'
+import { useTutorialProgressRefs } from 'hooks/progress'
 import useCurrentPath from 'hooks/use-current-path'
 import { useOptInAnalyticsTracking } from 'hooks/use-opt-in-analytics-tracking'
 import { useMobileMenu } from 'contexts'

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -4,12 +4,12 @@ import Head from 'next/head'
 import { MDXRemote } from 'next-mdx-remote'
 
 // Global imports
-import { useTutorialProgressRefs } from 'hooks/progress'
+import { useCollectionProgress, useTutorialProgressRefs } from 'hooks/progress'
 import useCurrentPath from 'hooks/use-current-path'
 import { useOptInAnalyticsTracking } from 'hooks/use-opt-in-analytics-tracking'
 import { useMobileMenu } from 'contexts'
 import InstruqtProvider from 'contexts/instruqt-lab'
-import { ProductOption } from 'lib/learn-client/types'
+import { ProductOption, TutorialLite } from 'lib/learn-client/types'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import {
 	CollectionCategorySidebarSection,
@@ -50,6 +50,7 @@ import {
 	getNextPrevious,
 } from './components'
 import s from './tutorial-view.module.css'
+import { useProgressToast } from './utils/use-progress-toast'
 
 /**
  * The purpose of this wrapper component is to make it possible to invoke the
@@ -199,6 +200,17 @@ function TutorialView({
 	const progressRefs = useTutorialProgressRefs({
 		tutorialId: id,
 		collectionId: collectionCtx.current.id,
+	})
+
+	/**
+	 * Display toast when progress changes to complete.
+	 */
+	useProgressToast({
+		tutorialId: id,
+		collectionId: collectionCtx.current.id,
+		collectionTutorialIds: collectionCtx.current.tutorials.map(
+			(t: TutorialLite) => t.id
+		),
 	})
 
 	return (

--- a/src/views/tutorial-view/utils/make-progress-toast/index.tsx
+++ b/src/views/tutorial-view/utils/make-progress-toast/index.tsx
@@ -3,7 +3,7 @@ import {
 	ToastColor,
 } from 'components/toast/components/toast-display/types'
 import { IconCheckCircle24 } from '@hashicorp/flight-icons/svg-react/check-circle-24'
-import { IconCheck24 } from '@hashicorp/flight-icons/svg-react/check-24'
+import { IconCheckCircleFill24 } from '@hashicorp/flight-icons/svg-react/check-circle-fill-24'
 import { toast } from 'components/toast'
 import s from './progress-toast.module.css'
 
@@ -18,7 +18,7 @@ function generateProgressToast(
 		return {
 			title: 'Collection complete!',
 			description: `Great job, keep up the momentum!`,
-			icon: <IconCheck24 className={s.collectionCompleteIcon} />,
+			icon: <IconCheckCircleFill24 className={s.collectionCompleteIcon} />,
 			color: ToastColor.success,
 		}
 	} else {

--- a/src/views/tutorial-view/utils/make-progress-toast/index.tsx
+++ b/src/views/tutorial-view/utils/make-progress-toast/index.tsx
@@ -24,7 +24,9 @@ function generateProgressToast(
 	} else {
 		return {
 			title: 'Tutorial complete!',
-			description: `You have ${remainingTutorialsCount} tutorials left in this collection.`,
+			description: `You have ${remainingTutorialsCount} tutorial${
+				remainingTutorialsCount == 1 ? '' : 's'
+			} left in this collection.`,
 			icon: <IconCheckCircle24 className={s.tutorialCompleteIcon} />,
 		}
 	}

--- a/src/views/tutorial-view/utils/make-progress-toast/index.tsx
+++ b/src/views/tutorial-view/utils/make-progress-toast/index.tsx
@@ -1,0 +1,34 @@
+import {
+	ToastDisplayProps,
+	ToastColor,
+} from 'components/toast/components/toast-display/types'
+import { IconCheckCircle24 } from '@hashicorp/flight-icons/svg-react/check-circle-24'
+import { IconCheck24 } from '@hashicorp/flight-icons/svg-react/check-24'
+import { toast } from 'components/toast'
+import s from './progress-toast.module.css'
+
+function generateToastMessage(
+	remainingTutorialsCount: number
+): Omit<ToastDisplayProps, 'dismissSelf'> {
+	if (remainingTutorialsCount == 0) {
+		return {
+			title: 'Collection complete!',
+			description: `Great job, keep up the momentum!`,
+			icon: <IconCheck24 className={s.collectionCompleteIcon} />,
+			color: ToastColor.success,
+		}
+	} else {
+		return {
+			title: 'Tutorial complete!',
+			description: `You have ${remainingTutorialsCount} tutorials left in this collection.`,
+			icon: <IconCheckCircle24 className={s.tutorialCompleteIcon} />,
+		}
+	}
+}
+
+export default function makeProgressToast(remainingTutorialsCount) {
+	toast({
+		...generateToastMessage(remainingTutorialsCount),
+		autoDismiss: 15000,
+	})
+}

--- a/src/views/tutorial-view/utils/make-progress-toast/index.tsx
+++ b/src/views/tutorial-view/utils/make-progress-toast/index.tsx
@@ -7,7 +7,11 @@ import { IconCheck24 } from '@hashicorp/flight-icons/svg-react/check-24'
 import { toast } from 'components/toast'
 import s from './progress-toast.module.css'
 
-function generateToastMessage(
+/**
+ * Given the count of remaining tutorials in the current collection context,
+ * Return props for a congratulatory progress toast.
+ */
+function generateProgressToast(
 	remainingTutorialsCount: number
 ): Omit<ToastDisplayProps, 'dismissSelf'> {
 	if (remainingTutorialsCount == 0) {
@@ -26,9 +30,9 @@ function generateToastMessage(
 	}
 }
 
-export default function makeProgressToast(remainingTutorialsCount) {
+export default function makeProgressToast(remainingTutorialsCount: number) {
 	toast({
-		...generateToastMessage(remainingTutorialsCount),
+		...generateProgressToast(remainingTutorialsCount),
 		autoDismiss: 15000,
 	})
 }

--- a/src/views/tutorial-view/utils/make-progress-toast/progress-toast.module.css
+++ b/src/views/tutorial-view/utils/make-progress-toast/progress-toast.module.css
@@ -1,0 +1,14 @@
+.progressToastIcon {
+	width: 20px;
+	height: 20px;
+}
+
+.collectionCompleteIcon {
+	composes: progressToastIcon;
+	color: green;
+}
+
+.tutorialCompleteIcon {
+	composes: progressToastIcon;
+	color: gray;
+}

--- a/src/views/tutorial-view/utils/make-progress-toast/progress-toast.module.css
+++ b/src/views/tutorial-view/utils/make-progress-toast/progress-toast.module.css
@@ -5,10 +5,10 @@
 
 .collectionCompleteIcon {
 	composes: progressToastIcon;
-	color: green;
+	color: var(--token-color-foreground-success-on-surface);
 }
 
 .tutorialCompleteIcon {
 	composes: progressToastIcon;
-	color: gray;
+	color: var(--token-color-foreground-faint);
 }

--- a/src/views/tutorial-view/utils/use-progress-toast.ts
+++ b/src/views/tutorial-view/utils/use-progress-toast.ts
@@ -1,0 +1,104 @@
+import { useEffect } from 'react'
+import { useCollectionProgress, useTutorialProgress } from 'hooks/progress'
+import usePrevious from 'hooks/use-previous'
+import { Collection, Tutorial } from 'lib/learn-client/types'
+import makeProgressToast from './make-progress-toast'
+
+/**
+ * Given a tutorialId, collectionId, and count of tutorials in the collection,
+ *
+ * Show progress toast when the specified tutorial shifts from some other
+ * status to "complete". This toast will give information related to
+ * collection progress, which is why we need the count of tutorials
+ * in the collection.
+ */
+export function useProgressToast({
+	tutorialId,
+	collectionId,
+	collectionTutorialIds,
+}: {
+	tutorialId: Tutorial['id']
+	collectionId: Collection['id']
+	collectionTutorialIds: Tutorial['id'][]
+}): void {
+	// Keep track of current status, so when know when it hits "complete"
+	const { tutorialProgressStatus } = useTutorialProgress({
+		tutorialId,
+		collectionId,
+	})
+	// Keep track of previous status so we can compare
+	const prevStatus = usePrevious(tutorialProgressStatus)
+
+	/**
+	 * If this is the last incomplete tutorial in a collection,
+	 * then when it becomes complete, we'll make *special* toast.
+	 */
+	const { data: collectionProgress } = useCollectionProgress({ collectionId })
+
+	/**
+	 * When tutorialProgressStatus changes, we might need to show toast.
+	 */
+	useEffect(() => {
+		/**
+		 * We need collectionProgress to accurately display toast.
+		 * If there's no collectionProgress, there's no toast worth showing.
+		 */
+		if (typeof collectionProgress == 'undefined') {
+			return
+		}
+
+		/**
+		 * We need to compare to previous status to know if the change merits toast.
+		 */
+		if (!prevStatus) {
+			return
+		}
+
+		/**
+		 * If status has shifted to "complete", we'll show some toast
+		 */
+		const isTimeForToast =
+			prevStatus !== 'complete' && tutorialProgressStatus === 'complete'
+
+		const incompleteTutorials = collectionTutorialIds.filter((id) => {
+			const isComplete = collectionProgress
+				.filter((r) => r.complete_percent == '100')
+				.map((r) => r.tutorial_id)
+				.includes(id)
+			return !isComplete
+		})
+
+		const otherIncompleteTutorials = incompleteTutorials.filter((id) => {
+			return id !== tutorialId
+		})
+		const remainingTutorialsCount = otherIncompleteTutorials.length
+
+		console.log(
+			`progToast:\n${JSON.stringify(
+				{
+					isTimeForToast,
+					prevStatus,
+					tutorialProgressStatus,
+					remainingTutorialsCount,
+				},
+				null,
+				2
+			)}`
+		)
+
+		/**
+		 * If there are 0 remaining tutorials to complete in this collection,
+		 * we'll show a toast with congrats on completing the collection.
+		 * Otherwise, we'll show a toast with the remaining tutorials count.
+		 */
+		if (isTimeForToast) {
+			makeProgressToast(remainingTutorialsCount)
+		}
+	}, [
+		collectionProgress,
+		prevStatus,
+		collectionTutorialIds,
+		tutorialId,
+		tutorialProgressStatus,
+	])
+}

--- a/src/views/tutorial-view/utils/use-progress-toast.ts
+++ b/src/views/tutorial-view/utils/use-progress-toast.ts
@@ -49,7 +49,7 @@ export function useProgressToast({
 		 * We need to compare to previous status to know if the change merits toast.
 		 * If we don't have prevStatus, we can't be certain about change.
 		 */
-		if (!prevStatus) {
+		if (typeof prevStatus == 'undefined') {
 			return
 		}
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

When a tutorial changes to `"complete"` on a tutorial view, displays a tutorial progress toast notification.

## 🤷 Why

To continue user progress implementation, for feature parity with <https://learn.hashicorp.com/>

## 🛠️ How

- Adds `get-all-progress` `learn-client` utility, to allow fetching batched progress data from the Learn API
- Adds `use-collection-progress` hook, to query collection progress by ID, using `get-all-progress`
- Adds `use-previous` utility function, to track changes in a variable (same as existing `learn` implementation)
- Adds `use-progress-toast` hook
    - Uses `use-previous` to detect when progress status for a tutorial changes
    - Uses `use-collection-progress` to detect when completing a specific tutorial means the collection is complete too

## 📸 Design Screenshots

### Design Spec

<img width="1016" alt="Screen Shot 2022-08-19 at 6 13 34 PM" src="https://user-images.githubusercontent.com/4624598/188676571-59c0c1c2-97ad-4c71-9acb-ac7edb96311e.png">

### Screenshot from this PR

<img width="1440" alt="CleanShot 2022-09-06 at 11 37 10@2x" src="https://user-images.githubusercontent.com/4624598/188677218-e60f05de-7fb6-4fea-9177-2f928d08333b.png">

### Screen recording from this PR

https://user-images.githubusercontent.com/4624598/188677241-e57d0fd1-b27d-4144-af9b-89a2eb876506.mp4

## 🧪 Testing

- [ ] Pull this branch down locally
- [ ] Sign in
- [ ] Visit any tutorial view
- [ ] When you complete the first few tutorials in a collection...
    - [ ] The progress should be indicated in the sidebar, same as in #901
    - [ ] You should _also_ see a `Tutorial complete` toast pop up
- [ ] When you complete the last remaining incomplete tutorial in a collection...
    - [ ] Same as other tutorials, except you should see special green success toast, with a `Collection complete` message

## 💭 Anything else?

- This PR also includes two minor but general toast VQA fixes, which I noticed while working on the progress toasts. Figured they're both one-line CSS fixes, so made sense to include.

[task]: https://app.asana.com/0/1202097197789424/1202831197852602/f
[preview]: https://dev-portal-git-zstutorial-progress-toast-hashicorp.vercel.app/
