### PR TITLE
chore: hide_versions hides version selector

### DIFF
--- a/src/lib/integrations-api-client/index.ts
+++ b/src/lib/integrations-api-client/index.ts
@@ -39,6 +39,7 @@ export interface Integration {
 	description?: string
 	repo_url: string
 	subdirectory?: string
+	hide_versions: boolean
 	organization?: Organization
 }
 

--- a/src/views/product-integration/components/header/index.tsx
+++ b/src/views/product-integration/components/header/index.tsx
@@ -13,6 +13,7 @@ interface HeaderProps {
 	author: string
 	versions: string[]
 	description?: string
+	hideVersions?: boolean
 }
 
 export default function Header({
@@ -21,12 +22,14 @@ export default function Header({
 	tier,
 	author,
 	versions,
+	hideVersions,
 	description,
 }: HeaderProps) {
 	// note - the backend will not return pre-releases,
 	// and will sort by semver DESC.
 	const latestVersion: string = versions[0]
 	const otherVersions: Array<string> = versions.slice(1)
+	const showVersions = !hideVersions && versions.length > 1
 	return (
 		<div className={classNames(s.header, className)}>
 			<div className={s.left}>
@@ -43,7 +46,7 @@ export default function Header({
 				<p>{description}</p>
 			</div>
 			<div className={s.right}>
-				{versions.length > 1 && (
+				{showVersions ? (
 					<DropdownDisclosure
 						className={s.versionDropdown}
 						color="secondary"
@@ -60,7 +63,7 @@ export default function Header({
 							)
 						})}
 					</DropdownDisclosure>
-				)}
+				) : null}
 			</div>
 		</div>
 	)

--- a/src/views/product-integration/index.tsx
+++ b/src/views/product-integration/index.tsx
@@ -58,6 +58,7 @@ export default function ProductIntegrationLanding({
 								tier={integration.tier}
 								author={integration.organization.slug}
 								versions={integration.releases.map((r) => r.version)}
+								hideVersions={integration.hide_versions}
 								description={integration.description}
 							/>
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task][task] 🎟️

## 🗒️ What

Updates the integrations demo front-end to hide the version selector when the integration in question has `hide_versions` set to `true`.

## 💭 Anything else?

I imagine there might be more we might want to do in the future.

For example, if we start rendering versioned integration docs with `v0.0.0` or whatnot in the URL, similar to docs (eg <https://developer.hashicorp.com/vault/docs/v1.10.x/secrets/kv>), then there might be some `getStaticProps` logic needed to prevent not-latest-version URLs of `hide_versions` integrations from rendering. Though maybe it's possible we go with the approach we took with downloads pages, where the version selector doesn't change the URL, and so the version selector being hidden is all we need? 🤷 

[task]: https://app.asana.com/0/0/1203401870478721/f