### PR TITLE
[rewriteTutorialsLink] Handle links with complex query params

### DIFF
--- a/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
@@ -129,33 +129,22 @@ export function rewriteTutorialsLink(
 		}
 
 		if (isBetaProduct || isValidSection) {
+			// General variables
 			const urlObject = new URL(url, 'https://learn.hashicorp.com/')
 			const { origin, pathname } = urlObject
 			const urlWithoutOrigin = urlObject.toString().replace(origin, '')
-
-			const collectionPathRegex = new RegExp('^/collections')
-			const isCollectionPath = collectionPathRegex.test(pathname)
-			if (isCollectionPath) {
-				newUrl = handleCollectionLink(urlWithoutOrigin)
-			}
-
-			const tutorialPathRegex = new RegExp('^/tutorials')
-			const isTutorialPath = tutorialPathRegex.test(pathname)
-			if (isTutorialPath) {
-				newUrl = handleTutorialLink(urlWithoutOrigin, tutorialMap)
-			}
-
-			const productHubPathRegex = new RegExp(`^/${product}/?$`)
-			const isProductHubPath = productHubPathRegex.test(pathname)
-			if (isProductHubPath) {
-				newUrl = `/${product}/tutorials`
-			}
-
 			const productIOHostName = productSlugsToHostNames[product]
+
+			// Regexes for each path type
+			const collectionPathRegex = new RegExp('^/collections')
+			const tutorialPathRegex = new RegExp('^/tutorials')
+			const productHubPathRegex = new RegExp(`^/${product}/?$`)
+
+			// Derived path type booleans
+			const isCollectionPath = collectionPathRegex.test(pathname)
+			const isTutorialPath = tutorialPathRegex.test(pathname)
+			const isProductHubPath = productHubPathRegex.test(pathname)
 			const isDocsPath = origin.includes(productIOHostName)
-			if (isDocsPath) {
-				newUrl = handleDocsLink(urlWithoutOrigin, product as ProductSlug)
-			}
 
 			/**
 			 * Check if multiple conditions above were true. Only one should be true
@@ -169,6 +158,19 @@ export function rewriteTutorialsLink(
 			})
 			if (isUrlAmbiguous) {
 				throw new Error(`[rewriteTutorialsLink] found an ambiguous url: ${url}`)
+			}
+
+			/**
+			 * If the path type is not ambiguous, handle the path by type.
+			 */
+			if (isCollectionPath) {
+				newUrl = handleCollectionLink(urlWithoutOrigin)
+			} else if (isTutorialPath) {
+				newUrl = handleTutorialLink(urlWithoutOrigin, tutorialMap)
+			} else if (isProductHubPath) {
+				newUrl = `/${product}/tutorials`
+			} else if (isDocsPath) {
+				newUrl = handleDocsLink(urlWithoutOrigin, product as ProductSlug)
 			}
 
 			/**

--- a/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
@@ -126,7 +126,6 @@ export function rewriteTutorialsLink(
 		if (!isBetaProduct && !isExternalLearnLink && !isAnchorLink) {
 			// If its an internal link, rewrite to an external learn link
 			newUrl = new URL(url, 'https://learn.hashicorp.com/').toString()
-			console.log(url, '\n', newUrl, '\n')
 		}
 
 		if (isBetaProduct || isValidSection) {
@@ -172,18 +171,21 @@ export function rewriteTutorialsLink(
 				throw new Error(`[rewriteTutorialsLink] found an ambiguous url: ${url}`)
 			}
 
+			/**
+			 * If the link wasn't found in the map, default to original link. Could be
+			 * a typo, it's up to the author to correct -- this feedback should help.
+			 */
 			if (!newUrl) {
-				// If the link wasn't found in the map, default to original link
-				// Could be a typo, its up to the author to correct -- this feedback should help
 				throw new Error(
 					`[MDX TUTORIAL]: internal link could not be rewritten: ${url} \nPlease check all Learn links in that tutorial to ensure they are correct.`
 				)
 			}
 		}
 	} catch (e) {
-		console.error(e) // we don't want an incorrect link to break the build
+		// we don't want an incorrect link to break the build
+		console.error(e)
 	}
 
-	// Return the modified URL
-	return newUrl
+	// Return the modified URL, or default to the original one
+	return newUrl || url
 }

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/handle-learn-links.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/handle-learn-links.ts
@@ -56,6 +56,14 @@ export function handleTutorialLink(
 	}
 
 	/**
+	 * If the path could not be determined, then the `tutorialSlug` was not found
+	 * in the `tutorialMap`.
+	 */
+	if (!path) {
+		return
+	}
+
+	/**
 	 * Remove the `in` parameter from the give `nodePath`, since it's not needed
 	 * on this platform.
 	 */

--- a/src/views/product-tutorials-view/helpers/__tests__/detect-and-reformat-learn-url.test.ts
+++ b/src/views/product-tutorials-view/helpers/__tests__/detect-and-reformat-learn-url.test.ts
@@ -166,6 +166,12 @@ describe('detectAndReformatLearnUrl', () => {
 				input: '/tutorials/waypoint/aws-ecs',
 				expected: '/waypoint/tutorials/deploy-aws/aws-ecs',
 			},
+			{
+				input:
+					'/tutorials/consul/gossip-encryption-secure?utm_source=consul.io&utm_medium=docs',
+				expected:
+					'/consul/tutorials/gossip-encryption-secure?utm_source=consul.io&utm_medium=docs',
+			},
 		]
 		for (let n = 0; n < tutorialUrls.length; n++) {
 			const { input, expected } = tutorialUrls[n]

--- a/src/views/product-tutorials-view/helpers/__tests__/detect-and-reformat-learn-url.test.ts
+++ b/src/views/product-tutorials-view/helpers/__tests__/detect-and-reformat-learn-url.test.ts
@@ -9,6 +9,8 @@ import detectAndReformatLearnUrl from '../detect-and-reformat-learn-url'
  * [key: database tutorial slug]: value — dev dot absolute path
  */
 const MOCK_TUTORIALS_MAP = {
+	'consul/gossip-encryption-secure':
+		'/consul/tutorials/gossip-encryption-secure',
 	'waypoint/aws-ecs': '/waypoint/tutorials/deploy-aws/aws-ecs',
 	'vault/getting-started-install':
 		'/vault/tutorials/getting-started/getting-started-install',


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Primarily updates the checks in `rewriteTutorialsLink` to be stronger
- Adds an error check (that doesn't break builds) for links that meet multiple link-type conditions (only one should be met)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- In cases where a product's .io hostname is within a value for a query string param, the link is being detected as both a learn link _and_ a docs link. Because the `isDocsPath` check was being handled first, the link was always being handled as a docs link even if it was actually a learn link.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/consul/docs/security/encryption#encryption](https://dev-portal-git-ambcomplex-params-in-tutorials-links-hashicorp.vercel.app/consul/docs/security/encryption#encryption)
- [ ] Click the "enable gossip encryption" link
- [ ] The link should not 404
