### PR TITLE
fix: add back description to try-hcp-callout

### DIFF
--- a/src/components/try-hcp-callout/components/try-hcp-callout/index.tsx
+++ b/src/components/try-hcp-callout/components/try-hcp-callout/index.tsx
@@ -30,6 +30,7 @@ export function TryHcpCallout({
 				) : (
 					<ProductIconHeading productSlug={productSlug} headingText={heading} />
 				)}
+				<Description description={description} />
 				<StandaloneLinkContents text={ctaText} />
 			</div>
 			<div className={s.imageContainer}>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- ~Asana task~ N/A 🎟️

## 🗒️ What

This PR fixes an issue where the `<Description />` part of `TryHcpCallout` was missing. I slipped up and introduced this issue was during a refactor in https://github.com/hashicorp/dev-portal/pull/1373.

## 🧪 Testing

- [ ] Visit a page with an HCP callout, such as [/boundary][/boundary]. The description text should be shown.

## 💭 Anything else?

Not at the moment.

[preview]: https://dev-portal-git-zsfix-hcp-callout-description-hashicorp.vercel.app/
[/boundary]: https://dev-portal-git-zsfix-hcp-callout-description-hashicorp.vercel.app/boundary