### PR TITLE
fix: transform URLs for Packer plugins

### DIFF
--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.test.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.test.ts
@@ -1,0 +1,80 @@
+import { fixupPackerPluginUrls } from './fixup-plugin-urls'
+
+type TestCase = {
+	url: string
+	expected: string
+}
+
+describe('fixupPackerPluginUrls', () => {
+	it('does not modify non-plugin links', () => {
+		const testCases: TestCase[] = [
+			{
+				url: '/docs/test',
+				expected: '/docs/test',
+			},
+			{
+				url: '/docs/test/builders',
+				expected: '/docs/test/builders',
+			},
+			{
+				url: '/docs/test/hashicups',
+				expected: '/docs/test/hashicups',
+			},
+		]
+		testCases.forEach(({ url, expected }: TestCase) => {
+			expect(fixupPackerPluginUrls(url)).toBe(expected)
+		})
+	})
+
+	it('fixes up base links for known plugin slugs', () => {
+		const testCases: TestCase[] = [
+			{
+				url: '/docs/builders/alicloud',
+				expected: '/plugins/builders/alicloud',
+			},
+			{
+				url: '/docs/builders/hyperone',
+				expected: '/plugins/builders/hyperone',
+			},
+		]
+		testCases.forEach(({ url, expected }: TestCase) => {
+			expect(fixupPackerPluginUrls(url)).toBe(expected)
+		})
+	})
+
+	it('fixes up base links for known plugin types', () => {
+		const testCases: TestCase[] = [
+			{
+				url: '/docs/builders/hashicups',
+				expected: '/plugins/builders/hashicups',
+			},
+			{
+				url: '/docs/datasources/hashicups',
+				expected: '/plugins/datasources/hashicups',
+			},
+			{
+				url: '/docs/post-processors/hashicups',
+				expected: '/plugins/post-processors/hashicups',
+			},
+			{
+				url: '/docs/provisioners/hashicups',
+				expected: '/plugins/provisioners/hashicups',
+			},
+		]
+		testCases.forEach(({ url, expected }: TestCase) => {
+			expect(fixupPackerPluginUrls(url)).toBe(expected)
+		})
+	})
+
+	it('does not modify links with unknown plugin slugs', () => {
+		const testCases: TestCase[] = [
+			{
+				url: '/docs/builders/foobar',
+				expected: '/docs/builders/foobar',
+			},
+		]
+		testCases.forEach(({ url, expected }: TestCase) => {
+			expect(fixupPackerPluginUrls(url)).toBe(expected)
+		})
+	})
+})

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.ts
@@ -18,9 +18,8 @@
  *
  * Note: previously, on packer.io, we used redirects to make this correction.
  * See `proxied-redirects/www.packer.io.redirects.js` at the root of this
