### PR TITLE
Prefixing actual RefreshAccessTokenError message for string equality checks

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -93,9 +93,7 @@ export default NextAuth({
 					console.error('failed to refresh token set', err)
 					return {
 						...token,
-						// NOTE: temporary prefix of [next-auth] for existing log monitor
-						// TODO: abstract logging so everything is grouped
-						error: `[next-auth] ${AuthErrors.RefreshAccessTokenError}`,
+						error: AuthErrors.RefreshAccessTokenError,
 					}
 				}
 			} else {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -28,7 +28,9 @@ export type { SessionData, UserData }
 export { ValidAuthProviderId }
 
 export enum AuthErrors {
-	RefreshAccessTokenError = 'RefreshAccessTokenError',
+	// NOTE: temporary prefix of [next-auth] for existing log monitor
+	// TODO: abstract logging so everything is grouped
+	RefreshAccessTokenError = '[next-auth] RefreshAccessTokenError',
 }
 
 /** The response shape from `POST {IDENTITY_PROVIDER}/oauth2/token` */


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Moves the `"[next-auth]"` prefix on `RefreshAccessTokenError` to the definition of the error. The string equality check in `useAuthentication` was broken in #1329.
