### PR TITLE
Upgrade remark-plugins for tabbedSectionDepth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
 				"@hashicorp/react-text-splits": "^3.2.7",
 				"@hashicorp/react-use-cases": "^5.0.0",
 				"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-				"@hashicorp/remark-plugins": "4.1.0-canary.1",
+				"@hashicorp/remark-plugins": "^4.1.1",
 				"@hashicorp/sentinel-embedded": "^0.0.14",
 				"@octokit/core": "^3.5.1",
 				"@octokit/openapi-types": "^11.2.0",
@@ -4389,9 +4389,9 @@
 			}
 		},
 		"node_modules/@hashicorp/remark-plugins": {
-			"version": "4.1.0-canary.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.1.tgz",
-			"integrity": "sha512-XH6vTKGWvyHAY9UBdnM4gbZioDc6YPTpA60vUfEzi8hXqm+Dqogovxue+OBH8/qzFiqIgje3cyB/ldnrZfE3HQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.1.tgz",
+			"integrity": "sha512-4BO5ZyS2U9H4CIJVUUb1rYzn6ZT5zRYOHDTv27EDAwhjS3YHgK/23otdMsxLhan7A4laYPC95d8a8SuP4Djnuw==",
 			"dependencies": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",
@@ -37924,9 +37924,9 @@
 			}
 		},
 		"@hashicorp/remark-plugins": {
-			"version": "4.1.0-canary.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.1.tgz",
-			"integrity": "sha512-XH6vTKGWvyHAY9UBdnM4gbZioDc6YPTpA60vUfEzi8hXqm+Dqogovxue+OBH8/qzFiqIgje3cyB/ldnrZfE3HQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.1.tgz",
+			"integrity": "sha512-4BO5ZyS2U9H4CIJVUUb1rYzn6ZT5zRYOHDTv27EDAwhjS3YHgK/23otdMsxLhan7A4laYPC95d8a8SuP4Djnuw==",
 			"requires": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
 				"@hashicorp/react-text-splits": "^3.2.7",
 				"@hashicorp/react-use-cases": "^5.0.0",
 				"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-				"@hashicorp/remark-plugins": "^4.0.1",
+				"@hashicorp/remark-plugins": "4.1.0-canary.0",
 				"@hashicorp/sentinel-embedded": "^0.0.14",
 				"@octokit/core": "^3.5.1",
 				"@octokit/openapi-types": "^11.2.0",
@@ -4389,9 +4389,9 @@
 			}
 		},
 		"node_modules/@hashicorp/remark-plugins": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.0.1.tgz",
-			"integrity": "sha512-pWBXCEFL0qQoUpOyOkS/S+X/X6g0SUF2NS3TJzdBfFUnKOnPDKB6k0OIyV67EVoOrL1VT4vJcD1jObZnbI+6+g==",
+			"version": "4.1.0-canary.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.0.tgz",
+			"integrity": "sha512-QU1Cv/imn4ClwNnOorKcUWBUfVDUQ3VSTTmPHb58LExxyOGn2aJSCWZmvSiHhViRQOpaHg4Z+iPXcixcD0KYQA==",
 			"dependencies": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",
@@ -37924,9 +37924,9 @@
 			}
 		},
 		"@hashicorp/remark-plugins": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.0.1.tgz",
-			"integrity": "sha512-pWBXCEFL0qQoUpOyOkS/S+X/X6g0SUF2NS3TJzdBfFUnKOnPDKB6k0OIyV67EVoOrL1VT4vJcD1jObZnbI+6+g==",
+			"version": "4.1.0-canary.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.0.tgz",
+			"integrity": "sha512-QU1Cv/imn4ClwNnOorKcUWBUfVDUQ3VSTTmPHb58LExxyOGn2aJSCWZmvSiHhViRQOpaHg4Z+iPXcixcD0KYQA==",
 			"requires": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
 				"@hashicorp/react-text-splits": "^3.2.7",
 				"@hashicorp/react-use-cases": "^5.0.0",
 				"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-				"@hashicorp/remark-plugins": "4.1.0-canary.0",
+				"@hashicorp/remark-plugins": "4.1.0-canary.1",
 				"@hashicorp/sentinel-embedded": "^0.0.14",
 				"@octokit/core": "^3.5.1",
 				"@octokit/openapi-types": "^11.2.0",
