### PR TITLE
feat: add remaining landing content

### DIFF
--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -13,6 +13,10 @@ This folder contains the authorable content for Certifications pages.
 
 The content for the landing page hero is managed in [content/certifications/landing.json](/src/content/certifications/landing.json).
 
+### FAQs
+
+The content for the landing page's FAQ content is managed in [content/certifications/landing-faq.mdx](/src/content/certifications/landing-faq.mdx). FAQs are derived from this MDX file by extracting title text and content from each `## Heading Two` section.
+
 ## Program Pages
 
 Program pages at `/certifications/<slug>` are rendered based on the `<slug>.json` files present in the [content/certifications/programs](/src/content/certifications/programs) directory.

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -13,6 +13,10 @@ This folder contains the authorable content for Certifications pages.
 
 The content for the landing page hero is managed in [content/certifications/landing.json](/src/content/certifications/landing.json).
 
+### Program Summaries
+
+The `programSummarySlugs` array allows authors to control which programs are summarized on the landing page, and in what order those summaries appear. The content for program summaries on the landing page is driven by [content for each Program Page](#program-pages).
+
 ### FAQs
 
 The content for the landing page's FAQ content is managed in [content/certifications/landing-faq.mdx](/src/content/certifications/landing-faq.mdx). FAQs are derived from this MDX file by extracting title text and content from each `## Heading Two` section.

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -15,7 +15,7 @@ The content for the landing page hero is managed in [content/certifications/land
 
 ### Program Summaries
 
-The `programSummarySlugs` array allows authors to control which programs are summarized on the landing page, and in what order those summaries appear. The content for program summaries on the landing page is driven by [content for each Program Page](#program-pages).
+The `programSummaryOrder` array allows authors to control which programs are summarized on the landing page, and in what order those summaries appear. The content for program summaries on the landing page is driven by [content for each Program Page](#program-pages).
 
 ### FAQs
 

--- a/src/content/certifications/landing-faq.mdx
+++ b/src/content/certifications/landing-faq.mdx
@@ -1,0 +1,17 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Exam Experience
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers. The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.
+
+## Another Disclosure
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers. The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.
+
+## Content For This Section TBD
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers. The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.
+
+## High Elevation On Hover
+
+Certification exams are taken online with a live proctor. This means that all locations and time zones are accommodated. Online proctoring provides the same benefits of a physical test center while being more accessible to exam-takers. The live proctor verifies the exam-taker’s identity, walks them through rules and procedures, and watches them take the exam. Be sure to follow the instructions on your exam appointment confirmation email about how to prepare your computer and physical environment to take the exam.

--- a/src/content/certifications/landing.json
+++ b/src/content/certifications/landing.json
@@ -2,5 +2,10 @@
 	"hero": {
 		"heading": "HashiCorp Cloud Engineer Certifications",
 		"description": "Each certification program tests both conceptual knowledge and real-world experience using HashiCorp multi-cloud tools. Upon passing the exam, you can easily communicate your proficiency and employers can quickly verify your results."
-	}
+	},
+	"programSummarySlugs": [
+		"infrastructure-automation",
+		"security-automation",
+		"networking-automation"
+	]
 }

--- a/src/content/certifications/landing.json
+++ b/src/content/certifications/landing.json
@@ -3,7 +3,7 @@
 		"heading": "HashiCorp Cloud Engineer Certifications",
 		"description": "Each certification program tests both conceptual knowledge and real-world experience using HashiCorp multi-cloud tools. Upon passing the exam, you can easily communicate your proficiency and employers can quickly verify your results."
 	},
-	"programSummarySlugs": [
+	"programSummaryOrder": [
 		"infrastructure-automation",
 		"security-automation",
 		"networking-automation"

--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -1,5 +1,9 @@
 {
 	"title": "Infrastructure Automation",
+	"summary": {
+		"heading": "Infrastructure Automation Certifications",
+		"description": "Brief intro. Short but enough to help practitioners take that next step. Suggestion is a max of 5 lines of content. Verify your basic automation skills. If you have passed the existing exams wait until the new version comes out to re-certify."
+	},
 	"hero": {
 		"heading": "Infrastructure Automation Overview",
 		"description": "Cloud engineers will be able to use either version of the Terraform Associate certification to verify their basic infrastructure automation skills."

--- a/src/content/certifications/programs/networking-automation.json
+++ b/src/content/certifications/programs/networking-automation.json
@@ -1,5 +1,9 @@
 {
 	"title": "Networking Automation",
+	"summary": {
+		"heading": "Networking Automation Certifications",
+		"description": "Brief intro. Short but enough to help practitioners take that next step. Suggestion is a max of 5 lines of content. Verify your basic automation skills. If you have passed the existing exams wait until the new version comes out to re-certify."
+	},
 	"hero": {
 		"heading": "Networking Automation Overview",
 		"description": "Cloud engineers can use the Consul Associate certification exam from HashiCorp to verify their basic networking automation skills."

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -1,5 +1,9 @@
 {
 	"title": "Security Automation",
+	"summary": {
+		"heading": "Security Automation Certifications",
+		"description": "Brief intro. Short but enough to help practitioners take that next step. Suggestion is a max of 5 lines of content. Verify your basic automation skills. If you have passed the existing exams wait until the new version comes out to re-certify."
+	},
 	"hero": {
 		"heading": "Security Automation Overview",
 		"description": "Cloud engineers can use the Security Automation certification exams from HashiCorp to verify their basic security automation skills."

--- a/src/views/certifications/content/schemas/certification-program.ts
+++ b/src/views/certifications/content/schemas/certification-program.ts
@@ -34,6 +34,10 @@ export const CertificationProgramSchema = z.object({
 		heading: z.string(),
 		description: z.string(),
 	}),
+	summary: z.object({
+		heading: z.string(),
+		description: z.string(),
+	}),
 	exams: z.array(CertificationExamSchema),
 })
 

--- a/src/views/certifications/content/schemas/landing-page.ts
+++ b/src/views/certifications/content/schemas/landing-page.ts
@@ -1,6 +1,23 @@
 import { z } from 'zod'
 
 /**
+ * We support a limited set of program slugs.
+ * Program slugs are mainly used for stylistic tweaks. This schema, and related
+ * components that use the ProgramSlug type, will need to expanded
+ * when additional certification programs are added.
+ */
+const ProgramSlugSchema = z.enum([
+	'infrastructure-automation',
+	'networking-automation',
+	'security-automation',
+])
+
+/**
+ * Export the ProgramSlug enum as a type.
+ */
+export type ProgramSlug = z.infer<typeof ProgramSlugSchema>
+
+/**
  * Content schema for the /certifications landing page.
  *
  * Note that much of the landing page content will be derived from
@@ -14,7 +31,7 @@ export const LandingPageSchema = z.object({
 	/**
 	 * Note: these must be valid ProgramSlug values.
 	 */
-	programSummarySlugs: z.array(z.string()),
+	programSummaryOrder: z.array(ProgramSlugSchema),
 })
 
 /**

--- a/src/views/certifications/content/schemas/landing-page.ts
+++ b/src/views/certifications/content/schemas/landing-page.ts
@@ -11,6 +11,10 @@ export const LandingPageSchema = z.object({
 		heading: z.string(),
 		description: z.string(),
 	}),
+	/**
+	 * Note: these must be valid ProgramSlug values.
+	 */
+	programSummarySlugs: z.array(z.string()),
 })
 
 /**

--- a/src/views/certifications/content/utils/get-certifications.ts
+++ b/src/views/certifications/content/utils/get-certifications.ts
@@ -38,3 +38,14 @@ export function getCertificationProgram(
 	)
 	return { slug, pageContent }
 }
+
+/**
+ * Get data for all certification programs at once.
+ *
+ * Useful for rendering detailed overview sections
+ * on the `/certifications` landing page.
+ */
+export function getAllCertificationPrograms(): RawCertificationProgramItem[] {
+	const programSlugs = getAllCertificationProgramSlugs()
+	return programSlugs.map(getCertificationProgram)
+}

--- a/src/views/certifications/types.ts
+++ b/src/views/certifications/types.ts
@@ -3,6 +3,12 @@ import type {
 	RawCertificationExam,
 	RawCertificationProgram,
 } from './content/schemas/certification-program'
+import { ProgramSlug } from './content/schemas/landing-page'
+
+/**
+ * Re-export ProgramSlug from this file, for convenience.
+ */
+export type { ProgramSlug }
 
 /**
  * An FAQ item consists of a title representing the questions,
@@ -12,15 +18,6 @@ export interface FaqItem {
 	title: string
 	mdxSource: MDXRemoteSerializeResult
 }
-
-/**
- * Program slugs are mainly used for stylistic tweaks. This type, and related
- * components,  will need to expanded if additional programs are added.
- */
-export type ProgramSlug =
-	| 'infrastructure-automation'
-	| 'security-automation'
-	| 'networking-automation'
 
 /**
  * Certification exam content, after being prepared for the client.
@@ -42,6 +39,6 @@ export interface CertificationProgram
  * Raw page content for individual certification program pages.
  */
 export interface RawCertificationProgramItem {
-	slug: string
+	slug: ProgramSlug
 	pageContent: RawCertificationProgram
 }

--- a/src/views/certifications/views/landing/index.tsx
+++ b/src/views/certifications/views/landing/index.tsx
@@ -4,7 +4,10 @@ import BaseNewLayout from 'layouts/base-new'
 import { LandingHero } from './components'
 import { CertificationLandingProps } from './types'
 
-function CertificationsLandingView({ pageContent }: CertificationLandingProps) {
+function CertificationsLandingView({
+	pageContent,
+	faqItems,
+}: CertificationLandingProps) {
 	const { hero } = pageContent
 	return (
 		<>
@@ -12,7 +15,7 @@ function CertificationsLandingView({ pageContent }: CertificationLandingProps) {
 			<pre style={{ border: '1px solid magenta' }}>
 				<code>
 					{JSON.stringify(
-						{ note: 'Landing page placeholder', pageContent },
+						{ note: 'Landing page placeholder', pageContent, faqItems },
 						null,
 						2
 					)}

--- a/src/views/certifications/views/landing/index.tsx
+++ b/src/views/certifications/views/landing/index.tsx
@@ -6,6 +6,7 @@ import { CertificationLandingProps } from './types'
 
 function CertificationsLandingView({
 	pageContent,
+	programSummaries,
 	faqItems,
 }: CertificationLandingProps) {
 	const { hero } = pageContent
@@ -15,7 +16,12 @@ function CertificationsLandingView({
 			<pre style={{ border: '1px solid magenta' }}>
 				<code>
 					{JSON.stringify(
-						{ note: 'Landing page placeholder', pageContent, faqItems },
+						{
+							note: 'Landing page placeholder',
+							pageContent,
+							programSummaries,
+							faqItems,
+						},
 						null,
 						2
 					)}

--- a/src/views/certifications/views/landing/server.ts
+++ b/src/views/certifications/views/landing/server.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { readLocalFile } from 'lib/read-local-file'
 import { GetStaticPropsResult } from 'next'
 import { CertificationLandingProps } from './types'
+import { getFaqsFromMdx } from 'views/certifications/content/utils'
 import { LandingPageSchema } from 'views/certifications/content/schemas/landing-page'
 
 const CONTENT_DIR = 'src/content/certifications'
@@ -18,9 +19,14 @@ export async function getStaticProps(): Promise<
 	const contentString = readLocalFile(path.join(CONTENT_DIR, 'landing.json'))
 	const pageContent = LandingPageSchema.parse(JSON.parse(contentString))
 	/**
+	 * Parse landing page FAQs from an MDX file
+	 */
+	const faqMdxString = readLocalFile(path.join(CONTENT_DIR, 'landing-faq.mdx'))
+	const faqItems = await getFaqsFromMdx(faqMdxString)
+	/**
 	 * Return static props
 	 */
 	return {
-		props: { pageContent },
+		props: { pageContent, faqItems },
 	}
 }

--- a/src/views/certifications/views/landing/server.ts
+++ b/src/views/certifications/views/landing/server.ts
@@ -2,8 +2,12 @@ import path from 'path'
 import { readLocalFile } from 'lib/read-local-file'
 import { GetStaticPropsResult } from 'next'
 import { CertificationLandingProps } from './types'
-import { getFaqsFromMdx } from 'views/certifications/content/utils'
+import {
+	getFaqsFromMdx,
+	getAllCertificationPrograms,
+} from 'views/certifications/content/utils'
 import { LandingPageSchema } from 'views/certifications/content/schemas/landing-page'
+import { formatProgramSummaries } from './utils/format-program-summaries'
 
 const CONTENT_DIR = 'src/content/certifications'
 
@@ -18,15 +22,26 @@ export async function getStaticProps(): Promise<
 	 */
 	const contentString = readLocalFile(path.join(CONTENT_DIR, 'landing.json'))
 	const pageContent = LandingPageSchema.parse(JSON.parse(contentString))
+
+	/**
+	 * Format all program data into program summaries
+	 */
+	const allPrograms = getAllCertificationPrograms()
+	const programSummaries = formatProgramSummaries(
+		allPrograms,
+		pageContent.programSummarySlugs
+	)
+
 	/**
 	 * Parse landing page FAQs from an MDX file
 	 */
 	const faqMdxString = readLocalFile(path.join(CONTENT_DIR, 'landing-faq.mdx'))
 	const faqItems = await getFaqsFromMdx(faqMdxString)
+
 	/**
 	 * Return static props
 	 */
 	return {
-		props: { pageContent, faqItems },
+		props: { pageContent, programSummaries, faqItems },
 	}
 }

--- a/src/views/certifications/views/landing/server.ts
+++ b/src/views/certifications/views/landing/server.ts
@@ -29,7 +29,7 @@ export async function getStaticProps(): Promise<
 	const allPrograms = getAllCertificationPrograms()
 	const programSummaries = formatProgramSummaries(
 		allPrograms,
-		pageContent.programSummarySlugs
+		pageContent.programSummaryOrder
 	)
 
 	/**

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -1,11 +1,40 @@
 import { RawLandingPageContent } from 'views/certifications/content/schemas/landing-page'
 import { FaqItem } from 'views/certifications/types'
 
+/**
+ * Summaries of each certification program are displayed on the landing page.
+ */
+export interface CertificationProgramSummary {
+	slug: string
+	title: string
+	description: string
+	exams: {
+		title: string
+		productSlug: 'consul' | 'terraform' | 'vault'
+		url?: string
+	}[]
+}
+
+/**
+ * Processed landing page content contains collected program summary data,
+ * rather than the authored list of program slugs.
+ */
+export type LandingPageContent = Omit<
+	RawLandingPageContent,
+	'programSummarySlugs'
+>
+
 export interface CertificationLandingProps {
 	/**
 	 * Content for the hero on the landing page.
 	 */
-	pageContent: RawLandingPageContent
+	pageContent: LandingPageContent
+
+	/**
+	 * Summaries of each individual certification program.
+	 * Each program contains multiple exams.
+	 */
+	programSummaries: CertificationProgramSummary[]
 
 	/**
 	 * FAQ items to render on the landing page.

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -21,7 +21,7 @@ export interface CertificationProgramSummary {
  */
 export type LandingPageContent = Omit<
 	RawLandingPageContent,
-	'programSummarySlugs'
+	'programSummaryOrder'
 >
 
 export interface CertificationLandingProps {

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -1,17 +1,21 @@
+import {
+	RawCertificationExam,
+	RawCertificationProgram,
+} from 'views/certifications/content/schemas/certification-program'
 import { RawLandingPageContent } from 'views/certifications/content/schemas/landing-page'
-import { FaqItem } from 'views/certifications/types'
+import { FaqItem, ProgramSlug } from 'views/certifications/types'
 
 /**
  * Summaries of each certification program are displayed on the landing page.
  */
 export interface CertificationProgramSummary {
-	slug: string
-	title: string
-	description: string
+	slug: ProgramSlug
+	heading: RawCertificationProgram['summary']['heading']
+	description: RawCertificationProgram['summary']['description']
 	exams: {
-		title: string
-		productSlug: 'consul' | 'terraform' | 'vault'
-		url?: string
+		title: RawCertificationExam['title']
+		productSlug: RawCertificationExam['productSlug']
+		prepareUrl?: RawCertificationExam['links']['prepare']
 	}[]
 }
 

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -1,8 +1,14 @@
 import { RawLandingPageContent } from 'views/certifications/content/schemas/landing-page'
+import { FaqItem } from 'views/certifications/types'
 
 export interface CertificationLandingProps {
 	/**
 	 * Content for the hero on the landing page.
 	 */
 	pageContent: RawLandingPageContent
+
+	/**
+	 * FAQ items to render on the landing page.
+	 */
+	faqItems: FaqItem[]
 }

--- a/src/views/certifications/views/landing/utils/format-program-summaries.ts
+++ b/src/views/certifications/views/landing/utils/format-program-summaries.ts
@@ -7,7 +7,7 @@ import { CertificationProgramSummary } from '../types'
  */
 export function formatProgramSummaries(
 	programs: RawCertificationProgramItem[],
-	slugsInOrder: string[]
+	slugsInOrder: ProgramSlug[]
 ): CertificationProgramSummary[] {
 	// Transform the provided `slugsInOrder` array into summary objects
 	const programSummaries: CertificationProgramSummary[] = slugsInOrder.map(

--- a/src/views/certifications/views/landing/utils/format-program-summaries.ts
+++ b/src/views/certifications/views/landing/utils/format-program-summaries.ts
@@ -1,0 +1,39 @@
+import { RawCertificationProgramItem } from 'views/certifications/types'
+import { CertificationProgramSummary } from '../types'
+
+/**
+ * Given an array of programs data, and an array of program slugs in order,
+ * Return an array of program summary objects, in the specified order.
+ */
+export function formatProgramSummaries(
+	programs: RawCertificationProgramItem[],
+	slugsInOrder: string[]
+): CertificationProgramSummary[] {
+	// Transform the provided `slugsInOrder` array into summary objects
+	const programSummaries: CertificationProgramSummary[] = slugsInOrder.map(
+		(targetSlug: string) => {
+			const program = programs.find((p) => p.slug === targetSlug)
+			// If we can't find the target program, throw an error
+			if (!program) {
+				throw new Error(
+					`formatProgramSummaries: could not find Certification program with slug "${targetSlug}". Please ensure all slugs in "" reference existing Certification programs in "src/content/certifications/programs".`
+				)
+			}
+			// Format the full program data into a summary object
+			return {
+				slug: program.slug,
+				title: program.pageContent.summary.heading,
+				description: program.pageContent.summary.description,
+				exams: program.pageContent.exams.map((exam) => {
+					return {
+						title: exam.title,
+						productSlug: exam.productSlug,
+						url: exam.links?.prepare ?? null,
+					}
+				}),
+			}
+		}
+	)
+	// Return the summary objects
+	return programSummaries
+}

--- a/src/views/certifications/views/landing/utils/format-program-summaries.ts
+++ b/src/views/certifications/views/landing/utils/format-program-summaries.ts
@@ -1,4 +1,7 @@
-import { RawCertificationProgramItem } from 'views/certifications/types'
+import {
+	ProgramSlug,
+	RawCertificationProgramItem,
+} from 'views/certifications/types'
 import { CertificationProgramSummary } from '../types'
 
 /**
@@ -22,13 +25,13 @@ export function formatProgramSummaries(
 			// Format the full program data into a summary object
 			return {
 				slug: program.slug,
-				title: program.pageContent.summary.heading,
+				heading: program.pageContent.summary.heading,
 				description: program.pageContent.summary.description,
 				exams: program.pageContent.exams.map((exam) => {
 					return {
 						title: exam.title,
 						productSlug: exam.productSlug,
-						url: exam.links?.prepare ?? null,
+						prepareUrl: exam.links?.prepare ?? null,
 					}
 				}),
 			}


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR implements content loading for the remaining landing page content. Specifically:
- Loads and formats program data into program summaries, for display on the landing page
- Loads and formats FAQ content for the landing page from `src/content/certifications/landing-faq.mdx`

## 🛠️ How

- Adds docs to the `content/certifications/README.md`
- Adds stubbed content to `content/certifications/landing-faq.mdx`
- Adds `programSummarySlugs` to the landing page content schema (and add that content)
- Adds `summary` to the individual program page content schemas (and add that content)
- Process FAQ content in the landing page `getStaticProps`, and pass `faqItems` to the view
- Process programs into summary data with a new `format-program-summaries` function, and pass the `programSummaries` data to the view

## 🧪 Testing

- [ ] Visit the landing page at [/certifications][/certifications]
    - The landing page should now render an array of `programSummaries` in the content debug block
    - The landing page should now render an array of `faqItems` in the content debug block

As well, the remaining certifications pages should continue to render as they do upstream. There should also be added `summary` data in the content debug block on each page:
- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

[preview]: https://dev-portal-git-zscertifications-landing-content-hashicorp.vercel.app
[/certifications]: https://dev-portal-git-zscertifications-landing-content-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscertifications-landing-content-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscertifications-landing-content-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscertifications-landing-content-hashicorp.vercel.app/certifications/security-automation


