### PR TITLE
Adding script for listing open docs PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
 				"@hashicorp/platform-postcss-config": "^0.1.0",
 				"@hashicorp/platform-tools": "^0.6.0",
 				"@hashicorp/platform-types": "^0.3.0",
+				"@octokit/rest": "^19.0.5",
 				"@playwright/test": "^1.28.0",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/react": "^13.3.0",
@@ -156,7 +157,8 @@
 				"react-test-renderer": "^18.2.0",
 				"simple-git-hooks": "^2.7.0",
 				"stylelint": "^13.8.0",
-				"typescript": "^4.5.5"
+				"typescript": "^4.5.5",
+				"yargs": "^17.6.2"
 			},
 			"engines": {
 				"node": ">=14.x <=16.x",
@@ -2895,42 +2897,6 @@
 				"hc-tools": "dist/index.js"
 			}
 		},
-		"node_modules/@hashicorp/platform-tools/node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@hashicorp/platform-tools/node_modules/yargs": {
-			"version": "17.4.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-			"integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@hashicorp/platform-tools/node_modules/yargs-parser": {
-			"version": "21.0.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@hashicorp/platform-types": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@hashicorp/platform-types/-/platform-types-0.3.0.tgz",
@@ -5450,6 +5416,46 @@
 			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
 			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
 		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+			"dev": true,
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.7.0.tgz",
+			"integrity": "sha512-orxQ0fAHA7IpYhG2flD2AygztPlGYNAdlzYz8yrD8NDgelPfOYoRPROfEyIe035PlxvbYrgkfUZIhSBKju/Cvw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^8.0.0",
+				"deprecation": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+			"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+			"dev": true
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+			"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/openapi-types": "^14.0.0"
+			}
+		},
 		"node_modules/@octokit/request": {
 			"version": "5.6.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
@@ -5477,6 +5483,149 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@octokit/rest": {
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.5.tgz",
+			"integrity": "sha512-+4qdrUFq2lk7Va+Qff3ofREQWGBeoTKNqlJO+FGjFP35ZahP+nBenhZiGdu8USSgmq4Ky3IJ/i4u0xbLqHaeow==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/core": "^4.1.0",
+				"@octokit/plugin-paginate-rest": "^5.0.0",
+				"@octokit/plugin-request-log": "^1.0.4",
+				"@octokit/plugin-rest-endpoint-methods": "^6.7.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
+			"integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/core": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+			"integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/auth-token": "^3.0.0",
+				"@octokit/graphql": "^5.0.0",
+				"@octokit/request": "^6.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^8.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.3.tgz",
+			"integrity": "sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^8.0.0",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.4.tgz",
+			"integrity": "sha512-amO1M5QUQgYQo09aStR/XO7KAl13xpigcy/kI8/N1PnZYSS69fgte+xA4+c2DISKqUZfsh0wwjc2FaCt99L41A==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/request": "^6.0.0",
+				"@octokit/types": "^8.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+			"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+			"dev": true
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-5.0.1.tgz",
+			"integrity": "sha512-7A+rEkS70pH36Z6JivSlR7Zqepz3KVucEFVDnSrgHXzG7WLAzYwcHZbKdfTXHwuTHbkT1vKvz7dHl1+HNf6Qyw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=4"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
+			"integrity": "sha512-6VDqgj0HMc2FUX2awIs+sM6OwLgwHvAi4KCK3mT2H2IKRt6oH9d0fej5LluF5mck1lRR/rFWN0YIDSYXYSylbw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/endpoint": "^7.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^8.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.7",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.2.tgz",
+			"integrity": "sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^8.0.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/types": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+			"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/openapi-types": "^14.0.0"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10317,13 +10466,17 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/clone": {
@@ -17933,6 +18086,44 @@
 				}
 			}
 		},
+		"node_modules/jest-cli/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/jest-cli/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jest-cli/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/jest-config": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
@@ -22875,6 +23066,16 @@
 				"postcss": "^8.0.0"
 			}
 		},
+		"node_modules/postcss-cli/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
 		"node_modules/postcss-cli/node_modules/get-stdin": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
