### PR TITLE
chore: Adds no index to non default tutorials

### DIFF
--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -29,7 +29,6 @@ import TutorialsSidebar, {
 } from 'components/tutorials-sidebar'
 import TutorialMeta from 'components/tutorial-meta'
 import VideoEmbed from 'components/video-embed'
-import { getLearnRedirectPath } from 'components/opt-in-out/helpers/get-learn-redirect-path'
 
 // Local imports
 import {
@@ -147,10 +146,6 @@ function TutorialView({
 
 	const canonicalCollectionSlug = tutorial.collectionCtx.default.slug
 	const canonicalUrl = generateCanonicalUrl(canonicalCollectionSlug, slug)
-	const redirectPath = getLearnRedirectPath(
-		currentPath,
-		slug.split('/')[0] as ProductOption
-	)
 
 	const sidebarNavDataLevels = [
 		generateTopLevelSidebarNavData(product.name),
@@ -239,6 +234,10 @@ function TutorialView({
 		<>
 			<Head>
 				<link rel="canonical" href={canonicalUrl.toString()} key="canonical" />
+				{/** Don't index non canonical tutorials */}
+				{canonicalUrl.pathname === currentPath ? (
+					<meta name="robots" content="noindex, nofollow" />
+				) : null}
 			</Head>
 			<InteractiveLabWrapper
 				key={slug}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-no-index-non-default-tutorials-hashicorp.vercel.app/terraform/tutorials/azure-get-started/install-cli) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1203116999389468) 🎟️

## 🗒️ What

Adds 'noindex' to non default collection tutorials. 


## 🤷 Why

This was a recommendation from the SEO consultant. 

## 🧪 Testing

- [check a tutorial ](https://dev-portal-git-ksadds-no-index-non-default-tutorials-hashicorp.vercel.app/terraform/tutorials/aws-get-started/install-cli)in the default collection context, it shouldn't have 'noindex' tag.
- [check a tutorial ](https://dev-portal-git-ksadds-no-index-non-default-tutorials-hashicorp.vercel.app/terraform/tutorials/azure-get-started/install-cli)that should be 'no index', ensure that it has the tag

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
