### PR TITLE
[Global Search] Fixing Tutorial Library suggested page link

### DIFF
--- a/src/components/command-bar/commands/search/helpers/generate-suggested-pages.tsx
+++ b/src/components/command-bar/commands/search/helpers/generate-suggested-pages.tsx
@@ -6,13 +6,12 @@ import { ProductSlug } from 'types/products'
 import { productSlugsToNames } from 'lib/products'
 import ProductIcon from 'components/product-icon'
 import { SuggestedPage } from '../components'
+import { generateTutorialLibraryCta } from './generate-tutorial-library-cta'
 
 const generateTutorialLibrarySuggestedPage = (productSlug?: ProductSlug) => {
-	// TODO abstract this, or leverage abstraction from tutorial library feature
-	let url = '/tutorials/library'
-	if (productSlug) {
-		url += `?product=${productSlug}`
-	}
+	const { href: url } = generateTutorialLibraryCta(
+		productSlug ? { id: productSlug, text: '' } : null
+	)
 
 	return {
 		icon: <IconGuide16 />,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambgs-tutorial-library-link-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202520168081556/1203053381984286/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the link for the Tutorial Library suggested page under the HCP product context

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Open the command bar
- [ ] Scroll to the bottom of the list
- [ ] The Tutorial Library list item's href should be `/tutorials/library`
- [ ] Go to a page under HCP
- [ ] Open the command bar
- [ ] Scroll to the bottom of the list
- [ ] The Tutorial Library list item's href should be `/tutorials/library?edition=hcp`
- [ ] Go to a page under Waypoint
- [ ] Open the command bar
- [ ] Scroll to the bottom of the list
- [ ] The Tutorial Library list item's href should be `/tutorials/library?product=waypoint`
