### PR TITLE
fix: rm font-weight shift from sidecar

### DIFF
--- a/src/layouts/sidebar-sidecar/components/table-of-contents/table-of-contents.module.css
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/table-of-contents.module.css
@@ -31,7 +31,6 @@
 .activeTableOfContentsListItem {
 	& a {
 		color: var(--token-color-palette-neutral-700);
-		font-weight: 500;
 	}
 }
 


### PR DESCRIPTION
Removes the `font-weight` shift for active items from the sidecar `TableOfContents`.

Intent here is prevent layout jank. Have confirmed using `400` as the consistent weight via Slack DM.

### Before

https://user-images.githubusercontent.com/4624598/193311975-7a3f43df-1629-4762-87c8-7368f6da8673.mp4

### After

https://user-images.githubusercontent.com/4624598/193311998-ca04630d-a4d7-49b6-a6b0-903d879d90a2.mp4

