### PR TITLE
fix: code block hydration mismatches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@hashicorp/react-alert-banner": "^7.0.1",
 				"@hashicorp/react-button": "^6.2.1",
 				"@hashicorp/react-call-to-action": "^5.1.0",
-				"@hashicorp/react-code-block": "^6.2.2-canary-20221130173256",
+				"@hashicorp/react-code-block": "^6.2.2",
 				"@hashicorp/react-command-line-terminal": "^2.0.4",
 				"@hashicorp/react-consent-manager": "^8.2.1",
 				"@hashicorp/react-docs-page": "^17.7.0",
@@ -3028,9 +3028,9 @@
 			}
 		},
 		"node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.2-canary-20221130173256",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2-canary-20221130173256.tgz",
-			"integrity": "sha512-NdFfTAlRzOsoCirugu+/0ZYXDrh1U2wa6h+yLf0byGbgu77ADX2tcENQsNIUo+nrpunuGlyhnLDaIS7t7TBTeg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2.tgz",
+			"integrity": "sha512-1S2w17Z7In706sl36ZlD1Ef1KPISw3FQbw3VM+nbWsMUw/JDKtAqhafuaix/UxxJV1mvD/cHEJacsXi6FjCuNg==",
 			"dependencies": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -3249,136 +3249,6 @@
 				"react": ">= 16.x"
 			}
 		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
-			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
-			"dependencies": {
-				"@hashicorp/react-inline-svg": "^6.0.3",
-				"@reach/listbox": "^0.17.0",
-				"shellwords": "^0.1.1"
-			},
-			"peerDependencies": {
-				"@hashicorp/mktg-global-styles": ">=3.x",
-				"react": ">=16.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/auto-id": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-			"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/descendants": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
-			"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/listbox": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
-			"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
-			"dependencies": {
-				"@reach/auto-id": "0.17.0",
-				"@reach/descendants": "0.17.0",
-				"@reach/machine": "0.17.0",
-				"@reach/popover": "0.17.0",
-				"@reach/utils": "0.17.0",
-				"prop-types": "^15.7.2"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/machine": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
-			"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"@xstate/fsm": "1.4.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/popover": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
-			"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
-			"dependencies": {
-				"@reach/portal": "0.17.0",
-				"@reach/rect": "0.17.0",
-				"@reach/utils": "0.17.0",
-				"tabbable": "^4.0.0",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/portal": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
-			"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
-			"dependencies": {
-				"@reach/utils": "0.17.0",
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/rect": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
-			"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
-			"dependencies": {
-				"@reach/observe-rect": "1.2.0",
-				"@reach/utils": "0.17.0",
-				"prop-types": "^15.7.2",
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/utils": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-			"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-			"dependencies": {
-				"tiny-warning": "^1.0.3",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || 17.x",
-				"react-dom": "^16.8.0 || 17.x"
-			}
-		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3413,11 +3283,6 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
-		},
-		"node_modules/@hashicorp/react-docs-page/node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/unified": {
 			"version": "9.2.2",
@@ -36287,9 +36152,9 @@
 			}
 		},
 		"@hashicorp/react-code-block": {
-			"version": "6.2.2-canary-20221130173256",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2-canary-20221130173256.tgz",
-			"integrity": "sha512-NdFfTAlRzOsoCirugu+/0ZYXDrh1U2wa6h+yLf0byGbgu77ADX2tcENQsNIUo+nrpunuGlyhnLDaIS7t7TBTeg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2.tgz",
+			"integrity": "sha512-1S2w17Z7In706sl36ZlD1Ef1KPISw3FQbw3VM+nbWsMUw/JDKtAqhafuaix/UxxJV1mvD/cHEJacsXi6FjCuNg==",
 			"requires": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -36452,100 +36317,6 @@
 						"@mdx-js/react": "1.6.22"
 					}
 				},
-				"@hashicorp/react-code-block": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
-					"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
-					"requires": {
-						"@hashicorp/react-inline-svg": "^6.0.3",
-						"@reach/listbox": "^0.17.0",
-						"shellwords": "^0.1.1"
-					}
-				},
-				"@reach/auto-id": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
-					"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/descendants": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
-					"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/listbox": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
-					"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
-					"requires": {
-						"@reach/auto-id": "0.17.0",
-						"@reach/descendants": "0.17.0",
-						"@reach/machine": "0.17.0",
-						"@reach/popover": "0.17.0",
-						"@reach/utils": "0.17.0",
-						"prop-types": "^15.7.2"
-					}
-				},
-				"@reach/machine": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
-					"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"@xstate/fsm": "1.4.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/popover": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
-					"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
-					"requires": {
-						"@reach/portal": "0.17.0",
-						"@reach/rect": "0.17.0",
-						"@reach/utils": "0.17.0",
-						"tabbable": "^4.0.0",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/portal": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
-					"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
-					"requires": {
-						"@reach/utils": "0.17.0",
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/rect": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
-					"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
-					"requires": {
-						"@reach/observe-rect": "1.2.0",
-						"@reach/utils": "0.17.0",
-						"prop-types": "^15.7.2",
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
-				"@reach/utils": {
-					"version": "0.17.0",
-					"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
-					"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
-					"requires": {
-						"tiny-warning": "^1.0.3",
-						"tslib": "^2.3.0"
-					}
-				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -36571,11 +36342,6 @@
 					"requires": {
 						"picomatch": "^2.2.1"
 					}
-				},
-				"tslib": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 				},
 				"unified": {
 					"version": "9.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@hashicorp/react-alert-banner": "^7.0.1",
 				"@hashicorp/react-button": "^6.2.1",
 				"@hashicorp/react-call-to-action": "^5.1.0",
-				"@hashicorp/react-code-block": "^6.2.1",
+				"@hashicorp/react-code-block": "^6.2.2-canary-20221130173256",
 				"@hashicorp/react-command-line-terminal": "^2.0.4",
 				"@hashicorp/react-consent-manager": "^8.2.1",
 				"@hashicorp/react-docs-page": "^17.7.0",
@@ -3028,9 +3028,9 @@
 			}
 		},
 		"node_modules/@hashicorp/react-code-block": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
-			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
+			"version": "6.2.2-canary-20221130173256",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2-canary-20221130173256.tgz",
+			"integrity": "sha512-NdFfTAlRzOsoCirugu+/0ZYXDrh1U2wa6h+yLf0byGbgu77ADX2tcENQsNIUo+nrpunuGlyhnLDaIS7t7TBTeg==",
 			"dependencies": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -3249,6 +3249,136 @@
 				"react": ">= 16.x"
 			}
 		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-code-block": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
