### PR TITLE
[CommandBar] Rendering missing icon badge in footer

### DIFF
--- a/src/components/command-bar/components/dialog/footer.tsx
+++ b/src/components/command-bar/components/dialog/footer.tsx
@@ -6,6 +6,7 @@ import Text from 'components/text'
 import { FORM_URL } from 'components/navigation-header/components/give-feedback-button'
 import StandaloneLink from 'components/standalone-link'
 import s from './command-bar-dialog.module.css'
+import { IconCornerDownLeft16 } from '@hashicorp/flight-icons/svg-react/corner-down-left-16'
 
 const CommandBarDialogFooter = () => {
 	return (
@@ -34,6 +35,13 @@ const CommandBarDialogFooter = () => {
 				<Text asElement="span" size={100} weight="regular">
 					to navigate,
 				</Text>
+				<Badge
+					ariaLabel="Enter key"
+					color="neutral"
+					icon={<IconCornerDownLeft16 />}
+					type="outlined"
+					size="small"
+				/>
 				<Text asElement="span" size={100} weight="regular">
 					to select,
 				</Text>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambgs-missing-return-key-badge-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202520168081556/1203053381984289/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds missing `Badge` for the enter key in the command bar dialog footer

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=12357%3A141909&viewport=-6265%2C2683%2C1.15)

![image](https://user-images.githubusercontent.com/43934258/192576061-e41509ff-09be-46d7-9ff3-abd9f82c1c52.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page
- [ ] Open the command bar
- [ ] The enter key `Badge` should no longer be missing from the footer