- * repository for those redirects.
- * @TODO we may be able to remove those redirects? As they don't seem to apply
- * now that packer.io docs & plugins are served from developer.hashicorp.com?
+ * repository for those redirects. These redirects still apply to packer.io,
+ * but do not work for developer.hashicorp.com.
  */
 export function fixupPackerPluginUrls(url: string): string {
 	// We want to match /docs/:type/:pluginSlug URLs.

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-plugin-urls.ts
@@ -1,0 +1,101 @@
+/**
+ * Fixes up Packer plugin links that use an "old" URL format.
+ *
+ * For context, Packer plugins used to be served from "old" URLs like:
+ * https://www.packer.io/docs/:type/<pluginName>
+ * where `:type` is one of:
+ * "builders", "datasources", "post-processor", "provisioners"
+ * and `<pluginName>` is the name of the plugin repository.
+ *
+ * Before the move to Dev Dot, we separated external plugin docs
+ * out from within `/docs` and gave them a dedicated "new" `/plugins` URL:
+ * https://www.packer.io/plugins/:type/<pluginName>
+ * So, in addition to the link correct that happens for Dev Dot
+ * (which will happen *after* this function runs), for Packer plugins MDX,
+ * we need to detect "old" plugin URLs and transform them to the "new" format.
+ *
+ * This function handles this "old" to "new" conversion.
+ *
+ * Note: previously, on packer.io, we used redirects to make this correction.
+ * See `proxied-redirects/www.packer.io.redirects.js` at the root of this
+ * repository for those redirects.
+ * @TODO we may be able to remove those redirects? As they don't seem to apply
+ * now that packer.io docs & plugins are served from developer.hashicorp.com?
+ */
+export function fixupPackerPluginUrls(url: string): string {
+	// We want to match /docs/:type/:pluginSlug URLs.
+	const typesPart = `(${PACKER_PLUGIN_TYPES.join('|')})`
+	const slugPart = `(${PACKER_PLUGIN_SLUGS.join('|')})`
+	const pluginUrlRegex = new RegExp(`^\\/docs\\/${typesPart}\\/${slugPart}`)
+	const isMatch = pluginUrlRegex.test(url)
+	if (isMatch) {
+		// If we have a match, replace /docs at the start with /plugins.
+		return url.replace(/^\/docs/, '/plugins')
+	} else {
+		// If we don't have a match, no URLs should be harmed.
+		return url
+	}
+}
+
+/**
+ * A snapshot of the types of plugins from when Packer plugins
+ * were served from the "old" URLS, nested under `/docs`.
+ */
+const PACKER_PLUGIN_TYPES = [
+	'builders',
+	'datasources',
+	'post-processors',
+	'provisioners',
+]
+
+/**
+ * A snapshot of the plugin URLs from when Packer plugins
+ * were served from the "old" URLS, nested under `/docs`.
+ */
+const PACKER_PLUGIN_SLUGS = [
+	'alicloud',
+	'amazon',
+	'anka',
+	'ansible',
+	'azure',
+	'chef',
+	'cloudstack',
+	'converge',
+	'digitalocean',
+	'docker',
+	'git',
+	'googlecompute',
+	'hashicups',
+	'hetzner-cloud',
+	'huaweicloud',
+	'hyperone',
+	'hyperv',
+	'inspec',
+	'jdcloud',
+	'kamatera',
+	'linode',
+	'lxc',
+	'lxd',
+	'ncloud',
+	'oneandone',
+	'openstack',
+	'oracle',
+	'outscale',
+	'parallels',
+	'profitbricks',
+	'proxmox',
+	'puppet',
+	'qemu',
+	'salt',
+	'scaleway',
+	'sshkey',
+	'tencentcloud',
+	'triton',
+	'ucloud',
+	'vagrant',
+	'virtualbox',
+	'vmware',
+	'vsphere',
+	'vultr',
+	'yandex',
+]

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -2,15 +2,20 @@ import fs from 'fs'
 import path from 'path'
 import grayMatter from 'gray-matter'
 import { Pluggable } from 'unified'
+import { ProductData } from 'types/products'
 import {
 	getNodeFromPath,
 	getPathsFromNavData,
 } from '@hashicorp/react-docs-page/server'
 import renderPageMdx from '@hashicorp/react-docs-page/render-page-mdx'
+import remarkPluginAdjustLinkUrls from 'lib/remark-plugin-adjust-link-urls'
+import { getProductUrlAdjuster } from 'views/docs-view/utils/product-url-adjusters'
 import resolveNavDataWithRemotePlugins, {
 	appendRemotePluginsNavData,
 } from './utils/resolve-nav-data'
 import fetchLatestReleaseTag from './utils/fetch-latest-release-tag'
+// packer product data
+import packerProductData from 'data/packer.json'
 // remark plugins
 import {
 	// includeMarkdown,
@@ -24,6 +29,7 @@ import rehypePrism from '@mapbox/rehype-prism'
 // alternative to the includeMarkdown plugin,
 // which we need to shim cause of how we're fetching remote content here
 import shimRemoteIncludes from 'lib/shim-remote-includes'
+import { fixupPackerPluginUrls } from './fixup-plugin-urls'
 
 async function generateStaticPaths({
 	navDataFile,
@@ -164,6 +170,11 @@ async function generateStaticProps({
 	}
 	const content = await mdxContentHook(rawContent)
 
+	// Set up URL adjuster function
+	const dotIoToDevDotUrlAdjuster = getProductUrlAdjuster(
+		packerProductData as ProductData
+	)
+
 	// Render MDX source, with options
 	const headings = [] // populated by anchorLinks plugin below
 	const mdxOptions: { remarkPlugins: Pluggable[]; rehypePlugins: Pluggable[] } =
@@ -172,6 +183,23 @@ async function generateStaticProps({
 				typography,
 				[anchorLinks, { headings }],
 				paragraphCustomAlerts,
+				/**
+				 * Rewrite docs content links, which are authored without prefix.
+				 * For Packer plugins, we need to account for both plugin URL
+				 * structure changes (which happened before the move to Dev Dot,
+				 * but have not yet been updated in source), as well as for
+				 * the usual dot-io-to-dev-dot transformations we run for
+				 * all other products.
+				 */
+				[
+					remarkPluginAdjustLinkUrls,
+					{
+						urlAdjustFn: (url) => {
+							const fixedPluginUrl = fixupPackerPluginUrls(url)
+							return dotIoToDevDotUrlAdjuster(fixedPluginUrl)
+						},
+					},
+				],
 			],
 			rehypePlugins: [
 				[rehypePrism, { ignoreMissing: true }],


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes up Packer plugin links.

## 🤷 Why

- "the plugins move" - Packer plugins were moved from `/docs/:type/:slug` to `/plugins/:type/:slug`, before Dev Dot move
- "the Dev Dot move" - Packer plugins and other docs were moved onto Dev Dot, URLs need to be `/packer/docs/...etc` or `/packer/plugins/...etc`

## 🛠️ How

- For "the plugins move", this PR sets up a regex to fix up the old `/docs` URLs to the new `/plugins` URL format
- For "the Dev Dot move", this PR adds in the remark "URL fixer upper" plugin that we use for all other products. This was missed earlier for Packer plugins (separate server-side function strikes again).

## 🧪 Testing

- [ ] Visit a Packer plugins page, such as [/packer/plugins/builders/virtualbox][/packer/plugins/builders/virtualbox] or [/packer/plugins/builders/digitalocean][/packer/plugins/builders/digitalocean]
    - Packer plugin links on the page should be corrected to the `/packer/plugins` format, docs links should be corrected to the `/packer/docs` format, etc. (Note however that links may still 404, see `Anything else` for details).

## 💭 Anything else?
 
Many plugins have changed URLs, but have not been updated in source. So, many links within Packer plugin documentation may still lead to 404s, as [our redirects that were previously applied to dot-io](https://github.com/hashicorp/dev-portal/blob/main/proxied-redirects/www.packer.io.redirects.js) are not applied to Dev Dot.

[task]: https://app.asana.com/0/1202097197789424/1203260848279095/f
[preview]: https://dev-portal-git-zsfix-up-packer-plugin-urls-hashicorp.vercel.app
[/packer/plugins/builders/virtualbox]: https://dev-portal-git-zsfix-up-packer-plugin-urls-hashicorp.vercel.app/packer/plugins/builders/virtualbox
[/packer/plugins/builders/digitalocean]: https://dev-portal-git-zsfix-up-packer-plugin-urls-hashicorp.vercel.app/packer/plugins/builders/digitalocean