### PR TITLE
Update home page with all certification exams

### DIFF
--- a/src/content/home-page.json
+++ b/src/content/home-page.json
@@ -17,17 +17,23 @@
 		}
 	},
 	"learnSection": {
-		"heading": "Become HashiCorp Vault Certified",
+		"heading": "Become HashiCorp Certified",
 		"description": [
-			"As a Cloud Engineer specializing in security, development, or operations, you can take the Vault Associate exam to validate your knowledge of the basic concepts, skills, and use cases associated with open source HashiCorp Vault. Or take the Vault Operations Professional exam to demonstrate your proficiency with deploying, configuring, managing, and monitoring HashiCorp Vault in production.",
-			"Upon passing either exam, you can easily communicate your proficiency and employers can quickly verify your results."
+			"As a Cloud Engineer specializing in infrastructure, security, development, networking, or operations, you can take HashiCorp Certification exams to validate your knowledge of the basic concepts, skills, and use cases associated with HashiCorp tools.",
+			"Take the Associate level exam for Terraform, Vault, or Consul to demonstrate your proficiency by answering multiple-choice questions. Or step up to the Vault Operations Professional exam to demonstrate your proficiency with deploying, configuring, managing, and monitoring HashiCorp Vault in production on live cloud compute.",
+			"Upon passing any exam, you can easily share your badge and employers can quickly verify your results online."
 		],
 		"imageSrc": "https://www.datocms-assets.com/2885/1655305480-vault-certified-expert-badge.svg",
 		"link": {
 			"url": "/vault/tutorials/associate-cert",
 			"text": "Start learning"
 		},
-		"collectionSlugs": ["vault/associate-cert", "vault/ops-pro-cert"]
+		"collectionSlugs": [
+			"terraform/certification",
+			"vault/associate-cert",
+			"vault/ops-pro-cert",
+			"consul/certification"
+		]
 	},
 	"preFooter": {
 		"heading": "Looking for help?",


### PR DESCRIPTION
Update title, copy, and cards with links to all four certification exams which are now published on DevDot.

## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-gghome-certifications-hashicorp.vercel.app/) 🔎

## 🗒️ What

Add all four certification exam cards to home page.

## 🤷 Why

Only Vault was present in June but now we have all content. Therefore, all exams can be listed on the home page.

## 🛠️ How

Update JSON.

## 📸 Design Screenshots

<img width="1365" alt="Screen Shot 2022-09-30 at 5 59 44 PM" src="https://user-images.githubusercontent.com/26/193376964-11e5d94c-546b-466f-826c-93eb6473ae23.png">

