### PR TITLE
chore: bump code-block for shell-sesh fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@hashicorp/react-button": "^6.2.1",
 				"@hashicorp/react-call-to-action": "^4.1.1",
 				"@hashicorp/react-checkbox-input": "^5.0.2",
-				"@hashicorp/react-code-block": "^6.2.0",
+				"@hashicorp/react-code-block": "^6.2.1-canary-20221019235743",
 				"@hashicorp/react-command-line-terminal": "^2.0.4",
 				"@hashicorp/react-consent-manager": "^8.0.1",
 				"@hashicorp/react-docs-page": "^17.7.0",
@@ -3372,9 +3372,9 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
-			"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
+			"version": "6.2.1-canary-20221019235743",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1-canary-20221019235743.tgz",
+			"integrity": "sha512-I3jZF5IEDLqomW4HmtT42EPGidh+XzEcykINlTQALbbLGNRCVRlt34bZElPEHn5uQFK0R8g7aqijw3azNIZ2xA==",
 			"dependencies": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -3593,6 +3593,136 @@
 				"react": ">= 16.x"
 			}
 		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-code-block": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
+			"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
+			"dependencies": {
+				"@hashicorp/react-inline-svg": "^6.0.3",
+				"@reach/listbox": "^0.17.0",
+				"shellwords": "^0.1.1"
+			},
+			"peerDependencies": {
+				"@hashicorp/mktg-global-styles": ">=3.x",
+				"react": ">=16.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/auto-id": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+			"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/descendants": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+			"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/listbox": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+			"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+			"dependencies": {
+				"@reach/auto-id": "0.17.0",
+				"@reach/descendants": "0.17.0",
+				"@reach/machine": "0.17.0",
+				"@reach/popover": "0.17.0",
+				"@reach/utils": "0.17.0",
+				"prop-types": "^15.7.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/machine": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+			"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"@xstate/fsm": "1.4.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/popover": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+			"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+			"dependencies": {
+				"@reach/portal": "0.17.0",
+				"@reach/rect": "0.17.0",
+				"@reach/utils": "0.17.0",
+				"tabbable": "^4.0.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/portal": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+			"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/rect": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+			"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+			"dependencies": {
+				"@reach/observe-rect": "1.2.0",
+				"@reach/utils": "0.17.0",
+				"prop-types": "^15.7.2",
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/utils": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+			"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+			"dependencies": {
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3627,6 +3757,11 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/unified": {
 			"version": "9.2.2",
@@ -37061,9 +37196,9 @@
 			}
 		},
 		"@hashicorp/react-code-block": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
-			"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
+			"version": "6.2.1-canary-20221019235743",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1-canary-20221019235743.tgz",
+			"integrity": "sha512-I3jZF5IEDLqomW4HmtT42EPGidh+XzEcykINlTQALbbLGNRCVRlt34bZElPEHn5uQFK0R8g7aqijw3azNIZ2xA==",
 			"requires": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -37226,6 +37361,100 @@
 						"@mdx-js/react": "1.6.22"
 					}
 				},
