### PR TITLE
feat: separate exam code in titles

### DIFF
--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -10,7 +10,8 @@
 	},
 	"exams": [
 		{
-			"title": "Terraform Associate 002",
+			"title": "Terraform Associate",
+			"examCode": "002",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
 			"description": "The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with open source HashiCorp Terraform. Candidates will be best prepared for this exam if they have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands which enterprise features exist and what can and cannot be done using the open source offering.",
@@ -21,7 +22,8 @@
 			"faqSlug": "terraform-associate-002"
 		},
 		{
-			"title": "Terraform Associate 003",
+			"title": "Terraform Associate",
+			"examCode": "003",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
 			"description": "The Terraform Associate 003 is an upcoming certification for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with HashiCorp Terraform. This person understands the difference in functionality between Terraform Cloud, Terraform Enterprise, and open source Terraform.\n\nThe draft Terraform Associate 003 exam’s objectives are listed below, and dedicated study materials are coming soon. The objective differences between the (existing 002 exam and the upcoming 003 exam) versions are a reorganization and rewording of objectives to comfortably cover recent and future Terraform product growth.",

--- a/src/content/certifications/programs/networking-automation.json
+++ b/src/content/certifications/programs/networking-automation.json
@@ -10,7 +10,8 @@
 	},
 	"exams": [
 		{
-			"title": "Consul Associate 002",
+			"title": "Consul Associate",
+			"examCode": "002",
 			"productSlug": "consul",
 			"versionTested": "Consul 1.8 or higher",
 			"description": "The Consul Associate Certification is for Site Reliability Engineers, Solutions Architects, DevOps professionals, or other Cloud Engineers who know the basic concepts and skills to build, secure, and maintain open source HashiCorp Consul. Candidates will be best prepared for this exam if they have professional experience using Consul in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands what enterprise features exist and what can and cannot be done using the open source offering.",

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -10,7 +10,8 @@
 	},
 	"exams": [
 		{
-			"title": "Vault Associate 002",
+			"title": "Vault Associate",
+			"examCode": "002",
 			"productSlug": "vault",
 			"versionTested": "Vault 1.6.0 and higher",
 			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with open source HashiCorp Vault. Candidates will be best prepared for this exam if they have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may also be sufficient. This person understands what enterprise features exist and what can and cannot be done using the open source offering.",

--- a/src/views/certifications/content/schemas/certification-program.ts
+++ b/src/views/certifications/content/schemas/certification-program.ts
@@ -25,6 +25,7 @@ export type CertificationProductSlug = z.infer<
  */
 export const CertificationExamSchema = z.object({
 	title: z.string(),
+	examCode: z.string().optional(),
 	productSlug: CertificationProductSlugSchema,
 	versionTested: z.string(),
 	description: z.string(),

--- a/src/views/certifications/views/[slug]/index.tsx
+++ b/src/views/certifications/views/[slug]/index.tsx
@@ -28,10 +28,12 @@ function CertificationProgramView({
 				<CertificationsMaxWidth key={slug}>
 					<div className={s.examsSection}>
 						{exams.map((exam) => {
+							const { title, examCode } = exam
+							const fullTitle = title + (examCode ? ` (${examCode})` : '')
 							return (
-								<div key={slug}>
+								<div key={fullTitle}>
 									<ExamDetailsCard
-										title={exam.title}
+										title={fullTitle}
 										description={exam.description}
 										links={exam.links}
 										productSlug={exam.productSlug}

--- a/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
+++ b/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
@@ -31,18 +31,19 @@ export function CertificationProgramSummaryCard({
 				}
 			/>
 			<div className={s.examCards}>
-				{exams.map(({ title, prepareUrl, productSlug }) => {
+				{exams.map(({ title, prepareUrl, examCode, productSlug }) => {
+					const fullTitle = title + (examCode ? ` (${examCode})` : '')
 					return prepareUrl ? (
 						<ExamCard
-							key={title}
-							title={title}
+							key={fullTitle}
+							title={fullTitle}
 							url={prepareUrl}
 							productSlug={productSlug}
 						/>
 					) : (
 						<ExamCardComingSoon
-							key={title}
-							title={title}
+							key={fullTitle}
+							title={fullTitle}
 							productSlug={productSlug}
 						/>
 					)

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -14,6 +14,7 @@ export interface CertificationProgramSummary {
 	description: RawCertificationProgram['summary']['description']
 	exams: {
 		title: RawCertificationExam['title']
+		examCode: RawCertificationExam['examCode']
 		productSlug: RawCertificationExam['productSlug']
 		prepareUrl?: RawCertificationExam['links']['prepare']
 	}[]

--- a/src/views/certifications/views/landing/utils/format-program-summaries.ts
+++ b/src/views/certifications/views/landing/utils/format-program-summaries.ts
@@ -30,6 +30,7 @@ export function formatProgramSummaries(
 				exams: program.pageContent.exams.map((exam) => {
 					return {
 						title: exam.title,
+						examCode: exam.examCode ?? null,
 						productSlug: exam.productSlug,
 						prepareUrl: exam.links?.prepare ?? null,
 					}


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR fixes an issue where brackets were not used in exam title display in the expected way.

### Expectation

The ask from the Certifications stakeholder side is to display exam codes in brackets where the full title is shown, but display exam codes not in brackets where the short title is shown. For example, for the Terraform Associate 002 exam:
- Full title: `HashiCorp Certified: Terraform Associate (002)`
- Short title: `Terraform Associate 002`

### Implementation Details

This PR updates the `CertificationExamSchema` to contain separate fields for `title` and `examCode`. Note that not all exams have an `examCode`.

This PR also updates content to match the new schema. Examples:
- For the Terraform Associate 002 exam, `title` is `Terraform Associate` and `examCode` is `002`.
- For the Vault Operations Professional exam, `title` is `Vault Operations Professional` and `examCode` is not defined.

## 📸 Design Screenshots

| Page | Before | After |
| - | - | - |
| Landing | <img width="1245" alt="landing-before" src="https://user-images.githubusercontent.com/4624598/208174315-aafb81b1-53d1-49c5-bcdf-bc1b160cf1ca.png"> | <img width="1253" alt="landing-after" src="https://user-images.githubusercontent.com/4624598/208174309-a355f064-8f53-46b6-a040-6b00d3d9f093.png"> |
| Program | <img width="1253" alt="program-before" src="https://user-images.githubusercontent.com/4624598/208174322-ab80594b-5c62-4c38-8236-fdc23c621c43.png"> | <img width="1256" alt="program-after" src="https://user-images.githubusercontent.com/4624598/208174317-ec826609-25e6-4fbc-813c-ec32b8df3504.png"> |

## 🔗 Preview links

- [/certifications][/certifications]
- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

## 🧪 Testing

- [ ] Visit each of the preview links listed above
    - The landing page overview section should show brackets around exam codes where applicable. For example, `HashiCorp Certified: Terraform Associate (002)` should be shown.
    - Individual program pages should show brackets around exam codes in each exam overview card.

[preview]: https://dev-portal-git-zscert-exam-code-braccys-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscert-exam-code-braccys-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscert-exam-code-braccys-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscert-exam-code-braccys-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscert-exam-code-braccys-hashicorp.vercel.app/certifications/security-automation