### PR TITLE
Add auth error dialog

### DIFF
--- a/src/components/authentication-error-dialog/authentication-error-dialog.module.css
+++ b/src/components/authentication-error-dialog/authentication-error-dialog.module.css
@@ -1,0 +1,27 @@
+.content {
+	position: relative;
+}
+
+.closeButton {
+	/* composition */
+	composes: g-focus-ring-from-box-shadow from global;
+
+	/* properties */
+	appearance: none;
+	background-color: transparent;
+	border-radius: 5px;
+	border: none;
+	cursor: pointer;
+	display: flex;
+	height: fit-content;
+	padding: 8px;
+	position: absolute;
+	right: 16px;
+	top: 16px;
+	width: fit-content;
+}
+
+.body {
+	margin-bottom: 24px;
+	margin-top: 4px;
+}

--- a/src/components/authentication-error-dialog/helpers/guess-method-of-dismissal.ts
+++ b/src/components/authentication-error-dialog/helpers/guess-method-of-dismissal.ts
@@ -1,0 +1,31 @@
+/**
+ * Guess the method of dismissal for analytics tracking. This informs us
+ * of how users are interacting with the dialog.
+ *
+ * Depending on how long the modal is in use (a longer term solution is in
+ * progress), we can gather insights about how users interact with this
+ * component over time.
+ *
+ * Examples questions that can be answered with this data:
+ *  - How many users choose to sign in again?
+ *  - How many users stop signing in again over time?
+ *  - How many users take no action on the modal and do something else?
+ *    - Refresh the page
+ *    - Close the tab/window
+ */
+const guessMethodOfDismissal = ({ dismissEvent, closeButtonRef }) => {
+	let methodOfDismissal = 'unknown'
+	const eventType = dismissEvent.type
+	if (eventType === 'click') {
+		const isCloseButtonClick = closeButtonRef?.current?.contains(
+			dismissEvent.target
+		)
+		methodOfDismissal = isCloseButtonClick ? 'close button' : 'overlay click'
+	} else if (eventType === 'keydown') {
+		methodOfDismissal = 'ESCAPE key'
+	}
+
+	return methodOfDismissal
+}
+
+export { guessMethodOfDismissal }

--- a/src/components/authentication-error-dialog/helpers/index.ts
+++ b/src/components/authentication-error-dialog/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './guess-method-of-dismissal'

--- a/src/components/authentication-error-dialog/index.tsx
+++ b/src/components/authentication-error-dialog/index.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { IconSignIn16 } from '@hashicorp/flight-icons/svg-react/sign-in-16'
+import { IconX16 } from '@hashicorp/flight-icons/svg-react/x-16'
+import { AuthErrors } from 'types/auth'
+import { safeAnalyticsTrack } from 'lib/analytics'
+import useAuthentication from 'hooks/use-authentication'
+import Button from 'components/button'
+import Dialog from 'components/dialog'
+import Text from 'components/text'
+import { guessMethodOfDismissal } from './helpers'
+import s from './authentication-error-dialog.module.css'
+
+/**
+ * A dialog that renders for `AuthErrors.RefreshAccessTokenError` errors.
+ * Provides an option for users to sign in again. When dismissed, automatically
+ * signs the user out.
+ */
+const AuthenticationErrorDialog = () => {
+	const closeButtonRef = useRef<HTMLButtonElement>()
+	const { error, signIn, signOut } = useAuthentication()
+	const isRefreshAccessTokenError = error === AuthErrors.RefreshAccessTokenError
+	const label = 'Are you still there?'
+
+	useEffect(() => {
+		if (isRefreshAccessTokenError) {
+			safeAnalyticsTrack('AuthenticationErrorDialog rendered', {
+				error,
+			})
+		}
+	}, [error, isRefreshAccessTokenError])
+
+	/**
+	 * Set up callback for when the dialog is dismissed. Tracks an analytics event
+	 * and signs the user out.
+	 *
+	 * @NOTE The dismissEvent variable can be multiple types of events, but
+	 * Reach's DialogProps only specifies MouseEvent. Probably better to replace
+	 * Reach Dialog with our custom build when the HDS Modal component is stable,
+	 * rather than mess with the TypeScript.
+	 */
+	const handleDismiss = useCallback(
+		// TODO: this can be a click or keydown event
+		(dismissEvent: $TSFixMe) => {
+			const methodOfDismissal = guessMethodOfDismissal({
+				dismissEvent,
+				closeButtonRef,
+			})
+			safeAnalyticsTrack('AuthenticationErrorDialog dismissed', {
+				methodOfDismissal,
+			})
+			signOut()
+		},
+		[signOut]
+	)
+
+	/**
+	 * Set up the callback for the "Sign in" button's click. Tracks an analytics
+	 * event and starts the sign in UI flow.
+	 */
+	const handleButtonClick = useCallback(() => {
+		safeAnalyticsTrack('Click', {
+			category: 'AuthenticationErrorDialog sign in',
+		})
+		signIn()
+	}, [signIn])
+
+	return (
+		<Dialog
+			isOpen={isRefreshAccessTokenError}
+			label={label}
+			onDismiss={handleDismiss}
+			contentClassName={s.content}
+		>
+			<Text asElement="p" size={300} weight="semibold">
+				{label}
+			</Text>
+			<button
+				className={s.closeButton}
+				onClick={handleDismiss}
+				ref={closeButtonRef}
+			>
+				<IconX16 />
+			</button>
+			<Text asElement="p" className={s.body}>
+				You have been signed out due to inactivity.
+			</Text>
+			<Button
+				icon={<IconSignIn16 />}
+				iconPosition="leading"
+				text="Sign in"
+				onClick={handleButtonClick}
+			/>
+		</Dialog>
+	)
+}
+
+export default AuthenticationErrorDialog

