### PR TITLE
Fix duplicate link rewrites e2e test names

### DIFF
--- a/scripts/docs-content-link-rewrites/generate-page-paths-for-repo-and-base-path.ts
+++ b/scripts/docs-content-link-rewrites/generate-page-paths-for-repo-and-base-path.ts
@@ -41,7 +41,8 @@ const main = async () => {
 	const allPathsByBasePath = {}
 	navDataResults.forEach((result: string[], index: number) => {
 		const basePath = relevantRootDocsPaths[index].path
-		allPathsByBasePath[basePath] = result
+		const uniqueArray = Array.from(new Set(result))
+		allPathsByBasePath[basePath] = uniqueArray
 	})
 
 	// Create the output folder if it doesn't exist


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Uses a `Set` when building up a list of paths to test for the link rewrites e2e tests

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Duplicate test names were found when trying to test Vagrant link rewrites ([link to failed workflow](https://github.com/hashicorp/vagrant/actions/runs/3851148750/jobs/6562039649#step:7:20)):

```
========================================
 duplicate test titles are not allowed.
 - title: docs-content-link-rewrites › Main assertions › docs › vagrant/docs/
   - docs-content-link-rewrites.spec.ts:82
   - docs-content-link-rewrites.spec.ts:82
 - title: docs-content-link-rewrites › Main assertions › intro › vagrant/intro/
   - docs-content-link-rewrites.spec.ts:82
   - docs-content-link-rewrites.spec.ts:82
========================================
```
