### PR TITLE
Add chown to node_modules copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN npm install -g npm@latest
 
 WORKDIR /app
 COPY . ./website-preview
-COPY --from=deps /app/node_modules ./website-preview/node_modules
+COPY --chown=0:0 --from=deps /app/node_modules ./website-preview/node_modules
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 🗒️ What

Add chown to node_modules copy

## Why

See linked ticket for more information; npm packages appear to have all sorts of weird user/group combinations, which will occasionally break containers. Given that we're executing as a single user, and given that we used to provision these with root/root, it should be safe to chown all of these files on copy.

This should fix issues pulling the container with Podman 3.4.4 on Ubuntu 22.04.

Resolves: #1491

Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>

## 🧪 Testing

- [ ] Cut a new container image with our existing process and ensure the build doesn't break and that the issue isn't reproducible any more. 
