### PR TITLE
feat: add Tutorial Library to resources section

### DIFF
--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -50,6 +50,36 @@ const generateAdditionalResources = (productSlug?: ProductSlug) => {
 }
 
 /**
+ * Given a product slug,
+ * Return a link to the Tutorials Library with filters applied
+ * that correspond to that product.
+ */
+function getTutorialLibraryUrl(productSlug?: ProductSlug) {
+	const baseUrl = '/tutorials/library'
+	if (!productSlug) {
+		return baseUrl
+	}
+	const products = [
+		'boundary',
+		'consul',
+		'nomad',
+		'packer',
+		'terraform',
+		'vagrant',
+		'vault',
+		'waypoint',
+	]
+	const editions = ['hcp']
+	if (products.includes(productSlug)) {
+		return `${baseUrl}/?product=${productSlug}`
+	} else if (editions.includes(productSlug)) {
+		return `${baseUrl}/?edition=${productSlug}`
+	} else {
+		return baseUrl
+	}
+}
+
+/**
  * Generates the sidebar nav items for the Resources section of the sidebar.
  * Optionally accepts a Product slug for customization of links.
  */
@@ -58,6 +88,10 @@ const generateResourcesNavItems = (productSlug?: ProductSlug) => {
 
 	return [
 		{ heading: 'Resources' },
+		{
+			title: 'Tutorial Library',
+			href: getTutorialLibraryUrl(productSlug),
+		},
 		{
 			title: 'Community Forum',
 			href: productSlug

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -1,4 +1,9 @@
 import { ProductSlug } from 'types/products'
+import {
+	EDITIONS,
+	VALID_EDITION_SLUGS_FOR_FILTERING,
+	VALID_PRODUCT_SLUGS_FOR_FILTERING,
+} from 'views/tutorial-library/constants'
 
 const DEFAULT_COMMUNITY_FORUM_LINK = 'https://discuss.hashicorp.com/'
 const DEFAULT_GITHUB_LINK = 'https://github.com/hashicorp'
@@ -59,20 +64,9 @@ function getTutorialLibraryUrl(productSlug?: ProductSlug) {
 	if (!productSlug) {
 		return baseUrl
 	}
-	const products = [
-		'boundary',
-		'consul',
-		'nomad',
-		'packer',
-		'terraform',
-		'vagrant',
-		'vault',
-		'waypoint',
-	]
-	const editions = ['hcp']
-	if (products.includes(productSlug)) {
+	if (VALID_PRODUCT_SLUGS_FOR_FILTERING.includes(productSlug)) {
 		return `${baseUrl}/?product=${productSlug}`
-	} else if (editions.includes(productSlug)) {
+	} else if (VALID_EDITION_SLUGS_FOR_FILTERING.includes(productSlug)) {
 		return `${baseUrl}/?edition=${productSlug}`
 	} else {
 		return baseUrl

--- a/src/views/tutorial-library/constants.ts
+++ b/src/views/tutorial-library/constants.ts
@@ -32,6 +32,13 @@ export const EDITIONS = [
 ]
 
 /**
+ * Valid edition slugs for filtering tutorials by.
+ */
+export const VALID_EDITION_SLUGS_FOR_FILTERING = EDITIONS.map(
+	(edition) => edition.value
+)
+
+/**
  * Valid product slugs for filtering tutorials by. Currently, excludes hcp and sentinel and
  * only has our core products.
  */


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds a `Tutorial Library` link to the `Resources` section of all sidebars.

## 🤷 Why

To increase discoverability of [/tutorials/library][/tutorials/library]

## 🛠️ How

- Adds a function `getTutorialLibraryUrl`, that returns links to `/tutorials/library` with specific filters applied based on the current "product" (which may actually be a non-`product` filter in the context of tutorials, eg `hcp` is really an `edition` filter)
- Adds a `Tutorial Library` link to the generated sidebar resource links, using `getTutorialLibraryUrl` for the URL

## 📸 Design Screenshots

### Before

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/4624598/194618782-9ac46ba6-9aac-488b-9c7d-7b7a81cfd895.png">

### After

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/4624598/194618807-563affd8-2a33-4deb-b42a-cf4a14edd14c.png">

## 🧪 Testing

- [ ] Visit the HCP product view, [/hcp][/hcp]
    - A `Tutorial Library` link should appear at the top of the `Resources` section in the sidebar
    - The link should lead to [/tutorials/library?edition=hcp][/tutorials/library?edition=hcp]
- [ ] Visit a product view, such as [/terraform][/terraform]
    - A `Tutorial Library` link should appear at the top of the `Resources` section in the sidebar
    - The link should lead to `/tutorials/library?product=<productSlug>`, i.e. for `terraform` it should link to [/tutorials/library?product=terraform][/tutorials/library?product=terraform]
- [ ] Visit a view with no associated product, such as [/onboarding/hcp-vault-week-2/hcp-vault-w2-welcome][/onboarding/hcp-vault-week-2/hcp-vault-w2-welcome]
    - A `Tutorial Library` link should appear at the top of the `Resources` section in the sidebar
    - The link should lead to [/tutorials/library][/tutorials/library]

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app
[task]: https://app.asana.com/0/1202097197789424/1203120359235764/f
[/hcp]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/hcp
[/tutorials/library?edition=hcp]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/tutorials/library?edition=hcp
[/terraform]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/terraform
[/onboarding/hcp-vault-week-2/hcp-vault-w2-welcome]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/onboarding/hcp-vault-week-2/hcp-vault-w2-welcome
[/tutorials/library]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/tutorials/library
[/tutorials/library?product=terraform]: https://dev-portal-git-zsadd-tutorial-library-to-sidebar-hashicorp.vercel.app/tutorials/library?product=terraform