### PR TITLE
feat: add full program and exam content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
 				"jsonwebtoken": "^8.5.1",
 				"klaw-sync": "^6.0.0",
 				"mdast": "^3.0.0",
+				"mdast-util-to-string": "^2.0.0",
 				"moize": "^6.1.0",
 				"next": "^13.0.5",
 				"next-auth": "^4.17.0",
@@ -117,6 +118,7 @@
 				"unified": "^9.2.0",
 				"unist-util-is": "^5.1.1",
 				"unist-util-visit": "^4.1.0",
+				"unist-util-visit-children": "^1.1.4",
 				"validator": "^13.7.0",
 				"zod": "^3.20.2"
 			},
@@ -34959,6 +34961,15 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/unist-util-visit-children": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz",
+			"integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/unist-util-visit-parents": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
@@ -63770,6 +63781,11 @@
 				"unist-util-is": "^5.0.0",
 				"unist-util-visit-parents": "^5.0.0"
 			}
+		},
+		"unist-util-visit-children": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz",
+			"integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ=="
 		},
 		"unist-util-visit-parents": {
 			"version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"klaw-sync": "^6.0.0",
 		"mdast": "^3.0.0",
+		"mdast-util-to-string": "^2.0.0",
 		"moize": "^6.1.0",
 		"next": "^13.0.5",
 		"next-auth": "^4.17.0",
@@ -199,6 +200,7 @@
 		"unified": "^9.2.0",
 		"unist-util-is": "^5.1.1",
 		"unist-util-visit": "^4.1.0",
+		"unist-util-visit-children": "^1.1.4",
 		"validator": "^13.7.0",
 		"zod": "^3.20.2"
 	},

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -7,6 +7,7 @@ This folder contains the authorable, marketing-style content for various landing
 - [Product landing pages](#3-product-landing-pages)
 - [Product Docs landing pages](#4-product-docs-landing-pages)
 - [Product Install landing pages](#5-product-install-landing-pages)
+- [Certifications pages](#6-certifications-pages)
 
 ## 1. Additional Sidebar "Resources" section navigation items
 
@@ -628,3 +629,7 @@ This is an object for the marketing content located in a `Card` in the Sidecar o
   - `label`: The text to show for the link
 
 </details>
+
+## 6. Certifications Pages
+
+For details on editing the content on `/certifications` pages, see [the README in `src/content/certifications`](src/content/certifications/README.md).

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -1,0 +1,32 @@
+# Certifications Authorable Content
+
+This folder contains the authorable content for Certifications pages.
+
+- [Landing Page](#landing-page), at `/certifications`
+  - Visit [/certifications](https://developer.hashicorp.com/certifications)
+- [Program Pages](#program-pages), at `/certifications/<program>`
+  - Visit for example [/certifications/security-automation](https://developer.hashicorp.com/certifications/security-automation)
+
+## Landing Page
+
+### Hero
+
+The content for the landing page hero is managed in [content/certifications/landing.json](/src/content/certifications/landing.json).
+
+## Program Pages
+
+Program pages at `/certifications/<slug>` are rendered based on the `<slug>.json` files present in the [content/certifications/programs](/src/content/certifications/programs) directory.
+
+Each `<slug>.json` file in that directory controls the content for an individual program page. For example, [content/certifications/programs/security-automation.json](/src/content/certifications/programs/security-automation.json) controls the content for [/certifications/security-automation](https://developer.hashicorp.com/certifications/security-automation).
+
+### Copy on Program Pages
+
+Most copy on program pages is managed directly in each `<slug>.json` file. Details on the content schema can be found in [src/views/certifications/content/schemas/certification-program.ts](/src/views/certifications/content/schemas/certification-program.ts).
+
+### Exam FAQs on Program Pages
+
+Each program page can specific one or many exams, in the `exams` array in each `<slug>.json` file.
+
+Each exam must reference an `.mdx` document within the `src/content/certifications/exam-faqs` directory, where FAQ content for each exam is authored. FAQs are derived from MDX files by extracting the FAQ title text and content from each `## Heading Two` section.
+
+For example, on the [/certifications/security-automation](https://developer.hashicorp.com/certifications/security-automation) we can see the exam FAQs for the `Vault Associate 002` exam. These FAQs are authored in [src/content/certifications/exam-faqs/vault-associate-002.mdx](/src/content/certifications/exam-faqs/vault-associate-002.mdx). This filepath is specified in the associated `exams` array item, specifically using the `faqSlug` attribute on the `Vault Associate 002` exam item within [src/content/certifications/programs/vault.json](/src/content/certifications/programs/vault.json).

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -19,9 +19,9 @@ Program pages at `/certifications/<slug>` are rendered based on the `<slug>.json
 
 Each `<slug>.json` file in that directory controls the content for an individual program page. For example, [content/certifications/programs/security-automation.json](/src/content/certifications/programs/security-automation.json) controls the content for [/certifications/security-automation](https://developer.hashicorp.com/certifications/security-automation).
 
-### Copy on Program Pages
+### Copy for Programs and Exams
 
-Most copy on program pages is managed directly in each `<slug>.json` file. Details on the content schema can be found in [src/views/certifications/content/schemas/certification-program.ts](/src/views/certifications/content/schemas/certification-program.ts).
+Most copy on program pages, including copy related to individual exams, is managed directly in each `<slug>.json` file. Details on the content schema can be found in [src/views/certifications/content/schemas/certification-program.ts](/src/views/certifications/content/schemas/certification-program.ts).
 
 ### Exam FAQs on Program Pages
 

--- a/src/content/certifications/exam-faqs/consul-associate-002.mdx
+++ b/src/content/certifications/exam-faqs/consul-associate-002.mdx
@@ -1,0 +1,100 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Prerequisites
+
+- Containerization knowledge
+- Basic terminal skills
+- Networking skills including load balancing and distributed systems
+- Understand the purpose of ACLs
+- Experience with TLS certificate lifecycle
+
+## Product Version Tested
+
+Consul 1.8 or higher.
+
+## Preparing for the Exam
+
+You will be tested based on the objectives below.
+
+The Consul Associate exam has both a study guide and a review guide. While much of the information in these two guides are the same, they are presented differently for different uses.
+
+- Use the [study guide](https://learn.hashicorp.com/tutorials/consul/associate-study) if you want to study all the exam objectives.
+- Use the [review guide](https://learn.hashicorp.com/tutorials/consul/associate-review) if you already have Consul experience and/or training and want to pick and choose which objectives to review before taking the exam.
+
+There are also [sample questions](https://learn.hashicorp.com/tutorials/consul/associate-questions) available so you can get a feel for what the exam will be like.
+
+## Exam Details
+
+|                     |                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------- |
+| **Assessment Type** | Multiple choice                                                                   |
+| **Format**          | Online proctored                                                                  |
+| **Duration**        | 1 hour                                                                            |
+| **Price**           | $70.50 USD, plus locally applicable taxes and fees. Free retake **not included**. |
+| **Language**        | English                                                                           |
+| **Expiration**      | 2 years                                                                           |
+
+## Exam Objectives
+
+| 1   | Explain Consul architecture                                                                |
+| --- | ------------------------------------------------------------------------------------------ |
+| 1a  | Identify the components of Consul datacenter, including agents and communication protocols |
+| 1b  | Prepare Consul for high availability and performance                                       |
+| 1c  | Identify Consul's core functionality                                                       |
+| 1d  | Differentiate agent roles                                                                  |
+
+| 2   | Deploy a single datacenter                            |
+| --- | ----------------------------------------------------- |
+| 2a  | Start and manage the Consul process                   |
+| 2b  | Interpret a Consul agent configuration                |
+| 2c  | Configure Consul network addresses and ports          |
+| 2d  | Describe and configure agent join and leave behaviors |
+
+| 3   | Register services and use service discovery                                                    |
+| --- | ---------------------------------------------------------------------------------------------- |
+| 3a  | Interpret a service registration                                                               |
+| 3b  | Differentiate ways to register a single service                                                |
+| 3c  | Interpret a service configuration with health check                                            |
+| 3d  | Check the service catalog status from the output of the DNS/API interface or via the Consul UI |
+| 3e  | Interpret a prepared query                                                                     |
+| 3f  | Use a prepared query                                                                           |
+
+| 4   | Access the Consul key/value (KV)                            |
+| --- | ----------------------------------------------------------- |
+| 4a  | Understand the capabilities and limitations of the KV store |
+| 4b  | Interact with the KV store using both the Consul CLI and UI |
+| 4c  | Monitor KV changes using `watch`                            |
+| 4d  | Monitor KV changes using `envconsul` and `consul-template`  |
+
+| 5   | Back up and restore                                             |
+| --- | --------------------------------------------------------------- |
+| 5a  | Describe the content of a snapshot                              |
+| 5b  | Back up and restore the datacenter                              |
+| 5c  | \[Enterprise\] Describe the benefits of snapshot agent features |
+
+| 6   | Use Consul service mesh                                        |
+| --- | -------------------------------------------------------------- |
+| 6a  | Understand Consul Connect service mesh high level architecture |
+| 6b  | Describe configuration for registering a service proxy         |
+| 6c  | Describe intentions for Consul Connect service mesh            |
+| 6d  | Check intentions in both the Consul CLI and UI                 |
+
+| 7   | Secure agent communication                                                     |
+| --- | ------------------------------------------------------------------------------ |
+| 7a  | Understanding Consul security/threat model                                     |
+| 7b  | Differentiate certificate types needed for TLS encryption                      |
+| 7c  | Understand the different TLS encryption settings for a fully secure datacenter |
+
+| 8   | Secure services with basic access control lists (ACL)                                    |
+| --- | ---------------------------------------------------------------------------------------- |
+| 8a  | Set up and configure a basic ACL system                                                  |
+| 8b  | Create policies                                                                          |
+| 8c  | Manage token lifecycle: multiple policies, token revoking, ACL roles, service identities |
+| 8d  | Perform a CLI request using a token                                                      |
+| 8e  | Perform an API request using a token                                                     |
+
+| 9   | Use gossip encryption                                    |
+| --- | -------------------------------------------------------- |
+| 9a  | Understanding the Consul security/threat model           |
+| 9b  | Configure gossip encryption for the existing data center |
+| 9c  | Manage the lifecycle of encryption keys                  |

--- a/src/content/certifications/exam-faqs/terraform-associate-002.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-002.mdx
@@ -1,0 +1,98 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Exam Experience
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers.
+
+The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.
+
+## Prerequisites
+
+- Basic terminal skills
+- Basic understanding of on premises and cloud architecture
+
+## Product Version Tested
+
+Terraform 1.0 and higher.
+
+## Preparing for the Exam
+
+Certification preparation learning guides for the new version of the Terraform Associate will be posted soon. For now, use the current [Terraform Associate Tutorial List](https://learn.hashicorp.com/collections/terraform/certification-associate-tutorials) to start your studying.
+
+## Exam Details
+
+|                     |                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------- |
+| **Assessment Type** | Multiple choice                                                                   |
+| **Format**          | Online proctored                                                                  |
+| **Duration**        | 1 hour                                                                            |
+| **Price**           | $70.50 USD, plus locally applicable taxes and fees. Free retake **not included**. |
+| **Language**        | English                                                                           |
+| **Expiration**      | 2 years                                                                           |
+
+## Exam Objectives
+
+| 1   | Understand infrastructure as code (IaC) concepts |
+| --- | ------------------------------------------------ |
+| 1a  | Explain what IaC is                              |
+| 1b  | Describe advantages of IaC patterns              |
+
+| 2   | Understand the purpose of Terraform (vs other IaC) |
+| --- | -------------------------------------------------- |
+| 2a  | Explain multi-cloud and provider-agnostic benefits |
+| 2b  | Explain the benefits of state                      |
+
+| 3   | Understand Terraform basics                            |
+| --- | ------------------------------------------------------ |
+| 3a  | Install and version Terraform providers                |
+| 3b  | Describe plugin-based architecture                     |
+| 3c  | Write Terraform configuration using multiple providers |
+| 3d  | Describe how Terraform finds and fetches providers     |
+
+| 4   | Use Terraform outside of core workflow                                                              |
+| --- | --------------------------------------------------------------------------------------------------- |
+| 4a  | Describe when to use `terraform import` to import existing infrastructure into your Terraform state |
+| 4b  | Use `terraform state` to view Terraform state                                                       |
+| 4c  | Describe when to enable verbose logging and what the outcome/value is                               |
+
+| 5   | Interact with Terraform modules                                                                 |
+| --- | ----------------------------------------------------------------------------------------------- |
+| 5a  | Contrast and use different module source options including the public Terraform Module Registry |
+| 5b  | Interact with module inputs and outputs                                                         |
+| 5c  | Describe variable scope within modules/child modules                                            |
+| 5d  | Set module version                                                                              |
+
+| 6   | Use the core Terraform workflow                                             |
+| --- | --------------------------------------------------------------------------- |
+| 6a  | Describe Terraform workflow ( Write -> Plan -> Create )                     |
+| 6b  | Initialize a Terraform working directory (`terraform init`)                 |
+| 6c  | Validate a Terraform configuration (`terraform validate`)                   |
+| 6d  | Generate and review an execution plan for Terraform (`terraform plan`)      |
+| 6e  | Execute changes to infrastructure with Terraform (`terraform apply`)        |
+| 6f  | Destroy Terraform managed infrastructure (`terraform destroy`)              |
+| 6g  | Apply formatting and style adjustments to a configuration (`terraform fmt`) |
+
+| 7   | Implement and maintain state                                    |
+| --- | --------------------------------------------------------------- |
+| 7a  | Describe default `local` backend                                |
+| 7b  | Describe state locking                                          |
+| 7c  | Handle backend and cloud integration authentication methods     |
+| 7d  | Differentiate remote state back end options                     |
+| 7e  | Manage resource drift and Terraform state                       |
+| 7f  | Describe `backend` block and cloud integration in configuration |
+| 7g  | Understand secret management in state files                     |
+
+| 8   | Read, generate, and modify configuration                                      |
+| --- | ----------------------------------------------------------------------------- |
+| 8a  | Demonstrate use of variables and outputs                                      |
+| 8b  | Describe secure secret injection best practice                                |
+| 8c  | Understand the use of collection and structural types                         |
+| 8d  | Create and differentiate `resource` and `data` configuration                  |
+| 8e  | Use resource addressing and resource parameters to connect resources together |
+| 8f  | Use HCL and Terraform functions to write configuration                        |
+| 8g  | Describe built-in dependency management (order of execution based)            |
+
+| 9   | Understand Terraform Cloud capabilities                           |
+| --- | ----------------------------------------------------------------- |
+| 9a  | Explain how Terraform Cloud helps to manage infrastructure        |
+| 9b  | Describe how Terraform Cloud enables collaboration and governance |

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -1,0 +1,111 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Exam Experience
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers.
+
+The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.
+
+## Which Exam to Take
+
+The Terraform Associate 002 certification is still relevant and will be accepted as a validation of Terraform knowledge until each individual badge’s expiration date. Receiving a Terraform Associate 003 certification will not impact any existing Terraform Associate 002 credentials, and a single candidate can hold both at the same time. However, either certification alone can be used to validate Terraform knowledge at the associate level.
+
+- **If you have passed the Terraform Associate 002 exam**, wait until the new version comes out to recertify. We have extended all current badge expirations dates so you have time to wait for the new exam.
+- **If you have never passed the Terraform Associate exam**, the choice is up to you and your timeline.
+
+## Timeline TBA
+
+The Terraform Associate 002 certification is available today and will become unavailable shortly after 003 is released. Exact timelines are coming soon.
+
+![](https://www.datocms-assets.com/2885/1654637486-terraform-associate-002-vs-003-timeline.png)
+
+## Prerequisites
+
+- Basic terminal skills
+- Basic understanding of on premises and cloud architecture;
+
+## Product Version Tested
+
+Terraform 1.0 and higher.
+
+## Preparing for the Exam
+
+Certification preparation learning guides for the new version of the Terraform Associate will be posted soon. For now, use the current [Terraform Associate Tutorial List](https://developer.hashicorp.com/terraform/tutorials/certification-associate-tutorials) to start your studying.
+
+## Exam Details
+
+|                     |                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------- |
+| **Assessment Type** | Multiple choice                                                                   |
+| **Format**          | Online proctored                                                                  |
+| **Duration**        | 1 hour                                                                            |
+| **Price**           | $70.50 USD, plus locally applicable taxes and fees. Free retake **not included**. |
+| **Language**        | English                                                                           |
+| **Expiration**      | 2 years                                                                           |
+
+## Exam Objectives
+
+| 1   | Understand infrastructure as code (IaC) concepts |
+| --- | ------------------------------------------------ |
+| 1a  | Explain what IaC is                              |
+| 1b  | Describe advantages of IaC patterns              |
+
+| 2   | Understand the purpose of Terraform (vs other IaC) |
+| --- | -------------------------------------------------- |
+| 2a  | Explain multi-cloud and provider-agnostic benefits |
+| 2b  | Explain the benefits of state                      |
+
+| 3   | Understand Terraform basics                            |
+| --- | ------------------------------------------------------ |
+| 3a  | Install and version Terraform providers                |
+| 3b  | Describe plugin-based architecture                     |
+| 3c  | Write Terraform configuration using multiple providers |
+| 3d  | Describe how Terraform finds and fetches providers     |
+
+| 4   | Use Terraform outside of core workflow                                                              |
+| --- | --------------------------------------------------------------------------------------------------- |
+| 4a  | Describe when to use `terraform import` to import existing infrastructure into your Terraform state |
+| 4b  | Use `terraform state` to view Terraform state                                                       |
+| 4c  | Describe when to enable verbose logging and what the outcome/value is                               |
+
+| 5   | Interact with Terraform modules                                                                 |
+| --- | ----------------------------------------------------------------------------------------------- |
+| 5a  | Contrast and use different module source options including the public Terraform Module Registry |
+| 5b  | Interact with module inputs and outputs                                                         |
+| 5c  | Describe variable scope within modules/child modules                                            |
+| 5d  | Set module version                                                                              |
+
+| 6   | Use the core Terraform workflow                                             |
+| --- | --------------------------------------------------------------------------- |
+| 6a  | Describe Terraform workflow ( Write -> Plan -> Create )                     |
+| 6b  | Initialize a Terraform working directory (`terraform init`)                 |
+| 6c  | Validate a Terraform configuration (`terraform validate`)                   |
+| 6d  | Generate and review an execution plan for Terraform (`terraform plan`)      |
+| 6e  | Execute changes to infrastructure with Terraform (`terraform apply`)        |
+| 6f  | Destroy Terraform managed infrastructure (`terraform destroy`)              |
+| 6g  | Apply formatting and style adjustments to a configuration (`terraform fmt`) |
+
+| 7   | Implement and maintain state                                    |
+| --- | --------------------------------------------------------------- |
+| 7a  | Describe default `local` backend                                |
+| 7b  | Describe state locking                                          |
+| 7c  | Handle backend and cloud integration authentication methods     |
+| 7d  | Differentiate remote state back end options                     |
+| 7e  | Manage resource drift and Terraform state                       |
+| 7f  | Describe `backend` block and cloud integration in configuration |
+| 7g  | Understand secret management in state files                     |
+
+| 8   | Read, generate, and modify configuration                                      |
+| --- | ----------------------------------------------------------------------------- |
+| 8a  | Demonstrate use of variables and outputs                                      |
+| 8b  | Describe secure secret injection best practice                                |
+| 8c  | Understand the use of collection and structural types                         |
+| 8d  | Create and differentiate `resource` and `data` configuration                  |
+| 8e  | Use resource addressing and resource parameters to connect resources together |
+| 8f  | Use HCL and Terraform functions to write configuration                        |
+| 8g  | Describe built-in dependency management (order of execution based)            |
+
+| 9   | Understand Terraform Cloud capabilities                           |
+| --- | ----------------------------------------------------------------- |
+| 9a  | Explain how Terraform Cloud helps to manage infrastructure        |
+| 9b  | Describe how Terraform Cloud enables collaboration and governance |

--- a/src/content/certifications/exam-faqs/vault-associate-002.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-002.mdx
@@ -1,0 +1,111 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Prerequisites
+
+- Basic terminal skills
+- Basic understanding of on premise or cloud architecture
+- Basic level of security understanding
+
+## Product Version Tested
+
+Vault 1.6.0 and higher.
+
+## Preparing for the Exam
+
+The Vault Associate exam has both a study guide and a review guide. While much of the information in these two guides are the same, they are presented differently for different uses.
+
+- Use the [study guide](https://learn.hashicorp.com/tutorials/vault/associate-study) if you want to study all the exam objectives.
+- Use the [review guide](https://learn.hashicorp.com/tutorials/vault/associate-review) if you already have Vault experience and/or training and want to pick and choose which objectives to review before taking the exam.
+
+There are also [sample questions](https://learn.hashicorp.com/tutorials/vault/associate-questions) available so you can get a feel for what the exam will be like.
+
+## Exam Details
+
+|                     |                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| **Assessment Type** | Multiple choice                                                                    |
+| **Format**          | Online proctored                                                                   |
+| **Duration**        | 1 hour                                                                             |
+| **Price**           | $ 70.50 USD, plus locally applicable taxes and fees. Free retake **not included**. |
+| **Language**        | English                                                                            |
+| **Expiration**      | 2 years                                                                            |
+
+## Exam Objectives
+
+| 1   | Compare authentication methods                    |
+| --- | ------------------------------------------------- |
+| 1a  | Describe authentication methods                   |
+| 1b  | Choose an authentication method based on use case |
+| 1c  | Differentiate human vs. system auth methods       |
+
+| 2   | Create Vault policies                      |
+| --- | ------------------------------------------ |
+| 2a  | Illustrate the value of Vault policy       |
+| 2b  | Describe Vault policy syntax: path         |
+| 2c  | Describe Vault policy syntax: capabilities |
+| 2d  | Craft a Vault policy based on requirements |
+
+| 3   | Assess Vault tokens                                                          |
+| --- | ---------------------------------------------------------------------------- |
+| 3a  | Describe Vault token                                                         |
+| 3b  | Differentiate between service and batch tokens. Choose one based on use-case |
+| 3c  | Describe root token uses and lifecycle                                       |
+| 3d  | Define token accessors                                                       |
+| 3e  | Explain time-to-live                                                         |
+| 3f  | Explain orphaned tokens                                                      |
+| 3g  | Create tokens based on need                                                  |
+
+| 4   | Manage Vault leases               |
+| --- | --------------------------------- |
+| 4a  | Explain the purpose of a lease ID |
+| 4b  | Renew leases                      |
+| 4c  | Revoke leases                     |
+
+| 5   | Compare and configure Vault secrets engines                     |
+| --- | --------------------------------------------------------------- |
+| 5a  | Choose a secret method based on use case                        |
+| 5b  | Contrast dynamic secrets vs. static secrets and their use cases |
+| 5c  | Define transit engine                                           |
+| 5d  | Define secrets engines                                          |
+
+| 6   | Utilize Vault CLI                |
+| --- | -------------------------------- |
+| 6a  | Authenticate to Vault            |
+| 6b  | Configure authentication methods |
+| 6c  | Configure Vault policies         |
+| 6d  | Access Vault secrets             |
+| 6e  | Enable Secret engines            |
+| 6f  | Configure environment variables  |
+
+| 7   | Utilize Vault UI                 |
+| --- | -------------------------------- |
+| 7a  | Authenticate to Vault            |
+| 7b  | Configure authentication methods |
+| 7c  | Configure Vault policies         |
+| 7d  | Access Vault secrets             |
+| 7e  | Enable Secret engines            |
+
+| 8   | Be aware of the Vault API      |
+| --- | ------------------------------ |
+| 8a  | Authenticate to Vault via Curl |
+| 8b  | Access Vault secrets via Curl  |
+
+| 9   | Explain Vault architecture                                      |
+| --- | --------------------------------------------------------------- |
+| 9a  | Describe the encryption of data stored by Vault                 |
+| 9b  | Describe cluster strategy                                       |
+| 9c  | Describe storage backends                                       |
+| 9d  | Describe the Vault agent                                        |
+| 9e  | Describe secrets caching                                        |
+| 9f  | Be aware of identities and groups                               |
+| 9g  | Describe Shamir secret sharing and unsealing                    |
+| 9h  | Be aware of replication                                         |
+| 9i  | Describe seal/unseal                                            |
+| 9j  | Explain response wrapping                                       |
+| 9k  | Explain the value of short-lived, dynamically generated secrets |
+
+| 10  | Explain encryption as a service |
+| --- | ------------------------------- |
+| 10a | Configure transit secret engine |
+| 10b | Encrypt and decrypt secrets     |
+| 10c | Rotate the encryption key       |

--- a/src/content/certifications/exam-faqs/vault-operations-professional.mdx
+++ b/src/content/certifications/exam-faqs/vault-operations-professional.mdx
@@ -1,0 +1,90 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Prerequisites
+
+We strongly recommend passing the associate-level Vault exam before taking the professional-level exam. Practitioners who are already experienced with Vault operations in a production environment—and understand the concepts covered in the associate exam— may be able to successfully pass the professional-level exam.
+
+- HashiCorp Certified: Vault Associate Certification (recommended)
+- Linux skills such as list and edit files via command terminal
+- Understanding of IP networking
+- Experience with Public Key Infrastructure (PKI), including PGP and TLS
+- Information security fundamentals such as network security and RBAC
+- Understand the concepts and functionality of infrastructure running in containers including starting and stopping services, and reading logs
+
+![](https://www.datocms-assets.com/2885/1646693404-hcvop-prereq-wide-small.png)
+
+## Product Version Tested
+
+Vault 1.8.0 and higher.
+
+## Exam Details
+
+|                        |                                                                          |
+| ---------------------- | ------------------------------------------------------------------------ |
+| **Assessment Type**`*` | Lab-based and multiple choice                                            |
+| **Format**             | Online proctored                                                         |
+| **Duration**           | 4 hours                                                                  |
+| **Price**              | $ 295 USD, plus locally applicable taxes and fees. Includes free retake. |
+| **Language**           | English                                                                  |
+| **Expiration**         | 2 years                                                                  |
+
+> `*` **Note on assessment type**: This exam is primarily lab-based, in addition to a shorter multiple-choice section. During the lab scenarios, exam-takers will be tested on performing real-world Vault operational tasks on the command line. The Vault UI and API can also be used where applicable, and exam-takers will have access to the Vault and Vault API documentation.
+
+## Preparing for the Exam
+
+Visit the [Prepare for Vault Operations Pro Exam page](/vault/tutorials/ops-pro-cert) to start your exam prep. There you will find an [overview](/vault/tutorials/ops-pro-cert/ops-pro-overview), a study guide, and a review guide. The [study guide](/vault/tutorials/ops-pro-cert/ops-pro-study) includes tips and example questions, while the [review guide](/vault/tutorials/ops-pro-cert/ops-pro-review) is a direct mapping of where what documentation and tutorials to study each exam objective.
+
+## Exam Objectives
+
+| 1   | Create a working Vault server configuration given a scenario      |
+| --- | ----------------------------------------------------------------- |
+| 1a  | Enable and configure secret engines                               |
+| 1b  | Practice production hardening                                     |
+| 1c  | Auto unseal Vault                                                 |
+| 1d  | Implement integrated storage for open source and Enterprise Vault |
+| 1e  | Enable and configure authentication methods                       |
+| 1f  | Practice secure Vault initialization                              |
+| 1g  | Regenerate a root token                                           |
+| 1h  | Rekey Vault and rotate encryption keys                            |
+
+| 2   | Monitor a Vault environment                   |
+| --- | --------------------------------------------- |
+| 2a  | Monitor and understand Vault telemetry        |
+| 2b  | Monitor and understand Vault audit logs       |
+| 2c  | Monitor and understand Vault operational logs |
+
+| 3   | Employ the Vault security model                                   |
+| --- | ----------------------------------------------------------------- |
+| 3a  | Describe secure introduction of Vault clients                     |
+| 3b  | Describe the security implications of running Vault in Kubernetes |
+
+| 4   | Build fault-tolerant Vault environments                                      |
+| --- | ---------------------------------------------------------------------------- |
+| 4a  | Configure a highly available (HA) cluster                                    |
+| 4b  | \[Vault Enterprise\] Enable and configure disaster recovery (DR) replication |
+| 4c  | \[Vault Enterprise\] Promote a secondary cluster                             |
+
+| 5   | Understand the hardware security module (HSM) integration                       |
+| --- | ------------------------------------------------------------------------------- |
+| 5a  | \[Vault Enterprise\] Describe the benefits of auto unsealing with HSM           |
+| 5b  | \[Vault Enterprise\] Describe the benefits and use cases of seal wrap (PKCS#11) |
+
+| 6   | Scale Vault for performance                                              |
+| --- | ------------------------------------------------------------------------ |
+| 6a  | Use batch tokens                                                         |
+| 6b  | \[Vault Enterprise\] Describe the use cases of performance standby nodes |
+| 6c  | \[Vault Enterprise\] Enable and configure performance replication        |
+| 6d  | \[Vault Enterprise\] Create a paths filter                               |
+
+| 7   | Configure access control                                                     |
+| --- | ---------------------------------------------------------------------------- |
+| 7a  | Interpret Vault identity entities and groups                                 |
+| 7b  | Write, deploy, and troubleshoot ACL policies                                 |
+| 7c  | \[Vault Enterprise\] Understand Sentinel policies                            |
+| 7d  | \[Vault Enterprise\] Define control groups and describe their basic workflow |
+| 7e  | \[Vault Enterprise\] Describe and interpret multi-tenancy with namespaces    |
+
+| 8   | Configure Vault Agent                       |
+| --- | ------------------------------------------- |
+| 8a  | Securely configure auto-auth and token sink |
+| 8b  | Configure templating                        |

--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -3,5 +3,25 @@
 	"hero": {
 		"heading": "Infrastructure Automation Overview",
 		"description": "Cloud engineers will be able to use either version of the Terraform Associate certification to verify their basic infrastructure automation skills."
-	}
+	},
+	"exams": [
+		{
+			"title": "Terraform Associate 002",
+			"productSlug": "terraform",
+			"versionTested": "Terraform 1.0 or higher",
+			"description": "The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with open source HashiCorp Terraform. Candidates will be best prepared for this exam if they have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands which enterprise features exist and what can and cannot be done using the open source offering.",
+			"links": {
+				"prepare": "/terraform/tutorials/certification",
+				"register": "https://hashicorp-certifications.zendesk.com/hc/en-us/articles/360049382552"
+			},
+			"faqSlug": "terraform-associate-002"
+		},
+		{
+			"title": "Terraform Associate 003",
+			"productSlug": "terraform",
+			"versionTested": "Terraform 1.0 or higher",
+			"description": "The Terraform Associate 003 is an upcoming certification for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with HashiCorp Terraform. This person understands the difference in functionality between Terraform Cloud, Terraform Enterprise, and open source Terraform.\n\nThe draft Terraform Associate 003 exam’s objectives are listed below, and dedicated study materials are coming soon. The objective differences between the (existing 002 exam and the upcoming 003 exam) versions are a reorganization and rewording of objectives to comfortably cover recent and future Terraform product growth.",
+			"faqSlug": "terraform-associate-003"
+		}
+	]
 }

--- a/src/content/certifications/programs/networking-automation.json
+++ b/src/content/certifications/programs/networking-automation.json
@@ -3,5 +3,18 @@
 	"hero": {
 		"heading": "Networking Automation Overview",
 		"description": "Cloud engineers can use the Consul Associate certification exam from HashiCorp to verify their basic networking automation skills."
-	}
+	},
+	"exams": [
+		{
+			"title": "Consul Associate 002",
+			"productSlug": "consul",
+			"versionTested": "Consul 1.8 or higher",
+			"description": "The Consul Associate Certification is for Site Reliability Engineers, Solutions Architects, DevOps professionals, or other Cloud Engineers who know the basic concepts and skills to build, secure, and maintain open source HashiCorp Consul. Candidates will be best prepared for this exam if they have professional experience using Consul in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands what enterprise features exist and what can and cannot be done using the open source offering.",
+			"links": {
+				"prepare": "https://learn.hashicorp.com/tutorials/consul/associate-study",
+				"register": "https://hashicorp-certifications.zendesk.com/hc/en-us/articles/360049382552"
+			},
+			"faqSlug": "consul-associate-002"
+		}
+	]
 }

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -3,5 +3,29 @@
 	"hero": {
 		"heading": "Security Automation Overview",
 		"description": "Cloud engineers can use the Security Automation certification exams from HashiCorp to verify their basic security automation skills."
-	}
+	},
+	"exams": [
+		{
+			"title": "Vault Associate 002",
+			"productSlug": "vault",
+			"versionTested": "Vault 1.6.0 and higher",
+			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with open source HashiCorp Vault. Candidates will be best prepared for this exam if they have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands what enterprise features exist and what can and cannot be done using the open source offering.",
+			"links": {
+				"prepare": "/vault/tutorials/associate-cert/associate-study",
+				"register": "https://hashicorp-certifications.zendesk.com/hc/en-us/articles/360049382552"
+			},
+			"faqSlug": "vault-associate-002"
+		},
+		{
+			"title": "Vault Operations Professional",
+			"productSlug": "vault",
+			"versionTested": "Vault 1.8.0 and higher",
+			"description": "The Vault Operations Professional exam is for Cloud Engineers focused on deploying, configuring, managing, and monitoring HashiCorp Vault. Well-qualified candidates hold the `Vault Associate Certification` (or equivalent knowledge), have experience operating Vault in production, and can evaluate Vault Enterprise functionality and use cases. Certification holders have proven they have the skills, knowledge, and competency to perform the Vault operational tasks listed in the objectives.",
+			"links": {
+				"prepare": "/vault/tutorials/ops-pro-cert",
+				"register": "https://hashicorp-certifications.zendesk.com/hc/en-us/articles/360049382552"
+			},
+			"faqSlug": "vault-operations-professional"
+		}
+	]
 }

--- a/src/views/certifications/content/schemas/certification-program.ts
+++ b/src/views/certifications/content/schemas/certification-program.ts
@@ -1,6 +1,27 @@
 import { z } from 'zod'
 
 /**
+ * Content schema for an exam.
+ *
+ * Each certification program can reference multiple exams.
+ * For example, the Security Automation certification program
+ * contains both the Vault Associate and Vault Professional exams.
+ */
+export const CertificationExamSchema = z.object({
+	title: z.string(),
+	productSlug: z.enum(['consul', 'terraform', 'vault']),
+	versionTested: z.string(),
+	description: z.string(),
+	faqSlug: z.string(),
+	links: z
+		.object({
+			prepare: z.string().optional(),
+			register: z.string().optional(),
+		})
+		.optional(),
+})
+
+/**
  * Content schema for an individual certification program.
  *
  * Certification programs are oriented around solution areas, such as
@@ -13,6 +34,7 @@ export const CertificationProgramSchema = z.object({
 		heading: z.string(),
 		description: z.string(),
 	}),
+	exams: z.array(CertificationExamSchema),
 })
 
 /**
@@ -22,3 +44,8 @@ export const CertificationProgramSchema = z.object({
  * It may need to be transformed before it can be used at the view level.
  */
 export type RawCertificationProgram = z.infer<typeof CertificationProgramSchema>
+
+/**
+ * Raw content for an individual exam item.
+ */
+export type RawCertificationExam = z.infer<typeof CertificationExamSchema>

--- a/src/views/certifications/content/utils/collect-md-content-by-heading.ts
+++ b/src/views/certifications/content/utils/collect-md-content-by-heading.ts
@@ -1,0 +1,139 @@
+import remark from 'remark'
+import { Parent } from 'unist-util-visit'
+import visitChildren from 'unist-util-visit-children'
+import toString from 'mdast-util-to-string'
+import { is, Node } from 'unist-util-is'
+// types
+import type { Content, Heading, Root } from 'mdast'
+import type { Plugin } from 'unified'
+
+/**
+ * Content sections immediately after collection.
+ * contentNodes are arrays of nodes from the original `mdast` tree.
+ */
+export type ContentSectionNodes = {
+	level: number
+	title: string
+	contentNodes: Content[]
+}
+
+/**
+ * Content sections formatted before returning to the consumer.
+ * Content has been stringified from `mdast` nodes back into an MDX string.
+ */
+export type ContentSection = {
+	level: number
+	title: string
+	content: string
+}
+
+/**
+ * Options for the content section collector remark plugin.
+ */
+type ContentSectionCollectorPluginOptions = {
+	collector: ContentSectionNodes[]
+	targetLevel: Heading['depth']
+}
+
+/**
+ * A remark plugin that collects content nodes in the document,
+ * splitting them by headings
+ *
+ * Populates a provided collector variable with an array of sections.
+ * Each section consists of a title string, derived from the heading,
+ * as well as an array of top-level content nodes found under the heading.
+ */
+const contentSectionCollector: Plugin<[ContentSectionCollectorPluginOptions]> =
+	({ collector, targetLevel } = { collector: [], targetLevel: 2 }) =>
+	(tree: Node) => {
+		// Ensure that the provided tree has `children`. If not, error.
+		if (!isParent(tree)) {
+			throw new Error(
+				`contentSectionCollector: provided "tree" does not seem to have "children", so could not be traversed. Please ensure the provided "tree" is a valid unist Parent type.`
+			)
+		}
+		let currentSection: null | ContentSectionNodes = null
+		visitChildren(function (node: Content) {
+			if (isHeading(node) && node.depth === targetLevel) {
+				// Push any existing sections to the collector
+				if (currentSection !== null) {
+					collector.push(currentSection)
+				}
+				// Start a new section for this heading's content
+				const title = toString(node)
+				currentSection = {
+					level: node.depth,
+					title: title,
+					contentNodes: [],
+				}
+			} else {
+				// Push this node to the current section, if there is one.
+				// If there is no current section, we're in a space before
+				// any headings of the target level have appeared.
+				// We ignore content that is not under a target heading.
+				if (currentSection !== null) {
+					currentSection.contentNodes.push(node)
+				}
+			}
+		})(tree)
+		// Ensure any final section gets added
+		if (currentSection !== null) {
+			collector.push(currentSection)
+		}
+	}
+
+/**
+ * Given some MDX content, split content on headings of the provided level, and
+ * Return an array of content sections.
+ */
+export async function collectMdContentByHeading(
+	mdxContent: string,
+	headingLevel: Heading['depth']
+): Promise<ContentSection[]> {
+	const contentSectionNodes: ContentSectionNodes[] = []
+
+	/**
+	 * Run remark using the extraction plugin,
+	 * which populates the contentSections array.
+	 */
+	await remark()
+		.use(contentSectionCollector, {
+			collector: contentSectionNodes,
+			targetLevel: headingLevel,
+		})
+		.process(mdxContent)
+
+	/**
+	 * Stringify the contentNodes in each content section into an mdx string.
+	 */
+	const contentSections: ContentSection[] = await Promise.all(
+		contentSectionNodes.map(async function (contentSection) {
+			const { level, title, contentNodes } = contentSection
+			const tree: Root = { type: 'root', children: contentNodes }
+			// const contentString = toMarkdown(tree)
+			const contentString = await remark().stringify(tree)
+			return { level, title, content: contentString }
+		})
+	)
+
+	/**
+	 * Return the processed content sections
+	 */
+	return contentSections
+}
+
+/**
+ * unist-util-is for `paragraph` nodes,
+ * with a type guard so we don't have to cast types.
+ */
+function isParent(node: unknown): node is Parent {
+	return typeof node === 'object' && 'children' in node
+}
+
+/**
+ * unist-util-is for `heading` nodes,
+ * with a type guard so we don't have to cast types.
+ */
+function isHeading(node: unknown): node is Heading {
+	return is(node, 'heading')
+}

--- a/src/views/certifications/content/utils/get-faqs-from-mdx.ts
+++ b/src/views/certifications/content/utils/get-faqs-from-mdx.ts
@@ -1,0 +1,22 @@
+import { serialize } from 'next-mdx-remote/serialize'
+import { FaqItem } from 'views/certifications/types'
+import {
+	collectMdContentByHeading,
+	ContentSection,
+} from './collect-md-content-by-heading'
+
+/**
+ * Given a filepath to an MDX file,
+ * Return an array of FAQ items, sourced from an .mdx file for the exam.
+ */
+export async function getFaqsFromMdx(mdxString: string): Promise<FaqItem[]> {
+	// Sort MDX source into heading sections, using level 2 headings
+	const contentSections = await collectMdContentByHeading(mdxString, 2)
+	// Format into FAQ items
+	const faqItems = await Promise.all(
+		contentSections.map(async ({ title, content }: ContentSection) => {
+			return { title, mdxSource: await serialize(content) }
+		})
+	)
+	return faqItems
+}

--- a/src/views/certifications/content/utils/index.ts
+++ b/src/views/certifications/content/utils/index.ts
@@ -1,1 +1,3 @@
+export * from './collect-md-content-by-heading'
 export * from './get-certifications'
+export * from './get-faqs-from-mdx'

--- a/src/views/certifications/types.ts
+++ b/src/views/certifications/types.ts
@@ -1,5 +1,8 @@
-import type { RawCertificationProgram } from './content/schemas/certification-program'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import type {
+	RawCertificationExam,
+	RawCertificationProgram,
+} from './content/schemas/certification-program'
 
 /**
  * An FAQ item consists of a title representing the questions,
@@ -18,6 +21,22 @@ export type ProgramSlug =
 	| 'infrastructure-automation'
 	| 'security-automation'
 	| 'networking-automation'
+
+/**
+ * Certification exam content, after being prepared for the client.
+ */
+export interface CertificationExam
+	extends Omit<RawCertificationExam, 'faqSlug'> {
+	faqItems: FaqItem[]
+}
+
+/**
+ * Certification program content, after being prepared for the client.
+ */
+export interface CertificationProgram
+	extends Omit<RawCertificationProgram, 'exams'> {
+	exams: CertificationExam[]
+}
 
 /**
  * Raw page content for individual certification program pages.

--- a/src/views/certifications/types.ts
+++ b/src/views/certifications/types.ts
@@ -1,4 +1,14 @@
 import type { RawCertificationProgram } from './content/schemas/certification-program'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+/**
+ * An FAQ item consists of a title representing the questions,
+ * and some serialized MDX representing the answer content.
+ */
+export interface FaqItem {
+	title: string
+	mdxSource: MDXRemoteSerializeResult
+}
 
 /**
  * Program slugs are mainly used for stylistic tweaks. This type, and related

--- a/src/views/certifications/views/[slug]/server.ts
+++ b/src/views/certifications/views/[slug]/server.ts
@@ -4,6 +4,8 @@ import {
 	getCertificationProgram,
 } from 'views/certifications/content/utils'
 import { ProgramSlug } from 'views/certifications/types'
+// Local
+import { preparePageContent } from './utils/prepare-page-content'
 import { CertificationProgramViewProps } from './types'
 
 export async function getStaticProps({
@@ -12,7 +14,9 @@ export async function getStaticProps({
 	props: CertificationProgramViewProps
 }> {
 	// Fetch the authored page content
-	const { pageContent } = getCertificationProgram(slug)
+	const { pageContent: rawPageContent } = getCertificationProgram(slug)
+	// Prepare the page content for rendering, such as prepping MDX source
+	const pageContent = await preparePageContent(rawPageContent)
 	// Return static props
 	return { props: { pageContent, slug } }
 }

--- a/src/views/certifications/views/[slug]/types.ts
+++ b/src/views/certifications/views/[slug]/types.ts
@@ -1,5 +1,5 @@
-import { RawCertificationProgram } from 'views/certifications/content/schemas/certification-program'
 import { ProgramSlug } from 'views/certifications/types'
+import { CertificationProgram } from 'views/certifications/types'
 
 export interface CertificationProgramViewProps {
 	/**
@@ -10,5 +10,5 @@ export interface CertificationProgramViewProps {
 	/**
 	 * Content to render for this certification program.
 	 */
-	pageContent: RawCertificationProgram
+	pageContent: CertificationProgram
 }

--- a/src/views/certifications/views/[slug]/utils/prepare-page-content.ts
+++ b/src/views/certifications/views/[slug]/utils/prepare-page-content.ts
@@ -1,0 +1,31 @@
+import path from 'path'
+import { readLocalFile } from 'lib/read-local-file'
+import {
+	CertificationExam,
+	CertificationProgram,
+} from 'views/certifications/types'
+import {
+	RawCertificationExam,
+	RawCertificationProgram,
+} from 'views/certifications/content/schemas/certification-program'
+import { getFaqsFromMdx } from 'views/certifications/content/utils'
+
+const EXAM_CONTENT_DIR = 'src/content/certifications/exam-faqs'
+
+export async function preparePageContent(
+	rawPageContent: RawCertificationProgram
+): Promise<CertificationProgram> {
+	const preparedExamsContent = await Promise.all(
+		rawPageContent.exams.map(prepareExamContent)
+	)
+	return { ...rawPageContent, exams: preparedExamsContent }
+}
+
+async function prepareExamContent(
+	exam: RawCertificationExam
+): Promise<CertificationExam> {
+	const faqFile = `${exam.faqSlug}.mdx`
+	const faqMdxString = readLocalFile(path.join(EXAM_CONTENT_DIR, faqFile))
+	const parsedFaqItems = await getFaqsFromMdx(faqMdxString)
+	return { ...exam, faqItems: parsedFaqItems }
+}

--- a/src/views/certifications/views/[slug]/utils/prepare-page-content.ts
+++ b/src/views/certifications/views/[slug]/utils/prepare-page-content.ts
@@ -12,6 +12,12 @@ import { getFaqsFromMdx } from 'views/certifications/content/utils'
 
 const EXAM_CONTENT_DIR = 'src/content/certifications/exam-faqs'
 
+/**
+ * Process raw authored page content.
+ *
+ * Currently focused on transforming FAQ MDX slugs for each exam
+ * into FAQ items, each with processed `mdxSource`.
+ */
 export async function preparePageContent(
 	rawPageContent: RawCertificationProgram
 ): Promise<CertificationProgram> {
@@ -21,6 +27,10 @@ export async function preparePageContent(
 	return { ...rawPageContent, exams: preparedExamsContent }
 }
 
+/**
+ * Transforms an exam item with an `faqSlug` into an exam item
+ * with full `faqItems` data, ready to render in the view.
+ */
 async function prepareExamContent(
 	exam: RawCertificationExam
 ): Promise<CertificationExam> {


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR implements content loading for the `exam` items on each individual certification program page.

## 🛠️ How

- Installs some `unified`-related utilities
- Sets up content utilities for working with FAQ content in MDX
    - `collect-md-content-by-heading` splits an MDX string into an array of `{ title, content }` items, where `title` is the heading of a section, and `content` is the MDX string for content within that section
    - `get-faqs-from-mdx` uses `collect-md-content-by-heading` to split an MDX document on `## Heading Two` headings, and also transforms the `content` string into `mdxSource` using `next-mdx-remote`
- Adds in `exams` to each Certification program's content schema
    - `exams` content will drive the exam details on each certifications page. It will also be used for the overview of certification programs on the landing page.
- Stubs in content for exams
    - Adds `exams` arrays to each `<program>.json` content file
    - Adds `.mdx` files for each `exam` item's FAQ content
- Adds a `prepare-page-content` utility for the individual program view
   - This uses the `get-faqs-from-mdx` utilities, and the updated schemas, to process MDX content for FAQs and pass it to the view component

## 🔗 Page Links

- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

## 🧪 Testing

- [ ] Visit each of the pages listed above.
    - Each page should now render an array of `exam` content in the content debug block
- [ ] Visit [/certifications][/certifications], it should still render as expected
    - No new content on the landing page, though

[preview]: https://dev-portal-git-zscertifications-program-content-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscertifications-program-content-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscertifications-program-content-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscertifications-program-content-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscertifications-program-content-hashicorp.vercel.app/certifications/security-automation


