### PR TITLE
fix(terraform): downloads

### DIFF
--- a/src/pages/terraform/downloads/index.tsx
+++ b/src/pages/terraform/downloads/index.tsx
@@ -76,6 +76,12 @@ const getStaticProps: GetStaticProps = async () => {
 	const filteredVersions = filterVersions(rawVersions, VERSION_DOWNLOAD_CUTOFF)
 	generatedProps.props.releases.versions = filteredVersions
 
+	// @ts-expect-error - sortedAndFilteredVersions is present on generatedProps.props
+	//
+	// leverage the same TF-specific version filtering behavior on `.releases.versions`
+	generatedProps.props.sortedAndFilteredVersions =
+		Object.values(filteredVersions)
+
 	return generatedProps
 }
 


### PR DESCRIPTION
# Description

We do some custom filtering on Terraform downloads filtering. This ensures that two different server-side values are in-sync with each other

https://dev-portal-git-kevin-fix-tf-downloads-hashicorp.vercel.app/terraform/downloads