### PR TITLE
chore: update Nomad subnav links post-dev-dot-GA

### DIFF
--- a/src/components/_proxied-dot-io/nomad/subnav/index.jsx
+++ b/src/components/_proxied-dot-io/nomad/subnav/index.jsx
@@ -20,7 +20,11 @@ export default function NomadSubnav({ menuItems }) {
 			}}
 			ctaLinks={[
 				{ text: 'GitHub', url: 'https://www.github.com/hashicorp/nomad' },
-				{ text: 'Download', url: '/downloads', theme: { brand: 'nomad' } },
+				{
+					text: 'Download',
+					url: 'https://developer.hashicorp.com/nomad/downloads',
+					theme: { brand: 'nomad' },
+				},
 			]}
 			currentPath={currentPath}
 			menuItemsAlign="right"

--- a/src/constants/hostname-map.ts
+++ b/src/constants/hostname-map.ts
@@ -27,7 +27,7 @@ export const HOSTNAME_MAP = {
 export const SLUG_TO_HOSTNAME_MAP = {
 	boundary: 'www.boundaryproject.io',
 	consul: 'www.consul.io',
-	nomad: 'wwww.nomadproject.io',
+	nomad: 'www.nomadproject.io',
 	packer: 'www.packer.io',
 	sentinel: 'docs.hashicorp.com',
 	vagrant: 'www.vagrantup.com',

--- a/src/layouts/_proxied-dot-io/nomad/index.tsx
+++ b/src/layouts/_proxied-dot-io/nomad/index.tsx
@@ -87,22 +87,22 @@ function NomadIoLayout({ children, data }: Props): React.ReactElement {
 							},
 							{
 								text: 'Docs',
-								url: '/docs',
+								url: 'https://developer.hashicorp.com/nomad/docs',
 								type: 'inbound',
 							},
 							{
 								text: 'API',
-								url: '/api-docs',
+								url: 'https://developer.hashicorp.com/nomad/api-docs',
 								type: 'inbound',
 							},
 							{
 								text: 'Plugins',
-								url: '/plugins',
+								url: 'https://developer.hashicorp.com/nomad/plugins',
 								type: 'inbound',
 							},
 							{
 								text: 'Tools',
-								url: '/tools',
+								url: 'https://developer.hashicorp.com/nomad/tools',
 								type: 'inbound',
 							},
 							{


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates Nomad subnav items that redirect to <https://developer.hashicorp.com>, to use direct URLs rather than URLs that we know will be redirected.

## 🧪 Testing

- [ ] Visit the preview, and switch to Nomad mode
- [ ] Clicking `Docs`, `API`, `Plugins`, and `Tools` in the top nav of the <https://nomadproject.io> preview should lead to <https://developer.hashicorp.com> Nomad docs categories

[task]: https://app.asana.com/0/0/1203168563666038/f
[preview]: https://dev-portal-git-zspost-nomad-ga-subnav-links-hashicorp.vercel.app