### PR TITLE
Use `useErrorPageAnalytics` hook on 404 page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@hashicorp/localstorage-polyfill": "^1.0.14",
 				"@hashicorp/mktg-global-styles": "^4.2.3",
 				"@hashicorp/mktg-logos": "^1.3.1",
-				"@hashicorp/platform-analytics": "^0.6.0",
+				"@hashicorp/platform-analytics": "^0.6.1",
 				"@hashicorp/platform-cms": "^0.3.0",
 				"@hashicorp/platform-code-highlighting": "^0.1.2",
 				"@hashicorp/platform-docs-mdx": "^0.1.3",
@@ -1557,9 +1557,9 @@
 			}
 		},
 		"node_modules/@hashicorp/platform-analytics": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.0.tgz",
-			"integrity": "sha512-gmKg5VRWj7FhWxIgpSLUC/QDrcjVgyliTh0E9/Rw0RtJOf+lxRh8DNqGo3HIDgB9PEqg0jU7desunFEfEb7H0Q==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.1.tgz",
+			"integrity": "sha512-qRdHFq8Wic87dYaibso/IKLr2qXBVauqsG8HpShoI11LP0Jn1cC8uI+Lj3BiN75YPq8Q4IWrsa94MYW8I9lpvw==",
 			"dependencies": {
 				"fathom-client": "^3.2.0",
 				"js-cookie": "^2.2.1"
@@ -34853,9 +34853,9 @@
 			}
 		},
 		"@hashicorp/platform-analytics": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.0.tgz",
-			"integrity": "sha512-gmKg5VRWj7FhWxIgpSLUC/QDrcjVgyliTh0E9/Rw0RtJOf+lxRh8DNqGo3HIDgB9PEqg0jU7desunFEfEb7H0Q==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.6.1.tgz",
+			"integrity": "sha512-qRdHFq8Wic87dYaibso/IKLr2qXBVauqsG8HpShoI11LP0Jn1cC8uI+Lj3BiN75YPq8Q4IWrsa94MYW8I9lpvw==",
 			"requires": {
 				"fathom-client": "^3.2.0",
 				"js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"@hashicorp/localstorage-polyfill": "^1.0.14",
 		"@hashicorp/mktg-global-styles": "^4.2.3",
 		"@hashicorp/mktg-logos": "^1.3.1",
-		"@hashicorp/platform-analytics": "^0.6.0",
+		"@hashicorp/platform-analytics": "^0.6.1",
 		"@hashicorp/platform-cms": "^0.3.0",
 		"@hashicorp/platform-code-highlighting": "^0.1.2",
 		"@hashicorp/platform-docs-mdx": "^0.1.3",

--- a/src/pages/_proxied-dot-io/vault/not-found/index.jsx
+++ b/src/pages/_proxied-dot-io/vault/not-found/index.jsx
@@ -1,20 +1,8 @@
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useErrorPageAnalytics } from '@hashicorp/platform-analytics'
 
 export default function NotFound() {
-	useEffect(() => {
-		if (
-			typeof window !== 'undefined' &&
-			typeof window?.analytics?.track === 'function' &&
-			typeof window?.document?.referrer === 'string' &&
-			typeof window?.location?.href === 'string'
-		) {
-			window.analytics.track(window.location.href, {
-				category: '404 Response',
-				label: window.document.referrer || 'No Referrer',
-			})
-		}
-	}, [])
+	useErrorPageAnalytics(404)
 
 	return (
 		<main id="p-404">

--- a/src/views/404/index.jsx
+++ b/src/views/404/index.jsx
@@ -1,21 +1,9 @@
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useErrorPageAnalytics } from '@hashicorp/platform-analytics'
 import s from './404.module.css'
 
 export default function NotFound() {
-	useEffect(() => {
-		if (
-			typeof window !== 'undefined' &&
-			typeof window?.analytics?.track === 'function' &&
-			typeof window?.document?.referrer === 'string' &&
-			typeof window?.location?.href === 'string'
-		) {
-			window.analytics.track(window.location.href, {
-				category: '404 Response',
-				label: window.document.referrer || 'No Referrer',
-			})
-		}
-	}, [])
+	useErrorPageAnalytics(404)
 
 	return (
 		<div className={s.root}>


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1202865459293217/f)

---
## 🗒️ What

This PR leverages the new `useErrorPageAnalytics` hook (see [this PR](https://github.com/hashicorp/web-platform-packages/pull/86)) for pushing 404-related data to Segment. This PR replaces the `window.analytics.track` call on the 404 page with said hook.

## 🤷 Why

It was recently discovered that, across our various web properties, we make the following call:

`window.analytics.track(window.location.href, { ... } )`

The first parameter of the `track` method is used downstream in our various data warehouses to create a new table. Since we're using `window.location.href`, we're creating a table for _every_ URL that 404s. This is not ideal for analytics.
## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
