### PR TITLE
feat: typography update for cards

### DIFF
--- a/src/components/callout-card/callout-card.module.css
+++ b/src/components/callout-card/callout-card.module.css
@@ -10,7 +10,7 @@
 }
 
 .body {
-	composes: hds-typography-body-100 from global;
+	composes: hds-typography-body-200 from global;
 	color: var(--token-color-foreground-faint);
 	margin: 8px 0 0 0;
 }

--- a/src/components/card/components/card-description/card-description.module.css
+++ b/src/components/card/components/card-description/card-description.module.css
@@ -4,7 +4,7 @@
 
 .text {
 	/* composition */
-	composes: hds-typography-body-100 from global;
+	composes: hds-typography-body-200 from global;
 	composes: hds-font-weight-regular from global;
 
 	/* properties */

--- a/src/components/card/components/card-description/index.tsx
+++ b/src/components/card/components/card-description/index.tsx
@@ -8,7 +8,7 @@ const CardDescription = ({ className, text }: CardDescriptionProps) => {
 		<div className={classNames(s.root, className)}>
 			<TruncateMaxLines
 				className={s.text}
-				lineHeight="var(--token-typography-body-100-line-height)"
+				lineHeight="var(--token-typography-body-200-line-height)"
 				maxLines={3}
 			>
 				{text}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Bumps the text size for card descriptions from `body-100` to `body-200`.

## 🛠️ How

- In `CalloutCard`, bumps body `<p />` from `body-100` to `body-200`. Affects these components:
    - `VagrantDownloadsPage`, in the merchandising slot
    - `ProductLanding`, for the authored `get_started` block on all product pages, and for more freeform authored `callout` blocks
    - `ProductRootDocsPathLandingMarketingContent`, for the authored `getting-started-card` blocks
- In `CardDescription`, bumps font from `body-100` to `body-200`. Affects these components:
    - `CollectionCard`
    - `TutorialCard`
    - `LinkedCard` - author-facing component on `/<product>` landing pages, as a block with type `linked_cards`. Often used for docs page linked cards.
    - `CardGrid` - author-facing component on `/<product>/docs` landing pages, as a block with type `card-grid`. Often used for docs page linked cards.

## 📸 Design Screenshots

🎨 [Figma link][figma]

### Design Spec

<img width="1211" alt="CleanShot 2023-01-11 at 13 46 47@2x" src="https://user-images.githubusercontent.com/4624598/211899555-3affa790-d3b5-4f28-bd5e-57eeab33aea0.png">

### Screenshots of affected pages

| Page | Before | After |
| - | - | - |
| [Home][preview] | ![home-before](https://user-images.githubusercontent.com/4624598/211904290-fd473593-d7cc-46f7-80ac-a652e0d96944.png) | ![home-after](https://user-images.githubusercontent.com/4624598/211904267-689c7087-5ed8-407b-9f0d-cff8243e22f2.png) |
| [Product landing][/terraform] | ![product-landing-before](https://user-images.githubusercontent.com/4624598/211904247-d317a220-c1b0-45d1-8fd3-3422a8fe7907.png) | ![product-landing-after](https://user-images.githubusercontent.com/4624598/211904229-74105dc6-77e6-4fc9-b2b2-c2022229af33.png) |
| [Downloads][/packer/downloads] | ![install-before](https://user-images.githubusercontent.com/4624598/211904059-fd610b4e-4385-46f7-9f90-636b3ea72ad6.png) | ![install-after](https://user-images.githubusercontent.com/4624598/211904151-27fb4e8d-9e00-43f1-b015-5b3f369fcad9.png) |
| [Docs landing][/vault/docs] | ![docs-landing-before](https://user-images.githubusercontent.com/4624598/211904038-946cde93-126f-4264-9cbc-17e059775e7d.png) | ![docs-landing-after](https://user-images.githubusercontent.com/4624598/211904095-ff68797c-5c46-4aad-876f-39be4c926f38.png) |
| [Tutorial landing][/waypoint/tutorials] | ![tutorials-landing-before](https://user-images.githubusercontent.com/4624598/211904219-942d4cdb-24f0-487e-8b7e-d792b84fff85.png) | ![tutorials-landing-after](https://user-images.githubusercontent.com/4624598/211904200-16912cda-270b-43ec-8940-a2ce2a735004.png) |
| [Collection][/waypoint/tutorials/deploy-aws] | ![collections-before](https://user-images.githubusercontent.com/4624598/211904181-f5a5262c-eb06-475b-8362-46d7c09dcd6d.png) | ![collections-after](https://user-images.githubusercontent.com/4624598/211904172-09cc27fe-b5a0-4f66-9368-1656f9497cf3.png) |
| [Tutorial][/terraform/tutorials/aws-get-started/infrastructure-as-code] | ![tutorial-featured-in-before](https://user-images.githubusercontent.com/4624598/211904125-2a303083-3e74-4de9-a52a-aeffce6ffac8.png) | ![tutorial-featured-in-after](https://user-images.githubusercontent.com/4624598/211904106-c9cc2e5d-0215-498c-a0a3-c1811c6ed4b4.png) |

## 🧪 Testing

- [ ] Visit each of the card-containing pages (listed in the section above)
    - All cards on each of these page should use the `body-200` type style
- [ ] Optional: surf around the site and look for other cards placements
    - I think I got all of them, but wouldn't mind another set of eyes if you have a few spare minutes

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1203683839823852/f
[figma]: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=17545%3A226744&t=1RXzZEgNMvZkgSlC-4
[preview]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/
[/terraform]:https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/terraform
[/vault/docs]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/vault/docs
[/waypoint/tutorials]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/waypoint/tutorials
[/waypoint/tutorials/deploy-aws]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/waypoint/tutorials/deploy-aws
[/terraform/tutorials/aws-get-started/infrastructure-as-code]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/terraform/tutorials/aws-get-started/infrastructure-as-code
[/packer/downloads]: https://dev-portal-git-zscard-typography-updates-hashicorp.vercel.app/packer/downloads