### PR TITLE
feat: rm packer docs icon grid cards

### DIFF
--- a/src/content/packer/docs-landing.json
+++ b/src/content/packer/docs-landing.json
@@ -1,5 +1,6 @@
 {
 	"pageSubtitle": "Packer lets you create identical machine images for multiple platforms from a single source configuration. A common use case is creating golden images for organizations to use in cloud infrastructure.",
+	"iconCardGridItems": [],
 	"marketingContentBlocks": [
 		{
 			"type": "card-grid",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Removes icon cards from [/packer/docs][preview].

## 🛠️ How

Updates `src/content/packer/docs-landing.json`.

## 📸 Design Screenshots

### Before

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/4624598/191574937-3eb0a7d6-9fb5-4f70-a327-971685115b49.png">

### After, from this PR

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/4624598/191574963-be485bca-eba4-412e-b3ea-207688627bfa.png">

## 🧪 Testing

- [ ] Visit [/packer/docs][preview], and ensure the grid of icon cards is no longer displaying

[task]: https://app.asana.com/0/1202097197789424/1203016864094230/f
[preview]: https://dev-portal-git-zsrm-packer-docs-links-hashicorp.vercel.app/packer/docs