@@ -4389,9 +4389,9 @@
 			}
 		},
 		"node_modules/@hashicorp/remark-plugins": {
-			"version": "4.1.0-canary.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.0.tgz",
-			"integrity": "sha512-QU1Cv/imn4ClwNnOorKcUWBUfVDUQ3VSTTmPHb58LExxyOGn2aJSCWZmvSiHhViRQOpaHg4Z+iPXcixcD0KYQA==",
+			"version": "4.1.0-canary.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.1.tgz",
+			"integrity": "sha512-XH6vTKGWvyHAY9UBdnM4gbZioDc6YPTpA60vUfEzi8hXqm+Dqogovxue+OBH8/qzFiqIgje3cyB/ldnrZfE3HQ==",
 			"dependencies": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",
@@ -37924,9 +37924,9 @@
 			}
 		},
 		"@hashicorp/remark-plugins": {
-			"version": "4.1.0-canary.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.0.tgz",
-			"integrity": "sha512-QU1Cv/imn4ClwNnOorKcUWBUfVDUQ3VSTTmPHb58LExxyOGn2aJSCWZmvSiHhViRQOpaHg4Z+iPXcixcD0KYQA==",
+			"version": "4.1.0-canary.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-4.1.0-canary.1.tgz",
+			"integrity": "sha512-XH6vTKGWvyHAY9UBdnM4gbZioDc6YPTpA60vUfEzi8hXqm+Dqogovxue+OBH8/qzFiqIgje3cyB/ldnrZfE3HQ==",
 			"requires": {
 				"@mdx-js/util": "1.6.22",
 				"github-slugger": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"@hashicorp/react-text-splits": "^3.2.7",
 		"@hashicorp/react-use-cases": "^5.0.0",
 		"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-		"@hashicorp/remark-plugins": "4.1.0-canary.1",
+		"@hashicorp/remark-plugins": "^4.1.1",
 		"@hashicorp/sentinel-embedded": "^0.0.14",
 		"@octokit/core": "^3.5.1",
 		"@octokit/openapi-types": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"@hashicorp/react-text-splits": "^3.2.7",
 		"@hashicorp/react-use-cases": "^5.0.0",
 		"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-		"@hashicorp/remark-plugins": "4.1.0-canary.0",
+		"@hashicorp/remark-plugins": "4.1.0-canary.1",
 		"@hashicorp/sentinel-embedded": "^0.0.14",
 		"@octokit/core": "^3.5.1",
 		"@octokit/openapi-types": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"@hashicorp/react-text-splits": "^3.2.7",
 		"@hashicorp/react-use-cases": "^5.0.0",
 		"@hashicorp/react-vertical-text-block-list": "^7.0.0",
-		"@hashicorp/remark-plugins": "^4.0.1",
+		"@hashicorp/remark-plugins": "4.1.0-canary.0",
 		"@hashicorp/sentinel-embedded": "^0.0.14",
 		"@octokit/core": "^3.5.1",
 		"@octokit/openapi-types": "^11.2.0",

--- a/src/layouts/sidebar-sidecar/components/table-of-contents/types.ts
+++ b/src/layouts/sidebar-sidecar/components/table-of-contents/types.ts
@@ -2,6 +2,8 @@ export interface TableOfContentsHeading {
 	title: string
 	slug: string
 	level: 1 | 2 | 3 | 4 | 5 | 6
+	// TODO: make not optional?
+	tabbedSectionDepth?: number
 }
 
 export interface TableOfContentsProps {

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -30,6 +30,7 @@ import {
 	useSidebarNavData,
 } from './contexts/sidebar-nav-data'
 import { ScrollProgressBar } from './components/scroll-progress-bar'
+import { filterTableOfContentsHeadings } from './utils/filter-table-of-contents-headings'
 import s from './sidebar-sidecar-layout.module.css'
 
 const SidebarSidecarLayout = (props: SidebarSidecarLayoutProps) => {
@@ -94,9 +95,7 @@ const SidebarSidecarLayoutContent = ({
 		}
 
 		return (
-			<TableOfContents
-				headings={headings.filter((heading) => heading.level <= 2)}
-			/>
+			<TableOfContents headings={filterTableOfContentsHeadings(headings)} />
 		)
 	}
 

--- a/src/layouts/sidebar-sidecar/utils/filter-table-of-contents-headings.ts
+++ b/src/layouts/sidebar-sidecar/utils/filter-table-of-contents-headings.ts
@@ -7,6 +7,12 @@ import { TableOfContentsHeading } from '../components/table-of-contents'
  * 	- Headings <h3> through <h6> are filtered out.
  * - Retain headings that are not nested in <Tabs />
  * 	- Headings with `tabbedSectionDepth !== 0` are filtered out.
+ *
+ * Note that to filter based on `tabbedSectionDepth`, we rely on functionality
+ * in our `anchor-links` `remark-plugin` to add that property. For details, see
+ * the `tabbedSectionDepth` logic here:
+ * https://github.com/hashicorp/remark-plugins/blob/0f2d21516ab3c7120a24456838d83390e3ab179d/plugins/anchor-links/index.js#L29
+ *
  */
 export function filterTableOfContentsHeadings(
 	headings: TableOfContentsHeading[]

--- a/src/layouts/sidebar-sidecar/utils/filter-table-of-contents-headings.ts
+++ b/src/layouts/sidebar-sidecar/utils/filter-table-of-contents-headings.ts
@@ -1,0 +1,44 @@
+import { TableOfContentsHeading } from '../components/table-of-contents'
+
+/**
+ * Filter headings for display in table of contents.
+ *
+ * - Retain headings that are <h1> or <h2>
+ * 	- Headings <h3> through <h6> are filtered out.
+ * - Retain headings that are not nested in <Tabs />
+ * 	- Headings with `tabbedSectionDepth !== 0` are filtered out.
+ */
+export function filterTableOfContentsHeadings(
+	headings: TableOfContentsHeading[]
+): TableOfContentsHeading[] {
+	return headings.filter((heading: TableOfContentsHeading) => {
+		const { level, tabbedSectionDepth } = heading
+
+		/**
+		 * Only include <h2> in the table of contents.
+		 *
+		 * Note that <h1> are also included, this is as a stopgap
+		 * while we implement content conformance that ensures there is
+		 * exactly one <h1> per page (which we would likely not include here).
+		 */
+		if (level > 2) {
+			return false
+		}
+
+		/**
+		 * Only include headings that are *outside* of <Tabs />.
+		 *
+		 * In other words, the `tabbedSectionDepth` must be 0 for a heading
+		 * to be included in the table of contents.
+		 */
+		if (typeof tabbedSectionDepth === 'number' && tabbedSectionDepth !== 0) {
+			return false
+		}
+
+		/**
+		 * Return true for headings that have not been filtered out
+		 * by previous criteria.
+		 */
+		return true
+	})
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR is nearly identical to #1344. The difference is that this PR uses a fixed version of `remark-plugins` to handle multi-level `<Tabs />` nesting correctly.

Previously, if multiple subsequent `<Tabs />` JSX were in a single block of JSX, tab depth was not calculated correctly. This has been fixed in https://github.com/hashicorp/remark-plugins/pull/49.

## 🤷 Why

Displaying headings nested within `<Tabs />` can create a table-of-contents that is both overwhelming, due to the sheer number of headings, and duplicative and confusing, as content between tabbed sections often contains parallel headings.

## 🛠️ How

- Pulls in an updated & patched release of `remark-plugins`, where the `anchor-links` plugin now provides `tabbedSectionDepth` property for all `headings`
    - See https://github.com/hashicorp/remark-plugins/pull/49 for details
- Filters out headings where `tabbedSectionDepth` is not `0`.

## 📸 Design Screenshots

| Before | After |
| - | - |
| <img width="1662" alt="CleanShot 2022-11-15 at 14 39 07@2x" src="https://user-images.githubusercontent.com/4624598/202010496-9a866c71-ffcc-4259-a264-c6ee46365333.png"> | <img width="1662" alt="CleanShot 2022-11-15 at 14 38 26@2x" src="https://user-images.githubusercontent.com/4624598/202010555-98ba8204-6aa0-47f0-b5cd-59d38799b08b.png"> |
| <img width="1661" alt="CleanShot 2022-11-15 at 14 39 17@2x" src="https://user-images.githubusercontent.com/4624598/202010524-2aa423e3-a6a2-46cc-af23-ed6ba5b2a83d.png"> | <img width="1662" alt="CleanShot 2022-11-15 at 14 38 39@2x" src="https://user-images.githubusercontent.com/4624598/202010566-b711a505-462e-44b7-b6bd-7254a5796aed.png"> |
| <img width="1662" alt="CleanShot 2022-11-15 at 14 39 28@2x" src="https://user-images.githubusercontent.com/4624598/202010536-7baae3cf-7573-401a-a7bc-ae7ab6071c1b.png"> | <img width="1661" alt="CleanShot 2022-11-15 at 14 38 51@2x" src="https://user-images.githubusercontent.com/4624598/202010571-1a13ecc5-90d4-4f8b-a00c-fbe5919747a9.png"> |

## 🧪 Testing

- [ ] Visit a page with headings nested in `<Tabs />`, such as [/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms][/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms]
    - Headings nested within `<Tabs />` should not be shown in the table of contents

And also:

- [ ] Visit a page with multi-level `<Tabs />` nesting, such as [/terraform/tutorials/kubernetes/aks][/terraform/tutorials/kubernetes/aks] or [/terraform/tutorials/kubernetes/gke][/terraform/tutorials/kubernetes/gke]
    - Headings _not_ nested within `<Tabs />` should still be shown in the table of contents. This was not the case in #1344.

List of example pages, in preview and production:

| Preview | Production |
| - | - |
| [/terraform/tutorials/kubernetes/gke](https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/terraform/tutorials/kubernetes/gke) | [/terraform/tutorials/kubernetes/gke](https://developer.hashicorp.com/terraform/tutorials/kubernetes/gke) |
| [/terraform/tutorials/kubernetes/aks](https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/terraform/tutorials/kubernetes/aks) | [/terraform/tutorials/kubernetes/aks](https://developer.hashicorp.com/terraform/tutorials/kubernetes/aks) |
| [/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms](https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms) | [/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms](https://developer.hashicorp.com/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms) |

[preview]: https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1202097197789424/1202518894520801/f
[/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms]: https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/vault/tutorials/adp/key-management-secrets-engine-gcp-cloud-kms
[/terraform/tutorials/kubernetes/gke]: https://developer.hashicorp.com/terraform/tutorials/kubernetes/gke
[/terraform/tutorials/kubernetes/aks]: https://dev-portal-git-ambtest-tabbed-section-depth-hashicorp.vercel.app/terraform/tutorials/kubernetes/aks