+				"@hashicorp/react-code-block": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
+					"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
+					"requires": {
+						"@hashicorp/react-inline-svg": "^6.0.3",
+						"@reach/listbox": "^0.17.0",
+						"shellwords": "^0.1.1"
+					}
+				},
+				"@reach/auto-id": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+					"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/descendants": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+					"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/listbox": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+					"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+					"requires": {
+						"@reach/auto-id": "0.17.0",
+						"@reach/descendants": "0.17.0",
+						"@reach/machine": "0.17.0",
+						"@reach/popover": "0.17.0",
+						"@reach/utils": "0.17.0",
+						"prop-types": "^15.7.2"
+					}
+				},
+				"@reach/machine": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+					"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"@xstate/fsm": "1.4.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/popover": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+					"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+					"requires": {
+						"@reach/portal": "0.17.0",
+						"@reach/rect": "0.17.0",
+						"@reach/utils": "0.17.0",
+						"tabbable": "^4.0.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/portal": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+					"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/rect": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+					"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+					"requires": {
+						"@reach/observe-rect": "1.2.0",
+						"@reach/utils": "0.17.0",
+						"prop-types": "^15.7.2",
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/utils": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+					"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+					"requires": {
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -37251,6 +37480,11 @@
 					"requires": {
 						"picomatch": "^2.2.1"
 					}
+				},
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 				},
 				"unified": {
 					"version": "9.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@hashicorp/react-button": "^6.2.1",
 				"@hashicorp/react-call-to-action": "^4.1.1",
 				"@hashicorp/react-checkbox-input": "^5.0.2",
-				"@hashicorp/react-code-block": "^6.2.1-canary-20221019235743",
+				"@hashicorp/react-code-block": "^6.2.1",
 				"@hashicorp/react-command-line-terminal": "^2.0.4",
 				"@hashicorp/react-consent-manager": "^8.0.1",
 				"@hashicorp/react-docs-page": "^17.7.0",
@@ -3372,9 +3372,9 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.1-canary-20221019235743",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1-canary-20221019235743.tgz",
-			"integrity": "sha512-I3jZF5IEDLqomW4HmtT42EPGidh+XzEcykINlTQALbbLGNRCVRlt34bZElPEHn5uQFK0R8g7aqijw3azNIZ2xA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
+			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
 			"dependencies": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -3593,136 +3593,6 @@
 				"react": ">= 16.x"
 			}
 		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
