### PR TITLE
[e2e] Fixing navDataPrefix for cloud.hashicorp.com

### DIFF
--- a/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
@@ -11,7 +11,7 @@ const getMdxAndNavDataDirectoriesForRepo = (repo: string) => {
 	// HCP and Terraform docs content repos use slightly different values
 	if (repo === 'cloud.hashicorp.com') {
 		mdxPrefix = 'content'
-		navDataPrefix = 'content'
+		navDataPrefix = 'data'
 	} else if (repo.startsWith('terraform') || repo.startsWith('ptfe-releases')) {
 		mdxPrefix = 'website/docs'
 	}


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the `navDataPrefix` set for `cloud.hashicorp.com` in `getMdxAndNavDataDirectoriesForRepo`, which is used when loading data for the link rewrites e2e workflow.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out this branch locally
- [ ] Run this command in a terminal from the root of the project: `REPO="cloud.hashicorp.com" npm run test:e2e:linkRewrites:loadData`
- [ ] A new file should be generated: `src/.generated/all-page-paths-by-base-path.json`
- [ ] The file should have the correct data (nothing needed for `api-docs/packer`)
