### PR TITLE
[NextAuth] Adding signOut event to sign out of provider

### DIFF
--- a/src/lib/auth/cloud-idp-provider.ts
+++ b/src/lib/auth/cloud-idp-provider.ts
@@ -1,10 +1,28 @@
 import { Provider } from 'next-auth/providers'
 import { ValidAuthProviderId } from 'types/auth'
 
+type CloudIdpProviderConfig = Provider & {
+	wellKnown: string
+	authorization: {
+		params: {
+			scope: string
+		}
+	}
+	idToken: boolean
+	checks: string[]
+	clientId: string
+	clientSecret: string
+	client: {
+		name: string
+		token_endpoint_auth_method: string
+	}
+	profile(profile: $TSFixMe): $TSFixMe
+}
+
 /**
  * A custom next-auth provider to authenticate via HashiCorp's Cloud IDP service
  */
-const CloudIdpProvider: Provider = {
+const CloudIdpProvider: CloudIdpProviderConfig = {
 	id: ValidAuthProviderId.CloudIdp,
 	name: 'Cloud IDP',
 	type: 'oauth',
@@ -19,7 +37,7 @@ const CloudIdpProvider: Provider = {
 		name: 'HashiCorp Developer',
 		token_endpoint_auth_method: 'client_secret_post',
 	},
-	profile(profile) {
+	profile(profile: $TSFixMe) {
 		return { id: profile.sub, ...profile }
 	},
 }

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,6 @@
 import createFetch from '@vercel/fetch'
 import NextAuth from 'next-auth'
+import { URL } from 'url'
 import CloudIdpProvider from 'lib/auth/cloud-idp-provider'
 import refreshTokenSet from 'lib/auth/refresh-token-set'
 import isJwtExpired from 'lib/auth/is-jwt-expired'
@@ -26,7 +27,11 @@ export default NextAuth({
 					await fetch(CloudIdpProvider.wellKnown)
 				).json()
 				const endSessionEndpoint = wellKnownConfiguration.end_session_endpoint
-				await fetch(`${endSessionEndpoint}?id_token_hint=${token.id_token}`)
+
+				const endSessionUrl = new URL(endSessionEndpoint)
+				endSessionUrl.searchParams.set('id_token_hint', token.id_token)
+
+				await fetch(endSessionUrl.toString())
 			} catch (e) {
 				console.error(
 					'[NextAuth] There was an error in the `signOut` event:',

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -16,7 +16,7 @@ export default NextAuth({
 	// https://next-auth.js.org/configuration/options#events
 	events: {
 		/**
-		 * NOTE: NextAuth log out of auth providers, so we have to handle doing that
+		 * NOTE: NextAuth does not log out of auth providers, so we have to handle doing that
 		 * ourselves in this signOut event.
 		 * https://github.com/nextauthjs/next-auth/discussions/3938
 		 *

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -19,9 +19,6 @@ export default NextAuth({
 		 * NOTE: NextAuth does not log out of auth providers, so we have to handle doing that
 		 * ourselves in this signOut event.
 		 * https://github.com/nextauthjs/next-auth/discussions/3938
-		 *
-		 * cloud-idp and Ory Hydra docs:
-		 * https://hashicorp.atlassian.net/wiki/spaces/CLOUD/pages/2321449597/cloud-idp+and+Ory+Hydra
 		 */
 		async signOut({ token }) {
 			await fetch(

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -22,9 +22,11 @@ export default NextAuth({
 		 */
 		async signOut({ token }) {
 			try {
-				await fetch(
-					`${__config.dev_dot.auth.idp_url}/oauth2/sessions/logout?id_token_hint=${token.id_token}`
-				)
+				const wellKnownConfiguration = await (
+					await fetch(CloudIdpProvider.wellKnown)
+				).json()
+				const endSessionEndpoint = wellKnownConfiguration.end_session_endpoint
+				await fetch(`${endSessionEndpoint}?id_token_hint=${token.id_token}`)
 			} catch (e) {
 				console.error(
 					'[NextAuth] There was an error in the `signOut` event:',

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -21,9 +21,16 @@ export default NextAuth({
 		 * https://github.com/nextauthjs/next-auth/discussions/3938
 		 */
 		async signOut({ token }) {
-			await fetch(
-				`${__config.dev_dot.auth.idp_url}/oauth2/sessions/logout?id_token_hint=${token.id_token}`
-			)
+			try {
+				await fetch(
+					`${__config.dev_dot.auth.idp_url}/oauth2/sessions/logout?id_token_hint=${token.id_token}`
+				)
+			} catch (e) {
+				console.error(
+					'[NextAuth] There was an error in the `signOut` event:',
+					e
+				)
+			}
 		},
 	},
 	providers: [CloudIdpProvider],

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,5 @@
 import { Session } from 'next-auth'
+import { JWT } from 'next-auth/jwt'
 
 /**
  * Object representing an authentication session.
@@ -31,7 +32,7 @@ export enum AuthErrors {
 }
 
 /** The response shape from `POST {IDENTITY_PROVIDER}/oauth2/token` */
-export interface TokenSet {
+export interface TokenSet extends JWT {
 	access_token: string
 	refresh_token: string
 	scope: string


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Configures a `signOut` function in NextAuth's `events` configuration object
- Persists the `id_token` on `account` in `jwt()` for the new `signOut` event function

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- According to https://github.com/nextauthjs/next-auth/discussions/3938, NextAuth does not log out of an auth provider entirely for us. So we need to do an extra step on `signOut` in order to completely log out of Cloud IDP.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- [`NextAuth.options.events.signOut`](https://next-auth.js.org/configuration/options#events)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page on the preview
- [ ] Sign in
- [ ] Sign out
- [ ] Go to /sign-up
- [ ] Click the sign up button
- [ ] You should be taken to the cloud idp sign up page:
  ![image](https://user-images.githubusercontent.com/43934258/198137650-b9c18279-ff58-472e-bd3f-d3217b28b84c.png)
- [ ] Go to the home page
- [ ] Click the sign in button
- [ ] You should be taken to the cloud idp sign in page:
  ![image](https://user-images.githubusercontent.com/43934258/198138452-ce48adf6-cddc-4d5f-a882-6ced22facd9e.png)
