### PR TITLE
feat: adds vagrant 'try cloud' link to nav

### DIFF
--- a/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
@@ -14,9 +14,16 @@ const TRY_CLOUD_ITEM_PRODUCT_SLUGS = [
 	'hcp',
 	'packer',
 	'terraform',
+	'vagrant',
 	'vault',
 	'waypoint',
 ]
+
+enum TRY_CLOUD_PRODUCT_LINKS {
+	default = 'https://portal.cloud.hashicorp.com/sign-up',
+	terraform = 'https://app.terraform.io/public/signup/account',
+	vagrant = 'https://app.vagrantup.com/account/new',
+}
 
 /**
  * Given current product data,
@@ -93,9 +100,8 @@ export function getNavItems(currentProduct: ProductData): NavItem[] {
 		items.push({
 			label: 'Try Cloud',
 			url:
-				currentProduct.slug === 'terraform'
-					? 'https://app.terraform.io/public/signup/account'
-					: 'https://portal.cloud.hashicorp.com/sign-up',
+				TRY_CLOUD_PRODUCT_LINKS[currentProduct.slug] ??
+				TRY_CLOUD_PRODUCT_LINKS['default'],
 			opensInNewTab: true,
 		})
 	}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-try-cloud-link-vagrant-hashicorp.vercel.app/vagrant) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1203493882541996) 🎟️

## 🗒️ What

Adds 'try cloud' link to vagrant product nav. Also test that the other try cloud links work as expected. 
