### PR TITLE
feat: add certifications to resources links

### DIFF
--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -1,4 +1,5 @@
 import { ProductSlug } from 'types/products'
+import { certificationProgramSlugMap } from 'views/certifications/content/utils/program-slug-map'
 import {
 	EDITIONS,
 	VALID_EDITION_SLUGS_FOR_FILTERING,
@@ -74,6 +75,33 @@ function getTutorialLibraryUrl(productSlug?: ProductSlug) {
 }
 
 /**
+ * Given a product slug,
+ * Return an array of resource links.
+ *
+ * If we have a corresponding certification program page to link to,
+ * we return that single link item in an array.
+ *
+ * If the given product does not have a certifications page,
+ * we return an empty array.
+ */
+function getCertificationsLink(productSlug?: ProductSlug): {
+	title: string
+	href: string
+}[] {
+	// If this product does not have a certifications link, return an empty array
+	const programSlug = certificationProgramSlugMap[productSlug]
+	if (!programSlug) {
+		return []
+	}
+	// If this product does have a certifications link, return a single-item array
+	const link = {
+		title: 'Certifications',
+		href: `/certifications/${programSlug}`,
+	}
+	return [link]
+}
+
+/**
  * Generates the sidebar nav items for the Resources section of the sidebar.
  * Optionally accepts a Product slug for customization of links.
  */
@@ -86,6 +114,7 @@ const generateResourcesNavItems = (productSlug?: ProductSlug) => {
 			title: 'Tutorial Library',
 			href: getTutorialLibraryUrl(productSlug),
 		},
+		...getCertificationsLink(productSlug),
 		{
 			title: 'Community Forum',
 			href: productSlug

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -1,7 +1,6 @@
 import { ProductSlug } from 'types/products'
 import { certificationProgramSlugMap } from 'views/certifications/content/utils/program-slug-map'
 import {
-	EDITIONS,
 	VALID_EDITION_SLUGS_FOR_FILTERING,
 	VALID_PRODUCT_SLUGS_FOR_FILTERING,
 } from 'views/tutorial-library/constants'

--- a/src/views/certifications/content/schemas/certification-program.ts
+++ b/src/views/certifications/content/schemas/certification-program.ts
@@ -31,7 +31,7 @@ export type CertificationProductSlug = z.infer<
 const ExamTierSchema = z.enum(['associate', 'pro'])
 
 /**
- * Export the CertificationProductSlug enum as a type.
+ * Export the ExamTier enum as a type.
  */
 export type ExamTier = z.infer<typeof ExamTierSchema>
 

--- a/src/views/certifications/content/schemas/certification-program.ts
+++ b/src/views/certifications/content/schemas/certification-program.ts
@@ -7,7 +7,13 @@ import { z } from 'zod'
  * This schema, and components that use the CertificationProductSlug type,
  * will need to be expanded when additional certification programs are added.
  */
-const CertificationProductSlugSchema = z.enum(['consul', 'terraform', 'vault'])
+export const productsWithCertifications = [
+	'consul',
+	'terraform',
+	'vault',
+] as const
+
+const CertificationProductSlugSchema = z.enum(productsWithCertifications)
 
 /**
  * Export the CertificationProductSlug enum as a type.

--- a/src/views/certifications/content/utils/program-slug-map.ts
+++ b/src/views/certifications/content/utils/program-slug-map.ts
@@ -1,0 +1,14 @@
+import { CertificationProductSlug, ProgramSlug } from '../../types'
+
+/**
+ * Map a product that has certifications
+ * to its corresponding certification program name.
+ */
+export const certificationProgramSlugMap: Record<
+	CertificationProductSlug,
+	ProgramSlug
+> = {
+	consul: 'networking-automation',
+	terraform: 'infrastructure-automation',
+	vault: 'security-automation',
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds certification links to product page sidebars where applicable. This new link is located under the `Resources` section of the sidebar.

## 🛠️ How

- Modifies program schema types to make them easier to use as variables, not just as types
- Adds a map utility to get a certification program slug from a valid product slug
- Uses the above utilities to add certifications links in `get-resources-nav-items`
- Minor updates (remove unused import, fix a typo'd comment)

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/4624598/208785752-d91b2161-89b1-44eb-b087-967ccc04955a.png) | ![after](https://user-images.githubusercontent.com/4624598/208785754-502381f9-c7c9-4d25-931f-64c88343e2da.png) |

## 🧪 Testing

- [ ] Visit product pages that do have certifications
    - [/consul][/consul], [/terraform][/terraform] and [/vault][/vault]
    - All these products should have `Certifications` linked in their sidebar resources section
    - The `Certifications` link should lead to the correct program page
- [ ] Visit other product pages
    - No other products should have `Certifications` linked in their sidebar resources section

## 💭 Anything else?

Not at the moment.

[task]: https://app.asana.com/0/1203301890649977/1203564111583583/f
[preview]: https://dev-portal-git-zscert-resources-links-hashicorp.vercel.app