### PR TITLE
Updating UserDropdownDisclosure to work for non-auth'd users

### DIFF
--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -3,8 +3,8 @@ import { useRouter } from 'next/router'
 
 // HashiCorp imports
 import { IconMenu24 } from '@hashicorp/flight-icons/svg-react/menu-24'
-import { IconSignIn16 } from '@hashicorp/flight-icons/svg-react/sign-in-16'
 import { IconSearch16 } from '@hashicorp/flight-icons/svg-react/search-16'
+import { IconSignIn16 } from '@hashicorp/flight-icons/svg-react/sign-in-16'
 import { IconUserPlus16 } from '@hashicorp/flight-icons/svg-react/user-plus-16'
 import { IconX24 } from '@hashicorp/flight-icons/svg-react/x-24'
 
@@ -12,9 +12,7 @@ import { IconX24 } from '@hashicorp/flight-icons/svg-react/x-24'
 import { getUserMenuItems } from 'lib/auth/user'
 import useAuthentication from 'hooks/use-authentication'
 import { useCurrentProduct, useMobileMenu } from 'contexts'
-import Button from 'components/button'
 import { CommandBarActivator } from 'components/command-bar'
-import StandaloneLink from 'components/standalone-link'
 import UserDropdownDisclosure from 'components/user-dropdown-disclosure'
 
 // Local imports
@@ -50,50 +48,33 @@ const MobileMenuButton = () => {
  * the elements with CSS on tablet and smaller viewports.
  */
 const AuthenticationControls = () => {
-	const { showAuthenticatedUI, signIn, signOut, user } = useAuthentication()
+	const { signIn, signOut, user } = useAuthentication()
 
-	/**
-	 * @TODO implement loading skeleton
-	 * https://app.asana.com/0/1202097197789424/1202791375540720/f
-	 *
-	 * The `showUnauthenticatedUI` boolean is not used here because we want to
-	 * show the sign in/up elements by default until loading skeletons are
-	 * implemented. Most of our users do not have Learn accounts, so our goal is
-	 * to remove the flash for the majority of a users as a temporary effort.
-	 */
-
-	let content
-	if (showAuthenticatedUI) {
-		content = (
+	return (
+		<div className={s.authenticationControls}>
 			<UserDropdownDisclosure
 				className={s.userDropdownDisclosure}
 				listPosition="right"
-				items={getUserMenuItems({ signOut })}
+				items={
+					user
+						? getUserMenuItems({ signOut })
+						: [
+								{
+									icon: <IconSignIn16 />,
+									label: 'Sign in',
+									onClick: () => signIn(),
+								},
+								{
+									href: '/sign-up',
+									icon: <IconUserPlus16 />,
+									label: 'Sign up',
+								},
+						  ]
+				}
 				user={user}
 			/>
-		)
-	} else {
-		content = (
-			<>
-				<Button
-					icon={<IconSignIn16 />}
-					iconPosition="trailing"
-					onClick={() => signIn()}
-					text="Sign In"
-				/>
-				<StandaloneLink
-					className={s.signUpLink}
-					textClassName={s.signUpLinkText}
-					href="/sign-up"
-					icon={<IconUserPlus16 />}
-					iconPosition="trailing"
-					text="Sign Up"
-				/>
-			</>
-		)
-	}
-
-	return <div className={s.authenticationControls}>{content}</div>
+		</div>
+	)
 }
 
 /**

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -1,3 +1,6 @@
+import { IconUser16 } from '@hashicorp/flight-icons/svg-react/user-16'
+import { getUserMeta } from 'lib/auth/user'
+import isAbsoluteUrl from 'lib/is-absolute-url'
 import DropdownDisclosure, {
 	DropdownDisclosureButtonItem,
 	DropdownDisclosureDescriptionItem,
@@ -5,8 +8,6 @@ import DropdownDisclosure, {
 	DropdownDisclosureLinkItem,
 	DropdownDisclosureSeparatorItem,
 } from 'components/dropdown-disclosure'
-import { getUserMeta } from 'lib/auth/user'
-import isAbsoluteUrl from 'lib/is-absolute-url'
 import {
 	UserDropdownDisclosureItem,
 	UserDropdownDisclosureProps,
@@ -53,7 +54,7 @@ const renderItem = (
 
 /**
  * A DropdownDisclosure intended to be used as a menu with actions/links for
- * authenticated users.
+ * both authenticated and unauthenticated users.
  */
 const UserDropdownDisclosure = ({
 	className,
@@ -61,20 +62,29 @@ const UserDropdownDisclosure = ({
 	listPosition,
 	user,
 }: UserDropdownDisclosureProps) => {
-	const { icon, label, description } = getUserMeta(user)
+	let userMeta
+	if (user) {
+		userMeta = getUserMeta(user)
+	}
 
 	return (
 		<DropdownDisclosure
 			aria-label="User menu"
 			className={className}
-			icon={icon}
+			icon={user ? userMeta.icon : <IconUser16 />}
 			listPosition={listPosition}
 		>
-			<DropdownDisclosureLabelItem>{label}</DropdownDisclosureLabelItem>
-			<DropdownDisclosureDescriptionItem>
-				{description}
-			</DropdownDisclosureDescriptionItem>
-			<DropdownDisclosureSeparatorItem />
+			{user ? (
+				<>
+					<DropdownDisclosureLabelItem>
+						{userMeta.label}
+					</DropdownDisclosureLabelItem>
+					<DropdownDisclosureDescriptionItem>
+						{userMeta.description}
+					</DropdownDisclosureDescriptionItem>
+					<DropdownDisclosureSeparatorItem />
+				</>
+			) : null}
 			{items.map(renderItem)}
 		</DropdownDisclosure>
 	)


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203346623842024/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `UserDropdownDisclosure` to show different content depending on whether or not a user is authenticated.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Two main reasons:
  - Take up less space in the navigation header
  - Prevent any layout shift after auth data has loaded

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=15929%3A213992&viewport=556%2C4874%2C0.95&t=IAorXYWUmL1K2kai-11)

![image](https://user-images.githubusercontent.com/43934258/201161323-57536f8d-199b-4e5d-8768-b355b565fd46.png)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview url
- [ ] Make sure you're not signed in
- [ ] Make sure the user dropdown menu shows as expected
- [ ] Sign in
- [ ] Make sure there is no layout shift when your user data loads
- [ ] Make sure the user dropdown menu shows as expected
