### PR TITLE
Setting GITHUB_TOKEN explicitly for use in docs-content-link-rewrites-e2e workflow

### DIFF
--- a/.github/workflows/docs-content-link-rewrites-e2e.yml
+++ b/.github/workflows/docs-content-link-rewrites-e2e.yml
@@ -28,6 +28,7 @@ jobs:
   docs-content-link-rewrites-e2e:
     runs-on: ubuntu-latest
     env:
+      GITHUB_TOKEN: ${{ github.token }}
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Explicitly sets the `GITHUB_TOKEN` under `env` for the `docs-content-link-rewrites-e2e` job, using `github.token` (which is automatically passed by the calling workflow)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This workflow was failing in `cloud.hashicorp.com` ([see example run](https://github.com/hashicorp/cloud.hashicorp.com/actions/runs/3840700738/jobs/6543024622#step:6:16)) because it's an internal repo and it requires a token to get the contents of files.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Nothing to manually test here, other than confirming that the test workflow call in `cloud.hashicorp.com` was successful in the "Load data for e2e tests" step here: https://github.com/hashicorp/cloud.hashicorp.com/actions/runs/3842269576/jobs/6543412397#step:6:1
