### PR TITLE
remove name from payload per MOPS

### DIFF
--- a/src/hooks/use-authentication/index.ts
+++ b/src/hooks/use-authentication/index.ts
@@ -83,7 +83,6 @@ const useAuthentication = (
 		if (canAnalyzeUser() && segmentUserId !== session.id) {
 			analytics?.identify(session.id, {
 				email: user.email,
-				name: user.name,
 				devPortalSignUp: true,
 			})
 		}


### PR DESCRIPTION
## 🔗 Relevant links

## 🗒️ What

Removes `name` from the recently added (#1353) `analytics.identify` call that sends sign-ins to Marketo. Name is problematic because it's never set as part of the sign-in process, and so Auth0 populates it with the user's email address. This results in name fields in Marketo getting overwritten with email addresses for existing records. 

