### PR TITLE
chore: removes reference to `name` in tutorial search object

### DIFF
--- a/src/components/command-bar/commands/search/components/tutorials-tab-contents/tutorial-hit.tsx
+++ b/src/components/command-bar/commands/search/components/tutorials-tab-contents/tutorial-hit.tsx
@@ -23,13 +23,13 @@ const TutorialHit = ({ hit }: TutorialHitProps) => {
 		return null
 	}
 
-	const { name, page_title, description } = _highlightResult
+	const { page_title, description } = _highlightResult
 
 	/**
 	 * If the `_highlightResult` has neither a name or description, there is
 	 * nothing to render for the result.
 	 */
-	if (!name && !description) {
+	if (!page_title && !description) {
 		if (IS_DEV) {
 			console.warn(
 				'[TutorialHit] Found a `hit` with no `name` or `description` in `_highlightResult`:\n',
@@ -51,7 +51,7 @@ const TutorialHit = ({ hit }: TutorialHitProps) => {
 
 	return (
 		<CommandBarLinkListItem
-			title={page_title?.value || name?.value}
+			title={page_title?.value}
 			description={description?.value}
 			url={resultUrl}
 			badges={badges}

--- a/src/components/command-bar/commands/search/components/tutorials-tab-contents/types.ts
+++ b/src/components/command-bar/commands/search/components/tutorials-tab-contents/types.ts
@@ -16,9 +16,8 @@ interface TutorialsTabContentsProps {
 
 type TutorialHitObject = Hit<{
 	description: string
-	name: string
+	page_title: string
 	headings: string[]
-	page_title?: string
 }> &
 	Pick<
 		TutorialLite,

--- a/src/views/tutorial-library/utils/get-tutorial-card-props-from-hit.ts
+++ b/src/views/tutorial-library/utils/get-tutorial-card-props-from-hit.ts
@@ -17,7 +17,7 @@ export function getTutorialCardPropsFromHit(
 		collectionId: hit.defaultContext.id,
 		url: getTutorialSlug(hit.slug, hit.defaultContext.slug),
 		duration: getReadableTime(hit.readTime),
-		heading: hit.page_title || hit.name, // todo, only use page_title once released
+		heading: hit.page_title,
 		description: hit.description,
 		productsUsed: hit.products,
 		hasVideo: hit.hasVideo,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksremove-name-tutorial-search-hashicorp.vercel.app/tutorials/library) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1203525052057390) 🎟️

## 🗒️ What

Follow up from #1423 to fully remove the reference to name. After merging this, will merge the [update in mktg-content-workflows](https://github.com/hashicorp/mktg-content-workflows/pull/279) to remove the property from the index.

## 🧪 Testing

- Visit the tutorials library page, interact with the search functions, see there are no errors
- Use the global search component, hit the tutorials tab, validate there are no errors.
