### PR TITLE
Adding "Redeploy Content Repo Previews" workflow

### DIFF
--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -20,6 +20,8 @@ jobs:
   redeploy-content-repo-previews:
     runs-on: ubuntu-latest
     steps:
+      - name: Trigger "boundary" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_BOUNDARY }}
       - name: Trigger "cloud-docs-developer-preview" deploy
         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}
       - name: Trigger "vagrant" deploy

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -15,16 +15,11 @@ jobs:
     if: ${{ github.event.label.name == 'workflow-test-label' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check if "RANDOM_SECRET_NAME_FOR_TESTING" secret exists
-        env:
-          RANDOM_SECRET_NAME_FOR_TESTING: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
-        if: ${{ env.RANDOM_SECRET_NAME_FOR_TESTING == '' }}
-        run: echo "The `RANDOM_SECRET_NAME_FOR_TESTING` secret does not exist."
+      - name: Test `curl` when secret doesn't exists
+        run: curl -X POST  ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
+
       - name: Echo something else if the secret exists
-        env:
-          RANDOM_SECRET_NAME_FOR_TESTING: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
-        if: ${{ env.RANDOM_SECRET_NAME_FOR_TESTING != '' }}
-        run: echo "Cool, the secret exists"
+        run: echo "Does this subsequent step run if the previous fails?"
 
       # TODO uncomment before merging (it works! :D)
       # - name: Trigger "cloud-docs-developer-preview" deploy

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -4,6 +4,12 @@ name: Redeploy Content Repo Previews
 # the listed docs content repositories. The redeploys are triggered through a
 # Deploy Hook created for each repository's Vercel project. These can be found
 # in the Git settings within the Vercel project.
+#
+# For consistency and traceability, each new secret should be named using the
+# following convention:
+#
+#   VERCEL_DEPLOY_HOOK_<vercel-project-slug>
+#
 
 on:
   push:

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -1,5 +1,10 @@
 name: Redeploy Content Repo Previews
 
+# When the dev-portal/main branch is pushed to, redeploy the `main` branches of
+# the listed docs content repositories. The redeploys are triggered through a
+# Deploy Hook created for each repository's Vercel project. These can be found
+# in the Git settings within the Vercel project.
+
 on:
   push:
     branches:

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -1,0 +1,19 @@
+name: Redeploy Content Repo Previews
+
+on:
+  # TODO remove before merging
+  pull_request:
+    types: [labeled]
+  # TODO uncomment before merging
+  # push:
+  #   branches:
+  #     - main
+
+jobs:
+  redeploy-content-repo-previews:
+    # TODO remove before merging
+    if: ${{ github.event.label.name == 'workflow-test-label' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger "cloud-docs-developer-preview" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -11,9 +11,17 @@ on:
 
 jobs:
   redeploy-content-repo-previews:
-    # TODO remove before merging
+    # TODO remove this `if` before merging
     if: ${{ github.event.label.name == 'workflow-test-label' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger "cloud-docs-developer-preview" deploy
-        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}
+      - name: Check if "RANDOM_SECRET_NAME_FOR_TESTING" secret exists
+        if: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING == '' }}
+        run: echo "The `RANDOM_SECRET_NAME_FOR_TESTING` secret does not exist."
+      - name: Echo something else if the secret exists
+        if: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING != '' }}
+        run: echo "Cool, the secret exists"
+
+      # TODO uncomment before merging (it works! :D)
+      # - name: Trigger "cloud-docs-developer-preview" deploy
+      #   run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -16,10 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if "RANDOM_SECRET_NAME_FOR_TESTING" secret exists
-        if: "${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING == '' }}"
+        env:
+          RANDOM_SECRET_NAME_FOR_TESTING: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
+        if: ${{ env.RANDOM_SECRET_NAME_FOR_TESTING == '' }}
         run: echo "The `RANDOM_SECRET_NAME_FOR_TESTING` secret does not exist."
       - name: Echo something else if the secret exists
-        if: "${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING != '' }}"
+        env:
+          RANDOM_SECRET_NAME_FOR_TESTING: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
+        if: ${{ env.RANDOM_SECRET_NAME_FOR_TESTING != '' }}
         run: echo "Cool, the secret exists"
 
       # TODO uncomment before merging (it works! :D)

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -1,26 +1,17 @@
 name: Redeploy Content Repo Previews
 
 on:
-  # TODO remove before merging
-  pull_request:
-    types: [labeled]
-  # TODO uncomment before merging
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 jobs:
   redeploy-content-repo-previews:
-    # TODO remove this `if` before merging
-    if: ${{ github.event.label.name == 'workflow-test-label' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Test `curl` when secret doesn't exists
-        run: curl -X POST  ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING }}
-
-      - name: Echo something else if the secret exists
-        run: echo "Does this subsequent step run if the previous fails?"
-
-      # TODO uncomment before merging (it works! :D)
-      # - name: Trigger "cloud-docs-developer-preview" deploy
-      #   run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}
+      - name: Trigger "cloud-docs-developer-preview" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}
+      - name: Trigger "vagrant" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_VAGRANT }}
+      - name: Trigger "waypoint" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_WAYPOINT }}

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if "RANDOM_SECRET_NAME_FOR_TESTING" secret exists
-        if: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING == '' }}
+        if: "${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING == '' }}"
         run: echo "The `RANDOM_SECRET_NAME_FOR_TESTING` secret does not exist."
       - name: Echo something else if the secret exists