--- a/src/components/authentication-error-dialog/index.tsx
+++ b/src/components/authentication-error-dialog/index.tsx
@@ -21,13 +21,16 @@ const AuthenticationErrorDialog = () => {
 	const isRefreshAccessTokenError = error === AuthErrors.RefreshAccessTokenError
 	const label = 'Are you still there?'
 
-	useEffect(() => {
-		if (isRefreshAccessTokenError) {
-			safeAnalyticsTrack('AuthenticationErrorDialog rendered', {
-				error,
-			})
-		}
-	}, [error, isRefreshAccessTokenError])
+	/**
+	 * @TODO uncomment when the events have been architected
+	 */
+	// useEffect(() => {
+	// 	if (isRefreshAccessTokenError) {
+	// 		safeAnalyticsTrack('AuthenticationErrorDialog rendered', {
+	// 			error,
+	// 		})
+	// 	}
+	// }, [error, isRefreshAccessTokenError])
 
 	/**
 	 * Set up callback for when the dialog is dismissed. Tracks an analytics event
@@ -41,13 +44,16 @@ const AuthenticationErrorDialog = () => {
 	const handleDismiss = useCallback(
 		// TODO: this can be a click or keydown event
 		(dismissEvent: $TSFixMe) => {
-			const methodOfDismissal = guessMethodOfDismissal({
-				dismissEvent,
-				closeButtonRef,
-			})
-			safeAnalyticsTrack('AuthenticationErrorDialog dismissed', {
-				methodOfDismissal,
-			})
+			/**
+			 * @TODO uncomment when the events have been architected
+			 */
+			// const methodOfDismissal = guessMethodOfDismissal({
+			// 	dismissEvent,
+			// 	closeButtonRef,
+			// })
+			// safeAnalyticsTrack('AuthenticationErrorDialog dismissed', {
+			// 	methodOfDismissal,
+			// })
 			signOut()
 		},
 		[signOut]
@@ -58,9 +64,12 @@ const AuthenticationErrorDialog = () => {
 	 * event and starts the sign in UI flow.
 	 */
 	const handleButtonClick = useCallback(() => {
-		safeAnalyticsTrack('Click', {
-			category: 'AuthenticationErrorDialog sign in',
-		})
+		/**
+		 * @TODO uncomment when the events have been architected
+		 */
+		// safeAnalyticsTrack('Click', {
+		// 	category: 'AuthenticationErrorDialog sign in',
+		// })
 		signIn()
 	}, [signIn])
 

--- a/src/components/dialog/types.ts
+++ b/src/components/dialog/types.ts
@@ -1,9 +1,11 @@
+import { DialogProps as ReachDialogProps } from '@reach/dialog'
+
 export interface DialogProps {
 	ariaDescribedBy?: string
 	children: React.ReactNode
 	contentClassName?: string
 	isOpen: boolean
 	label: string
-	onDismiss(): void
+	onDismiss: ReachDialogProps['onDismiss']
 	variant?: 'modal' | 'bottom'
 }

--- a/src/hooks/use-authentication/index.ts
+++ b/src/hooks/use-authentication/index.ts
@@ -3,12 +3,7 @@ import { useRouter } from 'next/router'
 import { useSession } from 'next-auth/react'
 import { saveAndLoadAnalytics } from '@hashicorp/react-consent-manager'
 import { preferencesSavedAndLoaded } from '@hashicorp/react-consent-manager/util/cookies'
-import {
-	AuthErrors,
-	SessionData,
-	UserData,
-	ValidAuthProviderId,
-} from 'types/auth'
+import { SessionData, UserData, ValidAuthProviderId } from 'types/auth'
 import { UseAuthenticationOptions, UseAuthenticationResult } from './types'
 import { makeSignIn, makeSignOut, signUp } from './helpers'
 
@@ -45,28 +40,14 @@ const useAuthentication = (
 		onUnauthenticated,
 	})
 
