### PR TITLE
chore: update home page link

### DIFF
--- a/src/content/home-page.json
+++ b/src/content/home-page.json
@@ -27,7 +27,7 @@
 		],
 		"imageSrc": "https://www.datocms-assets.com/2885/1655305480-vault-certified-expert-badge.svg",
 		"link": {
-			"url": "/vault/tutorials/associate-cert",
+			"url": "/certifications",
 			"text": "Start learning"
 		},
 		"collectionSlugs": [


### PR DESCRIPTION
> **Note**: 🏗 This PR targets the Certifications assembly branch. See #1447 for details.

## 🗒️ What

This PR updates the home page "Certifications" section URL to link to  `/certifications`.

## 🎨 Design Screenshots

### Before

https://user-images.githubusercontent.com/4624598/208542104-b1183965-d996-49c4-92fc-9e23dc2bb211.mp4

### After

https://user-images.githubusercontent.com/4624598/208542130-74b84897-ef46-49a4-84ff-dd0c73dcc7b3.mp4

## 🧪 Testing

- [ ] Visit [the home page][preview]
    - The link the the `Certifications` slot should link to [/certifications][/certifications]

## 💭 Anything else?

Note that we have a home page section update to make, which will update the visual style and content of the section shown in screen grabs above. This update will be made in a subsequent PR.

<details>

<summary>Preview of home page section update</summary> 

<img width="1017" alt="CleanShot 2022-12-19 at 17 55 00@2x" src="https://user-images.githubusercontent.com/4624598/208542494-840c294d-cf93-41b6-a82b-9d74360748f2.png">

</details>

[preview]: https://dev-portal-git-zscert-home-link-hashicorp.vercel.app/
[/certifications]: https://dev-portal-git-zscert-home-link-hashicorp.vercel.app/certifications
