### PR TITLE
[CommandBar] Close on navigation start

### DIFF
--- a/src/components/accordion-disclosure/accordion-disclosure.test.tsx
+++ b/src/components/accordion-disclosure/accordion-disclosure.test.tsx
@@ -1,6 +1,17 @@
 import { render } from '@testing-library/react'
 import AccordionDisclosure from '.'
 
+jest.mock('next/router', () => ({
+	useRouter() {
+		return {
+			events: {
+				on: jest.fn(),
+				off: jest.fn(),
+			},
+		}
+	},
+}))
+
 describe('AccordionDisclosure', () => {
 	it('renders without errors', () => {
 		const { getByRole, queryByText } = render(

--- a/src/components/algolia-search/index.tsx
+++ b/src/components/algolia-search/index.tsx
@@ -4,12 +4,12 @@ import {
 	AutocompleteState,
 	createAutocomplete,
 } from '@algolia/autocomplete-core'
-import { useRouter } from 'next/router'
 import { Hit } from '@algolia/client-search'
 import { IconSearch16 } from '@hashicorp/flight-icons/svg-react/search-16'
 import { IconX16 } from '@hashicorp/flight-icons/svg-react/x-16'
 import { IconSlashSquare16 } from '@hashicorp/flight-icons/svg-react/slash-square-16'
 import useFocusOnKeyClick from 'hooks/use-focus-on-key-click'
+import useOnRouteChangeStart from 'hooks/use-on-route-change-start'
 import Panel from './components/panel'
 import { useAlgoliaNavigatorNext } from './lib/use-algolia-navigator-next'
 import { AlgoliaSearchPops } from './types'
@@ -32,7 +32,6 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
 	const formRef = React.useRef<HTMLFormElement>(null)
 	const panelRef = React.useRef<HTMLDivElement>(null)
 
-	const router = useRouter()
 	const navigator = useAlgoliaNavigatorNext<THit>()
 
 	/**
@@ -80,17 +79,11 @@ export default function AlgoliaSearch<THit extends Hit<unknown>>({
 	/**
 	 * Clear the query input on route change
 	 */
-	React.useEffect(() => {
-		const handleRouteChangeStart = () => {
+	useOnRouteChangeStart({
+		handler: () => {
 			autocomplete.setQuery('')
-		}
-
-		router.events.on('routeChangeStart', handleRouteChangeStart)
-
-		return () => {
-			router.events.off('routeChangeStart', handleRouteChangeStart)
-		}
-	}, [autocomplete.setQuery])
+		},
+	})
 
 	/**
 	 * Initialize event listeners for touch events

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -6,7 +6,7 @@ import {
 	useMemo,
 	useReducer,
 } from 'react'
-import { useOnRouteChangeStart } from 'hooks/use-on-route-change-start'
+import useOnRouteChangeStart from 'hooks/use-on-route-change-start'
 import commands from './commands'
 import { CommandBarActivator, CommandBarDialog } from './components'
 import {

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useReducer,
 } from 'react'
+import { useOnRouteChangeStart } from 'hooks/use-on-route-change-start'
 import commands from './commands'
 import { CommandBarActivator, CommandBarDialog } from './components'
 import {
@@ -131,6 +132,11 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 			document.removeEventListener('keydown', handleKeyDown)
 		}
 	}, [toggleIsOpen])
+
+	/**
+	 * If it is open, handle closing the dialog on `routeChangeStart`.
+	 */
+	useOnRouteChangeStart({ handler: toggleIsOpen, shouldListen: state.isOpen })
 
 	/**
 	 * Memoize the Context value

--- a/src/components/disclosure/index.tsx
+++ b/src/components/disclosure/index.tsx
@@ -1,20 +1,13 @@
 // Third-party imports
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useRef,
-	useState,
-} from 'react'
-import { useRouter } from 'next/router'
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { useId } from '@react-aria/utils'
 
 // Global imports
-import useOnEscapeKeyDown from 'hooks/use-on-escape-key-down'
 import useOnClickOutside from 'hooks/use-on-click-outside'
+import useOnEscapeKeyDown from 'hooks/use-on-escape-key-down'
 import useOnFocusOutside from 'hooks/use-on-focus-outside'
+import useOnRouteChangeStart from 'hooks/use-on-route-change-start'
 
 // Local imports
 import { DisclosureContextState, DisclosureProps } from './types'
@@ -74,7 +67,6 @@ const Disclosure = ({
 	validateDisclosureChildren(children)
 
 	// continue rendering the component if `children` are valid
-	const router = useRouter()
 	const disclosureRef = useRef<HTMLDivElement>()
 	const [isOpen, setIsOpen] = useState<boolean>(initialOpen)
 	const uniqueId = `disclosure-${useId()}`
@@ -114,23 +106,7 @@ const Disclosure = ({
 	}, [closeDisclosure, contentContainerId])
 
 	// if the disclosure is open, handle closing it on `routeChangeStart`
-	useEffect(() => {
-		if (!isOpen) {
-			return
-		}
-
-		const handleRouteChangeStart = () => {
-			closeDisclosure()
-		}
-
-		router.events.on('routeChangeStart', handleRouteChangeStart)
-
-		return () => {
-			router.events.off('routeChangeStart', handleRouteChangeStart)
-		}
-		// Only need to base this on `isOpen`
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isOpen])
+	useOnRouteChangeStart({ handler: closeDisclosure, shouldListen: isOpen })
 
 	// if enabled, close the disclosure on click outside
 	useOnClickOutside(

--- a/src/components/navigation-header/components/dropdown-menu/index.tsx
+++ b/src/components/navigation-header/components/dropdown-menu/index.tsx
@@ -1,13 +1,5 @@
 // Third-party imports
-import {
-	Fragment,
-	KeyboardEvent,
-	ReactElement,
-	useEffect,
-	useRef,
-	useState,
-} from 'react'
-import { useRouter } from 'next/router'
+import { Fragment, KeyboardEvent, ReactElement, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useId } from '@react-aria/utils'
 import classNames from 'classnames'
@@ -21,6 +13,7 @@ import { ProductSlug } from 'types/products'
 import useCurrentPath from 'hooks/use-current-path'
 import useOnClickOutside from 'hooks/use-on-click-outside'
 import useOnFocusOutside from 'hooks/use-on-focus-outside'
+import useOnRouteChangeStart from 'hooks/use-on-route-change-start'
 import deriveKeyEventState from 'lib/derive-key-event-state'
 import Badge from 'components/badge'
 import ProductIcon from 'components/product-icon'
@@ -49,7 +42,6 @@ const NavigationHeaderDropdownMenu = ({
 	label,
 	leadingIcon,
 }: NavigationHeaderDropdownMenuProps) => {
-	const router = useRouter()
 	const uniqueId = useId()
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 	const menuRef = useRef<HTMLDivElement>()
@@ -73,23 +65,10 @@ const NavigationHeaderDropdownMenu = ({
 	}
 
 	// if the disclosure is open, handle closing it on `routeChangeStart`
-	useEffect(() => {
-		if (!isOpen) {
-			return
-		}
-
-		const handleRouteChangeStart = () => {
-			setIsOpen(false)
-		}
-
-		router.events.on('routeChangeStart', handleRouteChangeStart)
-
-		return () => {
-			router.events.off('routeChangeStart', handleRouteChangeStart)
-		}
-		// Only need to base this on `isOpen`
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isOpen])
+	useOnRouteChangeStart({
+		handler: () => setIsOpen(false),
+		shouldListen: isOpen,
+	})
 
 	// Check for an accesible label if there is a leading icon
 	const accessibleLabel = ariaLabel || label

--- a/src/hooks/use-on-route-change-start.ts
+++ b/src/hooks/use-on-route-change-start.ts
@@ -5,7 +5,7 @@ type Handler = Parameters<NextRouter['events']['on']>[1]
 
 interface UseOnRouteChangeStartOptions {
 	handler: Handler
-	shouldListen: boolean
+	shouldListen?: boolean
 }
 
 /**

--- a/src/hooks/use-on-route-change-start.ts
+++ b/src/hooks/use-on-route-change-start.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { NextRouter, useRouter } from 'next/router'
+
+type Handler = Parameters<NextRouter['events']['on']>[1]
+
+interface UseOnRouteChangeStartOptions {
+	handler: Handler
+	shouldListen: boolean
+}
+
+/**
+ * If `shouldListen` is true, then handles adding a `routeChangeStart` listener
+ * that executes the given `handler`.
+ */
+const useOnRouteChangeStart = ({
+	handler,
+	shouldListen = true,
+}: UseOnRouteChangeStartOptions) => {
+	const router = useRouter()
+
+	useEffect(() => {
+		if (!shouldListen) {
+			return
+		}
+
+		router.events.on('routeChangeStart', handler)
+
+		return () => {
+			router.events.off('routeChangeStart', handler)
+		}
+	}, [handler, router.events, shouldListen])
+}
+
+export type { UseOnRouteChangeStartOptions }
+export { useOnRouteChangeStart }

--- a/src/hooks/use-on-route-change-start.ts
+++ b/src/hooks/use-on-route-change-start.ts
@@ -32,4 +32,4 @@ const useOnRouteChangeStart = ({
 }
 
 export type { UseOnRouteChangeStartOptions }
-export { useOnRouteChangeStart }
+export default useOnRouteChangeStart


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202520168081556/1203053381984279/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `useOnRouteChangeStart` hook
- Leverages new hook to make `CommandBarDialog` close on `routeChangeStart` (like other disclosures do)
- Refactors references to `routeChangeStart` listeners to use the new hook
  - `AlgoliaSearch`
  - `Disclosure`
  - `NavigationHeaderDropdownMenu`
- Updates `AccordionDisclosure` tests to mock `next/router`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Without this listener, the `CommandBarDialog` remains open in many navigation interactions
- The hook feels like a nice abstraction since it's very repetitive logic

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

### `CommandBarDialog`

- [ ] Go to the home page
- [ ] Open the command bar
- [ ] Choose Terraform from the suggested pages list
- [ ] The dialog should close
- [ ] You should be taken to /terraform
- [ ] Open the command bar
- [ ] Choose "Terraform Documentation" from the suggested pages list
- [ ] The dialog should close
- [ ] You should be taken to /terraform/docs
- [ ] Open the command bar
- [ ] Choose "Terraform Cloud" from the suggested pages list
- [ ] The dialog should close
- [ ] You should be taken to /terraform/cloud-docs

### `AlgoliaSearch`

- [ ] Check out the code locally
- [ ] In `config/development.json`, set `enable_global_search` to `false`
- [ ] Start the server
- [ ] Go to /waypoint/docs
- [ ] Open the page search
- [ ] Search and navigate to a page
- [ ] The search input should clear

### `Disclosure`

- [ ] Go to [/waypoint/docs](https://dev-portal-git-ambclose-command-bar-on-navigation-hashicorp.vercel.app/waypoint/docs)
- [ ] Open the `DocsVersionSwitcher` (built on top of `DropdownDisclosure` & `Disclosure`)
- [ ] Select a different version
- [ ] The component should close
- [ ] You should be taken to the correct page

### `NavigationHeaderDropdownMenu`

- [ ] Go to the home page
- [ ] Open the Products dropdown menu
- [ ] Choose a link in the dropdown
- [ ] The component should close
- [ ] You should be taken to the correct page
