### PR TITLE
fix: boundary stable-website deleted, fix ref

### DIFF
--- a/src/pages/_proxied-dot-io/boundary/api-docs/[[...page]].jsx
+++ b/src/pages/_proxied-dot-io/boundary/api-docs/[[...page]].jsx
@@ -18,7 +18,7 @@ const targetFile = {
 	owner: 'hashicorp',
 	repo: 'boundary',
 	path: 'internal/gen/controller.swagger.json',
-	ref: 'stable-website',
+	ref: 'main',
 }
 // The path to read from when running local preview in the context of the boundary repository
 const targetLocalFile = '../../internal/gen/controller.swagger.json'

--- a/src/pages/boundary/api-docs/[[...page]].tsx
+++ b/src/pages/boundary/api-docs/[[...page]].tsx
@@ -22,7 +22,7 @@ const targetFile = {
 	owner: 'hashicorp',
 	repo: 'boundary',
 	path: 'internal/gen/controller.swagger.json',
-	ref: 'stable-website',
+	ref: 'main',
 }
 // The path to read from when running local preview in the context of the boundary repository
 const targetLocalFile = '../../internal/gen/controller.swagger.json'


### PR DESCRIPTION
🚨 EDIT: nvm `stable-website` was not intentionally deleted 👍 

## 🗒️ What

Fixes an issue where `dev-dot` builds fail because the `stable-website` ref no longer exists in `hashicorp/boundary`.

Updates to use `main` instead - this means the following pages will pull API docs from `main`:
- https://www.boundaryproject.io/api-docs
- https://developer.hashicorp.com/boundary/api-docs