### PR TITLE
[EXPERIMENT] test client-side error wo error-boundary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { SSRProvider } from '@react-aria/ssr'
+import { ErrorBoundary } from 'react-error-boundary'
 import { LazyMotion } from 'framer-motion'
 import { SessionProvider } from 'next-auth/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -29,6 +30,7 @@ import fetchLayoutProps, {
 import { isDeployPreview, isPreview } from 'lib/env-checks'
 import { makeDevAnalyticsLogger } from 'lib/analytics'
 import EmptyLayout from 'layouts/empty'
+import { DevDotClient } from 'views/error-views'
 import HeadMetadata from 'components/head-metadata'
 import { Toaster } from 'components/toast'
 
@@ -103,30 +105,32 @@ export default function App({
 		<QueryClientProvider client={queryClient}>
 			<SSRProvider>
 				<CurrentContentTypeProvider currentContentType={currentContentType}>
-					<SessionProvider session={session}>
-						<DeviceSizeProvider>
-							<CurrentProductProvider currentProduct={currentProduct}>
-								<CodeTabsProvider>
-									<HeadMetadata {...pageProps.metadata} host={host} />
-									<LazyMotion
-										features={() =>
-											import('lib/framer-motion-features').then(
-												(mod) => mod.default
-											)
-										}
-										strict={process.env.NODE_ENV === 'development'}
-									>
-										<Layout {...allLayoutProps} data={allLayoutProps}>
-											<Component {...pageProps} />
-										</Layout>
-										<Toaster />
-										{showProductSwitcher ? <PreviewProductSwitcher /> : null}
-										<ReactQueryDevtools />
-									</LazyMotion>
-								</CodeTabsProvider>
-							</CurrentProductProvider>
-						</DeviceSizeProvider>
-					</SessionProvider>
+					<ErrorBoundary FallbackComponent={DevDotClient}>
+						<SessionProvider session={session}>
+							<DeviceSizeProvider>
+								<CurrentProductProvider currentProduct={currentProduct}>
+									<CodeTabsProvider>
+										<HeadMetadata {...pageProps.metadata} host={host} />
+										<LazyMotion
+											features={() =>
+												import('lib/framer-motion-features').then(
+													(mod) => mod.default
+												)
+											}
+											strict={process.env.NODE_ENV === 'development'}
+										>
+											<Layout {...allLayoutProps} data={allLayoutProps}>
+												<Component {...pageProps} />
+											</Layout>
+											<Toaster />
+											{showProductSwitcher ? <PreviewProductSwitcher /> : null}
+											<ReactQueryDevtools />
+										</LazyMotion>
+									</CodeTabsProvider>
+								</CurrentProductProvider>
+							</DeviceSizeProvider>
+						</SessionProvider>
+					</ErrorBoundary>
 				</CurrentContentTypeProvider>
 			</SSRProvider>
 		</QueryClientProvider>

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -1,5 +1,5 @@
 // Third-party imports
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, useMemo, useState } from 'react'
 
 // Global imports
 import { productSlugs } from 'lib/products'
@@ -77,8 +77,17 @@ const HomePageContent = ({
 }
 
 function HomePageView({ content }: HomePageProps): ReactElement {
+	const [fakeError, setFakeError] = useState<string | null>(null)
+
+	if (fakeError) {
+		throw new Error(fakeError)
+	}
+
 	return (
 		<div className={s.homepage}>
+			<button onClick={() => setFakeError('This is a client side error!')}>
+				Throw error
+			</button>
 			<HomePageContent {...content} />
 		</div>
 	)


### PR DESCRIPTION
Testing out some error related stuff to get more familiar with NextJS error handling.

- Throw a client-side error without `ErrorBoundary`: https://dev-portal-2gu5ofe9y-hashicorp.vercel.app/
    - Adds a `button` to the home page that throws a client-side error
- Throw a client-side error with `ErrorBoundary`: https://dev-portal-qi93zjb6g-hashicorp.vercel.app/
    - Adds back `ErrorBoundary` in `_app.tsx`