### PR TITLE
Rewrite docs sidebar links to external Learn/Docs sites

### DIFF
--- a/src/content/packer/docs-landing.json
+++ b/src/content/packer/docs-landing.json
@@ -49,7 +49,7 @@
 				{
 					"description": "Centrally track image metadata and enforce up-to-date image versions.",
 					"title": "HCP Packer",
-					"url": "https://cloud.hashicorp.com/docs/packer"
+					"url": "/hcp/docs/packer"
 				},
 				{
 					"description": "Create custom builders, provisioners, post-processors, and data sources.",

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -78,13 +78,13 @@ async function prepareNavDataForClient({
 	let count = 0
 	for (let i = 0; i < nodes.length; i++) {
 		const node = nodes[i]
-		const result = prepareNavNodeForClient({
+		const result = await prepareNavNodeForClient({
 			basePaths,
 			node,
 			nodeIndex: startingIndex + count,
 		})
 		if (result) {
-			const { preparedItem, traversedNodes } = await result
+			const { preparedItem, traversedNodes } = result
 			preparedNodes.push(preparedItem)
 			count += traversedNodes
 		}

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -73,7 +73,7 @@ async function prepareNavDataForClient({
 }): Promise<{ preparedItems: MenuItem[]; traversedNodes: number }> {
 	const preparedNodes = []
 
-	TUTORIAL_MAP = await getTutorialMap()
+	TUTORIAL_MAP = TUTORIAL_MAP ?? await getTutorialMap()
 
 	let count = 0
 	for (let i = 0; i < nodes.length; i++) {

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -73,7 +73,7 @@ async function prepareNavDataForClient({
 }): Promise<{ preparedItems: MenuItem[]; traversedNodes: number }> {
 	const preparedNodes = []
 
-	TUTORIAL_MAP = TUTORIAL_MAP ?? await getTutorialMap()
+	TUTORIAL_MAP = TUTORIAL_MAP ?? (await getTutorialMap())
 
 	let count = 0
 	for (let i = 0; i < nodes.length; i++) {
@@ -194,17 +194,24 @@ async function prepareNavNodeForClient({
 			const preparedItem = { ...node, id }
 
 			/**
-			 * Rewrite external Learn and Docs links if needed.
+			 * Rewrite external Learn and Docs links if needed. Default to the
+			 * original `href`.
+			 *
 			 * 	- learn.hashicorp.com
 			 * 	- vaultproject.io
 			 * 	- waypointproject.io
 			 */
 			try {
+				let newHref
 				const urlObject = new URL(node.href)
 				if (getIsExternalLearnLink(node.href)) {
-					preparedItem.href = rewriteExternalLearnLink(urlObject, TUTORIAL_MAP)
+					newHref = rewriteExternalLearnLink(urlObject, TUTORIAL_MAP)
 				} else if (getIsRewriteableDocsLink(node.href)) {
-					preparedItem.href = rewriteExternalDocsLink(urlObject)
+					newHref = rewriteExternalDocsLink(urlObject)
+				}
+
+				if (newHref) {
+					preparedItem.href = newHref
 				}
 			} catch (error) {
 				console.error(

--- a/src/pages/packer/plugins/[...page].tsx
+++ b/src/pages/packer/plugins/[...page].tsx
@@ -81,7 +81,7 @@ export async function getStaticProps({ params, ...ctx }) {
 	/**
 	 * Prepare nav data for client, eg adding `fullPath`
 	 */
-	const { preparedItems: navData } = prepareNavDataForClient({
+	const { preparedItems: navData } = await prepareNavDataForClient({
 		basePaths: [productData.slug, basePath],
 		nodes: props.navData,
 	})

--- a/src/pages/packer/plugins/index.tsx
+++ b/src/pages/packer/plugins/index.tsx
@@ -51,7 +51,7 @@ async function getStaticProps(ctx) {
 		}
 
 		// Prepare nav data for client (such as adding `fullPath`)
-		const { preparedItems: navData } = prepareNavDataForClient({
+		const { preparedItems: navData } = await prepareNavDataForClient({
 			basePaths: ['packer', 'plugins'],
 			nodes: rawNavData,
 		})

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -238,10 +238,11 @@ export function getStaticGenerationFunctions<
 			/**
 			 * Add fullPaths and auto-generated ids to navData
 			 */
-			const { preparedItems: navDataWithFullPaths } = prepareNavDataForClient({
-				basePaths: [product.slug, basePath],
-				nodes: navData,
-			})
+			const { preparedItems: navDataWithFullPaths } =
+				await prepareNavDataForClient({
+					basePaths: [product.slug, basePath],
+					nodes: navData,
+				})
 
 			/**
 			 * Figure out of a specific docs version is being viewed


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1202981777114602/f) 🎟️
- Sourcegraph searches
  - [learn.hashicorp.com](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+learn.hashicorp.com+lang:json+&patternType=standard)
  - [boundaryproject.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+boundaryproject.io+lang:json+&patternType=standard)
  - [consul.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+consul.io+lang:json+&patternType=standard)
  - [cloud.hashicorp.com](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+cloud.hashicorp.com+lang:json+&patternType=standard)
  - [nomadproject.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+nomadproject.io+lang:json+&patternType=standard)
  - [packer.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+packer.io+lang:json+&patternType=standard)
  - [docs.hashicorp.com](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+docs.hashicorp.com+lang:json+&patternType=standard)
  - [terraform.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+terraform.io+lang:json&patternType=standard)
  - [vagrantup.com](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+vagrantup.com+lang:json&patternType=standard)
  - [vaultproject.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+vaultproject.io+lang:json&patternType=standard)
  - [waypointproject.io](https://hashicorp-mktg.sourcegraph.com/search?q=context:global+waypointproject.io+lang:json&patternType=standard)

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `prepareNavDataForClient` to handle rewriting docs sidebar links that point to external learn and .io sites
- Updates an external HCP Packer docs link on /packer to point to internal HCP docs link

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- In order for content to be backwards compatible with .io sites, we need to use external links in the source content. This means we need to automatically rewrite those links in DevDot in order to link to internal pages.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Make sure all of the sidebar links listed below have a valid URL, and that it's the URL you expect.

<details>
<summary>learn.hashicorp.com links</summary>

- [ ] [/terraform/intro](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/terraform/intro)
  - [ ] "Get Started"
- [ ] [/terraform/cli](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/terraform/cli)
  - [ ] under "Automating Terraform"
    - [ ] Running Terraform in Automation
    - [ ] GitHub Actions
- [ ] [/vault/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/vault/docs)
  - [ ] Two links under "Get Started"
    - [ ] CLI Quick Start
    - [ ] HCP Quick Start
  - [ ] "Troubleshoot"
- [ ] [/consul/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/consul/docs)
  - [ ] under "Get Started"
    - [ ] Learn HCP Consul
    - [ ] Learn Consul on Kubernetes
    - [ ] Learn Consul on VMs
  - [ ] under "Kubernetes" > "Platform Guides"
    - [ ] Minikube
    - [ ] Kind
    - [ ] AKS (Azure)
    - [ ] EKS (AWS)
    - [ ] GKE (Google Cloud)
    - [ ] Red Hat OpenShift
- [ ] [/vagrant/intro](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/vagrant/intro)
  - [ ] "Get Started"
- [ ] [/packer/guides](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/packer/guides)
  - [ ] under "HCL guides"
    - [ ] "Upgrade Packer JSON Template to HCL2"
- [ ] [/nomad/intro](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/nomad/intro)
  - [ ] under "Getting Started"
    - [ ] Overview
    - [ ] Running Nomad
    - [ ] Jobs
    - [ ] Clustering
    - [ ] Web UI
    - [ ] Next Steps
- [ ] [/nomad/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/nomad/docs)
  - [ ] under "Installing Nomad" > "Production"
    - [ ] Reference Architecture
    - [ ] Deployment Guide
  - [ ] under "Operations"
    - [ ] Cluster Management
    - [ ] Transport Security
    - [ ] Access Control
- [ ] [/waypoint/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/waypoint/docs)
  - [ ] under "Platforms" > "Nomad"
    - [ ] Deploy an Application to Nomad
  - [ ] under "Platforms" > "Kubernetes"
    - [ ] Deploy an Application to Kubernetes
    - [ ] Helm and GitOps
  - [ ] under "Platforms" > "Amazon Web Services"
    - [ ] Deploy an Application to AWS Elastic Container Service
    - [ ] Deploy an Application onto AWS Lambda
  - [ ] under "App Configuration"
    - [ ] Static Values
- [ ] [/terraform/cdktf](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/terraform/cdktf)
  - [ ] Get Started
- [ ] [/boundary/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/boundary/docs)
  - [ ] Common Workflows
- [ ] [/terraform/plugin/framework](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/terraform/plugin/framework)
  - [ ] Tutorial: Implement Create and Read
- [ ] [/terraform/cloud-docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/terraform/cloud-docs)
  - [ ] Getting Started
- [ ] [/hcp/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/hcp/docs)
  - [ ] under "HCP Boundary"
    - [ ] Get Started
  - [ ] under "HCP Consul" > "Additional Resources"
    - [ ] Tutorials
  - [ ] under "HCP Vault"
    - [ ] Get Started
    - [ ] Metrics
  - [ ] under "HCP Packer"
    - [ ] Get Started

</details>

<details>
<summary>boundaryproject.io links</summary>

- [ ] [/hcp/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/hcp/docs)
  - [ ] Under "HCP Boundary"
    - [ ] Boundary Documentation

</details>

<details>
<summary>consul.io links</summary>

- [ ] [/hcp/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/hcp/docs)
  - [ ] Under "HCP Consul" > "Additional Resources"
    - [ ] Consul Documentation

</details>

<details>
<summary>cloud.hashicorp.com links</summary>

- [ ] [/vault/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/vault/docs)
  - [ ] Under "Vault Enterprise"
    - [ ] HCP Vault
- [ ] [/consul/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/consul/docs)
  - [ ] HCP Consul
- [ ] [/packer/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/packer/docs)
  - [ ] HCP Packeracker

</details>

<details>
<summary>packer.io links</summary>

- [ ] [/hcp/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/hcp/docs)
  - [ ] Under "HCP Packer"
    - [ ] Packer Documentation

</details>

<details>
<summary>vagranup.com links</summary>

- [ ] [/vagrant/downloads/vmware](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/vagrant/downloads/vmware)
  - [ ] Community Resources

</details>

<details>
<summary>vaultproject.io links</summary>

- [ ] [vault/docs](https://dev-portal-git-ambrewrite-docs-sidebar-links-hashicorp.vercel.app/vault/docs)
  - [ ] Under "FAQ"
    - [ ] Feature Deprecation Notice and Plans
    - [ ] License
    - [ ] Client Count
    - [ ] Login MFA

</details>

## 💭 Anything else?

I thought about moving the files that are being leveraged from `lib/remark-plugins/rewrite-tutorial-links/utils` to a higher level, but it feels like that won't have enough impact anyways since we're going to delete that code in the next 1-2 months.
