### PR TITLE
feat: disable-datadog-rum-session-replay

### DIFF
--- a/src/lib/datadog/index.tsx
+++ b/src/lib/datadog/index.tsx
@@ -29,7 +29,7 @@ const datadogScriptBody = `(function(h,o,u,n,d) {
      ${COMMIT_SHA ? `version: '${COMMIT_SHA}',` : ''}
      sampleRate: 100,
      premiumSampleRate: 0,
-		 sessionReplaySampleRate: 0,
+     sessionReplaySampleRate: 0,
      trackInteractions: true,
      defaultPrivacyLevel: 'mask-user-input'
    })

--- a/src/lib/datadog/index.tsx
+++ b/src/lib/datadog/index.tsx
@@ -29,6 +29,7 @@ const datadogScriptBody = `(function(h,o,u,n,d) {
      ${COMMIT_SHA ? `version: '${COMMIT_SHA}',` : ''}
      sampleRate: 100,
      premiumSampleRate: 0,
+		 sessionReplaySampleRate: 0,
      trackInteractions: true,
      defaultPrivacyLevel: 'mask-user-input'
    })

--- a/src/lib/datadog/index.tsx
+++ b/src/lib/datadog/index.tsx
@@ -28,11 +28,10 @@ const datadogScriptBody = `(function(h,o,u,n,d) {
      env: '${ENV}', 
      ${COMMIT_SHA ? `version: '${COMMIT_SHA}',` : ''}
      sampleRate: 100,
-     premiumSampleRate: 100,
+     premiumSampleRate: 0,
      trackInteractions: true,
      defaultPrivacyLevel: 'mask-user-input'
    })
-   DD_RUM.startSessionReplayRecording()
  })`
 
 function DatadogHeadTag() {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Disables DataDog Session Replay recording on the site.

## 🛠️ How

Makes changes to the DataDog script body:
- changes `premiumSampleRate: 100` to `premiumSampleRate: 0`
- deletes the `DD_RUM.startSessionReplayRecording()` call

## 🧪 Testing

- [ ] Open the DataDog RUM Dashboard for the "non-prod" application
    - Datadog → UX Monitoring in sidebar → Sessions → Filter by `Version` for this preview's commit SHA (`2fc019601ff56c0b34a620a7aff18439dac870df` at time of writing)
- [ ] Visit the [preview][preview]
- [ ] Your session should show up in DataDog, _but_ the `Session Replay` button should be disabled, as shown in the screenshot below

## 📸 Screenshot

<img width="1439" alt="2022-10-06-datadog" src="https://user-images.githubusercontent.com/4624598/194434109-26e5702c-f24b-4d9a-97af-3859e1cc3afd.png">

[preview]: https://dev-portal-git-zsdisable-datadog-rum-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1202097197789424/1203111074373616/f