### PR TITLE
[TutorialView] Removes rewriteTutorialLinksPlugin

### DIFF
--- a/src/views/tutorial-view/utils/serialize-content.ts
+++ b/src/views/tutorial-view/utils/serialize-content.ts
@@ -8,7 +8,6 @@ import { Tutorial as ClientTutorial } from 'lib/learn-client/types'
 import { rewriteStaticAssetsPlugin } from 'lib/remark-plugins/rewrite-static-assets'
 import { TableOfContentsHeading } from 'layouts/sidebar-sidecar/components/table-of-contents'
 import { splitProductFromFilename } from '.'
-import { rewriteTutorialLinksPlugin } from 'lib/remark-plugins/rewrite-tutorial-links'
 
 export async function serializeContent(tutorial: ClientTutorial): Promise<{
 	content: MDXRemoteSerializeResult
@@ -38,7 +37,6 @@ export async function serializeContent(tutorial: ClientTutorial): Promise<{
 				[anchorLinks, { headings }],
 				paragraphCustomAlerts,
 				rewriteStaticAssetsPlugin,
-				rewriteTutorialLinksPlugin,
 			],
 			rehypePlugins: [
 				[rehypePrism, { ignoreMissing: true }],


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202097197789424/1202941566536490/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

These changes remove `rewriteTutorialLinksPlugin` from `TutorialView`'s `serializeContent` utility.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

All links in tutorial content have been updated to be internal dev dot paths, and we also have added a PR check in hashicorp/tutorials that notifies when legacy Learn link formats are found in a PR's diff. So there is no longer a need to rewrite these links in `TutorialView`.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Go to several tutorial pages and make sure that links to other tutorials, collections, and product tutorial landing pages in the content all go to the right places.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

`DocsView` still uses `rewriteTutorialLinksPlugin`, but the plan is to remove it after some other content work has been completed.
