### PR TITLE
Revert "chore: add Nextjs JSON paths to 'disallow' in robots.txt"

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,14 +3,5 @@ module.exports = {
 	siteUrl: process.env.SITE_URL || 'https://developer.hashicorp.com',
 	generateRobotsTxt: true, // (optional)
 	exclude: ['/swingset*', '/onboarding/*', '/profile*'],
-	robotsTxtOptions: {
-		policies: [
-			{
-				userAgent: '*',
-				allow: '/',
-				disallow: '/_next/data/*.json',
-			},
-		],
-	},
 	// ...other options
 }


### PR DESCRIPTION
Reverts hashicorp/dev-portal#1292

Reverting #1292 as it still breaks the site in Google's crawl, just not as bad as #1286