### PR TITLE
chore: add Nextjs JSON paths to 'disallow' in robots.txt

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,5 +3,14 @@ module.exports = {
 	siteUrl: process.env.SITE_URL || 'https://developer.hashicorp.com',
 	generateRobotsTxt: true, // (optional)
 	exclude: ['/swingset*', '/onboarding/*', '/profile*'],
+	robotsTxtOptions: {
+		policies: [
+			{
+				userAgent: '*',
+				allow: '/',
+				disallow: '/_next/data/*.json',
+			},
+		],
+	},
 	// ...other options
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Adds `/_next/data/*.json` paths to the 'disallow' list in `robots.txt`. This was previously addressed in #1286 but reverted because `/_next/` was added to 'disallow' in there which was too broad. The goal here is to limit crawling and indexing of Nextjs JSON URLs

## 🤷 Why

It seems search engine bots are crawling `/_next/data/*.json` paths when they should not be. Adding those paths to 'disallow' signals to crawlers that they should not be doing so.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

Current `robots.txt` at developer.hashicorp.com/robots.txt:

```
# *
User-agent: *
Allow: /

# Host
Host: https://developer.hashicorp.com

# Sitemaps
Sitemap: https://developer.hashicorp.com/sitemap.xml
```

New `robots.txt` via this PR, to be tested at preview/robots.txt:

```
# *
User-agent: *
Allow: /
Disallow: /_next/data/*.json

# Host
Host: https://developer.hashicorp.com

# Sitemaps
Sitemap: https://developer.hashicorp.com/sitemap.xml
```

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
