### PR TITLE
feat: show coming soon badge if no register URL

### DIFF
--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -27,7 +27,10 @@
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
 			"description": "The Terraform Associate 003 is an upcoming certification for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with HashiCorp Terraform. This person understands the difference in functionality between Terraform Cloud, Terraform Enterprise, and open source Terraform.\n\nThe draft Terraform Associate 003 exam’s objectives are listed below, and dedicated study materials are coming soon. The objective differences between the (existing 002 exam and the upcoming 003 exam) versions are a reorganization and rewording of objectives to comfortably cover recent and future Terraform product growth.",
-			"faqSlug": "terraform-associate-003"
+			"faqSlug": "terraform-associate-003",
+			"links": {
+				"prepare": "/terraform/tutorials/certification-003/"
+			}
 		}
 	]
 }

--- a/src/views/certifications/views/[slug]/components/exam-details-card/index.tsx
+++ b/src/views/certifications/views/[slug]/components/exam-details-card/index.tsx
@@ -69,11 +69,15 @@ export function ExamDetailsCard({
 											icon={<IconArrowRight16 />}
 											iconPosition="trailing"
 										/>
-									) : null}
+									) : (
+										<Badge
+											text="Coming Soon"
+											color="highlight"
+											type="outlined"
+										/>
+									)}
 								</CtaGroup>
-							) : (
-								<Badge text="Coming Soon" color="highlight" type="outlined" />
-							)}
+							) : null}
 						</div>
 					</>
 				}

--- a/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
+++ b/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
@@ -31,23 +31,27 @@ export function CertificationProgramSummaryCard({
 				}
 			/>
 			<div className={s.examCards}>
-				{exams.map(({ title, prepareUrl, examCode, productSlug }) => {
-					const fullTitle = title + (examCode ? ` (${examCode})` : '')
-					return prepareUrl ? (
-						<ExamCard
-							key={fullTitle}
-							title={fullTitle}
-							url={prepareUrl}
-							productSlug={productSlug}
-						/>
-					) : (
-						<ExamCardComingSoon
-							key={fullTitle}
-							title={fullTitle}
-							productSlug={productSlug}
-						/>
-					)
-				})}
+				{exams.map(
+					({ title, prepareUrl, registerUrl, examCode, productSlug }) => {
+						const fullTitle = title + (examCode ? ` (${examCode})` : '')
+						const showComingSoon = typeof registerUrl !== 'string'
+						return prepareUrl ? (
+							<ExamCard
+								key={fullTitle}
+								title={fullTitle}
+								url={prepareUrl}
+								productSlug={productSlug}
+								showComingSoon={showComingSoon}
+							/>
+						) : (
+							<ExamCardComingSoon
+								key={fullTitle}
+								title={fullTitle}
+								productSlug={productSlug}
+							/>
+						)
+					}
+				)}
 			</div>
 		</GradientCard>
 	)

--- a/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
+++ b/src/views/certifications/views/landing/components/certification-program-summary-card/index.tsx
@@ -6,7 +6,7 @@ import {
 } from 'views/certifications/components'
 import { CertificationProgramSummary } from 'views/certifications/views/landing/types'
 // Local
-import { ExamCard, ExamCardComingSoon } from '..'
+import { ExamCard, ExamCardUnlinked } from '..'
 // Styles
 import s from './certification-program-summary-card.module.css'
 