+			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
+			"dependencies": {
+				"@hashicorp/react-inline-svg": "^6.0.3",
+				"@reach/listbox": "^0.17.0",
+				"shellwords": "^0.1.1"
+			},
+			"peerDependencies": {
+				"@hashicorp/mktg-global-styles": ">=3.x",
+				"react": ">=16.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/auto-id": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+			"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/descendants": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+			"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/listbox": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+			"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+			"dependencies": {
+				"@reach/auto-id": "0.17.0",
+				"@reach/descendants": "0.17.0",
+				"@reach/machine": "0.17.0",
+				"@reach/popover": "0.17.0",
+				"@reach/utils": "0.17.0",
+				"prop-types": "^15.7.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/machine": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+			"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"@xstate/fsm": "1.4.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/popover": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+			"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+			"dependencies": {
+				"@reach/portal": "0.17.0",
+				"@reach/rect": "0.17.0",
+				"@reach/utils": "0.17.0",
+				"tabbable": "^4.0.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/portal": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+			"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+			"dependencies": {
+				"@reach/utils": "0.17.0",
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/rect": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+			"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+			"dependencies": {
+				"@reach/observe-rect": "1.2.0",
+				"@reach/utils": "0.17.0",
+				"prop-types": "^15.7.2",
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/@reach/utils": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+			"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+			"dependencies": {
+				"tiny-warning": "^1.0.3",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || 17.x",
+				"react-dom": "^16.8.0 || 17.x"
+			}
+		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3283,6 +3413,11 @@
 			"engines": {
 				"node": ">=8.10.0"
 			}
+		},
+		"node_modules/@hashicorp/react-docs-page/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 		},
 		"node_modules/@hashicorp/react-docs-page/node_modules/unified": {
 			"version": "9.2.2",
@@ -36152,9 +36287,9 @@
 			}
 		},
 		"@hashicorp/react-code-block": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
-			"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
+			"version": "6.2.2-canary-20221130173256",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.2-canary-20221130173256.tgz",
+			"integrity": "sha512-NdFfTAlRzOsoCirugu+/0ZYXDrh1U2wa6h+yLf0byGbgu77ADX2tcENQsNIUo+nrpunuGlyhnLDaIS7t7TBTeg==",
 			"requires": {
 				"@hashicorp/react-inline-svg": "^6.0.3",
 				"@reach/listbox": "^0.17.0",
@@ -36317,6 +36452,100 @@
 						"@mdx-js/react": "1.6.22"
 					}
 				},
