### PR TITLE
Adding currentCommand to CommandBarContext

### DIFF
--- a/src/components/command-bar/components/activator/index.tsx
+++ b/src/components/command-bar/components/activator/index.tsx
@@ -7,13 +7,13 @@ const CommandBarActivator = ({
 	leadingIcon,
 	visualLabel,
 }: CommandBarActivatorProps) => {
-	const { setIsOpen } = useCommandBar()
+	const { toggleIsOpen } = useCommandBar()
 
 	return (
 		<button
 			aria-label={visualLabel}
 			className={s.root}
-			onClick={() => setIsOpen(true)}
+			onClick={() => toggleIsOpen()}
 		>
 			{leadingIcon ? (
 				<span className={s.leadingIcon}>{leadingIcon}</span>

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react'
 import {
 	CommandBarActivator,
 	CommandBarDialog,
@@ -23,7 +29,16 @@ const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
 const CommandBarContext = createContext<CommandBarState>(undefined)
 
 const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
-	const [isOpen, setIsOpen] = useState<boolean>(false)
+	const [state, setState] = useState({
+		isOpen: false,
+	})
+
+	const toggleIsOpen = useCallback(() => {
+		setState((prevState) => {
+			const prevIsOpen = prevState.isOpen
+			return { ...prevState, isOpen: !prevIsOpen }
+		})
+	}, [])
 
 	/**
 	 * Sets up the cmd/ctrl + k keydown listener.
@@ -36,7 +51,7 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			const { ctrlKey, metaKey, key } = e
 			if (key === 'k' && (ctrlKey || metaKey)) {
-				setIsOpen((prevIsOpen: boolean) => !prevIsOpen)
+				toggleIsOpen()
 			}
 		}
 
@@ -48,9 +63,9 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	}, [])
 
 	return (
-		<CommandBarContext.Provider value={{ isOpen, setIsOpen }}>
+		<CommandBarContext.Provider value={{ ...state, toggleIsOpen }}>
 			{children}
-			<CommandBarDialog isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
+			<CommandBarDialog isOpen={state.isOpen} onDismiss={toggleIsOpen}>
 				<CommandBarDialogHeader>header</CommandBarDialogHeader>
 				<CommandBarDialogBody>body</CommandBarDialogBody>
 				<CommandBarDialogFooter>footer</CommandBarDialogFooter>

--- a/src/components/command-bar/types.ts
+++ b/src/components/command-bar/types.ts
@@ -1,4 +1,4 @@
-import { Dispatch, ReactNode, SetStateAction } from 'react'
+import { ReactNode } from 'react'
 
 interface CommandBarProviderProps {
 	children: ReactNode
@@ -6,7 +6,7 @@ interface CommandBarProviderProps {
 
 interface CommandBarState {
 	isOpen: boolean
-	setIsOpen: Dispatch<SetStateAction<boolean>>
+	toggleIsOpen: () => void
 }
 
 export type { CommandBarState, CommandBarProviderProps }

--- a/src/components/command-bar/types.ts
+++ b/src/components/command-bar/types.ts
@@ -1,12 +1,24 @@
 import { ReactNode } from 'react'
 
+type SupportedCommand = 'search' | 'settings'
+
 interface CommandBarProviderProps {
 	children: ReactNode
 }
 
-interface CommandBarState {
+interface CommandBarContextState {
+	currentCommand: SupportedCommand
 	isOpen: boolean
+}
+
+interface CommandBarContextValue extends CommandBarContextState {
+	setCurrentCommand: (command: SupportedCommand) => void
 	toggleIsOpen: () => void
 }
 
-export type { CommandBarState, CommandBarProviderProps }
+export type {
+	CommandBarContextState,
+	CommandBarContextValue,
+	CommandBarProviderProps,
+	SupportedCommand,
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/0/1202932738893664/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renames `setIsOpen` to `toggleIsOpen` and abstracts the toggling logic
- Adds `currentCommand` property to `CommandBarContext`'s state
- Exposes `setCurrentCommand` function from `CommandBarContext`
- Breaks `CommandBarState` `interface` into two new ones:
  - `CommandBarContextState`
  - `CommandBarContextValue`
- Renders a small demo in the `CommandBarDialog` body for testing `setCurrentCommand`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

This approach does some of the groundwork for supporting additional commands, with our current default being `"search"` since we don't have other commands yet.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] Make sure the dialog still opens with the button in the header
- [ ] Make sure the dialog still opens/closes with cmd/ctrl+k
- [ ] When the dialog opens the header should show "search" as the current command
- [ ] The body should have a button for toggling the current command
- [ ] Click the button to toggle the command
- [ ] The header text should update to show the correct command
