### PR TITLE
[CommandBarActivator] Only show search icon on mobile

### DIFF
--- a/src/components/command-bar/components/activator/command-bar-activator.module.css
+++ b/src/components/command-bar/components/activator/command-bar-activator.module.css
@@ -18,6 +18,12 @@
 	padding-right: 12px;
 	padding-top: 8px;
 	min-width: 220px;
+
+	@media (--dev-dot-show-mobile-menu) {
+		min-width: unset;
+		padding: 10px;
+		width: fit-content;
+	}
 }
 
 .left {
@@ -30,10 +36,18 @@
 .leadingIcon {
 	color: var(--token-color-palette-neutral-400);
 	display: flex;
+
+	@media (--dev-dot-show-mobile-menu) {
+		color: var(--token-color-palette-neutral-200);
+	}
 }
 
 .text {
 	color: var(--token-color-foreground-high-contrast);
+
+	@media (--dev-dot-show-mobile-menu) {
+		display: none;
+	}
 }
 
 .right {
@@ -41,4 +55,8 @@
 	display: flex;
 	flex-shrink: 0;
 	gap: 4px;
+
+	@media (--dev-dot-show-mobile-menu) {
+		display: none;
+	}
 }

--- a/src/components/command-bar/components/activator/index.tsx
+++ b/src/components/command-bar/components/activator/index.tsx
@@ -18,9 +18,7 @@ const CommandBarActivator = ({
 			onClick={() => toggleIsOpen()}
 		>
 			<span className={s.left}>
-				{leadingIcon ? (
-					<span className={s.leadingIcon}>{leadingIcon}</span>
-				) : null}
+				<span className={s.leadingIcon}>{leadingIcon}</span>
 				<Text asElement="span" className={s.text} size={200} weight="regular">
 					{visualLabel}
 				</Text>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/0/1202932738893689/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `CommandBarActivator` to only show its leading icon on mobile

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

### Tablet

[Figma link]()

![image](https://user-images.githubusercontent.com/43934258/189018751-79f6b2d2-33c3-47f4-ae37-bdaf2bac82fa.png)

### Mobile

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=13283%3A209191)

![image](https://user-images.githubusercontent.com/43934258/189018159-f80ef60e-8531-4df4-85fa-f9b4051cba69.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] Make sure the full activator button shows until your viewport is `728px`
- [ ] Make sure the icon-only activator button shows when youre viewport is `728px` or smaller

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

The spacing between this button and the mobile menu button is not being addressed yet. We need more information about how this button sits with other navigation header states before modifying that global-ish CSS.