### PR TITLE
fix: add Packer plugin redirect fixes

### DIFF
--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
@@ -1,0 +1,106 @@
+/**
+ * Fixes up Packer plugin links that use a redirected format
+ * in the "old" URL format, before plugins were moved to `/plugin`.
+ *
+ * Note: previously, on packer.io, we used redirects to make this correction.
+ * See `proxied-redirects/www.packer.io.redirects.js` at the root of this
+ * repository for those redirects. These redirects still apply to packer.io,
+ * but do not work for developer.hashicorp.com.
+ */
+export function fixupRedirectedPackerPlugins(url: string): string {
+	// Run through find-and-replaces that represent former redirects
+	const matchedFindReplace = PACKER_PLUGIN_REDIRECTS.find(({ find }) => {
+		console.log({ url, find })
+		return find.test(url)
+	})
+	// If there is a matched find and replace, run it
+	if (matchedFindReplace) {
+		const { find, replace } = matchedFindReplace
+		const result = url.replace(find, replace)
+		return result
+	} else {
+		return url
+	}
+}
+
+/**
+ * A snapshot of the plugin redirects from when Packer plugins
+ * were served from the "old" URLS, nested under `/docs`.
+ */
+const PACKER_PLUGIN_REDIRECTS: { find: RegExp; replace: string }[] = [
+	{
+		find: /^\/docs\/post-processors\/amazon-(.*)/,
+		replace: '/docs/post-processors/amazon/-$1',
+	},
+	{
+		find: /^\/docs\/builders\/virtualbox-(.*)/,
+		replace: '/docs/builders/virtualbox/$1',
+	},
+	{
+		find: /^\/docs\/builders\/vmware-(.*)/,
+		replace: '/docs/builders/vmware/$1',
+	},
+	{
+		find: /^\/docs\/builders\/vsphere-(.*)/,
+		replace: '/docs/builders/vmware/vsphere-$1',
+	},
+	{
+		find: /^\/docs\/post-processors\/docker-(.*)/,
+		replace: '/docs/post-processors/docker/docker-$1',
+	},
+]
+
+/*
+
+{
+		source: '/docs/builders/amazon-:path',
+		destination: '/docs/builders/amazon/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/azure-:path',
+		destination: '/docs/builders/azure/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/hyperv-:path',
+		destination: '/docs/builders/hyperv/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/oracle-:path',
+		destination: '/docs/builders/oracle/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/osc-:path',
+		destination: '/docs/builders/outscale/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/parallels-:path',
+		destination: '/docs/builders/parallels/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/virtualbox-:path',
+		destination: '/docs/builders/virtualbox/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/vmware-:path',
+		destination: '/docs/builders/vmware/:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/builders/vsphere-:path',
+		destination: '/docs/builders/vmware/vsphere-:path*',
+		permanent: true,
+	},
+	{
+		source: '/docs/post-processors/docker-:path',
+		destination: '/docs/post-processors/docker/docker-:path*',
+		permanent: true,
+	},
+	
+	*/

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
@@ -1,3 +1,8 @@
+type FindReplace = {
+	find: RegExp
+	replace: string
+}
+
 /**
  * Fixes up Packer plugin links that use a redirected format
  * in the "old" URL format, before plugins were moved to `/plugins`.
@@ -9,10 +14,11 @@
  */
 export function fixupRedirectedPackerPlugins(url: string): string {
 	// Run through find-and-replaces that represent former redirects
-	const matchedFindReplace = PACKER_PLUGIN_REDIRECTS.find(({ find }) => {
-		console.log({ url, find })
-		return find.test(url)
-	})
+	const matchedFindReplace = PACKER_PLUGIN_REDIRECTS.find(
+		({ find }: FindReplace) => {
+			return find.test(url)
+		}
+	)
 	// If there is a matched find and replace, run it
 	if (matchedFindReplace) {
 		const { find, replace } = matchedFindReplace
@@ -27,7 +33,7 @@ export function fixupRedirectedPackerPlugins(url: string): string {
  * A snapshot of the plugin redirects from when Packer plugins
  * were served from the "old" URLS, nested under `/docs`.
  */
-const PACKER_PLUGIN_REDIRECTS: { find: RegExp; replace: string }[] = [
+const PACKER_PLUGIN_REDIRECTS: FindReplace[] = [
 	{
 		find: /^\/docs\/builders\/amazon-(.*)/,
 		replace: '/docs/builders/amazon/$1',

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
@@ -29,8 +29,28 @@ export function fixupRedirectedPackerPlugins(url: string): string {
  */
 const PACKER_PLUGIN_REDIRECTS: { find: RegExp; replace: string }[] = [
 	{
-		find: /^\/docs\/post-processors\/amazon-(.*)/,
-		replace: '/docs/post-processors/amazon/-$1',
+		find: /^\/docs\/builders\/amazon-(.*)/,
+		replace: '/docs/builders/amazon/$1',
+	},
+	{
+		find: /^\/docs\/builders\/azure-(.*)/,
+		replace: '/docs/builders/azure/$1',
+	},
+	{
+		find: /^\/docs\/builders\/hyperv-(.*)/,
+		replace: '/docs/builders/hyperv/$1',
+	},
+	{
+		find: /^\/docs\/builders\/oracle-(.*)/,
+		replace: '/docs/builders/oracle/$1',
+	},
+	{
+		find: /^\/docs\/builders\/osc-(.*)/,
+		replace: '/docs/builders/outscale/$1',
+	},
+	{
+		find: /^\/docs\/builders\/parallels-(.*)/,
+		replace: '/docs/builders/parallels/$1',
 	},
 	{
 		find: /^\/docs\/builders\/virtualbox-(.*)/,
@@ -49,58 +69,3 @@ const PACKER_PLUGIN_REDIRECTS: { find: RegExp; replace: string }[] = [
 		replace: '/docs/post-processors/docker/docker-$1',
 	},
 ]
-
-/*
-
-{
-		source: '/docs/builders/amazon-:path',
-		destination: '/docs/builders/amazon/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/azure-:path',
-		destination: '/docs/builders/azure/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/hyperv-:path',
-		destination: '/docs/builders/hyperv/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/oracle-:path',
-		destination: '/docs/builders/oracle/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/osc-:path',
-		destination: '/docs/builders/outscale/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/parallels-:path',
-		destination: '/docs/builders/parallels/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/virtualbox-:path',
-		destination: '/docs/builders/virtualbox/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/vmware-:path',
-		destination: '/docs/builders/vmware/:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/builders/vsphere-:path',
-		destination: '/docs/builders/vmware/vsphere-:path*',
-		permanent: true,
-	},
-	{
-		source: '/docs/post-processors/docker-:path',
-		destination: '/docs/post-processors/docker/docker-:path*',
-		permanent: true,
-	},
-	
-	*/

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/fixup-redirected-plugin-urls.ts
@@ -1,6 +1,6 @@
 /**
  * Fixes up Packer plugin links that use a redirected format
- * in the "old" URL format, before plugins were moved to `/plugin`.
+ * in the "old" URL format, before plugins were moved to `/plugins`.
  *
  * Note: previously, on packer.io, we used redirects to make this correction.
  * See `proxied-redirects/www.packer.io.redirects.js` at the root of this

--- a/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
+++ b/src/components/_proxied-dot-io/packer/remote-plugin-docs/server.ts
@@ -30,6 +30,7 @@ import rehypePrism from '@mapbox/rehype-prism'
 // which we need to shim cause of how we're fetching remote content here
 import shimRemoteIncludes from 'lib/shim-remote-includes'
 import { fixupPackerPluginUrls } from './fixup-plugin-urls'
+import { fixupRedirectedPackerPlugins } from './fixup-redirected-plugin-urls'
 
 async function generateStaticPaths({
 	navDataFile,
@@ -195,8 +196,9 @@ async function generateStaticProps({
 					remarkPluginAdjustLinkUrls,
 					{
 						urlAdjustFn: (url) => {
-							const fixedPluginUrl = fixupPackerPluginUrls(url)
-							return dotIoToDevDotUrlAdjuster(fixedPluginUrl)
+							const withSpecificFixes = fixupRedirectedPackerPlugins(url)
+							const withAllFixes = fixupPackerPluginUrls(withSpecificFixes)
+							return dotIoToDevDotUrlAdjuster(withAllFixes)
 						},
 					},
 				],


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR adds a step to the Packer plugins URL corrector that fixes up links that previously would have been redirected.

## 🤷 Why

To ensure links that we render on our site do not 404.

## 🧪 Testing

- [ ] Visit a Packer plugins page, such as [/packer/plugins/builders/virtualbox][/packer/plugins/builders/virtualbox]
    - Links should work, and not 404!
    - If there are broken links, it might make sense to add more specific link corrections... or perhaps we may need to ask authors to fix them in source.

[task]: https://app.asana.com/0/1202097197789424/1203260848279095/f
[preview]: https://dev-portal-git-zspatch-packer-plugin-redirected-urls-hashicorp.vercel.app
[/packer/plugins/builders/virtualbox]: https://dev-portal-git-zspatch-packer-plugin-redirected-urls-hashicorp.vercel.app/packer/plugins/builders/virtualbox