### PR TITLE
feat: add footer link to /certifications

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -16,6 +16,11 @@ const FOOTER_ITEMS: FooterItem[] = [
 	},
 	{
 		type: 'link',
+		href: '/certifications',
+		text: 'Certifications',
+	},
+	{
+		type: 'link',
 		href: 'https://status.hashicorp.com',
 		text: 'System Status',
 	},


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR adds a link to `/certifications` to the Dev Dot footer.

## 🎨 Design Screenshots

### Before

<img width="1501" alt="footer-before" src="https://user-images.githubusercontent.com/4624598/208539523-9462275f-f56e-4b28-8cbb-e1e0ba8df295.png">

### After

<img width="1499" alt="footer-after" src="https://user-images.githubusercontent.com/4624598/208539547-f682a27b-9b7d-46d1-b33c-966714e771b2.png">

## 🔗 Page Links

- [/certifications][/certifications]
- [/certifications/infrastructure-automation][/certifications/infrastructure-automation]
- [/certifications/networking-automation][/certifications/networking-automation]
- [/certifications/security-automation][/certifications/security-automation]

## 🧪 Testing

- [ ] Visit any of the pages listed above, or any page on [the preview][preview]
    - There should be a `Certifications` link in the footer, which links to [/certifications][/certifications]

[preview]: https://dev-portal-git-zscert-footer-link-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscert-footer-link-hashicorp.vercel.app/certifications
[/certifications/infrastructure-automation]: https://dev-portal-git-zscert-footer-link-hashicorp.vercel.app/certifications/infrastructure-automation
[/certifications/networking-automation]: https://dev-portal-git-zscert-footer-link-hashicorp.vercel.app/certifications/networking-automation
[/certifications/security-automation]: https://dev-portal-git-zscert-footer-link-hashicorp.vercel.app/certifications/security-automation
