### PR TITLE
feat: add landing faq section

### DIFF
--- a/src/components/dev-dot-content/mdx-components/mdx-p/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/mdx-p/index.tsx
@@ -1,8 +1,10 @@
+import classNames from 'classnames'
 import Text from 'components/text'
 import s from './mdx-p.module.css'
 
 function MdxP(props) {
-	return <Text {...props} className={s.p} />
+	const { className, ...restProps } = props
+	return <Text {...restProps} className={classNames(s.p, className)} />
 }
 
 export { MdxP }

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -19,6 +19,8 @@ The `programSummaryOrder` array allows authors to control which programs are sum
 
 ### FAQs
 
+The heading for the FAQs on the landing page is managed by the `faqHeading` property in [content/certifications/landing.json](/src/content/certifications/landing.json).
+
 The content for the landing page's FAQ content is managed in [content/certifications/landing-faq.mdx](/src/content/certifications/landing-faq.mdx). FAQs are derived from this MDX file by extracting title text and content from each `## Heading Two` section.
 
 ## Program Pages

--- a/src/content/certifications/README.md
+++ b/src/content/certifications/README.md
@@ -19,7 +19,7 @@ The `programSummaryOrder` array allows authors to control which programs are sum
 
 ### FAQs
 
-The heading for the FAQs on the landing page is managed by the `faqHeading` property in [content/certifications/landing.json](/src/content/certifications/landing.json).
+The heading for the FAQ section on the landing page is managed by the `faqHeading` property in [content/certifications/landing.json](/src/content/certifications/landing.json).
 
 The content for the landing page's FAQ content is managed in [content/certifications/landing-faq.mdx](/src/content/certifications/landing-faq.mdx). FAQs are derived from this MDX file by extracting title text and content from each `## Heading Two` section.
 

--- a/src/content/certifications/landing.json
+++ b/src/content/certifications/landing.json
@@ -7,5 +7,6 @@
 		"infrastructure-automation",
 		"security-automation",
 		"networking-automation"
-	]
+	],
+	"faqHeading": "Program overview & FAQ"
 }

--- a/src/views/certifications/components/accordion-with-mdx-content/accordion-with-mdx-content.module.css
+++ b/src/views/certifications/components/accordion-with-mdx-content/accordion-with-mdx-content.module.css
@@ -1,0 +1,3 @@
+.lighterTextColor {
+	color: var(--token-color-foreground-faint);
+}

--- a/src/views/certifications/components/accordion-with-mdx-content/index.tsx
+++ b/src/views/certifications/components/accordion-with-mdx-content/index.tsx
@@ -1,0 +1,52 @@
+import { MDXRemote } from 'next-mdx-remote'
+import Accordion from 'components/accordion'
+import Image from 'components/image'
+import { ImageProps } from 'components/image/types'
+import {
+	MdxA,
+	MdxP,
+	MdxTable,
+	MdxInlineCode,
+	MdxOrderedList,
+	MdxUnorderedList,
+	MdxListItem,
+	MdxBlockquote,
+} from 'components/dev-dot-content/mdx-components'
+import { AccordionWithMdxContentProps, AccordionMdxItem } from './types'
+
+function MdxImage({
+	alt,
+	src,
+	title,
+}: Pick<ImageProps, 'alt' | 'src' | 'title'>) {
+	return <Image alt={alt} src={src} title={title} noBorder={true} />
+}
+
+const MDX_COMPONENTS = {
+	a: MdxA,
+	blockquote: MdxBlockquote,
+	p: MdxP,
+	table: MdxTable,
+	img: MdxImage,
+	inlineCode: MdxInlineCode,
+	ul: MdxUnorderedList,
+	ol: MdxOrderedList,
+	li: MdxListItem,
+}
+
+export function AccordionWithMdxContent({
+	items,
+}: AccordionWithMdxContentProps) {
+	return (
+		<Accordion
+			items={items.map((item: AccordionMdxItem) => {
+				return {
+					title: item.title,
+					content: (
+						<MDXRemote {...item.mdxSource} components={MDX_COMPONENTS} />
+					),
+				}
+			})}
+		/>
+	)
+}

