### PR TITLE
Hiding ProductDocsSearch when enable_global_search is true

### DIFF
--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -81,7 +81,9 @@ const DocsView = ({
 	const additionalComponents = productsToPrimitives[currentProduct.slug] || {}
 	const components = defaultMdxComponents({ additionalComponents })
 	const shouldRenderSearch =
-		!hideSearch && __config.flags.enable_product_docs_search
+		!__config.flags.enable_global_search &&
+		!hideSearch &&
+		__config.flags.enable_product_docs_search
 
 	const Layout = layouts[metadata?.layout?.name] ?? DefaultLayout
 

--- a/src/views/product-root-docs-path-landing/index.tsx
+++ b/src/views/product-root-docs-path-landing/index.tsx
@@ -17,7 +17,9 @@ const ProductRootDocsPathLanding = ({
 	product,
 }: ProductRootDocsPathLandingProps) => {
 	const { pageSubtitle, marketingContentBlocks } = pageContent
-	const showProductDocsSearch = __config.flags.enable_product_docs_search
+	const showProductDocsSearch =
+		!__config.flags.enable_global_search &&
+		__config.flags.enable_product_docs_search
 
 	let mdxSlot: ReactElement
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1202954349649032/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Hides `ProductDocsSearch` when global search is enabled

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- We do not want both searches to show at the same time

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- The `enable_global_search` feature flag 🤩 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out the code locally (to test the feature flag flipping)
- [ ] Run the server
- [ ] Go to any product's /docs landing page (such as /waypoint/docs)
- [ ] Global search should show in the header
- [ ] `ProductDocsSearch` should not show in the page
- [ ] Go to any product's nested docs (such as /waypoint/docs/intro/vs)
- [ ] Global search should show in the header
- [ ] `ProductDocsSearch` should not show in the page
- [ ] Open the `config/development.json` file
- [ ] Flip the `enable_global_search` flag to `false`
- [ ] Go to any product's /docs landing page (such as /waypoint/docs)
- [ ] Global search should **not** show in the header
- [ ] `ProductDocsSearch` should show in the page
- [ ] Go to any product's nested docs (such as /waypoint/docs/intro/vs)
- [ ] Global search should **not** show in the header
- [ ] `ProductDocsSearch` should show in the page
