### PR TITLE
Prefixing RefreshAccessTokenError message with "[next-auth]"

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -91,7 +91,12 @@ export default NextAuth({
 					token.refresh_token = refresh_token
 				} catch (err) {
 					console.error('failed to refresh token set', err)
-					return { ...token, error: AuthErrors.RefreshAccessTokenError }
+					return {
+						...token,
+						// NOTE: temporary prefix of [next-auth] for existing log monitor
+						// TODO: abstract logging so everything is grouped
+						error: `[next-auth] ${AuthErrors.RefreshAccessTokenError}`,
+					}
 				}
 			} else {
 				// Noop; log time until expiry


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Prefixes our custom `RefreshAccessTokenError` message with `"[next-auth]"`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- So an existing log monitor picks these errors up
- To group this error with others in hopes that it makes debugging the actual error easier

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Nothing to test ✅ 
