### PR TITLE
fix(boundary): Broken renamed collection

### DIFF
--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -41,7 +41,7 @@
 				{
 					"heading": "Identity-based Access",
 					"body": "Enable privileged sessions for users and applications based on user identity and role.",
-					"url": "/boundary/tutorials/oss-access-management/oidc-auth"
+					"url": "/boundary/tutorials/access-management/oidc-auth"
 				},
 				{
 					"heading": "Service Discovery",


### PR DESCRIPTION
# Description

This fixes a broken card link, caused by a collection-rename
- https://github.com/hashicorp/tutorials/commit/c9afc6c705ac5a59456b90931bd2d2332c6dc0c7#diff-704f3a51444e5f1ed6037cd1092a864210b3d8c84e6a20ee16e4b038d69d4893