--- a/src/views/certifications/components/accordion-with-mdx-content/index.tsx
+++ b/src/views/certifications/components/accordion-with-mdx-content/index.tsx
@@ -13,6 +13,7 @@ import {
 	MdxBlockquote,
 } from 'components/dev-dot-content/mdx-components'
 import { AccordionWithMdxContentProps, AccordionMdxItem } from './types'
+import s from './accordion-with-mdx-content.module.css'
 
 function MdxImage({
 	alt,
@@ -25,7 +26,8 @@ function MdxImage({
 const MDX_COMPONENTS = {
 	a: MdxA,
 	blockquote: MdxBlockquote,
-	p: MdxP,
+	/* Note: we intentionally don't accept className from MDX content here */
+	p: (props) => <MdxP {...props} className={s.lighterTextColor} />,
 	table: MdxTable,
 	img: MdxImage,
 	inlineCode: MdxInlineCode,

--- a/src/views/certifications/components/accordion-with-mdx-content/types.ts
+++ b/src/views/certifications/components/accordion-with-mdx-content/types.ts
@@ -1,0 +1,10 @@
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+export interface AccordionMdxItem {
+	title: string
+	mdxSource: MDXRemoteSerializeResult
+}
+
+export interface AccordionWithMdxContentProps {
+	items: AccordionMdxItem[]
+}

--- a/src/views/certifications/components/index.tsx
+++ b/src/views/certifications/components/index.tsx
@@ -1,3 +1,4 @@
+export * from './accordion-with-mdx-content'
 export * from './certifications-hero'
 export * from './certifications-max-width'
 export * from './cta-group'

--- a/src/views/certifications/content/schemas/landing-page.ts
+++ b/src/views/certifications/content/schemas/landing-page.ts
@@ -28,6 +28,7 @@ export const LandingPageSchema = z.object({
 		heading: z.string(),
 		description: z.string(),
 	}),
+	faqHeading: z.string(),
 	/**
 	 * Note: these must be valid ProgramSlug values.
 	 */

--- a/src/views/certifications/views/landing/index.tsx
+++ b/src/views/certifications/views/landing/index.tsx
@@ -1,7 +1,10 @@
 // Global
 import BaseNewLayout from 'layouts/base-new'
 // Shared components
-import { CertificationsMaxWidth } from 'views/certifications/components'
+import {
+	AccordionWithMdxContent,
+	CertificationsMaxWidth,
+} from 'views/certifications/components'
 // Local view
 import { CertificationProgramSummaryCard, LandingHero } from './components'
 import { CertificationLandingProps, CertificationProgramSummary } from './types'
@@ -14,7 +17,7 @@ function CertificationsLandingView({
 }: CertificationLandingProps) {
 	const { hero } = pageContent
 	return (
-		<>
+		<div className={s.root}>
 			{/* Hero */}
 			<LandingHero heading={hero.heading} description={hero.description} />
 			{/* Program Summaries */}
@@ -33,19 +36,13 @@ function CertificationsLandingView({
 					)
 				})}
 			</div>
-			{/* Content Debug */}
-			<pre style={{ border: '1px solid magenta', margin: '0' }}>
-				<code>
-					{JSON.stringify(
-						{
-							faqItems,
-						},
-						null,
-						2
-					)}
-				</code>
-			</pre>
-		</>
+			<div className={s.faqSection}>
+				<CertificationsMaxWidth>
+					<h2 className={s.faqHeading}>{pageContent.faqHeading}</h2>
+					<AccordionWithMdxContent items={faqItems} />
+				</CertificationsMaxWidth>
+			</div>
+		</div>
 	)
 }
 

--- a/src/views/certifications/views/landing/landing.module.css
+++ b/src/views/certifications/views/landing/landing.module.css
@@ -1,3 +1,19 @@
+.root {
+	/* Note: overlap is declared here, so that both the overlapping sections
+	   can access the same values consistently. */
+	--programs-hero-overlap: 72px;
+	--programs-faq-overlap: 80px;
+
+	/* Adjust section overlap based on viewport size */
+	@media (--dev-dot-desktop) {
+		--programs-faq-overlap: 128px;
+	}
+}
+
+/**
+ * Programs section
+ */
+
 .programsSection {
 	align-items: stretch;
 	display: flex;
@@ -5,14 +21,33 @@
 	gap: 56px;
 
 	/* Overlap onto the hero above, and the section below */
-	margin: -72px 0 -80px 0;
+	margin-top: calc(-1 * var(--programs-hero-overlap));
+	margin-bottom: calc(-1 * var(--programs-faq-overlap));
 
 	/* We want this section to be above the FAQ section below */
 	z-index: 1;
 
-	/* Adjust spacing based on viewport */
+	/* Adjust vertical rhythm  based on viewport */
 	@media (--dev-dot-desktop) {
 		gap: 72px;
-		margin: -72px 0 -128px 0;
 	}
+}
+
+/**
+ * FAQ section
+ */
+
+.faqSection {
+	--section-top-padding: 128px;
+
+	background: var(--token-color-surface-strong);
+	padding-top: calc(var(--section-top-padding) + var(--programs-faq-overlap));
+	padding-bottom: 168px;
+}
+
+.faqHeading {
+	composes: hds-typography-display-400 from global;
+	font-weight: var(--token-typography-font-weight-bold);
+	color: var(--token-color-foreground-strong);
+	margin: 0 0 32px 0;
 }


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR implements the FAQ section on the [/certifications][/certifications] landing page.

## 🛠️ How

- Adds a new `accordion-with-mdx-content` component
    - This uses existing `dev-dot-content` MDX components to render accordion content
    - This component will be re-used on individual program pages
- Adds `faqHeading` to the landing schema
- Adds the FAQ section, and associated spacing styles, to the home page
    - I've adjusted some styles related to overlapping sections to try to make things more clear & maintainable. Open to alternate suggestions 🙇
- Updates content `README` with short note on `faqHeading` for the landing page

## 📸 Design Screenshots

🎨 [Figma mockups](https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=16598%3A247078&t=5WoCCWIPOOQqiG57-4)

### Design

| Tablet | Desktop |
| - | - |
| <img width="510" alt="design-tablet" src="https://user-images.githubusercontent.com/4624598/207721906-92783102-0ff8-4eed-9226-c63e3bad754e.png"> | <img width="1257" alt="design-desktop" src="https://user-images.githubusercontent.com/4624598/207721915-16301cfa-c477-4f12-8ff0-bb16383af1d7.png"> |

### Implementation

| Mobile | Tablet | Desktop |
| - | - | - |
| <img width="325" alt="mobile" src="https://user-images.githubusercontent.com/4624598/207722667-e7c96c4b-7c37-4b36-8058-c69dada8df30.png"> | <img width="866" alt="tablet" src="https://user-images.githubusercontent.com/4624598/207722673-6636bac4-d25a-499d-9c2d-674e51a473fa.png"> | <img width="1582" alt="desktop" src="https://user-images.githubusercontent.com/4624598/207722675-056f414b-715d-4e21-859e-6093686cee53.png"> |

## 🧪 Testing

- [ ] Visit the landing page at [/certifications][/certifications]
    - The landing page should have an FAQ section that _nearly_ matches Figma mockups, as above
    - Note: we intend to make further tweaks to this work during once we're in VQA mode

There should be no changes to individual program pages:
- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

[preview]: https://dev-portal-git-zscertifications-landing-faq-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscertifications-landing-faq-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscertifications-landing-faq-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscertifications-landing-faq-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscertifications-landing-faq-hashicorp.vercel.app/certifications/security-automation