@@ -22884,6 +23085,31 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/postcss-cli/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/postcss-cli/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/postcss-color-functional-notation": {
@@ -33862,20 +34088,21 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"version": "17.6.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"dev": true,
 			"dependencies": {
-				"cliui": "^7.0.2",
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
+				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
+				"yargs-parser": "^21.1.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/yargs-parser": {
@@ -33890,8 +34117,18 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yargs/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yauzl": {
@@ -36169,35 +36406,6 @@
 				"ts-node": "^10.7.0",
 				"tsconfig-paths": "^3.14.1",
 				"yargs": "^17.4.1"
-			},
-			"dependencies": {
-				"y18n": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "17.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
-					"integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
-					"dev": true,
-					"requires": {
-						"cliui": "^7.0.2",
-						"escalade": "^3.1.1",
-						"get-caller-file": "^2.0.5",
-						"require-directory": "^2.1.1",
-						"string-width": "^4.2.3",
-						"y18n": "^5.0.5",
-						"yargs-parser": "^21.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "21.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-					"dev": true
-				}
 			}
 		},
 		"@hashicorp/platform-types": {
@@ -38097,6 +38305,40 @@
 			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
 			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
 		},
+		"@octokit/plugin-request-log": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+			"dev": true,
+			"requires": {}
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.7.0.tgz",
+			"integrity": "sha512-orxQ0fAHA7IpYhG2flD2AygztPlGYNAdlzYz8yrD8NDgelPfOYoRPROfEyIe035PlxvbYrgkfUZIhSBKju/Cvw==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^8.0.0",
+				"deprecation": "^2.3.1"
+			},
+			"dependencies": {
+				"@octokit/openapi-types": {
+					"version": "14.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+					"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+					"dev": true
+				},
+				"@octokit/types": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+					"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+					"dev": true,
+					"requires": {
+						"@octokit/openapi-types": "^14.0.0"
+					}
+				}
+			}
+		},
 		"@octokit/request": {
 			"version": "5.6.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
@@ -38125,6 +38367,121 @@
 				"@octokit/types": "^6.0.3",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
+			}
+		},
+		"@octokit/rest": {
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.5.tgz",
+			"integrity": "sha512-+4qdrUFq2lk7Va+Qff3ofREQWGBeoTKNqlJO+FGjFP35ZahP+nBenhZiGdu8USSgmq4Ky3IJ/i4u0xbLqHaeow==",
+			"dev": true,
+			"requires": {
+				"@octokit/core": "^4.1.0",
+				"@octokit/plugin-paginate-rest": "^5.0.0",
+				"@octokit/plugin-request-log": "^1.0.4",
+				"@octokit/plugin-rest-endpoint-methods": "^6.7.0"
+			},
+			"dependencies": {
+				"@octokit/auth-token": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
+					"integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^8.0.0"
+					}
+				},
+				"@octokit/core": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+					"integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
+					"dev": true,
+					"requires": {
+						"@octokit/auth-token": "^3.0.0",
+						"@octokit/graphql": "^5.0.0",
+						"@octokit/request": "^6.0.0",
+						"@octokit/request-error": "^3.0.0",
+						"@octokit/types": "^8.0.0",
+						"before-after-hook": "^2.2.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/endpoint": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.3.tgz",
+					"integrity": "sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^8.0.0",
+						"is-plain-object": "^5.0.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/graphql": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.4.tgz",
+					"integrity": "sha512-amO1M5QUQgYQo09aStR/XO7KAl13xpigcy/kI8/N1PnZYSS69fgte+xA4+c2DISKqUZfsh0wwjc2FaCt99L41A==",
+					"dev": true,
+					"requires": {
+						"@octokit/request": "^6.0.0",
+						"@octokit/types": "^8.0.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/openapi-types": {
+					"version": "14.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+					"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==",
+					"dev": true
+				},
+				"@octokit/plugin-paginate-rest": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-5.0.1.tgz",
+					"integrity": "sha512-7A+rEkS70pH36Z6JivSlR7Zqepz3KVucEFVDnSrgHXzG7WLAzYwcHZbKdfTXHwuTHbkT1vKvz7dHl1+HNf6Qyw==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^8.0.0"
+					}
+				},
+				"@octokit/request": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
+					"integrity": "sha512-6VDqgj0HMc2FUX2awIs+sM6OwLgwHvAi4KCK3mT2H2IKRt6oH9d0fej5LluF5mck1lRR/rFWN0YIDSYXYSylbw==",
+					"dev": true,
+					"requires": {
+						"@octokit/endpoint": "^7.0.0",
+						"@octokit/request-error": "^3.0.0",
+						"@octokit/types": "^8.0.0",
+						"is-plain-object": "^5.0.0",
+						"node-fetch": "^2.6.7",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/request-error": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.2.tgz",
+					"integrity": "sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^8.0.0",
+						"deprecation": "^2.0.0",
+						"once": "^1.4.0"
+					}
+				},
+				"@octokit/types": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+					"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+					"dev": true,
+					"requires": {
+						"@octokit/openapi-types": "^14.0.0"
+					}
+				},
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+					"dev": true
+				}
 			}
 		},
 		"@octokit/types": {
@@ -42023,12 +42380,13 @@
 			}
 		},
 		"cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"requires": {
 				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
