### PR TITLE
chore: fix vagrant vmware link

### DIFF
--- a/src/components/author-primitives/shared/button/index.tsx
+++ b/src/components/author-primitives/shared/button/index.tsx
@@ -1,0 +1,17 @@
+import Button from '@hashicorp/react-button'
+import { useCurrentProduct } from 'contexts'
+import { rewriteDocsUrl } from 'views/docs-view/utils/product-url-adjusters'
+
+/**
+ * This component will rewrite links to any docs paths to the dev dot context
+ */
+
+export default function MdxButton(props) {
+	const currentProduct = useCurrentProduct()
+	return (
+		<Button
+			{...props}
+			url={props.url ? rewriteDocsUrl(props.url, currentProduct) : undefined}
+		/>
+	)
+}

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -29,7 +29,9 @@ const Badge = dynamic(() => import('components/author-primitives/shared/badge'))
 const BadgesHeader = dynamic(
 	() => import('components/author-primitives/packer/badges-header')
 )
-const Button = dynamic(() => import('@hashicorp/react-button'))
+const Button = dynamic(
+	() => import('components/author-primitives/shared/button')
+)
 const Checklist = dynamic(
 	() => import('components/author-primitives/packer/checklist')
 )

--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -12,6 +12,13 @@ describe('rewriteDocsUrl', () => {
 				const expectedOutput =
 					productSlug === 'hcp' ? '/downloads' : `/${productSlug}/downloads`
 				expect(rewriteDocsUrl('/downloads', productData)).toBe(expectedOutput)
+
+				// special case for vagrant vmware utility downloads page
+				if (productSlug === 'vagrant') {
+					expect(rewriteDocsUrl('/vmware/downloads', productData)).toBe(
+						`/${productSlug}/downloads/vmware`
+					)
+				}
 			}
 		)
 	})

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -111,6 +111,11 @@ export function rewriteDocsUrl(
 		(basePath: string) => inputUrl.startsWith(`/${basePath}`)
 	)
 	if (isCurrentProductDocsUrl) {
+		// The vagrant vmware utility downloads page is a unique case, where we did
+		// adjust the url structure in the transition to devdot
+		if (currentProduct.slug === 'vagrant' && inputUrl.startsWith('/vmware')) {
+			return `/${currentProduct.slug}/downloads/vmware`
+		}
 		return `/${currentProduct.slug}${inputUrl}`
 	}
 

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -113,7 +113,10 @@ export function rewriteDocsUrl(
 	if (isCurrentProductDocsUrl) {
 		// The vagrant vmware utility downloads page is a unique case, where we did
 		// adjust the url structure in the transition to devdot
-		if (currentProduct.slug === 'vagrant' && inputUrl.startsWith('/vmware')) {
+		if (
+			currentProduct.slug === 'vagrant' &&
+			inputUrl.startsWith('/vmware/downloads')
+		) {
 			return `/${currentProduct.slug}/downloads/vmware`
 		}
 		return `/${currentProduct.slug}${inputUrl}`


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-vmware-downloads-link-hashicorp.vercel.app/vagrant/docs/providers/vmware/installation) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1202794559462712) 🎟️

## 🗒️ What

This link is broken in content and is a one-off compared to other docs links since we did restructure the path.

## 🧪 Testing

- [Visit this page](https://dev-portal-git-ksfix-vmware-downloads-link-hashicorp.vercel.app/vagrant/docs/providers/vmware/installation) and click the vmware utility downloads page link. It should resolve to the correct dev portal path.
