### PR TITLE
[CommandBarDialog] Render icon, text input, and Badges in header

### DIFF
--- a/src/components/command-bar/command-bar.module.css
+++ b/src/components/command-bar/command-bar.module.css
@@ -1,6 +1,0 @@
-.header {
-	align-items: center;
-	display: flex;
-	gap: 8px;
-	padding: 16px;
-}

--- a/src/components/command-bar/command-bar.module.css
+++ b/src/components/command-bar/command-bar.module.css
@@ -1,0 +1,40 @@
+.header {
+	align-items: center;
+	display: flex;
+	gap: 8px;
+	padding: 16px;
+}
+
+.icon {
+	flex-shrink: 0;
+}
+
+.input {
+	appearance: none;
+	background-color: transparent;
+	border-radius: 5px;
+	border: none;
+	color: var(--token-color-foreground-primary);
+	font-family: var(--token-typography-body-300-font-family);
+	font-size: var(--token-typography-body-300-font-size);
+	font-weight: var(--token-typography-font-weight-medium);
+	line-height: var(--token-typography-body-300-line-height);
+	padding-left: 2px;
+	padding-right: 2px;
+	width: 100%;
+
+	&::placeholder {
+		color: var(--token-color-foreground-disabled);
+		font-family: var(--token-typography-body-300-font-family);
+		font-size: var(--token-typography-body-300-font-size);
+		font-weight: var(--token-typography-font-weight-medium);
+		line-height: var(--token-typography-body-300-line-height);
+	}
+}
+
+.badges {
+	align-items: center;
+	display: flex;
+	flex-shrink: 0;
+	gap: 4px;
+}

--- a/src/components/command-bar/command-bar.module.css
+++ b/src/components/command-bar/command-bar.module.css
@@ -4,37 +4,3 @@
 	gap: 8px;
 	padding: 16px;
 }
-
-.icon {
-	flex-shrink: 0;
-}
-
-.input {
-	appearance: none;
-	background-color: transparent;
-	border-radius: 5px;
-	border: none;
-	color: var(--token-color-foreground-primary);
-	font-family: var(--token-typography-body-300-font-family);
-	font-size: var(--token-typography-body-300-font-size);
-	font-weight: var(--token-typography-font-weight-medium);
-	line-height: var(--token-typography-body-300-line-height);
-	padding-left: 2px;
-	padding-right: 2px;
-	width: 100%;
-
-	&::placeholder {
-		color: var(--token-color-foreground-disabled);
-		font-family: var(--token-typography-body-300-font-family);
-		font-size: var(--token-typography-body-300-font-size);
-		font-weight: var(--token-typography-font-weight-medium);
-		line-height: var(--token-typography-body-300-line-height);
-	}
-}
-
-.badges {
-	align-items: center;
-	display: flex;
-	flex-shrink: 0;
-	gap: 4px;
-}

--- a/src/components/command-bar/commands/index.ts
+++ b/src/components/command-bar/commands/index.ts
@@ -2,7 +2,7 @@ import { Command, SupportedCommand } from '../types'
 import searchCommand from './search'
 import settingsCommand from './settings'
 
