### PR TITLE
[rewriteTutorialLinksPlugin] Fixing tutorial lookup and section rewriting

### DIFF
--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-tutorial-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-tutorial-link.test.ts
@@ -4,7 +4,7 @@ import { rewriteExternalTutorialLink } from '../utils'
 const TEST_TUTORIAL_SLUG = 'vault/tutorial'
 const MOCK_TUTORIAL_MAP = {
 	'vault/tutorial': '/vault/tutorials/collection/tutorial',
-	'hcp/amazon-peering-hcp': '/hcp/tutorials/networking/amazon-peering-hcp',
+	'cloud/amazon-peering-hcp': '/hcp/tutorials/networking/amazon-peering-hcp',
 	'onboarding/tutorial': '/onboarding/collection/tutorial',
 	'well-architected-framework/tutorial':
 		'/well-architected-framework/collection/tutorial',

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -8,8 +8,7 @@ import { rewriteTutorialLinksPlugin } from 'lib/remark-plugins/rewrite-tutorial-
  * get-is-beta-product in order to provide a consistent testing config.
  */
 jest.mock('../../../get-is-beta-product', () => (productSlug) => {
-	const nonBetaProductsForTesting = ['boundary', 'packer', 'vagrant']
-	return nonBetaProductsForTesting.indexOf(productSlug) === -1
+	return ['hcp', 'vault', 'waypoint'].includes(productSlug)
 })
 
 // HELPERS ------------------------------------------------------
@@ -103,6 +102,7 @@ const MOCK_TUTORIALS_MAP = {
 	'waypoint/get-started': '/waypoint/tutorials/get-started-docker/get-started',
 	'well-architected-framework/cloud-operating-model':
 		'/well-architected-framework/com/cloud-operating-model',
+	'cloud/get-started-vault': '/vault/tutorials/cloud/get-started-vault',
 }
 
 // TESTS -----------------------------------------------------------------

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-learn-link.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-learn-link.ts
@@ -1,4 +1,5 @@
 import getIsBetaProduct from 'lib/get-is-beta-product'
+import { isSectionOption } from 'lib/learn-client/types'
 import { normalizeSlugForDevDot } from 'lib/tutorials/normalize-product-like-slug'
 import {
 	getIsExternalLearnLink,
@@ -36,7 +37,7 @@ const rewriteExternalLearnLink = (
 	}
 
 	const isBetaProduct = getIsBetaProduct(product)
-	if (isBetaProduct) {
+	if (isSectionOption(product) || isBetaProduct) {
 		// Regexes for each path type
 		const collectionPathRegex = new RegExp('^/collections')
 		const tutorialPathRegex = new RegExp('^/tutorials')

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-tutorial-link.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-tutorial-link.ts
@@ -15,7 +15,10 @@
 import { LearnProductSlug } from 'types/products'
 import getIsBetaProduct from 'lib/get-is-beta-product'
 import { SectionOption } from 'lib/learn-client/types'
-import { normalizeSlugForDevDot } from 'lib/tutorials/normalize-product-like-slug'
+import {
+	normalizeSlugForDevDot,
+	normalizeSlugForTutorials,
+} from 'lib/tutorials/normalize-product-like-slug'
 import { SplitLearnPath } from '../types'
 
 export function rewriteExternalTutorialLink(
@@ -63,7 +66,11 @@ export function rewriteExternalTutorialLink(
 		SectionOption[normalizedProductSlug] ||
 		getIsBetaProduct(normalizedProductSlug)
 	) {
-		const tutorialSlug = [normalizedProductSlug, filename].join('/')
+		// example: the map has keys with `cloud` instead of `hcp`
+		const tutorialSlug = [
+			normalizeSlugForTutorials(normalizedProductSlug),
+			filename,
+		].join('/')
 		path = tutorialMap[tutorialSlug]
 	}
 


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the part of the tutorial link rewriting where the `TUTORIAL_MAP` lookup is happening for `hcp` tutorials. The map stores `cloud`, but `hcp` was being used.
- Fixes valid `SectionOption`s not being rewritten, and updates the `get-is-beta-product` mock to be more restrictive so the tests were no longer false positives.
