### PR TITLE
[SidecarMarketingCard] Removing Learn more link

### DIFF
--- a/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
+++ b/src/views/product-downloads-view/components/sidecar-marketing-card/index.tsx
@@ -1,11 +1,7 @@
 import { ReactElement } from 'react'
 import Link from 'next/link'
 import slugify from 'slugify'
-import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
-import { productSlugsToHostNames } from 'lib/products'
-import { useCurrentProduct } from 'contexts'
 import Card from 'components/card'
-import StandaloneLink from 'components/standalone-link'
 import Text from 'components/text'
 import { SidecarMarketingCardProps } from './types'
 import s from './sidecar-marketing-card.module.css'
@@ -15,11 +11,6 @@ const SidecarMarketingCard = ({
 	subtitle,
 	featuredDocsLinks,
 }: SidecarMarketingCardProps): ReactElement => {
-	const currentProduct = useCurrentProduct()
-	const learnMoreLink = `https://www.${
-		productSlugsToHostNames[currentProduct.slug]
-	}`
-
 	return (
 		<Card elevation="base">
 			<Text className={s.cardTitle} size={300} weight="semibold">
@@ -28,14 +19,6 @@ const SidecarMarketingCard = ({
 			<Text className={s.cardSubtitle} size={200} weight="regular">
 				{subtitle}
 			</Text>
-			<StandaloneLink
-				color="secondary"
-				href={learnMoreLink}
-				icon={<IconExternalLink16 />}
-				iconPosition="trailing"
-				openInNewTab
-				text="Learn more"
-			/>
 			<Text className={s.featuredDocsLabel} size={200} weight="semibold">
 				Featured docs
 			</Text>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambremove-learn-more-links-hashicorp.vercel.app/waypoint/downloads) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1202981777114622/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes "Learn more" links from `SidecarMarketingCard`

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview link
- [ ] Make sure the "Learn more" standalone link is no longer present in the sidecar marketing card
