### PR TITLE
Fixing line-height of CardTitle

### DIFF
--- a/src/components/card/components/card-title/card-title.module.css
+++ b/src/components/card/components/card-title/card-title.module.css
@@ -5,4 +5,5 @@
 
 	/* properties */
 	color: var(--token-color-foreground-strong);
+	display: block;
 }


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the `line-height` of `CardTitle`s that go multiple lines

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- `display: block` 😎 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/tutorials/library?product=waypoint](https://dev-portal-git-ambfix-card-title-line-height-hashicorp.vercel.app/tutorials/library?product=waypoint)
- [ ] Make sure the `CardTitle`s are the correct height according to designs
