### PR TITLE
chore: typing for strip-undefined-props

### DIFF
--- a/src/lib/strip-undefined-props.ts
+++ b/src/lib/strip-undefined-props.ts
@@ -1,6 +1,11 @@
-// Hack needed to avoid JSON-Serialization validation error from Next.js https://github.com/zeit/next.js/discussions/11209
-// >>> Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.
+/**
+ * Hack needed to avoid JSON-Serialization validation error from Next.js.
+ * https://github.com/zeit/next.js/discussions/11209
+ *
+ * Reason: `undefined` cannot be serialized as JSON.
+ * Please use `null` or omit this value all together.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function stripUndefinedProperties(obj: any) {
+export function stripUndefinedProperties<T = any>(obj: T): T {
 	return JSON.parse(JSON.stringify(obj))
 }

--- a/src/pages/onboarding/[collectionSlug].tsx
+++ b/src/pages/onboarding/[collectionSlug].tsx
@@ -43,7 +43,7 @@ export async function getStaticProps({
 	)
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			collection: currentCollection,
 			layoutProps: { breadcrumbLinks, sidebarSections },
 			metadata: {

--- a/src/pages/well-architected-framework/index.tsx
+++ b/src/pages/well-architected-framework/index.tsx
@@ -33,7 +33,7 @@ export async function getStaticProps(): Promise<{
 	]
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			metadata: {
 				title: wafData.name,
 				name: wafData.name,

--- a/src/views/collection-view/server.ts
+++ b/src/views/collection-view/server.ts
@@ -125,7 +125,7 @@ export async function getCollectionPageProps(
 	}
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			metadata: {
 				title: collection.shortName,
 				description: collection.description,

--- a/src/views/onboarding/tutorial-view/server.ts
+++ b/src/views/onboarding/tutorial-view/server.ts
@@ -95,7 +95,7 @@ export async function getOnboardingTutorialProps(
 	}
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			tutorial: {
 				...fullTutorialData,
 				content: serializedContent,

--- a/src/views/product-tutorials-view/server.ts
+++ b/src/views/product-tutorials-view/server.ts
@@ -79,7 +79,7 @@ export async function getCloudTutorialsViewProps() {
 	const { pageData, headings } = await processPageData(rawPageData)
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			metadata: {
 				title: 'Tutorials',
 			},
@@ -164,7 +164,7 @@ export async function getProductTutorialsViewProps(
 	 */
 	const { description, docsUrl, id, name, slug } = product
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			metadata: {
 				title: 'Tutorials',
 			},

--- a/src/views/tutorial-library/utils/router-state.ts
+++ b/src/views/tutorial-library/utils/router-state.ts
@@ -49,5 +49,5 @@ export function searchStateToRouteState(
 		isInteractive: state?.toggle?.isInteractive,
 	}
 
-	return stripUndefinedProperties(result)
+	return stripUndefinedProperties<$TSFixMe>(result)
 }

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -117,7 +117,7 @@ export async function getTutorialPageProps(
 	}
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			metadata: {
 				title: fullTutorialData.name,
 				description: fullTutorialData.description,

--- a/src/views/well-architected-framework/tutorial-view/server.ts
+++ b/src/views/well-architected-framework/tutorial-view/server.ts
@@ -90,7 +90,7 @@ export async function getWafTutorialViewProps(
 	}
 
 	return {
-		props: stripUndefinedProperties({
+		props: stripUndefinedProperties<$TSFixMe>({
 			tutorial: {
 				...fullTutorialData,
 				content: serializedContent,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Modifies `stripUndefinedProperties` so that it better retains type information.

## 🤷 Why

To ensure we don't lose valuable type information when using `stripUndefinedProperties`.

## 🛠️ How

Takes the approach mentioned in [the task][task]:

```ts
export function stripUndefinedProperties<T = any>(obj: T): T {
  return JSON.parse(JSON.stringify(obj))
}
```

## 💭 Anything else?

- Adding a bunch of `$TSFixMe` was necessary to prevent type errors. Intent is to handle these, and add more accurate types, in future "someday" work.
    - Maybe a co-ordinated effort to root out `$TSFixMe` in the repo could be good, and could tie in with [`no-implicit-any` work](https://app.asana.com/0/1100423001970639/1202025665826439/f) or something

[task]: https://app.asana.com/0/1202097197789424/1202406907340320/f
[preview]: https://dev-portal-git-zssupport-type-for-strip-undefined-hashicorp.vercel.app/