### PR TITLE
[Safari bug] Fixing height of MdxHeadingPermalink

### DIFF
--- a/src/components/dev-dot-content/mdx-components/mdx-heading-permalink/mdx-heading-permalink.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-heading-permalink/mdx-heading-permalink.module.css
@@ -1,11 +1,11 @@
 .root {
 	composes: g-focus-ring-from-box-shadow from global;
-	opacity: 0;
 	border-radius: 6px;
-	padding: 4px;
-	height: fit-content;
+	display: flex;
 	float: right;
 	margin-left: 8px;
+	opacity: 0;
+	padding: 4px;
 
 	@media (prefers-reduced-motion: no-preference) {
 		transition: opacity 0.2s ease;


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Fixes the height of `MdxHeadingPermalink`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

In Safari, the component was rendering too tall and affecting the text below it.

![image](https://user-images.githubusercontent.com/43934258/193881576-1d95d925-48e1-474e-a973-7c5e03492e92.png)

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

`display: flex` 😊

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Open Safari
- [ ] Go to https://dev-portal-git-ambfix-permalink-on-safari-hashicorp.vercel.app/consul/docs/lambda/invoke-from-lambda#introduction
- [ ] Make sure the height of the component is as expected and no longer affecting text below it
