### PR TITLE
[Badge] Use g-screen-reader-only class for ariaLabel

### DIFF
--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -3,9 +3,7 @@ import { BadgeProps } from './types'
 import s from './badge.module.css'
 
 const Badge = ({
-	ariaDescribedBy,
 	ariaLabel,
-	ariaLabelledBy,
 	className,
 	color = 'neutral',
 	icon,
@@ -16,7 +14,7 @@ const Badge = ({
 	const classes = classNames(s.root, s[size], s[`${type}-${color}`], className)
 	const hasIcon = !!icon
 	const hasText = !!text
-	const hasLabel = !!ariaDescribedBy || !!ariaLabel || !!ariaLabelledBy
+	const hasLabel = !!ariaLabel
 	const isIconOnly = hasIcon && !hasText
 	const isStatusBadge =
 		color == 'success' || color == 'warning' || color == 'error'
@@ -35,26 +33,18 @@ const Badge = ({
 
 	if (isIconOnly && !hasLabel) {
 		throw new Error(
-			'Icon-only `Badge`s require an accessible label. Either provide the `text` prop or one of: `ariaLabel`, `ariaLabelledBy`, `ariaDescribedBy`.'
-		)
-	}
-
-	if (ariaLabel && ariaLabelledBy) {
-		throw new Error(
-			'`Badge` does not accept both `ariaLabel` and `ariaLabelledBy`. Only provide one or the other.'
+			'Icon-only `Badge`s require an accessible label. Either provide the `text` or `ariaLabel` prop.'
 		)
 	}
 
 	return (
-		<span
-			aria-describedby={ariaDescribedBy}
-			aria-label={ariaLabel}
-			aria-labelledby={ariaLabelledBy}
-			className={classes}
-		>
-			{icon}
-			{text && <span>{text}</span>}
-		</span>
+		<>
+			<span className="g-screen-reader-only">{ariaLabel ?? text}</span>
+			<span aria-hidden className={classes}>
+				{icon}
+				{text && <span>{text}</span>}
+			</span>
+		</>
 	)
 }
 

--- a/src/components/badge/types.ts
+++ b/src/components/badge/types.ts
@@ -2,29 +2,11 @@ import { ReactElement } from 'react'
 
 export interface BadgeProps {
 	/**
-	 * The value of the `id` of the element that describes the badge. The
-	 * describing element does not have to be visible. If there are multiple
-	 * labeling elements, this can be be a comma-separated list of `id`s.
-	 *
-	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-describedby
-	 */
-	ariaDescribedBy?: string
-
-	/**
-	 * A non-visual label accessible and descriptive label for the badge.
+	 * A non-visual and descriptive accessible label for the badge.
 	 *
 	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-label
 	 */
 	ariaLabel?: string
-
-	/**
-	 * The value of the `id` of the element that labels the badge. The labeling
-	 * element does not have to be visible. If there are multiple labeling
-	 * elements, this can be be a comma-separated list of `id`s.
-	 *
-	 * See: https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby
-	 */
-	ariaLabelledBy?: string
 
 	/**
 	 * A string of one or more classnames. Is appended to list of classnames


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes two properties from our `Badge` component
  - `ariaDescribedBy`
  - `ariaLabelledBy`
- Adds a `g-screen-reader-only` `<span>` next to the regular `Badge` span that handles labelling `Badge` for screen reader users

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- `<span>` doesn't actually accept `aria-label`, so it's not presented to users
- before these changes, the elements were announced as "<aria label>, group"

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [the `Badge` Swingset page](https://dev-portal-git-ambbadge-aria-label-hashicorp.vercel.app/swingset/components/badge) on the preview
- [ ] In the Playground, add an `ariaLabel` on the `Badge`: "This is an aria label test"
- [ ] Turn on your device's screen reader
- [ ] Bring your focus to the Playground heading
- [ ] Navigate to the `Badge` with arrow keys (not `TAB`)
  - In VoiceOver, this is VO + Arrow Right
- [ ] The `Badge` should be presented as "This is an arial label test"

No-audio demonstration:

https://user-images.githubusercontent.com/43934258/193285422-26fd7309-1bd3-49aa-b4fc-0f15db53c28a.mov
