### PR TITLE
Adds support for enterprise icon for enterprise tags

### DIFF
--- a/src/views/product-integrations-landing/components/tag-list/index.tsx
+++ b/src/views/product-integrations-landing/components/tag-list/index.tsx
@@ -1,4 +1,5 @@
 import { IconArchive16 } from '@hashicorp/flight-icons/svg-react/archive-16'
+import { IconEnterprise16 } from '@hashicorp/flight-icons/svg-react/enterprise-16'
 import { IconHandshake16 } from '@hashicorp/flight-icons/svg-react/handshake-16'
 import { IconHashicorp16 } from '@hashicorp/flight-icons/svg-react/hashicorp-16'
 import { IconRocket16 } from '@hashicorp/flight-icons/svg-react/rocket-16'
@@ -96,6 +97,10 @@ export function GetIntegrationTags(
 
 				case 'archived':
 					icon = <IconArchive16 />
+					break
+
+				case 'enterprise':
+					icon = <IconEnterprise16 />
 					break
 			}
 


### PR DESCRIPTION
![CleanShot 2022-12-19 at 13 33 11@2x](https://user-images.githubusercontent.com/2105067/208528319-9f5da369-7b62-4f32-a5fa-a767f7602145.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203548351779955