### PR TITLE
fix: migrate to next/future/image

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -112,7 +112,7 @@ module.exports = withSwingset({
 		},
 		experimental: {
 			images: {
-				layoutRaw: true,
+				allowFutureImage: true,
 			},
 		},
 	})

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, ReactElement } from 'react'
-import NextImage from 'next/image'
+import NextImage from 'next/future/image'
 import { ImageProps } from './types'
 import classNames from 'classnames'
 import s from './image.module.css'
@@ -97,7 +97,6 @@ function Image({
 					title={title}
 					width={dimensions.width}
 					height={dimensions.height}
-					layout="raw"
 					style={style}
 				/>
 			) : (


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR updates our usage of `next/image` to `next/future/image` in the single place where we were using an experimental property (`layout="raw"`) that is no longer available as of Next 12.2.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