-const commands: Record<keyof typeof SupportedCommand, Command> = {
+const commands: Record<SupportedCommand, Command> = {
 	search: searchCommand,
 	settings: settingsCommand,
 }

--- a/src/components/command-bar/commands/index.ts
+++ b/src/components/command-bar/commands/index.ts
@@ -1,0 +1,10 @@
+import { Command, SupportedCommand } from '../types'
+import searchCommand from './search'
+import settingsCommand from './settings'
+
+const commands: Record<keyof typeof SupportedCommand, Command> = {
+	search: searchCommand,
+	settings: settingsCommand,
+}
+
+export default commands

--- a/src/components/command-bar/commands/search.tsx
+++ b/src/components/command-bar/commands/search.tsx
@@ -1,0 +1,12 @@
+import { IconSearch24 } from '@hashicorp/flight-icons/svg-react/search-24'
+import { SupportedCommand } from '../types'
+
+const searchCommand = {
+	name: SupportedCommand.search,
+	icon: <IconSearch24 />,
+	inputProps: {
+		placeholder: 'Search...',
+	},
+}
+
+export default searchCommand

--- a/src/components/command-bar/commands/settings.tsx
+++ b/src/components/command-bar/commands/settings.tsx
@@ -1,0 +1,12 @@
+import { IconSettings24 } from '@hashicorp/flight-icons/svg-react/settings-24'
+import { SupportedCommand } from '../types'
+
+const settingsCommand = {
+	name: SupportedCommand.settings,
+	icon: <IconSettings24 />,
+	inputProps: {
+		placeholder: 'Settings...',
+	},
+}
+
+export default settingsCommand

--- a/src/components/command-bar/components/dialog/command-bar-dialog.module.css
+++ b/src/components/command-bar/components/dialog/command-bar-dialog.module.css
@@ -13,9 +13,13 @@
 }
 
 .header {
+	align-items: center;
 	border-bottom: 1px solid var(--token-color-border-primary);
+	display: flex;
 	flex-grow: 0;
 	flex-shrink: 0;
+	gap: 8px;
+	padding: 16px;
 }
 
 .icon {

--- a/src/components/command-bar/components/dialog/command-bar-dialog.module.css
+++ b/src/components/command-bar/components/dialog/command-bar-dialog.module.css
@@ -18,6 +18,40 @@
 	flex-shrink: 0;
 }
 
+.icon {
+	flex-shrink: 0;
+}
+
+.input {
+	appearance: none;
+	background-color: transparent;
+	border-radius: 5px;
+	border: none;
+	color: var(--token-color-foreground-faint);
+	font-family: var(--token-typography-body-300-font-family);
+	font-size: var(--token-typography-body-300-font-size);
+	font-weight: var(--token-typography-font-weight-medium);
+	line-height: var(--token-typography-body-300-line-height);
+	padding-left: 2px;
+	padding-right: 2px;
+	width: 100%;
+
+	&::placeholder {
+		color: var(--token-color-foreground-disabled);
+		font-family: var(--token-typography-body-300-font-family);
+		font-size: var(--token-typography-body-300-font-size);
+		font-weight: var(--token-typography-font-weight-medium);
+		line-height: var(--token-typography-body-300-line-height);
+	}
+}
+
+.badges {
+	align-items: center;
+	display: flex;
+	flex-shrink: 0;
+	gap: 4px;
+}
+
 .body {
 	flex-grow: 1;
 	flex-shrink: 1;

--- a/src/components/command-bar/components/dialog/command-bar-dialog.module.css
+++ b/src/components/command-bar/components/dialog/command-bar-dialog.module.css
@@ -23,6 +23,7 @@
 }
 
 .icon {
+	display: flex;
 	flex-shrink: 0;
 }
 

