### PR TITLE
feat: auto detect for visuallyHideSidebarTitle

### DIFF
--- a/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
@@ -93,7 +93,6 @@ describe('getNavItems', () => {
 					name: 'CDK for Terraform',
 					path: 'cdktf',
 					productSlugForLoader: 'terraform-cdk',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'terminal-screen',
@@ -105,7 +104,6 @@ describe('getNavItems', () => {
 					name: 'Terraform Cloud',
 					path: 'cloud-docs',
 					productSlugForLoader: 'terraform-docs-common',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'cloud',
@@ -113,7 +111,6 @@ describe('getNavItems', () => {
 					navDataPrefix: 'cloud-docs-agents',
 					path: 'cloud-docs/agents',
 					productSlugForLoader: 'terraform-docs-agents',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'docs',
@@ -126,32 +123,27 @@ describe('getNavItems', () => {
 					name: 'Terraform Enterprise',
 					path: 'enterprise',
 					productSlugForLoader: 'ptfe-releases',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'docs',
 					name: 'Internals',
 					path: 'internals',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'docs',
 					name: 'Intro',
 					path: 'intro',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'file-source',
 					name: 'Configuration Language',
 					path: 'language',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'plug',
 					name: 'Plugin Development',
 					path: 'plugin',
 					productSlugForLoader: 'terraform-docs-common',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'plug',
@@ -159,7 +151,6 @@ describe('getNavItems', () => {
 					navDataPrefix: 'plugin-framework',
 					path: 'plugin/framework',
 					productSlugForLoader: 'terraform-plugin-framework',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'plug',
@@ -167,7 +158,6 @@ describe('getNavItems', () => {
 					navDataPrefix: 'plugin-log',
 					path: 'plugin/log',
 					productSlugForLoader: 'terraform-plugin-log',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'plug',
@@ -175,7 +165,6 @@ describe('getNavItems', () => {
 					navDataPrefix: 'plugin-mux',
 					path: 'plugin/mux',
 					productSlugForLoader: 'terraform-plugin-mux',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'plug',
@@ -183,14 +172,12 @@ describe('getNavItems', () => {
 					path: 'plugin/sdkv2',
 					productSlugForLoader: 'terraform-plugin-sdk',
 					navDataPrefix: 'plugin-sdk',
-					visuallyHideSidebarTitle: true,
 				},
 				{
 					iconName: 'database',
 					name: 'Registry Publishing',
 					path: 'registry',
 					productSlugForLoader: 'terraform-docs-common',
-					visuallyHideSidebarTitle: true,
 				},
 			],
 		} as ProductData

--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -47,29 +47,25 @@
 			"iconName": "code",
 			"name": "CDK for Terraform",
 			"path": "cdktf",
-			"productSlugForLoader": "terraform-cdk",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-cdk"
 		},
 		{
 			"iconName": "terminal-screen",
 			"name": "Terraform CLI",
-			"path": "cli",
-			"visuallyHideSidebarTitle": true
+			"path": "cli"
 		},
 		{
 			"iconName": "cloud",
 			"name": "Terraform Cloud",
 			"path": "cloud-docs",
-			"productSlugForLoader": "terraform-docs-common",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-docs-common"
 		},
 		{
 			"iconName": "cloud",
 			"name": "Cloud Docs Agents",
 			"navDataPrefix": "cloud-docs-agents",
 			"path": "cloud-docs/agents",
-			"productSlugForLoader": "terraform-docs-agents",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-docs-agents"
 		},
 		{
 			"iconName": "docs",
@@ -82,72 +78,62 @@
 			"iconName": "org",
 			"name": "Terraform Enterprise",
 			"path": "enterprise",
-			"productSlugForLoader": "ptfe-releases",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "ptfe-releases"
 		},
 		{
 			"iconName": "docs",
 			"name": "Internals",
-			"path": "internals",
-			"visuallyHideSidebarTitle": true
+			"path": "internals"
 		},
 		{
 			"iconName": "docs",
 			"name": "Intro",
-			"path": "intro",
-			"visuallyHideSidebarTitle": true
+			"path": "intro"
 		},
 		{
 			"iconName": "file-source",
 			"name": "Configuration Language",
-			"path": "language",
-			"visuallyHideSidebarTitle": true
+			"path": "language"
 		},
 		{
 			"iconName": "wrench",
 			"name": "Plugin Development",
 			"path": "plugin",
-			"productSlugForLoader": "terraform-docs-common",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-docs-common"
 		},
 		{
 			"iconName": "plug",
 			"name": "Framework",
 			"navDataPrefix": "plugin-framework",
 			"path": "plugin/framework",
-			"productSlugForLoader": "terraform-plugin-framework",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-plugin-framework"
 		},
 		{
 			"iconName": "plug",
 			"name": "Logging",
 			"navDataPrefix": "plugin-log",
 			"path": "plugin/log",
-			"productSlugForLoader": "terraform-plugin-log",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-plugin-log"
 		},
 		{
 			"iconName": "plug",
 			"name": "Combining and Translating",
 			"navDataPrefix": "plugin-mux",
 			"path": "plugin/mux",
-			"productSlugForLoader": "terraform-plugin-mux",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-plugin-mux"
 		},
 		{
 			"iconName": "plug",
 			"name": "SDKv2",
 			"path": "plugin/sdkv2",
 			"productSlugForLoader": "terraform-plugin-sdk",
-			"navDataPrefix": "plugin-sdk",
-			"visuallyHideSidebarTitle": true
+			"navDataPrefix": "plugin-sdk"
 		},
 		{
 			"iconName": "plus-circle",
 			"name": "Registry Publishing",
 			"path": "registry",
-			"productSlugForLoader": "terraform-docs-common",
-			"visuallyHideSidebarTitle": true
+			"productSlugForLoader": "terraform-docs-common"
 		}
 	],
 	"devDotCutoverMessage": {

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -117,13 +117,6 @@ interface RootDocsPath {
 	mainBranch?: string
 
 	/**
-	 * An optional property to hide the title of this rootDocsPath
-	 * in the sidebar. Used for Terraform routes where sidebar titles
-	 * are present in nav-data.json.
-	 */
-	visuallyHideSidebarTitle?: boolean
-
-	/**
 	 * An optional description for this category of documentation.
 	 * Shown as the subtitle of the docs landing hero element.
 	 * If omitted, falls back to the page's authored frontMatter.description,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -272,8 +272,14 @@ export function getStaticGenerationFunctions<
 				menuItems: navDataWithFullPaths as EnrichedNavItem[],
 				title: currentRootDocsPath.shortName || currentRootDocsPath.name,
 			}
-			// If the title is not hidden for this rootDocsPath, include it
-			if (currentRootDocsPath.visuallyHideSidebarTitle) {
+			/**
+			 * In some cases, the first nav item is a heading.
+			 * In these case, we'll visually hide the sidebar title,
+			 * since it will redundant right next to the authored title.
+			 */
+			const firstItemIsHeading =
+				typeof navDataWithFullPaths[0]?.heading == 'string'
+			if (firstItemIsHeading) {
 				docsSidebarLevel.visuallyHideTitle = true
 			}
 
@@ -296,8 +302,6 @@ export function getStaticGenerationFunctions<
 			 * we'll avoid adding an overview item even if there's
 			 * no overview item match.
 			 */
-			const firstItemIsHeading =
-				typeof navDataWithFullPaths[0]?.heading == 'string'
 			if (!overviewItemMatch && !firstItemIsHeading) {
 				docsSidebarLevel.overviewItemHref = versionPathPart
 					? `/${product.slug}/${basePath}/${versionPathPart}`


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Switches from `visuallyHideSidebarTitle` config options, which need to be manually maintained, to automatic detection to meet similar ends.

## 🤷 Why

- Some `rootDocsPath` `nav-data.json` starts with a `heading` node, making the added sidebar title look odd
- Manually maintaining which `rootDocsPath` this condition applies to is brittle
- This brittleness puts content folks in a bind where removing those edge-case headings would result in no headings at all appearing in the sidebar.
- By automatically detecting this condition, we can fix the underlying content inconsistency at any time, with confidence that thing will look the way we expect.

## 🛠️ How

- Uses `firstItemIsHeading` from #1037 to replace `"visuallyHideSidebarTitle"`
- Removes `"visuallyHideSidebarTitle"` from config, and removes from the `RootDocsPath` type

## 🧪 Testing

- [ ] Visit each of the pages listed below that previously used `"visuallyHideSidebarTitle"` in `.json`.
    - These pages should continue to show only a single heading
- [ ] Visit some other docs landing pages
    - These pages should continue to show a heading

### Pages that previously used `"visuallyHideSidebarTitle"`

- [/terraform/cdktf][/terraform/cdktf]
- [/terraform/cli][/terraform/cli]
- [/terraform/cloud-docs][/terraform/cloud-docs]
- [/terraform/cloud-docs/agents][/terraform/cloud-docs/agents]
- [/terraform/enterprise][/terraform/enterprise]
- [/terraform/internals][/terraform/internals]
- [/terraform/intro][/terraform/intro]
- [/terraform/language][/terraform/language]
- [/terraform/plugin][/terraform/plugin]
- [/terraform/plugin/framework][/terraform/plugin/framework]
- [/terraform/plugin/log][/terraform/plugin/log]
- [/terraform/plugin/mux][/terraform/plugin/mux]
- [/terraform/plugin/sdkv2][/terraform/plugin/sdkv2]
- [/terraform/registry][/terraform/registry]

## 💭 Anything else?

Currently targets #1037 , planning to finalize and merge that PR first.

[task]: https://app.asana.com/0/1202097197789424/1203008011603164/f
[preview]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app/
[/terraform/cdktf]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/cdktf
[/terraform/cli]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/cli
[/terraform/cloud-docs]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/cloud-docs
[/terraform/cloud-docs/agents]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/cloud-docs/agents
[/terraform/enterprise]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/enterprise
[/terraform/internals]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/internals
[/terraform/intro]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/intro
[/terraform/language]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/language
[/terraform/plugin]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/plugin
[/terraform/plugin/framework]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/plugin/framework
[/terraform/plugin/log]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/plugin/log
[/terraform/plugin/mux]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/plugin/mux
[/terraform/plugin/sdkv2]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/plugin/sdkv2
[/terraform/registry]: https://dev-portal-git-zsauto-visually-hide-title-docs-985650-hashicorp.vercel.app//terraform/registry