### PR TITLE
Making docs-content-link-rewrites assertions more readable

### DIFF
--- a/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
+++ b/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
@@ -97,8 +97,8 @@ test.describe('docs-content-link-rewrites', () => {
 						})
 
 						// Assert that the hrefs are the same for both branches' preview pages
-						expect(JSON.stringify(prBranchHrefs)).toEqual(
-							JSON.stringify(mainBranchHrefs)
+						expect(JSON.stringify(prBranchHrefs, null, 2)).toEqual(
+							JSON.stringify(mainBranchHrefs, null, 2)
 						)
 					})
 				})


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Updates the strings that the `docs-content-link-rewrites` e2e tests compare to be formatted JSON so the output of failed tests is easier to read.
