### PR TITLE
fix: adjust breadcrumb margin

### DIFF
--- a/src/components/breadcrumb-bar/breadcrumb-bar.module.css
+++ b/src/components/breadcrumb-bar/breadcrumb-bar.module.css
@@ -5,62 +5,61 @@
    stopgap. */
 
 .root {
-  position: relative;
-  margin-bottom: 32px;
+	position: relative;
 }
 
 .listRoot {
-  display: flex;
-  flex-wrap: wrap;
-  list-style: none;
-  margin: 0;
-  padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 .listItem {
-  /**
+	/**
    * Note: display: flex is needed here to allow max-width to work 
    * on .breadCrumbText, which would otherwise be inline, while
    * keeping the ::after element for slash dividers working as well.
    */
-  display: flex;
-  padding-top: 4px;
-  padding-bottom: 4px;
+	display: flex;
+	padding-top: 4px;
+	padding-bottom: 4px;
 
-  &:not(:last-child)::after {
-    color: var(--token-color-palette-neutral-400);
-    content: '/';
-    padding: 0 8px;
-  }
+	&:not(:last-child)::after {
+		color: var(--token-color-palette-neutral-400);
+		content: '/';
+		padding: 0 8px;
+	}
 }
 
 .breadcrumbText {
-  composes: g-focus-ring-from-box-shadow from global;
-  border-radius: 5px;
-  color: var(--token-color-foreground-faint);
-  max-width: 16em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	composes: g-focus-ring-from-box-shadow from global;
+	border-radius: 5px;
+	color: var(--token-color-foreground-faint);
+	max-width: 16em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
-  &[href] {
-    &:hover {
-      text-decoration: underline;
-    }
+	&[href] {
+		&:hover {
+			text-decoration: underline;
+		}
 
-    &:active {
-      color: var(--token-color-foreground-primary);
-      text-decoration: underline;
-    }
+		&:active {
+			color: var(--token-color-foreground-primary);
+			text-decoration: underline;
+		}
 
-    &:focus-visible {
-      text-decoration: none;
-      margin: -5px;
-      padding: 5px;
-    }
+		&:focus-visible {
+			text-decoration: none;
+			margin: -5px;
+			padding: 5px;
+		}
 
-    &[aria-current='page'] {
-      color: var(--token-color-foreground-strong);
-    }
-  }
+		&[aria-current='page'] {
+			color: var(--token-color-foreground-strong);
+		}
+	}
 }

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -110,6 +110,7 @@ for further details.
 	display: flex;
 	justify-content: space-between;
 	align-items: baseline;
+	margin-bottom: 32px;
 }
 
 .optInOutSlot {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-double-space-docs-hashicorp.vercel.app/nomad/docs/commands/recommendation/list) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202983574737104/f) 🎟️

## 🗒️ What

Refactored where the breadcrumb margin lives so that things collapse properly with or without the docs searchbar (for previews and current prod) 

## previous

<img width="1001" alt="Screen Shot 2022-09-14 at 4 39 16 PM" src="https://user-images.githubusercontent.com/36613477/190281224-778d8c55-8363-4bd0-a603-a0b83bad16c4.png">


## current

<img width="1021" alt="Screen Shot 2022-09-14 at 4 41 13 PM" src="https://user-images.githubusercontent.com/36613477/190281401-ba9cf146-7f31-4649-b874-2d399ee86bd4.png">


## note prod 
<img width="1009" alt="Screen Shot 2022-09-14 at 4 20 21 PM" src="https://user-images.githubusercontent.com/36613477/190281109-9d62eb40-1553-4978-92a8-9d7dac324366.png">
To test for the prod view pull this down locally and set `enable_global_search` to false in the development config.