@@ -44,7 +44,7 @@ export function CertificationProgramSummaryCard({
 								showComingSoon={showComingSoon}
 							/>
 						) : (
-							<ExamCardComingSoon
+							<ExamCardUnlinked
 								key={fullTitle}
 								title={fullTitle}
 								productSlug={productSlug}

--- a/src/views/certifications/views/landing/components/exam-card/exam-card.module.css
+++ b/src/views/certifications/views/landing/components/exam-card/exam-card.module.css
@@ -12,7 +12,10 @@
 	flex-direction: column;
 	gap: 24px;
 
-	@media (--dev-dot-tablet-up) {
+	/* Note: --dev-dot-tablet-up almost works here... but for cards with both
+	   a "prepare" link and a "coming soon" badge, the layout breaks down
+		 slightly early. So we use a custom breakpoint here to prevent breakage. */
+	@media only screen and (min-width: 800px) {
 		justify-content: space-between;
 		align-items: center;
 		flex-direction: row;

--- a/src/views/certifications/views/landing/components/exam-card/index.tsx
+++ b/src/views/certifications/views/landing/components/exam-card/index.tsx
@@ -1,5 +1,8 @@
 import { ReactNode } from 'react'
-import { StandaloneLinkContents } from 'views/certifications/components'
+import {
+	CtaGroup,
+	StandaloneLinkContents,
+} from 'views/certifications/components'
 import { ExamBadgeAndTitle } from '../'
 import CardLink from 'components/card-link'
 import s from './exam-card.module.css'
@@ -15,7 +18,14 @@ function ExamCardContents({ children }: { children: ReactNode }) {
 }
 
 /**
- * "Coming Soon" exam cards are not linked.
+ * Badge that says "Coming Soon", may be rendered in linked & unlinked cards.
+ */
+function ComingSoonBadge() {
+	return <Badge text="Coming Soon" color="highlight" type="outlined" />
+}
+
+/**
+ * Unlinked exam cards are used where a "prepareUrl" is not available yet.
  */
 function ExamCardComingSoon({ title, productSlug }: ExamCardComingSoonProps) {
 	return (
@@ -26,13 +36,19 @@ function ExamCardComingSoon({ title, productSlug }: ExamCardComingSoonProps) {
 					eyebrow="HashiCorp Certified:"
 					productSlug={productSlug}
 				/>
-				<Badge text="Coming Soon" color="highlight" type="outlined" />
+				<ComingSoonBadge />
 			</ExamCardContents>
 		</Card>
 	)
 }
 
-function ExamCard({ title, productSlug, url }: ExamCardProps) {
+/**
+ * Linked exam cards are used where a "prepareUrl" is available for the exam.
+ *
+ * If a "registerUrl" for the exam is not yet available, we show
+ * a "Coming Soon" badge within this card as well.
+ */
+function ExamCard({ title, productSlug, url, showComingSoon }: ExamCardProps) {
 	return (
 		<CardLink className={s.examCard} href={url} ariaLabel="test">
 			<ExamCardContents>
@@ -41,7 +57,10 @@ function ExamCard({ title, productSlug, url }: ExamCardProps) {
 					eyebrow="HashiCorp Certified:"
 					productSlug={productSlug}
 				/>
-				<StandaloneLinkContents text="Prepare for the exam" />
+				<CtaGroup>
+					{showComingSoon ? <ComingSoonBadge /> : null}
+					<StandaloneLinkContents text="Prepare for the exam" />
+				</CtaGroup>
 			</ExamCardContents>
 		</CardLink>
 	)

--- a/src/views/certifications/views/landing/components/exam-card/index.tsx
+++ b/src/views/certifications/views/landing/components/exam-card/index.tsx
@@ -8,7 +8,7 @@ import CardLink from 'components/card-link'
 import s from './exam-card.module.css'
 import Card from 'components/card'
 import Badge from 'components/badge'
-import { ExamCardComingSoonProps, ExamCardProps } from './types'
+import { ExamCardUnlinkedProps, ExamCardProps } from './types'
 
 /**
  * Flex layout wrapper for the contents of an exam card.
@@ -27,7 +27,7 @@ function ComingSoonBadge() {
 /**
  * Unlinked exam cards are used where a "prepareUrl" is not available yet.
  */
-function ExamCardComingSoon({ title, productSlug }: ExamCardComingSoonProps) {
+function ExamCardUnlinked({ title, productSlug }: ExamCardUnlinkedProps) {
 	return (
 		<Card className={s.comingSoonCard}>
 			<ExamCardContents>
@@ -66,4 +66,4 @@ function ExamCard({ title, productSlug, url, showComingSoon }: ExamCardProps) {
 	)
 }
 
-export { ExamCard, ExamCardComingSoon }
+export { ExamCard, ExamCardUnlinked }

--- a/src/views/certifications/views/landing/components/exam-card/types.ts
+++ b/src/views/certifications/views/landing/components/exam-card/types.ts
@@ -8,4 +8,5 @@ interface ExamCardBaseProps {
 export type ExamCardComingSoonProps = ExamCardBaseProps
 export interface ExamCardProps extends ExamCardBaseProps {
 	url: string
+	showComingSoon?: boolean
 }

--- a/src/views/certifications/views/landing/components/exam-card/types.ts
+++ b/src/views/certifications/views/landing/components/exam-card/types.ts
@@ -5,7 +5,7 @@ interface ExamCardBaseProps {
 	productSlug: CertificationProductSlug
 }
 
-export type ExamCardComingSoonProps = ExamCardBaseProps
+export type ExamCardUnlinkedProps = ExamCardBaseProps
 export interface ExamCardProps extends ExamCardBaseProps {
 	url: string
 	showComingSoon?: boolean

--- a/src/views/certifications/views/landing/types.ts
+++ b/src/views/certifications/views/landing/types.ts
@@ -17,6 +17,7 @@ export interface CertificationProgramSummary {
 		examCode: RawCertificationExam['examCode']
 		productSlug: RawCertificationExam['productSlug']
 		prepareUrl?: RawCertificationExam['links']['prepare']
+		registerUrl?: RawCertificationExam['links']['register']
 	}[]
 }
 

--- a/src/views/certifications/views/landing/utils/format-program-summaries.ts
+++ b/src/views/certifications/views/landing/utils/format-program-summaries.ts
@@ -33,6 +33,7 @@ export function formatProgramSummaries(
 						examCode: exam.examCode ?? null,
 						productSlug: exam.productSlug,
 						prepareUrl: exam.links?.prepare ?? null,
+						registerUrl: exam.links?.register ?? null,
 					}
 				}),
 			}


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR adds a "prepare" URL for the `Terraform Associate 003` exam. It also updates the exam overview card on the [/certifications][/certifications] landing page to ensure that exams that have a "prepare" URL but no "register" URL show _both_ a `Coming Soon` badge and a `Prepare for the exam` linked card.

## 🛠️ How

- Adds "prepare" URL for `terraform-associate-003` exam in `content/certifications/infrastructure-automation.json`
- Adds optional `showComingSoon` prop to the `ExamCard` component, and display the badge when `true`
    - If the "prepare" URL is defined, we'll use the linked `ExamCard` component
    - When using `ExamCard`, if the "register" URL is not defined, we'll set `showComingSoon` to `true`
- Adjusts breakpoint for the exam card layout change to account for wider width of combined `Coming Soon` & `Prepare for the exam` link
- Renames `ExamCardComingSoon` to `ExamCardUnlinked` for clarity (both linked and unlinked cards may now show a `Coming Soon` badge)

## 🧪 Testing

- [ ] Visit the landing page at [/certifications][/certifications]
    - The card for `Terraform Associate 003` should show _both_ a `Coming Soon` badge and a `Prepare for the exam` linked card

[preview]: https://dev-portal-git-zsupdate-terraform-003-hashicorp.vercel.app
[/certifications]: https://dev-portal-git-zsupdate-terraform-003-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zsupdate-terraform-003-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zsupdate-terraform-003-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zsupdate-terraform-003-hashicorp.vercel.app/certifications/security-automation

