### PR TITLE
Mobile optimizations for Integration Card

### DIFF
--- a/src/views/product-integrations-landing/components/integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/integrations-list/index.tsx
@@ -44,15 +44,17 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
 		>
 			<div className={s.cardContent}>
 				<div className={s.left}>
-					<div className={s.nameVersionWrapper}>
-						<h3 className={s.heading}>{integration.name}</h3>
-						{!integration.hide_versions && (
-							<span className={s.version}>v{integration.versions[0]}</span>
-						)}
+					<div>
+						<div className={s.nameVersionWrapper}>
+							<h3 className={s.heading}>{integration.name}</h3>
+							{!integration.hide_versions && (
+								<span className={s.version}>v{integration.versions[0]}</span>
+							)}
+						</div>
+						<span
+							className={s.organization}
+						>{`@${integration.organization.slug}`}</span>
 					</div>
-					<span
-						className={s.organization}
-					>{`@${integration.organization.slug}`}</span>
 					<p className={s.body}>{integration.description}</p>
 				</div>
 				<div className={s.right}>

--- a/src/views/product-integrations-landing/components/integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/integrations-list/index.tsx
@@ -56,7 +56,10 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
 					<p className={s.body}>{integration.description}</p>
 				</div>
 				<div className={s.right}>
-					<TagList tags={GetIntegrationTags(integration, false)} />
+					<TagList
+						className={s.tagList}
+						tags={GetIntegrationTags(integration, false)}
+					/>
 					<span className={s.viewDetails}>
 						View Details
 						{isExternalLink ? <IconExternalLink16 /> : <IconArrowRight16 />}

--- a/src/views/product-integrations-landing/components/integrations-list/style.module.css
+++ b/src/views/product-integrations-landing/components/integrations-list/style.module.css
@@ -10,6 +10,9 @@
 
 	& .left {
 		max-width: 527px;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
 
 		& .nameVersionWrapper {
 			display: flex;
@@ -24,10 +27,12 @@
 		flex-direction: column;
 		justify-content: space-between;
 		align-items: flex-end;
+		min-width: 200px;
 
 		@media (max-width: 800px) {
 			margin-top: 14px;
 			align-items: flex-start;
+			min-width: unset;
 		}
 
 		& .tagList {

--- a/src/views/product-integrations-landing/components/integrations-list/style.module.css
+++ b/src/views/product-integrations-landing/components/integrations-list/style.module.css
@@ -1,5 +1,4 @@
 .integrationCard {
-	/* TODO: mobile breakpoint is 800px, that needs to be tweaked */
 	& .cardContent {
 		display: flex;
 		justify-content: space-between;
@@ -29,6 +28,16 @@
 		@media (max-width: 800px) {
 			margin-top: 14px;
 			align-items: flex-start;
+		}
+
+		& .tagList {
+			justify-content: flex-end;
+			margin-bottom: 14px;
+
+			@media (max-width: 800px) {
+				margin-bottom: 0;
+				justify-content: flex-start;
+			}
 		}
 
 		& .viewDetails {

--- a/src/views/product-integrations-landing/components/tag-list/index.tsx
+++ b/src/views/product-integrations-landing/components/tag-list/index.tsx
@@ -22,13 +22,18 @@ export interface Tag {
 
 interface TagListProps {
 	tags: Array<Tag>
+	className?: string
 	size?: Size
 }
 
-export default function TagList({ tags, size = 'small' }: TagListProps) {
+export default function TagList({
+	tags,
+	className,
+	size = 'small',
+}: TagListProps) {
 	return (
 		<ul
-			className={classNames(s.tagList, {
+			className={classNames(s.tagList, className, {
 				[s.medium]: size === 'medium',
 			})}
 		>


### PR DESCRIPTION
Improves the mobile layout for integration cards, specifically when there's a good amount of content in these cards.

Might be best to just open the [🔍 Preview](https://dev-portal-git-brmobile-breakpoints-hashicorp.vercel.app/vault/integrations) to see if it feels right.  Search `KMIP` for a good one with a good amount of Flags.

## Desktop, but small

<img width="689" alt="CleanShot 2022-12-19 at 14 02 46@2x" src="https://user-images.githubusercontent.com/2105067/208532851-8f1d6f0b-a103-41f5-b8fc-a9aabd6858bd.png">

## Mobile Proper

<img width="297" alt="CleanShot 2022-12-19 at 14 04 03@2x" src="https://user-images.githubusercontent.com/2105067/208533353-f5ea6073-a261-4420-97bd-7be4dcd4bbb9.png">