### PR TITLE
[addNavItemMetaData] Replace <sup> tags with Badges

### DIFF
--- a/src/components/sidebar/docs.mdx
+++ b/src/components/sidebar/docs.mdx
@@ -123,3 +123,41 @@ At the current time of writing, only the "highlight" and "neutral" [`Badge`](/sw
 		]}
 	/>
 </div>
+
+## Sidebar with `<sup>` tags in `title`
+
+At the current time of writing, only the "highlight" and "neutral" [`Badge`](/swingset/components/badge) colors are supported. This is because other `Badge` colors are for used for indicating a status, and so they must also have an icon. See [Understanding Success Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) for further reading on the topic. Supporting icons in Sidebar Badges has not been designed at this time.
+
+<div style={{ border: '1px solid black', maxWidth: 320, padding: 24 }}>
+	<Sidebar
+		menuItems={[
+			{
+				title: 'Internal link item with a "highlight" Badge <sup>Badge</sup>',
+				href: '/',
+			},
+			{
+				title: 'External link item with a Badge <sup>Badge</sup>',
+				href: 'https://hashicorp.com',
+			},
+			{ divider: true },
+			{ heading: 'Test Heading' },
+			{
+				title: 'Submenu item with a Badge <sup>Badge</sup>',
+				routes: [
+					{
+						title: 'Child item 1',
+						href: '/',
+					},
+					{
+						title: 'Child item 2',
+						href: '/',
+					},
+					{
+						title: 'Child item 3',
+						href: '/',
+					},
+				],
+			},
+		]}
+	/>
+</div>

--- a/src/components/sidebar/docs.mdx
+++ b/src/components/sidebar/docs.mdx
@@ -126,7 +126,7 @@ At the current time of writing, only the "highlight" and "neutral" [`Badge`](/sw
 
 ## Sidebar with `<sup>` tags in `title`
 
-At the current time of writing, only the "highlight" and "neutral" [`Badge`](/swingset/components/badge) colors are supported. This is because other `Badge` colors are for used for indicating a status, and so they must also have an icon. See [Understanding Success Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) for further reading on the topic. Supporting icons in Sidebar Badges has not been designed at this time.
+At the current time of writing, only the "highlight" and "neutral" [`Badge`](/swingset/components/badge) colors are supported. This is because other `Badge` colors are used for indicating a status, and so they must also have an icon. See [Understanding Success Criterion 1.4.1: Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) for further reading on the topic. Supporting icons in Sidebar Badges has not been designed at this time.
 
 <div style={{ border: '1px solid black', maxWidth: 320, padding: 24 }}>
 	<Sidebar

--- a/src/components/sidebar/helpers/add-nav-item-meta-data.ts
+++ b/src/components/sidebar/helpers/add-nav-item-meta-data.ts
@@ -15,6 +15,18 @@ interface AddNavItemMetaDataResult {
 /**
  * Returns an object for rendering a Badge in a sidebar item if a <sup> tag is
  * found in its title.
+ *
+ * Examples:
+ *
+ * getBadgeFromTitle("Audit Log Streaming <sup>BETA</sup>") returns:
+ *   {
+ *     text: "BETA",
+ *     color: "neutral",
+ *     type: "outlined",
+ *   }
+ *
+ * getBadgeFromTitle("Audit Log Streaming") returns:
+ *   null
  */
 const getBadgeFromTitle = (title: string) => {
 	let badge = null
@@ -62,6 +74,9 @@ export const addNavItemMetaData = (
 			/**
 			 * If a `badge` object can be determined from a `title` with `<sup>`,
 			 * create the `badge` object and remove the `<sup>` tags from the title.
+			 *
+			 * This should be in place until all nav data content (including past
+			 * versions) no longer contains `<sup>` tags in `title`s.
 			 */
 			if (item.hasOwnProperty('title')) {
 				const itemWithTitle = item as

--- a/src/components/sidebar/helpers/add-nav-item-meta-data.ts
+++ b/src/components/sidebar/helpers/add-nav-item-meta-data.ts
@@ -14,7 +14,7 @@ interface AddNavItemMetaDataResult {
 
 /**
  * Returns an object for rendering a Badge in a sidebar item if a <sup> tag is
- * founnd in its title.
+ * found in its title.
  */
 const getBadgeFromTitle = (title: string) => {
 	let badge = null

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -20,6 +20,7 @@ interface HeadingNavItem {
 }
 
 interface BaseNavItem {
+	badge?: SidebarNavMenuItemBadgeProps
 	hidden?: boolean
 	title: string
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambreplace-sups-with-badge-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203115842976140/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Creates `badge` properties for nav items that hav `<sup>` tags in their `titles`
- Removes the `<sup>` tags from the nav item titles if they're present

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- When the `dev-portal` branches were present, we handled this manually in the JSON files. Since we don't have those branches anymore, and some of the manual changes had to be undone, the changes proposed in this PR enable either the old or new format to work.
- This should also enable the new format that renders `Badge`s to work in old versions of docs.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Make sure the sidebars render as expected on these pages:

- [ ] [/vault/docs](https://dev-portal-git-ambreplace-sups-with-badge-hashicorp.vercel.app/vault/docs)
- [ ] [/waypoint/docs](https://dev-portal-git-ambreplace-sups-with-badge-hashicorp.vercel.app/waypoint/docs)
- [ ] [/hcp/docs](https://dev-portal-git-ambreplace-sups-with-badge-hashicorp.vercel.app/hcp/docs)
