### PR TITLE
[NavigationHeader] Show sign in/up elements by default

### DIFF
--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -53,8 +53,7 @@ const MobileMenuButton = () => {
  */
 const AuthenticationControls = () => {
 	const { asPath } = useRouter()
-	const { showAuthenticatedUI, showUnauthenticatedUI, signIn, signOut, user } =
-		useAuthentication()
+	const { showAuthenticatedUI, signIn, signOut, user } = useAuthentication()
 
 	/**
 	 * Upon signin
@@ -68,12 +67,27 @@ const AuthenticationControls = () => {
 		})
 	}
 
-	if (!showAuthenticatedUI && !showUnauthenticatedUI) {
-		return null
-	}
+	/**
+	 * @TODO implement loading skeleton
+	 * https://app.asana.com/0/1202097197789424/1202791375540720/f
+	 *
+	 * The `showUnauthenticatedUI` boolean is not used here because we want to
+	 * show the sign in/up elements by default until loading skeletons are
+	 * implemented. Most of our users do not have Learn accounts, so our goal is
+	 * to remove the flash for the majority of a users as a temporary effort.
+	 */
 
 	let content
-	if (showUnauthenticatedUI) {
+	if (showAuthenticatedUI) {
+		content = (
+			<UserDropdownDisclosure
+				className={s.userDropdownDisclosure}
+				listPosition="right"
+				items={getUserMenuItems({ signOut })}
+				user={user}
+			/>
+		)
+	} else {
 		content = (
 			<>
 				<Button
@@ -91,15 +105,6 @@ const AuthenticationControls = () => {
 					text="Sign Up"
 				/>
 			</>
-		)
-	} else if (showAuthenticatedUI) {
-		content = (
-			<UserDropdownDisclosure
-				className={s.userDropdownDisclosure}
-				listPosition="right"
-				items={getUserMenuItems({ signOut })}
-				user={user}
-			/>
 		)
 	}
 


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Renders sign in/up elements in the navigation header by default to reduce flashing for the majority of our users

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go the the preview URL
- [ ] Make sure you're not signed in
- [ ] The sign in/up elements should render by default with no flash
- [ ] Sign in
- [ ] The sign in/up elements should render by default
- [ ] The user disclosure dropdown should flash in