-			"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
-			"dependencies": {
-				"@hashicorp/react-inline-svg": "^6.0.3",
-				"@reach/listbox": "^0.17.0",
-				"shellwords": "^0.1.1"
-			},
-			"peerDependencies": {
-				"@hashicorp/mktg-global-styles": ">=3.x",
-				"react": ">=16.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/auto-id": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-			"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/descendants": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
-			"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/listbox": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
-			"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
-			"dependencies": {
-				"@reach/auto-id": "0.17.0",
-				"@reach/descendants": "0.17.0",
-				"@reach/machine": "0.17.0",
-				"@reach/popover": "0.17.0",
-				"@reach/utils": "0.17.0",
-				"prop-types": "^15.7.2"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/machine": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
-			"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"@xstate/fsm": "1.4.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/popover": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
-			"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
-			"dependencies": {
-				"@reach/portal": "0.17.0",
-				"@reach/rect": "0.17.0",
-				"@reach/utils": "0.17.0",
-				"tabbable": "^4.0.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/portal": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
-			"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/rect": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
-			"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
-			"dependencies": {
-				"@reach/observe-rect": "1.2.0",
-				"@reach/utils": "0.17.0",
-				"prop-types": "^15.7.2",
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/utils": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-			"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-			"dependencies": {
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3757,11 +3627,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/unified": {
 			"version": "9.2.2",
@@ -37196,9 +37061,9 @@
 			}
 		},
 		"@hashicorp/react-code-block": {
-			"version": "6.2.1-canary-20221019235743",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1-canary-20221019235743.tgz",
-			"integrity": "sha512-I3jZF5IEDLqomW4HmtT42EPGidh+XzEcykINlTQALbbLGNRCVRlt34bZElPEHn5uQFK0R8g7aqijw3azNIZ2xA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
+			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
 			"requires": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -37361,100 +37226,6 @@
 						"@mdx-js/react": "1.6.22"
 					}
 				},
-				"@hashicorp/react-code-block": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.0.tgz",
-					"integrity": "sha512-vwNblHt9WHeFhcLKroLq5LT/yd+W3zMWFkAJulpPUtXaRoTQgQY3RDJ6LcEyqMvKaRznjBkAy/ktRhMSS08T1Q==",
-					"requires": {
-						"@hashicorp/react-inline-svg": "^6.0.3",
-						"@reach/listbox": "^0.17.0",
-						"shellwords": "^0.1.1"
-					}
-				},
-				"@reach/auto-id": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-					"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/descendants": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
-					"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/listbox": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
-					"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
-					"requires": {
-						"@reach/auto-id": "0.17.0",
-						"@reach/descendants": "0.17.0",
-						"@reach/machine": "0.17.0",
-						"@reach/popover": "0.17.0",
-						"@reach/utils": "0.17.0",
-						"prop-types": "^15.7.2"
-					}
-				},
-				"@reach/machine": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
-					"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"@xstate/fsm": "1.4.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/popover": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
-					"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
-					"requires": {
-						"@reach/portal": "0.17.0",
-						"@reach/rect": "0.17.0",
-						"@reach/utils": "0.17.0",
-						"tabbable": "^4.0.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/portal": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
-					"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/rect": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
-					"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
-					"requires": {
-						"@reach/observe-rect": "1.2.0",
-						"@reach/utils": "0.17.0",
-						"prop-types": "^15.7.2",
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/utils": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-					"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-					"requires": {
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -37480,11 +37251,6 @@
 					"requires": {
 						"picomatch": "^2.2.1"
 					}
-				},
-				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 				},
 				"unified": {
 					"version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"@hashicorp/react-button": "^6.2.1",
 		"@hashicorp/react-call-to-action": "^4.1.1",
 		"@hashicorp/react-checkbox-input": "^5.0.2",
-		"@hashicorp/react-code-block": "^6.2.0",
+		"@hashicorp/react-code-block": "^6.2.1-canary-20221019235743",
 		"@hashicorp/react-command-line-terminal": "^2.0.4",
 		"@hashicorp/react-consent-manager": "^8.0.1",
 		"@hashicorp/react-docs-page": "^17.7.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"@hashicorp/react-button": "^6.2.1",
 		"@hashicorp/react-call-to-action": "^4.1.1",
 		"@hashicorp/react-checkbox-input": "^5.0.2",
-		"@hashicorp/react-code-block": "^6.2.1-canary-20221019235743",
+		"@hashicorp/react-code-block": "^6.2.1",
 		"@hashicorp/react-command-line-terminal": "^2.0.4",
 		"@hashicorp/react-consent-manager": "^8.0.1",
 		"@hashicorp/react-docs-page": "^17.7.0",


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Bumps `@hashicorp/react-code-block` to pull in a fix for `shell-session` `CodeTabs` from https://github.com/hashicorp/react-components/pull/768.

## 🤷 Why

Fixes a bug where `shell-session` snippets within `CodeTabs` would copy correctly via the `Copy` button, but would still include the `$` character when selected and copied by clicking and dragging.

## 🧪 Testing

- [ ] Visit a page with `shell-session` snippets in MDX `CodeTabs`, such as [/consul/tutorials/network-infrastructure-automation/consul-terraform-sync-intro][/consul/tutorials/network-infrastructure-automation/consul-terraform-sync-intro]
    - The `Copy` button should copy without the leading `$` or leading space that follows it
    - Selecting and copying all the text (eg by triple-clicking) should copy without the leading `$`.
        - Note the leading space will be copied, this is a difficult thing to optimize, and we haven't yet had the bandwidth to scope out a more holistic and robust approach to authoring and rendering `shell-session` snippets with multiple commands.
        - The leading space shouldn't affect the functionality of the command.

## 💭 Anything else?

See https://github.com/hashicorp/react-components/pull/768 for details, including screenshots etc.

[task]: https://app.asana.com/0/1202097197789424/1203204105610771/f
[preview]: https://dev-portal-git-zsfix-code-tabs-lang-undefined-hashicorp.vercel.app
[/consul/tutorials/network-infrastructure-automation/consul-terraform-sync-intro]: https://dev-portal-git-zsfix-code-tabs-lang-undefined-hashicorp.vercel.app/consul/tutorials/network-infrastructure-automation/consul-terraform-sync-intro#clone-github-repository
