### PR TITLE
fix(breadcrumb-bar): Structured Data

### DIFF
--- a/src/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
+++ b/src/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
@@ -1,0 +1,76 @@
+import BreadcrumbBar from '../index'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+// Mock next/head so that we can see its children
+jest.mock('next/head', () => {
+	return {
+		__esModule: true,
+		default: ({ children }: React.PropsWithChildren<any>) => {
+			return <div>{children}</div>
+		},
+	}
+})
+
+describe('BreadcrumbBar', () => {
+	it('should render structured data with only items that have a url', () => {
+		const { container } = render(
+			<BreadcrumbBar
+				links={[
+					{ title: 'Developer', url: '/' },
+					{ title: 'Consul', url: '/consul' },
+					{ title: 'Documentation', url: '/consul/docs', isCurrentPage: false },
+					{ title: 'Dynamic App Configuration' },
+					{
+						isCurrentPage: true,
+						title: 'Sessions',
+						url: '/consul/docs/dynamic-app-config/sessions',
+					},
+				]}
+			/>
+		)
+
+		const structuredDataScript = container.querySelector(
+			'script[type="application/ld+json"]'
+		)
+		expect(structuredDataScript).toBeInTheDocument()
+		const structuredData = JSON.parse(structuredDataScript.textContent)
+
+		expect(structuredData[0].itemListElement).toHaveLength(4)
+
+		expect(structuredData).toMatchInlineSnapshot(`
+		Array [
+		  Object {
+		    "@context": "https://schema.org",
+		    "@type": "BreadcrumbList",
+		    "itemListElement": Array [
+		      Object {
+		        "@type": "ListItem",
+		        "item": "https://developer.hashicorp.com/",
+		        "name": "Developer",
+		        "position": 1,
+		      },
+		      Object {
+		        "@type": "ListItem",
+		        "item": "https://developer.hashicorp.com/consul",
+		        "name": "Consul",
+		        "position": 2,
+		      },
+		      Object {
+		        "@type": "ListItem",
+		        "item": "https://developer.hashicorp.com/consul/docs",
+		        "name": "Documentation",
+		        "position": 3,
+		      },
+		      Object {
+		        "@type": "ListItem",
+		        "item": "https://developer.hashicorp.com/consul/docs/dynamic-app-config/sessions",
+		        "name": "Sessions",
+		        "position": 4,
+		      },
+		    ],
+		  },
+		]
+	`)
+	})
+})

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -36,18 +36,21 @@ function BreadcrumbBar({
 	// Now that we're sure all links are relative,
 	// we can render the breadcrumb links
 
+	// For google/SEO we'll omit any structured data items
+	// without a URL.
 	const structuredData = [
 		{
 			'@context': 'https://schema.org',
 			'@type': 'BreadcrumbList',
-			itemListElement: links.map((link, index) => ({
-				'@type': 'ListItem',
-				position: index + 1,
-				name: link.title,
-				item: link.url
-					? `https://developer.hashicorp.com${link.url}`
-					: undefined,
-			})),
+			itemListElement: links
+				// remove items without a url
+				.filter((e) => !!e.url)
+				.map((link, index) => ({
+					'@type': 'ListItem',
+					position: index + 1,
+					name: link.title,
+					item: `https://developer.hashicorp.com${link.url}`,
+				})),
 		},
 	]
 	const stringifiedStructuredData = JSON.stringify(structuredData)

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -19,6 +19,7 @@ function BreadcrumbBar({
 }: {
 	links: BreadcrumbLink[]
 }): React.ReactElement {
+	console.log('links', links)
 	// For now, we want to strictly require that all
 	// breadcrumb link URLs, if present, are relative rather
 	// than absolute links

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -19,7 +19,6 @@ function BreadcrumbBar({
 }: {
 	links: BreadcrumbLink[]
 }): React.ReactElement {
-	console.log('links', links)
 	// For now, we want to strictly require that all
 	// breadcrumb link URLs, if present, are relative rather
 	// than absolute links


### PR DESCRIPTION
## 🗒️ What

This removes items with no URL from our breadcrumbs' structure data, but retains the UI element.

## 🧪 Testing

- [Test result](https://search.google.com/test/rich-results/result/r%2Fbreadcrumbs?id=qwE8BAr1FVZJMwQvqwpPhA)

