### PR TITLE
chore: update Packer subnav links post-GA

### DIFF
--- a/src/components/_proxied-dot-io/packer/subnav/index.tsx
+++ b/src/components/_proxied-dot-io/packer/subnav/index.tsx
@@ -25,7 +25,7 @@ export default function PackerSubnav({ menuItems }) {
 				},
 				{
 					text: 'Install Packer',
-					url: '/downloads',
+					url: 'https://developer.hashicorp.com/packer/downloads',
 				},
 				{
 					text: 'Try HCP Packer',

--- a/src/layouts/_proxied-dot-io/packer/index.tsx
+++ b/src/layouts/_proxied-dot-io/packer/index.tsx
@@ -92,17 +92,17 @@ function PackerIoLayout({ children, data }: Props): React.ReactElement {
 							},
 							{
 								text: 'Docs',
-								url: '/docs',
+								url: 'https://developer.hashicorp.com/packer/docs',
 								type: 'inbound',
 							},
 							{
 								text: 'Guides',
-								url: '/guides',
+								url: 'https://developer.hashicorp.com/packer/guides',
 								type: 'inbound',
 							},
 							{
 								text: 'Plugins',
-								url: '/plugins',
+								url: 'https://developer.hashicorp.com/packer/plugins',
 								type: 'inbound',
 							},
 							{


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates Packer subnav items that redirect to <https://developer.hashicorp.com>, to use direct URLs rather than URLs that we know will be redirected.

## 🧪 Testing

- [ ] Visit the preview, and switch to Packer mode
- [ ] Clicking `Docs`, `Guides`, `Plugins` or `Downloads` in the top nav of the <https://packer.io> preview should lead to <https://developer.hashicorp.com> Packer URLs

[task]: https://app.asana.com/0/0/1203184381727446/f
[preview]: https://dev-portal-git-zsupdate-packer-subnav-links-hashicorp.vercel.app