-        if: ${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING != '' }}
+        if: "${{ secrets.RANDOM_SECRET_NAME_FOR_TESTING != '' }}"
         run: echo "Cool, the secret exists"
 
       # TODO uncomment before merging (it works! :D)

--- a/.github/workflows/redeploy-content-repos.yml
+++ b/.github/workflows/redeploy-content-repos.yml
@@ -10,6 +10,10 @@ name: Redeploy Content Repo Previews
 #
 #   VERCEL_DEPLOY_HOOK_<vercel-project-slug>
 #
+# And new Deploy Hooks should be named:
+#
+#   "Re-deploy when dev-portal/main updates"
+#
 
 on:
   push:
@@ -22,9 +26,26 @@ jobs:
     steps:
       - name: Trigger "boundary" deploy
         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_BOUNDARY }}
-      - name: Trigger "cloud-docs-developer-preview" deploy
+
+      - name: Trigger "cloud-docs-developer-preview (HCP)" deploy
         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CLOUD_DOCS_DEVELOPER_PREVIEW }}
+
+      - name: Trigger "consul" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_CONSUL }}
+
+      - name: Trigger "nomad" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_NOMAD }}
+
+      - name: Trigger "packer" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_PACKER }}
+
+      # TODO add Terraform
+
       - name: Trigger "vagrant" deploy
         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_VAGRANT }}
+
+      - name: Trigger "vault" deploy
+        run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_VAULT }}
+
       - name: Trigger "waypoint" deploy
         run: curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK_WAYPOINT }}


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds a new workflow that triggers redeploys various content repos' `main` branches.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This will speed up some of the process for the docs content link rewrites project. In order for the E2E tests to be accurate in each main migration PR, the `main` branch PR's URL for a repo needs to be built from the latest of `dev-portal/main`. With bug fixes happening every few days that fix issues identified in failing E2E tests, it takes a lot of time and context switching to make sure the `main` branch preview URLs get updated.
- A side benefit of this is that content repos's `main` branch preview URLs will always have the latest `dev-portal/main` features & fixes without having to update their `main` branches or perform manual deploys in the Vercel UI.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

For each content repo:

- Created a [Deploy Hook](https://vercel.com/docs/concepts/git/deploy-hooks) in the Vercel project's Git settings named `"Re-deploy when dev-portal/main updates"`
- Created an Actions Secret in the `dev-portal` repo settings named `"VERCEL_DEPLOY_HOOK_<vercel-project-slug>"`, with the value being the Deploy Hook URL
- Added a step in the new workflow that runs `curl -X POST` on each Deploy Hook URL through the GitHub `secrets` variable

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

I tested this workflow by:

- [ ] Adding a temporary label trigger
- [ ] Adding & removing the test label after pushes to trigger the workflow

The main test to see if triggering the Deploy Hook worked was sucessful in:

- [Commit b6387b5e57270a5283430f5b2d563414907a07da](https://github.com/hashicorp/dev-portal/pull/1526/commits/b6387b5e57270a5283430f5b2d563414907a07da)
- [Run 3903606269](https://github.com/hashicorp/dev-portal/actions/runs/3903606269)

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- We should refine the triggers for this workflow to save on Vercel builds. To keep the docs content link rewrites project moving, it'd be helpful if we could do that in a separate PR. ❤️
