### PR TITLE
Adding displayName to Contexts for devtools debugging

### DIFF
--- a/src/components/accordion-disclosure/accordion-disclosure-context.ts
+++ b/src/components/accordion-disclosure/accordion-disclosure-context.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 
 export const AccordionDisclosureContext = createContext<boolean>(false)
+AccordionDisclosureContext.displayName = 'AccordionDisclosureContext'
 
 /**
  * should return `true` if being called by a consumer that

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -82,6 +82,7 @@ const commandBarReducer = (
 }
 
 const CommandBarContext = createContext<CommandBarContextValue>(undefined)
+CommandBarContext.displayName = 'CommandBarContext'
 
 const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	const inputRef = useRef<HTMLInputElement>()

--- a/src/components/disclosure/index.tsx
+++ b/src/components/disclosure/index.tsx
@@ -26,6 +26,7 @@ import s from './disclosure.module.css'
  * not intended for use outside of this file.
  */
 const DisclosureContext = createContext<DisclosureContextState>(undefined)
+DisclosureContext.displayName = 'DisclosureContext'
 
 /**
  * A hook for exposing a `Disclosure`s state. Intended for use within the

--- a/src/components/feedback-form/index.tsx
+++ b/src/components/feedback-form/index.tsx
@@ -19,6 +19,7 @@ const wait = (delay: number) =>
 	new Promise((resolve) => setTimeout(resolve, delay))
 
 export const FeedbackFormContext = createContext<FeedbackFormContextType>({})
+FeedbackFormContext.displayName = 'FeedbackFormContext'
 
 export default function FeedbackForm({
 	questions,

--- a/src/components/tabs/helpers/tab-nesting-context.tsx
+++ b/src/components/tabs/helpers/tab-nesting-context.tsx
@@ -7,6 +7,7 @@ export function useIsNested(): NestedTabContextValue {
 }
 
 const NestedTabContext = createContext<NestedTabContextValue>(false)
+NestedTabContext.displayName = 'NestedTabContext'
 
 /**
  * This provider allows <Tabs /> to be aware of nesting. Specifically,

--- a/src/components/tabs/provider.tsx
+++ b/src/components/tabs/provider.tsx
@@ -18,6 +18,7 @@ export function useTabGroups(): TabContextValue {
 }
 
 const TabContext = createContext(undefined)
+TabContext.displayName = 'TabContext'
 
 export default function TabProvider({ children }: { children: ReactNode }) {
 	const [activeTabGroup, setActiveTabGroup] = useState<string>()

--- a/src/contexts/current-content-type.tsx
+++ b/src/contexts/current-content-type.tsx
@@ -3,6 +3,7 @@ import { createContext, ReactNode, useContext } from 'react'
 type CurrentContentType = 'global' | 'docs' | 'tutorials'
 
 const CurrentContentTypeContext = createContext<CurrentContentType>(undefined)
+CurrentContentTypeContext.displayName = 'CurrentContentTypeContext'
 
 interface CurrentContentTypeProviderProps {
 	children: ReactNode

--- a/src/contexts/current-product.tsx
+++ b/src/contexts/current-product.tsx
@@ -7,6 +7,7 @@ export type RouteChangeStartHandler = (url: string) => void
 type CurrentProduct = ProductData | undefined
 
 const CurrentProductContext = createContext<CurrentProduct>(undefined)
+CurrentProductContext.displayName = 'CurrentProductContext'
 
 interface CurrentProductProviderProps {
 	children: ReactNode

--- a/src/contexts/device-size.tsx
+++ b/src/contexts/device-size.tsx
@@ -11,6 +11,7 @@ interface DeviceSize {
 }
 
 const DeviceSizeContext = createContext<DeviceSize>(undefined)
+DeviceSizeContext.displayName = 'DeviceSizeContext'
 
 const DeviceSizeProvider: React.FC = ({ children }) => {
 	let mobileWidth: number

--- a/src/contexts/instruqt-lab/index.tsx
+++ b/src/contexts/instruqt-lab/index.tsx
@@ -23,6 +23,7 @@ interface InstruqtProviderProps {
 }
 
 const InstruqtContext = createContext<Partial<InstruqtContextProps>>({})
+InstruqtContext.displayName = 'InstruqtContext'
 
 export const useInstruqtEmbed = (): Partial<InstruqtContextProps> =>
 	useContext(InstruqtContext)

--- a/src/contexts/mobile-menu.tsx
+++ b/src/contexts/mobile-menu.tsx
@@ -29,6 +29,7 @@ interface MobileMenuProviderProps {
 const MobileMenuContext = createContext<MobileMenuContextState | undefined>(
 	undefined
 )
+MobileMenuContext.displayName = 'MobileMenuContext'
 
 /**
  * Provider for managing open/closed state of the mobile menu.

--- a/src/layouts/sidebar-sidecar/contexts/sidebar-nav-data.tsx
+++ b/src/layouts/sidebar-sidecar/contexts/sidebar-nav-data.tsx
@@ -22,6 +22,7 @@ interface State {
 }
 
 const SidebarNavDataContext = createContext<State | undefined>(undefined)
+SidebarNavDataContext.displayName = 'SidebarNavDataContext'
 
 interface SidebarNavDataProviderProps {
 	children: ReactNode

--- a/src/views/product-downloads-view/contexts/current-version-context.tsx
+++ b/src/views/product-downloads-view/contexts/current-version-context.tsx
@@ -18,6 +18,7 @@ interface CurrentVersion {
 const CurrentVersionContext = createContext<CurrentVersion | undefined>(
 	undefined
 )
+CurrentVersionContext.displayName = 'CurrentVersionContext'
 
 /**
  * Stores the currently selected version in the `ProductDownloadsView`, derives


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Sets the `displayName` property for all of our `Context`s.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

It's helpful when debugging with React devtools: https://reactjs.org/docs/context.html#contextdisplayname.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview url
- [ ] Open the React devtools
- [ ] Make sure `Context`s have the right display name
  - Note: some `Context`s do not have a display name because they are rendered by third-party code 
