### PR TITLE
[CommandBar] Adding focus ring to input

### DIFF
--- a/src/components/command-bar/components/dialog/command-bar-dialog.module.css
+++ b/src/components/command-bar/components/dialog/command-bar-dialog.module.css
@@ -34,6 +34,10 @@
 }
 
 .input {
+	/* composition */
+	composes: g-focus-ring-from-box-shadow from global;
+
+	/* properties */
 	appearance: none;
 	background-color: transparent;
 	border-radius: 5px;


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambcommand-bar-input-focus-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202520168081556/1203052996378512/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds a focus state for the command bar text input

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Open the command bar
- [ ] The text input should be focused and look like the following screenshot:

![image](https://user-images.githubusercontent.com/43934258/192551295-17bb8e19-2e62-4025-ac1c-df802e283dc3.png)