--- a/src/components/command-bar/components/dialog/index.tsx
+++ b/src/components/command-bar/components/dialog/index.tsx
@@ -1,3 +1,7 @@
+import classNames from 'classnames'
+import { IconCommand16 } from '@hashicorp/flight-icons/svg-react/command-16'
+import Badge from 'components/badge'
+import { useCommandBar } from 'components/command-bar'
 import Dialog from 'components/dialog'
 import {
 	CommandBarDialogBodyProps,
@@ -6,17 +10,60 @@ import {
 	CommandBarDialogProps,
 } from './types'
 import s from './command-bar-dialog.module.css'
-import classNames from 'classnames'
+import { SupportedCommand } from 'components/command-bar/types'
 
-const CommandBarDialogHeader = ({
-	children,
-	className,
-}: CommandBarDialogHeaderProps) => {
-	return <div className={classNames(s.header, className)}>{children}</div>
+const CommandBarDialogHeader = ({ className }: CommandBarDialogHeaderProps) => {
+	const { currentCommand } = useCommandBar()
+
+	return (
+		<div className={classNames(s.header, className)}>
+			<div className={s.icon}>{currentCommand.icon}</div>
+			<input
+				className={s.input}
+				placeholder={currentCommand.inputProps.placeholder}
+			/>
+			<div className={s.badges}>
+				<Badge
+					ariaLabel="Command key"
+					color="neutral"
+					icon={<IconCommand16 />}
+					size="small"
+					type="outlined"
+				/>
+				<Badge
+					ariaLabel="K key"
+					color="neutral"
+					size="small"
+					text="K"
+					type="outlined"
+				/>
+			</div>
+		</div>
+	)
 }
 
-const CommandBarDialogBody = ({ children }: CommandBarDialogBodyProps) => {
-	return <div className={s.body}>{children}</div>
+const CommandBarDialogBody = ({ className }: CommandBarDialogBodyProps) => {
+	const { currentCommand, setCurrentCommand } = useCommandBar()
+
+	return (
+		<div className={classNames(s.body, className)}>
+			<button
+				onClick={() =>
+					setCurrentCommand(
+						currentCommand.name === SupportedCommand.search
+							? SupportedCommand.search
+							: SupportedCommand.settings
+					)
+				}
+			>
+				Use{' '}
+				{currentCommand.name === SupportedCommand.search
+					? 'settings'
+					: 'search'}{' '}
+				command
+			</button>
+		</div>
+	)
 }
 
 const CommandBarDialogFooter = ({ children }: CommandBarDialogFooterProps) => {

--- a/src/components/command-bar/components/dialog/index.tsx
+++ b/src/components/command-bar/components/dialog/index.tsx
@@ -44,8 +44,8 @@ const CommandBarDialogBody = () => {
 				onClick={() =>
 					setCurrentCommand(
 						currentCommand.name === SupportedCommand.search
-							? SupportedCommand.search
-							: SupportedCommand.settings
+							? SupportedCommand.settings
+							: SupportedCommand.search
 					)
 				}
 			>

--- a/src/components/command-bar/components/dialog/index.tsx
+++ b/src/components/command-bar/components/dialog/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import { IconCommand16 } from '@hashicorp/flight-icons/svg-react/command-16'
 import Badge from 'components/badge'
-import { useCommandBar } from 'components/command-bar'
+import { useCommandBar, SupportedCommand } from 'components/command-bar'
 import Dialog from 'components/dialog'
 import {
 	CommandBarDialogBodyProps,
@@ -10,7 +10,6 @@ import {
 	CommandBarDialogProps,
 } from './types'
 import s from './command-bar-dialog.module.css'
-import { SupportedCommand } from 'components/command-bar/types'
 
 const CommandBarDialogHeader = ({ className }: CommandBarDialogHeaderProps) => {
 	const { currentCommand } = useCommandBar()

--- a/src/components/command-bar/components/dialog/index.tsx
+++ b/src/components/command-bar/components/dialog/index.tsx
@@ -6,9 +6,13 @@ import {
 	CommandBarDialogProps,
 } from './types'
 import s from './command-bar-dialog.module.css'
+import classNames from 'classnames'
 
-const CommandBarDialogHeader = ({ children }: CommandBarDialogHeaderProps) => {
-	return <div className={s.header}>{children}</div>
+const CommandBarDialogHeader = ({
+	children,
+	className,
+}: CommandBarDialogHeaderProps) => {
+	return <div className={classNames(s.header, className)}>{children}</div>
 }
 
 const CommandBarDialogBody = ({ children }: CommandBarDialogBodyProps) => {

--- a/src/components/command-bar/components/dialog/index.tsx
+++ b/src/components/command-bar/components/dialog/index.tsx
@@ -1,21 +1,15 @@
-import classNames from 'classnames'
 import { IconCommand16 } from '@hashicorp/flight-icons/svg-react/command-16'
 import Badge from 'components/badge'
 import { useCommandBar, SupportedCommand } from 'components/command-bar'
 import Dialog from 'components/dialog'
-import {
-	CommandBarDialogBodyProps,
-	CommandBarDialogFooterProps,
-	CommandBarDialogHeaderProps,
-	CommandBarDialogProps,
-} from './types'
+import { CommandBarDialogFooterProps, CommandBarDialogProps } from './types'
 import s from './command-bar-dialog.module.css'
 
-const CommandBarDialogHeader = ({ className }: CommandBarDialogHeaderProps) => {
+const CommandBarDialogHeader = () => {
 	const { currentCommand } = useCommandBar()
 
 	return (
-		<div className={classNames(s.header, className)}>
+		<div className={s.header}>
 			<div className={s.icon}>{currentCommand.icon}</div>
 			<input
 				className={s.input}
@@ -41,11 +35,11 @@ const CommandBarDialogHeader = ({ className }: CommandBarDialogHeaderProps) => {
 	)
 }
 
-const CommandBarDialogBody = ({ className }: CommandBarDialogBodyProps) => {
+const CommandBarDialogBody = () => {
 	const { currentCommand, setCurrentCommand } = useCommandBar()
 
 	return (
-		<div className={classNames(s.body, className)}>
+		<div className={s.body}>
 			<button
 				onClick={() =>
 					setCurrentCommand(
@@ -81,12 +75,7 @@ const CommandBarDialog = ({
 	)
 }
 
-export type {
-	CommandBarDialogBodyProps,
-	CommandBarDialogFooterProps,
-	CommandBarDialogHeaderProps,
-	CommandBarDialogProps,
-}
+export type { CommandBarDialogFooterProps, CommandBarDialogProps }
 export {
 	CommandBarDialog,
 	CommandBarDialogHeader,

--- a/src/components/command-bar/components/dialog/types.ts
+++ b/src/components/command-bar/components/dialog/types.ts
@@ -6,21 +6,8 @@ interface CommandBarDialogProps {
 	onDismiss?: () => void
 }
 
-interface CommandBarDialogHeaderProps {
-	className?: string
-}
-
-interface CommandBarDialogBodyProps {
-	className?: string
-}
-
 interface CommandBarDialogFooterProps {
 	children: ReactNode
 }
 
-export type {
-	CommandBarDialogBodyProps,
-	CommandBarDialogFooterProps,
-	CommandBarDialogHeaderProps,
-	CommandBarDialogProps,
-}
+export type { CommandBarDialogFooterProps, CommandBarDialogProps }

--- a/src/components/command-bar/components/dialog/types.ts
+++ b/src/components/command-bar/components/dialog/types.ts
@@ -7,12 +7,11 @@ interface CommandBarDialogProps {
 }
 
 interface CommandBarDialogHeaderProps {
-	children: ReactNode
 	className?: string
 }
 
 interface CommandBarDialogBodyProps {
-	children: ReactNode
+	className?: string
 }
 
 interface CommandBarDialogFooterProps {

--- a/src/components/command-bar/components/dialog/types.ts
+++ b/src/components/command-bar/components/dialog/types.ts
@@ -8,6 +8,7 @@ interface CommandBarDialogProps {
 
 interface CommandBarDialogHeaderProps {
 	children: ReactNode
+	className?: string
 }
 
 interface CommandBarDialogBodyProps {

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -20,7 +20,6 @@ import {
 	CommandBarProviderProps,
 	SupportedCommand,
 } from './types'
-import s from './command-bar.module.css'
 
 const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
 
@@ -95,7 +94,7 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 		<CommandBarContext.Provider value={contextValue}>
 			{children}
 			<CommandBarDialog isOpen={state.isOpen} onDismiss={toggleIsOpen}>
-				<CommandBarDialogHeader className={s.header} />
+				<CommandBarDialogHeader />
 				<CommandBarDialogBody />
 				<CommandBarDialogFooter>footer</CommandBarDialogFooter>
 			</CommandBarDialog>

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -3,11 +3,10 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useMemo,
 	useState,
 } from 'react'
-import { IconCode24 } from '@hashicorp/flight-icons/svg-react/code-24'
-import { IconCommand16 } from '@hashicorp/flight-icons/svg-react/command-16'
-import Badge from 'components/badge'
+import commands from './commands'
 import {
 	CommandBarActivator,
 	CommandBarDialog,
@@ -26,7 +25,7 @@ import s from './command-bar.module.css'
 const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
 
 const DEFAULT_CONTEXT_STATE: CommandBarContextState = {
-	currentCommand: 'search',
+	currentCommand: commands.search,
 	isOpen: false,
 }
 
@@ -56,10 +55,10 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	/**
 	 * Set up `setCurrentCommand` callback.
 	 */
-	const setCurrentCommand = useCallback((command: SupportedCommand) => {
+	const setCurrentCommand = useCallback((commandName: SupportedCommand) => {
 		setState((prevState: CommandBarContextState) => ({
 			...prevState,
-			currentCommand: command,
+			currentCommand: commands[commandName],
 		}))
 	}, [])
 
@@ -85,33 +84,19 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 		}
 	}, [toggleIsOpen])
 
+	/**
+	 * Memoize the Context value
+	 */
+	const contextValue = useMemo(() => {
+		return { ...state, setCurrentCommand, toggleIsOpen }
+	}, [setCurrentCommand, state, toggleIsOpen])
+
 	return (
-		<CommandBarContext.Provider
-			value={{ ...state, setCurrentCommand, toggleIsOpen }}
-		>
+		<CommandBarContext.Provider value={contextValue}>
 			{children}
 			<CommandBarDialog isOpen={state.isOpen} onDismiss={toggleIsOpen}>
-				<CommandBarDialogHeader className={s.header}>
-					<IconCode24 className={s.icon} />
-					<input className={s.input} placeholder="Search..." />
-					<div className={s.badges}>
-						<Badge
-							ariaLabel="Command key"
-							color="neutral"
-							icon={<IconCommand16 />}
-							size="small"
-							type="outlined"
-						/>
-						<Badge
-							ariaLabel="K key"
-							color="neutral"
-							size="small"
-							text="K"
-							type="outlined"
-						/>
-					</div>
-				</CommandBarDialogHeader>
-				<CommandBarDialogBody>body</CommandBarDialogBody>
+				<CommandBarDialogHeader className={s.header} />
+				<CommandBarDialogBody />
 				<CommandBarDialogFooter>footer</CommandBarDialogFooter>
 			</CommandBarDialog>
 		</CommandBarContext.Provider>

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+import { IconCode24 } from '@hashicorp/flight-icons/svg-react/code-24'
+import { IconCommand16 } from '@hashicorp/flight-icons/svg-react/command-16'
+import Badge from 'components/badge'
 import {
 	CommandBarActivator,
 	CommandBarDialog,
@@ -7,6 +10,7 @@ import {
 	CommandBarDialogFooter,
 } from './components'
 import { CommandBarProviderProps, CommandBarState } from './types'
+import s from './command-bar.module.css'
 
 const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
 
@@ -51,7 +55,26 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 		<CommandBarContext.Provider value={{ isOpen, setIsOpen }}>
 			{children}
 			<CommandBarDialog isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
-				<CommandBarDialogHeader>header</CommandBarDialogHeader>
+				<CommandBarDialogHeader className={s.header}>
+					<IconCode24 className={s.icon} />
+					<input className={s.input} placeholder="Search..." />
+					<div className={s.badges}>
+						<Badge
+							ariaLabel="Command key"
+							color="neutral"
+							icon={<IconCommand16 />}
+							size="small"
+							type="outlined"
+						/>
+						<Badge
+							ariaLabel="K key"
+							color="neutral"
+							size="small"
+							text="K"
+							type="outlined"
+						/>
+					</div>
+				</CommandBarDialogHeader>
 				<CommandBarDialogBody>body</CommandBarDialogBody>
 				<CommandBarDialogFooter>footer</CommandBarDialogFooter>
 			</CommandBarDialog>

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -112,4 +112,9 @@ const useCommandBar = (): CommandBarContextValue => {
 	return context
 }
 
-export { CommandBarActivator, CommandBarProvider, useCommandBar }
+export {
+	CommandBarActivator,
+	CommandBarProvider,
+	SupportedCommand,
+	useCommandBar,
+}

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -28,14 +28,6 @@ const DEFAULT_CONTEXT_STATE: CommandBarContextState = {
 	isOpen: false,
 }
 
-/**
- * @TODO items that will be easier to implement when there is a text input
- * rendered in the header:
- *
- * - Render CommandBarDialog contents based on `currentCommand`
- *
- */
-
 const CommandBarContext = createContext<CommandBarContextValue>(undefined)
 
 const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
@@ -54,12 +46,15 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	/**
 	 * Set up `setCurrentCommand` callback.
 	 */
-	const setCurrentCommand = useCallback((commandName: SupportedCommand) => {
-		setState((prevState: CommandBarContextState) => ({
-			...prevState,
-			currentCommand: commands[commandName],
-		}))
-	}, [])
+	const setCurrentCommand = useCallback(
+		(commandName: keyof typeof SupportedCommand) => {
+			setState((prevState: CommandBarContextState) => ({
+				...prevState,
+				currentCommand: commands[commandName],
+			}))
+		},
+		[]
+	)
 
 	/**
 	 * Set up the cmd/ctrl + k keydown listener.
@@ -86,7 +81,7 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	/**
 	 * Memoize the Context value
 	 */
-	const contextValue = useMemo(() => {
+	const contextValue = useMemo<CommandBarContextValue>(() => {
 		return { ...state, setCurrentCommand, toggleIsOpen }
 	}, [setCurrentCommand, state, toggleIsOpen])
 

--- a/src/components/command-bar/types.ts
+++ b/src/components/command-bar/types.ts
@@ -1,8 +1,8 @@
 import { ReactElement, ReactNode } from 'react'
 
 enum SupportedCommand {
-	search,
-	settings,
+	search = 'search',
+	settings = 'settings',
 }
 
 interface Command {

--- a/src/components/command-bar/types.ts
+++ b/src/components/command-bar/types.ts
@@ -1,13 +1,24 @@
-import { ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
-type SupportedCommand = 'search' | 'settings'
+enum SupportedCommand {
+	search,
+	settings,
+}
+
+interface Command {
+	name: SupportedCommand
+	icon: ReactElement
+	inputProps: {
+		placeholder: string
+	}
+}
 
 interface CommandBarProviderProps {
 	children: ReactNode
 }
 
 interface CommandBarContextState {
-	currentCommand: SupportedCommand
+	currentCommand: Command
 	isOpen: boolean
 }
 
@@ -17,8 +28,9 @@ interface CommandBarContextValue extends CommandBarContextState {
 }
 
 export type {
+	Command,
 	CommandBarContextState,
 	CommandBarContextValue,
 	CommandBarProviderProps,
-	SupportedCommand,
 }
+export { SupportedCommand }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1201147515801429/1202932738893668/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds support for two commands:
  - `search`
  - `settings` (not used, just to demonstrate future flexibility)
- Updates `setCurrentCommand` to accept a command name for pulling the new current command from the `commands` map
- Updates `CommandBarDialogHeader` to render content based on `currentCommand`
- Updates `CommandBarDialogBody` to render a temporary button for switching between commands
- Updates `CommandBarContext`'s value to be memoized with `useMemo`

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=12514%3A144676)

![image](https://user-images.githubusercontent.com/43934258/188965888-92a77069-b18a-48ab-aa08-5b7e0f6ef294.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] Open the command bar
- [ ] The search command should be active
- [ ] The icon and input placeholder should match the search command's config
- [ ] Click the button in the body of the dialog
- [ ] The settings command should now be active
- [ ] The icon and input placeholder should match the search command's config
