### PR TITLE
Fixing link on /consul/downloads

### DIFF
--- a/src/content/consul/install-landing.json
+++ b/src/content/consul/install-landing.json
@@ -26,7 +26,7 @@
 		},
 		{
 			"title": "Consul with Virtual Machines",
-			"fullPath": "/consul/tutorials/getting-started/get-started"
+			"fullPath": "/consul/tutorials/get-started-vms/virtual-machine-gs-deploy"
 		},
 		{
 			"title": "HCP Consul",


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes a link to a renamed tutorial on /consul/downloads

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [/consul/downloads](https://dev-portal-git-ambfix-consul-downloads-link-hashicorp.vercel.app/consul/downloads)
- [ ] Click the "Consul with Virtual Machines" link in the sidebar
- [ ] You should be taken to the correct page: /consul/tutorials/get-started-vms/virtual-machine-gs-deploy
