### PR TITLE
fix: progress bar posn on short tutorials

### DIFF
--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -100,6 +100,7 @@ for further details.
 .mainAreaWrapper {
 	display: flex;
 	justify-content: center;
+	min-height: calc(100vh - var(--navigation-header-height));
 	padding-left: var(--main-area-padding-left);
 	padding-right: var(--main-area-padding-right);
 	padding-top: var(--main-area-padding-top);


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes a bug in progress bar positioning.

## 🛠️ How

Sets `min-height` on `SidebarSidecar` layout main area, to ensure content always occupies the area leading up to the footer.

## 🧪 Testing

- [ ] Visit a tutorial view as an unauthenticated visitor
    - Any `SidebarSidecar` layout should still behave as expected. Short pages should look identical
- [ ] Visit a tutorial view as an authenticated visitor
    - On short tutorials, such as [/consul/tutorials/getting-started/get-started-learn-more][/consul/tutorials/getting-started/get-started-learn-more], the progress bar should always be at the bottom of the page

[preview]: https://dev-portal-git-zsfix-short-tutorial-progress-b-7081a6-hashicorp.vercel.app/consul/tutorials/getting-started/get-started-learn-more
[task]: https://app.asana.com/0/1202702246158644/1203102626996732/f
[/consul/tutorials/getting-started/get-started-learn-more]: https://dev-portal-git-zsfix-short-tutorial-progress-b-7081a6-hashicorp.vercel.app/consul/tutorials/getting-started/get-started-learn-more