### PR TITLE
fix: revert text color change in MDX FAQs

### DIFF
--- a/src/components/dev-dot-content/mdx-components/mdx-p/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/mdx-p/index.tsx
@@ -1,10 +1,8 @@
-import classNames from 'classnames'
 import Text from 'components/text'
 import s from './mdx-p.module.css'
 
 function MdxP(props) {
-	const { className, ...restProps } = props
-	return <Text {...restProps} className={classNames(s.p, className)} />
+	return <Text {...props} className={s.p} />
 }
 
 export { MdxP }

--- a/src/views/certifications/components/accordion-with-mdx-content/accordion-with-mdx-content.module.css
+++ b/src/views/certifications/components/accordion-with-mdx-content/accordion-with-mdx-content.module.css
@@ -1,3 +1,0 @@
-.lighterTextColor {
-	color: var(--token-color-foreground-faint);
-}

--- a/src/views/certifications/components/accordion-with-mdx-content/index.tsx
+++ b/src/views/certifications/components/accordion-with-mdx-content/index.tsx
@@ -13,7 +13,6 @@ import {
 	MdxBlockquote,
 } from 'components/dev-dot-content/mdx-components'
 import { AccordionWithMdxContentProps, AccordionMdxItem } from './types'
-import s from './accordion-with-mdx-content.module.css'
 
 function MdxImage({
 	alt,

--- a/src/views/certifications/components/accordion-with-mdx-content/index.tsx
+++ b/src/views/certifications/components/accordion-with-mdx-content/index.tsx
@@ -26,8 +26,7 @@ function MdxImage({
 const MDX_COMPONENTS = {
 	a: MdxA,
 	blockquote: MdxBlockquote,
-	/* Note: we intentionally don't accept className from MDX content here */
-	p: (props) => <MdxP {...props} className={s.lighterTextColor} />,
+	p: MdxP,
 	table: MdxTable,
 	img: MdxImage,
 	inlineCode: MdxInlineCode,


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR reverts a change to the text color of `MdxP` within accordion content.

### Details

The original commit that introduced this change was [e6a8304](https://github.com/hashicorp/dev-portal/pull/1463/commits/e6a8304f756cc4e85f39de09632aee347643687d).

This change was made due to some uncertainty about the implications of Figma designs (see [this PR comment](https://github.com/hashicorp/dev-portal/pull/1463#discussion_r1049079449)). I've since clarified & confirmed the desired output via Slack DMs.

## 📸 Design Screenshots

| Page | Before | After |
| - | - | - |
| Landing | <img width="1256" alt="landing-before" src="https://user-images.githubusercontent.com/4624598/208172613-a5bf5636-4de8-4b96-b9d1-844f1680d462.png"> | <img width="1247" alt="landing-after" src="https://user-images.githubusercontent.com/4624598/208172631-e0a855b0-4142-4092-b2ed-41b0977fd679.png"> |
| Program | <img width="1233" alt="program-before" src="https://user-images.githubusercontent.com/4624598/208172622-fd82e807-9bf3-40f9-b9f5-e00b53f28ce1.png"> | <img width="1230" alt="program-after" src="https://user-images.githubusercontent.com/4624598/208172625-6d827215-5cd2-400a-84da-cfab34781e7b.png"> |

## 🔗 Preview links

- [/certifications][/certifications]
- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

## 🧪 Testing

- [ ] Visit each of the preview links listed above
    - The landing page has an FAQ section near the bottom of the page
    - Individual program pages have FAQ sections under each exam details section
    - Each FAQ section should show text that is the default `--token-color-foreground-primary` (nearly black), rather than the previous `--token-color-foreground-faint`.

[preview]: https://dev-portal-git-zscert-revert-terxt-colort-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscert-revert-terxt-colort-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscert-revert-terxt-colort-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscert-revert-terxt-colort-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscert-revert-terxt-colort-hashicorp.vercel.app/certifications/security-automation