+				"@hashicorp/react-code-block": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-6.2.1.tgz",
+					"integrity": "sha512-yxrZJX5L44o0+L3Q+HLHckK55mwX1EmdnPRuWjxOgJNext9Lvurj+5ngFTy/2DAWwgmlsE8deCBEctfeWud7CQ==",
+					"requires": {
+						"@hashicorp/react-inline-svg": "^6.0.3",
+						"@reach/listbox": "^0.17.0",
+						"shellwords": "^0.1.1"
+					}
+				},
+				"@reach/auto-id": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+					"integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/descendants": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+					"integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/listbox": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+					"integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+					"requires": {
+						"@reach/auto-id": "0.17.0",
+						"@reach/descendants": "0.17.0",
+						"@reach/machine": "0.17.0",
+						"@reach/popover": "0.17.0",
+						"@reach/utils": "0.17.0",
+						"prop-types": "^15.7.2"
+					}
+				},
+				"@reach/machine": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+					"integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"@xstate/fsm": "1.4.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/popover": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+					"integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+					"requires": {
+						"@reach/portal": "0.17.0",
+						"@reach/rect": "0.17.0",
+						"@reach/utils": "0.17.0",
+						"tabbable": "^4.0.0",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/portal": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+					"integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+					"requires": {
+						"@reach/utils": "0.17.0",
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/rect": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+					"integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+					"requires": {
+						"@reach/observe-rect": "1.2.0",
+						"@reach/utils": "0.17.0",
+						"prop-types": "^15.7.2",
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
+				"@reach/utils": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+					"integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+					"requires": {
+						"tiny-warning": "^1.0.3",
+						"tslib": "^2.3.0"
+					}
+				},
 				"argparse": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -36342,6 +36571,11 @@
 					"requires": {
 						"picomatch": "^2.2.1"
 					}
+				},
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
 				},
 				"unified": {
 					"version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@hashicorp/react-alert-banner": "^7.0.1",
 		"@hashicorp/react-button": "^6.2.1",
 		"@hashicorp/react-call-to-action": "^5.1.0",
-		"@hashicorp/react-code-block": "^6.2.2-canary-20221130173256",
+		"@hashicorp/react-code-block": "^6.2.2",
 		"@hashicorp/react-command-line-terminal": "^2.0.4",
 		"@hashicorp/react-consent-manager": "^8.2.1",
 		"@hashicorp/react-docs-page": "^17.7.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@hashicorp/react-alert-banner": "^7.0.1",
 		"@hashicorp/react-button": "^6.2.1",
 		"@hashicorp/react-call-to-action": "^5.1.0",
-		"@hashicorp/react-code-block": "^6.2.1",
+		"@hashicorp/react-code-block": "^6.2.2-canary-20221130173256",
 		"@hashicorp/react-command-line-terminal": "^2.0.4",
 		"@hashicorp/react-consent-manager": "^8.2.1",
 		"@hashicorp/react-docs-page": "^17.7.0",


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Pulls in this code block change to address hydration issues: https://github.com/hashicorp/react-components/pull/834

Fixes #1401 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
- [ ] Visit https://dev-portal-git-brkfix-hydration-mismatch-codeblock-hashicorp.vercel.app/nomad/api-docs/jobs
- [ ] The page should load in a reasonable time and there should be no react errors in the console

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
