### PR TITLE
fix: /packer/plugins/* duplicate overview item

### DIFF
--- a/src/pages/packer/plugins/[...page].tsx
+++ b/src/pages/packer/plugins/[...page].tsx
@@ -102,7 +102,7 @@ export async function getStaticProps({ params, ...ctx }) {
 			},
 			menuItems: navData,
 			title: baseName,
-			overviewItemHref: `/${productData.slug}/${basePath}`,
+			visuallyHideTitle: true,
 		},
 	]
 


### PR DESCRIPTION
Fixes an issue where the docs sidebar on `/packer/plugins/*` pages would display duplicate `Overview` items, and duplicate headings (since those routes do _not_ have the same "automatic" overview item and visually-hide-title logic as other docs pages).