### PR TITLE
fix typo on terraform docs homepage

### DIFF
--- a/src/content/terraform/docs-landing.json
+++ b/src/content/terraform/docs-landing.json
@@ -1,5 +1,5 @@
 {
-	"pageSubtitle": "Terraform is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently. This includes low-level components like compute instances, storage, and networking as well as high-level components like DNS entries and SaaS features.",
+	"pageSubtitle": "Terraform is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently. This includes low-level components like compute instances, storage, and networking, as well as high-level components like DNS entries and SaaS features.",
 	"marketingContentBlocks": [
 		{
 			"type": "card-grid",

--- a/src/content/terraform/docs-landing.json
+++ b/src/content/terraform/docs-landing.json
@@ -1,5 +1,5 @@
 {
-	"pageSubtitle": "Terraform is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently. This includes both low-level components like compute instances, storage, and networking, as well as high-level components like DNS entries and SaaS features.",
+	"pageSubtitle": "Terraform is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently. This includes low-level components like compute instances, storage, and networking as well as high-level components like DNS entries and SaaS features.",
 	"marketingContentBlocks": [
 		{
 			"type": "card-grid",
@@ -33,7 +33,7 @@
 				},
 				{
 					"description": "Use the Terraform CLI to manage configuration, plugins, infrastructure, and state.",
-					"title": "Transform CLI",
+					"title": "Terraform CLI",
 					"url": "/terraform/cli"
 				},
 				{


### PR DESCRIPTION
## 🗒️ What

Terraform homepage mistakenly said "Transform CLI" instead of Terraform CLI.

