### PR TITLE
`boundary/oss-vault-cred-brokering-quickstart`

### DIFF
--- a/src/content/boundary/install-landing.json
+++ b/src/content/boundary/install-landing.json
@@ -1,7 +1,7 @@
 {
 	"featuredTutorialsSlugs": [
 		"boundary/oidc-auth",
-		"boundary/vault-cred-brokering-quickstart",
+		"boundary/oss-vault-cred-brokering-quickstart",
 		"boundary/hcp-manage-workers",
 		"boundary/hcp-ssh-cred-injection",
 		"boundary/oidc-idp-groups",

--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -70,7 +70,7 @@
 			"type": "tutorial_cards",
 			"tutorialSlugs": [
 				"boundary/oidc-auth",
-				"boundary/vault-cred-brokering-quickstart",
+				"boundary/oss-vault-cred-brokering-quickstart",
 				"boundary/hcp-manage-workers",
 				"boundary/hcp-ssh-cred-injection",
 				"boundary/oss-manage-targets",

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -80,7 +80,7 @@ const TEST_MD_LINKS = {
 	betaProductDocsLinkUseCases:
 		'[link to vault use cases](https://www.vaultproject.io/use-cases)',
 	nonBetaProductLinkWithBetaProductInTitle:
-		'[boundary link with vault in tutorial title](/tutorials/boundary/vault-cred-brokering-quickstart)',
+		'[boundary link with vault in tutorial title](/tutorials/boundary/oss-vault-cred-brokering-quickstart)',
 	wafTutorialLink:
 		'[waf link](/tutorials/well-architected-framework/cloud-operating-model)',
 	onboardingCollectionLink:


### PR DESCRIPTION
# Description

This updates a collection slug, which was renamed in 
- https://github.com/hashicorp/tutorials/pull/791