-	/**
-	 * Force sign in to hopefully resolve the error. The error is automatically
-	 * cleared in the process of initiating the login flow via `signIn`.
-	 *
-	 * Because `signOut` has to be invoked to fully log out of the provider, users
-	 * _should_ be re-signed in by this action without having to use the Cloud IDP
-	 * sign in screen.
-	 *
-	 * https://next-auth.js.org/tutorials/refresh-token-rotation#client-side
-	 */
-	useEffect(() => {
-		if (data?.error === AuthErrors.RefreshAccessTokenError) {
-			signOut()
-		}
-	}, [data?.error, signOut])
-
 	// Deriving booleans about auth state
 	const isLoading = status === 'loading'
 	const isAuthenticated = status === 'authenticated'
 	const showAuthenticatedUI = isAuthenticated
 	const showUnauthenticatedUI = !isLoading && !isAuthenticated
 	const preferencesLoaded = preferencesSavedAndLoaded()
+	const error = data?.error
+	const hasError = !!error
 
 	// We accept consent manager on the user's behalf. As per Legal & Compliance,
 	// signing-in means a user is accepting our privacy policy and so we can
@@ -87,6 +68,8 @@ const useAuthentication = (
 
 	// Return everything packaged up in an object
 	return {
+		error,
+		hasError,
 		isAuthenticated,
 		isLoading,
 		session,

--- a/src/hooks/use-authentication/types.ts
+++ b/src/hooks/use-authentication/types.ts
@@ -18,6 +18,9 @@ interface UseAuthenticationOptions {
 }
 
 interface UseAuthenticationResult {
+	// https://github.com/nextauthjs/next-auth/blob/next-auth@v4.10.3/packages/next-auth/src/core/types.ts#L422-L440
+	error: undefined | Session['error']
+	hasError: boolean
 	isAuthenticated: boolean
 	isLoading: boolean
 	session: SessionData

--- a/src/layouts/base-new/index.tsx
+++ b/src/layouts/base-new/index.tsx
@@ -10,6 +10,7 @@ import createConsentManager from '@hashicorp/react-consent-manager/loader'
 import { generateTopLevelSubNavItems } from 'lib/generate-top-level-sub-nav-items'
 import useScrollPercentageAnalytics from 'hooks/use-scroll-percentage-analytics'
 import CoreDevDotLayout from 'layouts/core-dev-dot-layout'
+import AuthenticationErrorDialog from 'components/authentication-error-dialog'
 import { CommandBarProvider } from 'components/command-bar'
 import Footer from 'components/footer'
 import MobileMenuContainer, {
@@ -88,6 +89,7 @@ const BaseNewLayout = ({
 				</div>
 			</CoreDevDotLayout>
 			<ConsentManager />
+			<AuthenticationErrorDialog />
 		</CommandBarProvider>
 	)
 }

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -22,6 +22,10 @@ export default NextAuth({
 		 * https://github.com/nextauthjs/next-auth/discussions/3938
 		 */
 		async signOut({ token }) {
+			if (isDev) {
+				console.log('Inside of NextAuth.events.signOut')
+			}
+
 			try {
 				// Fetch the wellknown configuration
 				const wellKnownConfiguration = await (


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-auth-error-dialog-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203346078532406/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds new `AuthenticationErrorDialog` component
- Renders `AuthenticationErrorDialog` in `BaseNewLayout`
- Adds `error` and `hasError` properties to `UseAuthenticationResult`
- Removes from `useAuthentication` the effect that auto signed out users on `AuthErrors.RefreshAccessTokenError`
- Updates `DialogProps["onDismiss"]` to reference Reach's `DialogProps["onDismiss"]`
- Adds debug log to `NextAuth.events.signOut` in `src/pages/api/auth/[...nextauth].ts`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The purpose of this dialog is to give a notice to authenticated users that their authentication state has changed. There are multiple analytics events added to the dialog so we can gather insights into things like how often the modal is seen and how users interact with it.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma frame](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=15915%3A212986&viewport=979%2C936%2C0.93&t=xkKbTMtzDfIyqmd0-11)

![image](https://user-images.githubusercontent.com/43934258/202310681-43ed648a-c0ac-41d1-801e-fb1bd331bc0d.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out this branch locally
- [ ] Start the local server
- [ ] In a browser, open the app in 10 tabs
- [ ] In an editor, open the `src/pages/api/auth/[...nextauth].ts` file
- [ ] In `callbacks.jwt`, change the `if (isAccessTokenExpired) {` line to `if (true) {`
- [ ] Go back to your browser window
- [ ] Switch between a few tabs
- [ ] The dialog should render
- [ ] Click the "Sign in" button
- [ ] You should be taken to the `auth.hcp.dev` sign in page
- [ ] Complete the sign in flow
- [ ] Switch between a few tabs to render the dialog again
- [ ] Click the close button
- [ ] You should be signed out of the app
- [ ] Check your terminal where the server is running
- [ ] There should be one occurrence of the `"Inside of NextAuth.events.signOut"` log (rather than one for each tab)
- [ ] Sign in to the app again
- [ ] Switch between a few tabs to render the dialog one more time
- [ ] Click on the overlay behind the dialog
- [ ] You should be signed out of the app
- [ ] Check your terminal where the server is running
- [ ] There should be one occurrence of the `"Inside of NextAuth.events.signOut"` log (rather than one for each tab)
