### PR TITLE
Removing optInBanner for sentinel

### DIFF
--- a/src/components/_proxied-dot-io/common/docs-page/index.tsx
+++ b/src/components/_proxied-dot-io/common/docs-page/index.tsx
@@ -24,11 +24,24 @@ export default function DocsPage({
 	devDotCutoverMessage,
 	...props
 }: ProxiedDocsPageProps) {
+	/**
+	 * Sentinel does not have a Developer page right now, so it cannot be opted-in
+	 * to and we shouldn't show this alert.
+	 */
+	let showOptInBanner = true
+	if ((props?.product?.slug as string) === 'sentinel') {
+		showOptInBanner = false
+	}
+
 	return (
 		<ReactDocsPage
 			additionalComponents={{ ...ioComponents, ...additionalComponents }}
 			optInBanner={
-				<DevDotOptIn {...(devDotCutoverMessage ? devDotCutoverMessage : {})} />
+				showOptInBanner ? (
+					<DevDotOptIn
+						{...(devDotCutoverMessage ? devDotCutoverMessage : {})}
+					/>
+				) : undefined
 			}
 			{...props}
 		/>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1203239476053454/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes the `optInBanner` slot in `DocsPage` (`src/components/_proxied-dot-io/common/docs-page/index.tsx`) if the current product's slug is `"sentinel"`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- It's not possible to opt in to sentinel docs on developer right now

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- Sentinel's docs are served from this repo, so I made the change in the shared `DocsPage` component

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] In the bottom left of the window, choose "Sentinel" from the floating product switcher
- [ ] Go to [/sentinel](https://dev-portal-git-ambno-sentinel-opt-in-hashicorp.vercel.app/sentinel)
- [ ] Make sure the page alert for opting in no longer shows
- [ ] Go to [/sentinel/intro](https://dev-portal-git-ambno-sentinel-opt-in-hashicorp.vercel.app/sentinel/intro)
- [ ] Make sure the page alert for opting in no longer shows
