### PR TITLE
chore(packer): rename Plugins to External Plugins

### DIFF
--- a/src/data/packer.json
+++ b/src/data/packer.json
@@ -29,33 +29,6 @@
 		"expirationDate": ""
 	},
 	"version": "1.7.10",
-	"subnavItems": [
-		{
-			"text": "Overview",
-			"url": "/",
-			"type": "inbound"
-		},
-		{
-			"text": "Tutorials",
-			"url": "https://learn.hashicorp.com/packer",
-			"type": "outbound"
-		},
-		{
-			"text": "Docs",
-			"url": "/docs",
-			"type": "inbound"
-		},
-		{
-			"text": "External Plugins",
-			"url": "/plugins",
-			"type": "inbound"
-		},
-		{
-			"text": "Community",
-			"url": "/community",
-			"type": "inbound"
-		}
-	],
 	"basePaths": ["docs", "guides", "intro", "plugins"],
 	"rootDocsPaths": [
 		{
@@ -80,7 +53,7 @@
 		{
 			"iconName": "docs",
 			"mainBranch": "master",
-			"name": "Plugins",
+			"name": "External Plugins",
 			"path": "plugins"
 		}
 	],

--- a/src/data/packer.json
+++ b/src/data/packer.json
@@ -46,7 +46,7 @@
 			"type": "inbound"
 		},
 		{
-			"text": "Plugins",
+			"text": "External Plugins",
 			"url": "/plugins",
 			"type": "inbound"
 		},


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates `/plugins` `rootDocsPath` name to `"External Plugins"`.

## 🤷 Why

VQA item.

## 🛠️ How

Updates `src/data/packer.json`.

## 📸 Design Screenshots

<img width="856" alt="CleanShot 2022-09-13 at 18 12 01@2x" src="https://user-images.githubusercontent.com/4624598/190018595-181601c0-61f3-4402-a8c2-4a90e74e7313.png">

## 🧪 Testing

- [ ] Visit [/packer][preview], and confirm the subnav item for `/plugins` is labelled `External Plugins`

## 💭 Anything else?

- This PR also removes `packer.json` `subnavItems`
    - These previously powered the dot-io site, but we've since moved to managing subnav items in Dato for Packer.

[task]: https://app.asana.com/0/1202702246158644/1202975892434100/f
[preview]: https://www.hashicorp.com