### PR TITLE
chore: fix overview item row gap

### DIFF
--- a/src/views/product-landing/components/overview-cta/overview-cta.module.css
+++ b/src/views/product-landing/components/overview-cta/overview-cta.module.css
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	column-gap: 48px;
+	row-gap: 24px;
 	justify-content: space-between;
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-overview-item-space-hashicorp.vercel.app/packer) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202954349649039) 🎟️

## 🗒️ What

Adds row gap to the overview item component for landing pages. 

## Testing
- Go to a [product landing page](https://dev-portal-git-ksfix-overview-item-space-hashicorp.vercel.app/consul)
- shrink down to mobile view, verify the spacing between the image and the overview text. 