### PR TITLE
[Tabs] Moving overflowTargetRef placement

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -68,13 +68,14 @@ const Tabs = ({
 
 	return (
 		<TabNestingProvider>
-			<div ref={overflowTargetRef}>
+			<div>
 				<div
 					className={classNames(s.tabControls, s[`variant--${variant}`], {
 						[s.isCheckingOverflow]: hasOverflow === null,
 						[s.showAnchorLine]: showAnchorLine,
 						[s.allowNestedStyles]: allowNestedStyles,
 					})}
+					ref={overflowTargetRef}
 				>
 					<TabControls
 						activeTabIndex={activeTabIndex}

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -80,7 +80,8 @@ for further details.
 	width: 100%;
 
 	@media (--dev-dot-hide-mobile-menu) {
-		max-width: calc(100vw - var(--dev-dot-sidebar-width));
+		/* 100vw - 100% is the scrollbar width */
+		max-width: calc(100vw - (100vw - 100%) - var(--dev-dot-sidebar-width));
 	}
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-tabs-controls-rendering-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203100487715425/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Moves the `overflowTargetRef ` from the `div` that contains both tab controls and panels to the `div` containing the tab controls.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Overflow was being detected due to the content of a tab panel, but we really only care about overflow in the element where the controls live.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/consul/downloads](https://dev-portal-git-ambfix-tabs-controls-rendering-hashicorp.vercel.app/consul/downloads)
- [ ] Set your viewport width to `1280px` (`1px` before the sidecar goes away)
- [ ] Click the "Linux" tab
- [ ] The `Tabs` should not turn into a `select`
