### PR TITLE
fix: gap in install view code tabs

### DIFF
--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -43,10 +43,6 @@
 	margin-bottom: 8px;
 }
 
-.codeTabsCodeBlock {
-	margin-top: 4px;
-}
-
 .textAndLinkCard {
 	align-items: center;
 	display: flex;

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -72,7 +72,6 @@ const PackageManagerSection = ({
 						return (
 							<CodeBlock
 								key={label}
-								className={s.codeTabsCodeBlock}
 								code={installCodeHtml}
 								language="shell-session"
 								options={{ showClipboard: true }}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes a visual bug where code blocks are spaced `4px` from their associated code tabs bar on install views.

## 🛠️ How

Removes class that adds spacing.

## 📸 Design Screenshots

### Before

<img width="1645" alt="CleanShot 2022-10-27 at 10 17 37@2x" src="https://user-images.githubusercontent.com/4624598/198310774-f57c8e92-efac-4e84-a9e6-b9fb28d41222.png">

### After

<img width="1644" alt="CleanShot 2022-10-27 at 10 18 31@2x" src="https://user-images.githubusercontent.com/4624598/198311081-b6390f7e-6151-44ad-afcc-b1bd83c2ae49.png">

## 🧪 Testing

- [ ] Visit an install page with code tabs, such as [/terraform/downloads][/terraform/downloads]
    - Open the "Linux" tab, which has code tabs within it
    - There should be no gap between the code tabs bar and the code block

[task]: https://app.asana.com/0/1202097197789424/1203252444555503/f
[preview]: https://dev-portal-git-zsfix-code-space-on-install-view-hashicorp.vercel.app
[/terraform/downloads]: https://dev-portal-git-zsfix-code-space-on-install-view-hashicorp.vercel.app/terraform/downloads