### PR TITLE
fix: ensure we don't error when setting the happykit cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 				"@algolia/autocomplete-core": "^1.6.2",
 				"@algolia/autocomplete-plugin-algolia-insights": "^1.6.2",
 				"@algolia/autocomplete-preset-algolia": "^1.6.2",
-				"@happykit/flags": "^3.0.0",
+				"@happykit/flags": "^3.1.1",
 				"@hashicorp/design-system-tokens": "^1.2.0",
 				"@hashicorp/flight-icons": "^2.12.0",
 				"@hashicorp/localstorage-polyfill": "^1.0.14",
@@ -1175,9 +1175,9 @@
 			}
 		},
 		"node_modules/@happykit/flags": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@happykit/flags/-/flags-3.0.0.tgz",
-			"integrity": "sha512-vZx0CBXgrZ0Q0LiHaikD4/oPQ1KO++erY9FaCLTunn3C5i2oh3/HqqGUzPPITFaadHyzqIQC4whbZ1SkyHSeew==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@happykit/flags/-/flags-3.1.1.tgz",
+			"integrity": "sha512-xYK28EaZNt1waKgErRQqQVgdzY6MYwmvhd70KlLtjYwgTni5lEV0wLOHVdfHKZhcNEZM0oL7QtMo10/40apWvQ==",
 			"dependencies": {
 				"nanoid": "3.2.0"
 			},
@@ -37606,9 +37606,9 @@
 			}
 		},
 		"@happykit/flags": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@happykit/flags/-/flags-3.0.0.tgz",
-			"integrity": "sha512-vZx0CBXgrZ0Q0LiHaikD4/oPQ1KO++erY9FaCLTunn3C5i2oh3/HqqGUzPPITFaadHyzqIQC4whbZ1SkyHSeew==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@happykit/flags/-/flags-3.1.1.tgz",
+			"integrity": "sha512-xYK28EaZNt1waKgErRQqQVgdzY6MYwmvhd70KlLtjYwgTni5lEV0wLOHVdfHKZhcNEZM0oL7QtMo10/40apWvQ==",
 			"requires": {
 				"nanoid": "3.2.0"
 			},

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@algolia/autocomplete-core": "^1.6.2",
 		"@algolia/autocomplete-plugin-algolia-insights": "^1.6.2",
 		"@algolia/autocomplete-preset-algolia": "^1.6.2",
-		"@happykit/flags": "^3.0.0",
+		"@happykit/flags": "^3.1.1",
 		"@hashicorp/design-system-tokens": "^1.2.0",
 		"@hashicorp/flight-icons": "^2.12.0",
 		"@hashicorp/localstorage-polyfill": "^1.0.14",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,10 +25,12 @@ function determineProductSlug(req: NextRequest): string {
 }
 
 function setHappyKitCookie(
-	cookie: Parameters<NextResponse['cookies']['set']>,
+	cookie: { args: Parameters<NextResponse['cookies']['set']> },
 	response: NextResponse
 ): NextResponse {
-	response.cookies.set(...cookie)
+	if (cookie) {
+		response.cookies.set(...cookie.args)
+	}
 	return response
 }
 
@@ -108,9 +110,9 @@ export async function middleware(req: NextRequest, ev: NextFetchEvent) {
 				if (flags?.ioHomeHeroCtas) {
 					const url = req.nextUrl.clone()
 					url.pathname = '/_proxied-dot-io/vault/without-cta-links'
-					response = setHappyKitCookie(cookie.args, NextResponse.rewrite(url))
+					response = setHappyKitCookie(cookie, NextResponse.rewrite(url))
 				} else {
-					response = setHappyKitCookie(cookie.args, NextResponse.next())
+					response = setHappyKitCookie(cookie, NextResponse.next())
 				}
 			}
 
@@ -118,9 +120,9 @@ export async function middleware(req: NextRequest, ev: NextFetchEvent) {
 				if (flags?.ioHomeHeroCtas) {
 					const url = req.nextUrl.clone()
 					url.pathname = '/_proxied-dot-io/packer/without-cta-links'
-					response = setHappyKitCookie(cookie.args, NextResponse.rewrite(url))
+					response = setHappyKitCookie(cookie, NextResponse.rewrite(url))
 				} else {
-					response = setHappyKitCookie(cookie.args, NextResponse.next())
+					response = setHappyKitCookie(cookie, NextResponse.next())
 				}
 			}
 
@@ -128,9 +130,9 @@ export async function middleware(req: NextRequest, ev: NextFetchEvent) {
 				if (flags?.ioHomeHeroCtas) {
 					const url = req.nextUrl.clone()
 					url.pathname = '/_proxied-dot-io/consul/without-cta-links'
-					response = setHappyKitCookie(cookie.args, NextResponse.rewrite(url))
+					response = setHappyKitCookie(cookie, NextResponse.rewrite(url))
 				} else {
-					response = setHappyKitCookie(cookie.args, NextResponse.next())
+					response = setHappyKitCookie(cookie, NextResponse.next())
 				}
 			}
 		} catch {

--- a/src/pages/_proxied-dot-io/vault/without-cta-links.tsx
+++ b/src/pages/_proxied-dot-io/vault/without-cta-links.tsx
@@ -50,7 +50,7 @@ export default function Homepage({ data }): React.ReactElement {
 	React.useEffect(() => {
 		abTestTrack({
 			type: 'Served',
-			test_name: 'CRO Vault CTA links 2022-10',
+			test_name: 'CRO home hero CTA links 2022-10',
 			variant: 'true',
 		})
 	}, [])


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
When HappyKit returns, it's possible that `cookies` is `null`, in which case we are not handling this and silently erroring when we call `setHappyKitCookie()`. A side-effect seems to be that our experiments are not getting properly served. I've updated the logic to handle this.

We should no longer see treatments incorrectly flashing on our .io sites.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
