### PR TITLE
fix: tweak alignment in landing card

### DIFF
--- a/src/views/certifications/views/landing/components/certification-program-summary-card/certification-program-summary-card.module.css
+++ b/src/views/certifications/views/landing/components/certification-program-summary-card/certification-program-summary-card.module.css
@@ -16,6 +16,7 @@
 	composes: hds-typography-body-300 from global;
 	font-weight: var(--token-typography-font-weight-medium);
 	color: var(--token-color-foreground-primary);
+	padding-top: 3px;
 }
 
 .buttonGroup {


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR tweaks the vertical alignment of `heading` and `description` in the landing page program overview card.

## 🎨 Design Screenshots

### Before

<img width="1280" alt="before" src="https://user-images.githubusercontent.com/4624598/208524682-79012fcf-f2cf-457b-96b0-44dff53fd5ef.png">

### After

<img width="1275" alt="after" src="https://user-images.githubusercontent.com/4624598/208524699-b003bc7d-7e1f-498a-9544-c6411ba87fa9.png">

## 🧪 Testing

- [ ] Visit the landing page at [/certifications][/certifications]
    - Each overview card should appear to have their `heading` and `description` top-aligned 

[/certifications]: https://dev-portal-git-zscert-exam-card-align-hashicorp.vercel.app/certifications