### PR TITLE
[Global Search] Fixing tabsWrapper padding

### DIFF
--- a/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
+++ b/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
@@ -1,8 +1,8 @@
 .tabsWrapper {
-	padding-bottom: 12px;
+	padding-bottom: 8px;
 	padding-left: 16px;
 	padding-right: 16px;
-	padding-top: 12px;
+	padding-top: 8px;
 }
 
 .suggestedPagesWrapper {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambgs-tabs-spacing-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202520168081556/1203053381984287/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates the spacing above the `Tabs` that show when a search query is typed in the command bar input

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=12357%3A141909&viewport=-11425%2C2763%2C2.06)

![image](https://user-images.githubusercontent.com/43934258/192573292-a323ab60-da92-4500-9665-9c2ad6a8503a.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Open the command bar
- [ ] Type anything in the search input
- [ ] Check that the spacing between the `Tabs` and the command bar dialog header is correct