+				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^7.0.0"
 			}
 		},
@@ -47937,6 +48295,40 @@
 				"jest-validate": "^27.5.1",
 				"prompts": "^2.0.1",
 				"yargs": "^16.2.0"
+			},
+			"dependencies": {
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				}
 			}
 		},
 		"jest-config": {
@@ -51821,10 +52213,39 @@
 				"yargs": "^16.0.0"
 			},
 			"dependencies": {
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
 				"get-stdin": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
 					"integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
 				}
 			}
 		},
@@ -60277,23 +60698,31 @@
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
 		},
 		"yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"version": "17.6.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"dev": true,
 			"requires": {
-				"cliui": "^7.0.2",
+				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
+				"string-width": "^4.2.3",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
+				"yargs-parser": "^21.1.1"
 			},
 			"dependencies": {
 				"y18n": {
 					"version": "5.0.8",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "21.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"@hashicorp/platform-postcss-config": "^0.1.0",
 		"@hashicorp/platform-tools": "^0.6.0",
 		"@hashicorp/platform-types": "^0.3.0",
+		"@octokit/rest": "^19.0.5",
 		"@playwright/test": "^1.28.0",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^13.3.0",
@@ -83,7 +84,8 @@
 		"react-test-renderer": "^18.2.0",
 		"simple-git-hooks": "^2.7.0",
 		"stylelint": "^13.8.0",
-		"typescript": "^4.5.5"
+		"typescript": "^4.5.5",
+		"yargs": "^17.6.2"
 	},
 	"dependencies": {
 		"@actions/core": "^1.9.1",

--- a/scripts/list-open-prs-with-docs-changes.ts
+++ b/scripts/list-open-prs-with-docs-changes.ts
@@ -1,0 +1,122 @@
+import yargs from 'yargs'
+import { Octokit } from '@octokit/rest'
+
+/**
+ * Given a hashicorp repository name, return an object with two properties:
+ *  - mdxPrefix: the filename prefix for MDX files
+ *  - navDataPrefix: the filename prefix for nav data JSON files
+ */
+const getRelevantFileNamePrefixes = (repo: string) => {
+	// The default values that most repos use
+	let mdxPrefix = 'website/content'
+	let navDataPrefix = 'website/data'
+
+	// HCP and Terraform docs content repos use slightly different values
+	if (repo === 'cloud.hashicorp.com') {
+		mdxPrefix = 'content'
+		navDataPrefix = 'content'
+	} else if (repo.startsWith('terraform') || repo.startsWith('ptfe-releases')) {
+		mdxPrefix = 'website/docs'
+	}
+
+	// Return the values in an object
+	return { mdxPrefix, navDataPrefix }
+}
+
+/**
+ * Handles describing, requiring, and parsing the arguments for the main script.
+ */
+const getScriptArguments = (): { repo: string } => {
+	const args = yargs
+		.option('repo', {
+			description: 'the name of the repo under `hashicorp` to check',
+		})
+		.demandOption(['repo'])
+		.help().argv
+
+	const repo = args.repo as string
+
+	return { repo }
+}
+
+/**
+ * Given a `--repo` option, lists the HTML URLs of open PRs that have changes on
+ * MDX and nav data JSON files.
+ *
+ * Examples of how to run this script from the root of the project:
+ *
+ *  - npx hc-tools ./scripts/list-open-prs-with-docs-changes.ts -- --repo waypoint
+ *  - npx hc-tools ./scripts/list-open-prs-with-docs-changes.ts -- --repo vault
+ *  - npx hc-tools ./scripts/list-open-prs-with-docs-changes.ts -- --repo terraform-cdk
+ */
+const main = async () => {
+	// Get the required `repo` argument
+	const { repo } = getScriptArguments()
+
+	// Get the mdx and nav-data file name prefixes from the helper
+	const { mdxPrefix, navDataPrefix } = getRelevantFileNamePrefixes(repo)
+
+	// Create a Set to get a unique list of PRs
+	const result = new Set()
+
+	// Initialize Octokit for interacting with GitHub REST API client
+	if (!process.env.GITHUB_TOKEN) {
+		console.warn(
+			'No GITHUB_TOKEN env variable found. Provide it to avoid rate limits with the GitHub REST API.'
+		)
+	}
+	const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
+
+	// Get a list of open PRs in the given repo.
+	const { data: pulls } = await octokit.request(
+		'GET /repos/{owner}/{repo}/pulls?state=open',
+		{
+			owner: 'hashicorp',
+			repo: repo,
+		}
+	)
+
+	// For each PR...
+	for (let i = 0; i < pulls.length - 1; i++) {
+		const pull = pulls[i]
+		const pullNumber = pull.number
+		const pullUrl = pull.html_url
+
+		// Get a list of the PR's files
+		const { data: files } = await octokit.request(
+			'GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+			{
+				owner: 'hashicorp',
+				repo: repo,
+				pull_number: pullNumber,
+			}
+		)
+
+		// For each filename...
+		files.forEach(({ filename }: { filename: string }) => {
+			const isMdxContentFile =
+				filename.startsWith(mdxPrefix) && filename.endsWith('.mdx')
+			const isNavDataJsonFile =
+				filename.startsWith(navDataPrefix) && filename.endsWith('nav-data.json')
+
+			// Check if each file is an MDX or nav-data file
+			if (isMdxContentFile || isNavDataJsonFile) {
+				// Add the PR html_url to the results Set if it has relevant files
+				result.add(pullUrl)
+			}
+		})
+	}
+
+	// Log the results
+	const sortedResult = Array.from(result).sort()
+	console.log('')
+	console.log(
+		`There are ${sortedResult.length} open PRs in "hashicorp/${repo}" with docs changes:\n`
+	)
+	sortedResult.forEach((prUrl: string) => {
+		console.log(` - ${prUrl}`)
+	})
+	console.log('')
+}
+
+main()

--- a/scripts/list-open-prs-with-docs-changes.ts
+++ b/scripts/list-open-prs-with-docs-changes.ts
@@ -77,7 +77,7 @@ const main = async () => {
 	)
 
 	// For each PR...
-	for (let i = 0; i < pulls.length - 1; i++) {
+	for (let i = 0; i < pulls.length; i++) {
 		const pull = pulls[i]
 		const pullNumber = pull.number
 		const pullUrl = pull.html_url


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds new `scripts/list-open-prs-with-docs-changes.ts` that uses the [GitHub REST API JavaScript client](https://github.com/octokit/rest.js/) to list open PRs that affect docs content (MDX and nav data) for a given repo
- Adds the newly used `@octokit/rest` and `yargs` as dev dependencies

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Not all of our content repos use the same labeling to denote a PR as having docs changes. This script provides an automated way to get the list regardless of how PRs are named or labeled for a repo.
- In the short term, this is most useful for the docs content link rewrite project so that it's easier to estimate rollout schedules and runbooks.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Pull down the code locally
- [ ] Install the new dev dependencies with `npm i`
- [ ] Run the script for a few different docs content repos
- [ ] Confirm that the PRs are listed by the script are accurate in the repo's `/pulls` GitHub page
