### PR TITLE
feat: rm nomad from beta slugs

### DIFF
--- a/build-libs/__tests__/build-beta-opt-in-redirect.test.ts
+++ b/build-libs/__tests__/build-beta-opt-in-redirect.test.ts
@@ -21,22 +21,6 @@ describe('buildBetaOptInRedirect', () => {
 		    "source": "/:base(docs|api-docs|downloads)/:path*",
 		  },
 		  Object {
-		    "destination": "https://developer.hashicorp.com/nomad/:base/:path*",
-		    "has": Array [
-		      Object {
-		        "key": "nomad-io-beta-opt-in",
-		        "type": "cookie",
-		        "value": "true",
-		      },
-		      Object {
-		        "type": "host",
-		        "value": "(www\\\\.nomadproject\\\\.io|test-nm\\\\.hashi-mktg\\\\.com)",
-		      },
-		    ],
-		    "permanent": false,
-		    "source": "/:base(docs|api-docs|plugins|tools|intro|downloads)/:path*",
-		  },
-		  Object {
 		    "destination": "https://developer.hashicorp.com/packer/:base/:path*",
 		    "has": Array [
 		      Object {

--- a/config/base.json
+++ b/config/base.json
@@ -25,7 +25,6 @@
 		"beta_product_slugs": [
 			"boundary",
 			"hcp",
-			"nomad",
 			"packer",
 			"terraform",
 			"vagrant",

--- a/config/production.json
+++ b/config/production.json
@@ -7,7 +7,6 @@
 		"beta_product_slugs": [
 			"boundary",
 			"hcp",
-			"nomad",
 			"packer",
 			"terraform",
 			"vagrant",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

This PR removes `"nomad"` from `beta_product_slugs`, as part of launching Nomad into GA. 

[task]: https://app.asana.com/0/0/1203168563666033/f
[preview]: https://dev-portal-git-zsrm-nomad-from-beta-hashicorp.vercel.app