### PR TITLE
feat: add HCP callout to sidecar

### DIFF
--- a/src/components/try-hcp-callout/components/index.tsx
+++ b/src/components/try-hcp-callout/components/index.tsx
@@ -1,5 +1,6 @@
 export * from './product-icon-heading'
 export * from './try-hcp-callout'
 export * from './try-hcp-callout-compact'
+export * from './try-hcp-callout-sidecar-placement'
 export * from './standalone-link-contents'
 export * from './description'

--- a/src/components/try-hcp-callout/components/try-hcp-callout-sidecar-placement/index.tsx
+++ b/src/components/try-hcp-callout/components/try-hcp-callout-sidecar-placement/index.tsx
@@ -1,0 +1,38 @@
+import { TryHcpCalloutCompact } from '..'
+import { tryHcpCalloutContent, hasHcpCalloutContent } from '../../content'
+
+/**
+ * A wrapper around TryHcpCalloutCompact.
+ *
+ * Handles conditionally rendering HCP callouts only for products with an
+ * HCP offering. Also populates the callout with pre-built content.
+ */
+export function TryHcpCalloutSidecarPlacement({
+	productSlug,
+}: {
+	productSlug: string
+}) {
+	/**
+	 * For products without an HCP offering, or products for which the compact
+	 * callout has not yet been design ("hcp"), don't render anything.
+	 */
+	if (!hasHcpCalloutContent(productSlug) || productSlug === 'hcp') {
+		return null
+	}
+
+	/**
+	 * For all other products, which have an HCP offering and pre-built content,
+	 * render the compact callout.
+	 */
+	const { ctaText, ctaUrl, description, heading } =
+		tryHcpCalloutContent[productSlug]
+	return (
+		<TryHcpCalloutCompact
+			ctaText={ctaText}
+			ctaUrl={ctaUrl}
+			description={description}
+			heading={heading}
+			productSlug={productSlug}
+		/>
+	)
+}

--- a/src/layouts/product-integration-layout/index.tsx
+++ b/src/layouts/product-integration-layout/index.tsx
@@ -4,6 +4,7 @@ import {
 	generateProductLandingSidebarNavData,
 	generateTopLevelSidebarNavData,
 } from 'components/sidebar/helpers'
+import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/components'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { Integration } from 'lib/integrations-api-client/integration'
 import { Release, ReleaseComponent } from 'lib/integrations-api-client/release'
@@ -98,7 +99,7 @@ export default function ProductIntegrationLayout({
 			// @ts-ignore
 			sidebarNavDataLevels={sidebarNavDataLevels}
 			breadcrumbLinks={breadcrumbLinks}
-			sidecarSlot={<></>}
+			sidecarSlot={<TryHcpCalloutSidecarPlacement productSlug="waypoint" />}
 		>
 			{!onLatestVersion && (
 				<HashiHead>

--- a/src/layouts/product-integration-layout/index.tsx
+++ b/src/layouts/product-integration-layout/index.tsx
@@ -99,7 +99,9 @@ export default function ProductIntegrationLayout({
 			// @ts-ignore
 			sidebarNavDataLevels={sidebarNavDataLevels}
 			breadcrumbLinks={breadcrumbLinks}
-			sidecarSlot={<TryHcpCalloutSidecarPlacement productSlug="waypoint" />}
+			sidecarSlot={
+				<TryHcpCalloutSidecarPlacement productSlug={currentProduct.slug} />
+			}
 		>
 			{!onLatestVersion && (
 				<HashiHead>

--- a/src/pages/[productSlug]/integrations/index.tsx
+++ b/src/pages/[productSlug]/integrations/index.tsx
@@ -1,3 +1,4 @@
+import { HeadMetadataProps } from 'components/head-metadata/types'
 import {
 	generateProductLandingSidebarNavData,
 	generateTopLevelSidebarNavData,
@@ -7,8 +8,11 @@ import {
 	Integration,
 	fetchAllProductIntegrations,
 } from 'lib/integrations-api-client/integration'
+import { GetStaticPropsResult } from 'next'
 import { ProductData } from 'types/products'
-import ProductIntegrationsLanding from 'views/product-integrations-landing'
+import ProductIntegrationsLanding, {
+	ViewProps,
+} from 'views/product-integrations-landing'
 
 export function generateProductIntegrationLibrarySidebarNavData(
 	product: ProductData
@@ -48,7 +52,9 @@ export function generateProductIntegrationLibrarySidebarNavData(
 	}
 }
 
-export async function getServerSideProps({ params }) {
+export async function getServerSideProps({
+	params,
+}): Promise<GetStaticPropsResult<ViewProps & { metadata: HeadMetadataProps }>> {
 	// Pull out the Product Config
 	const product = cachedGetProductData(params.productSlug)
 

--- a/src/pages/[productSlug]/integrations/index.tsx
+++ b/src/pages/[productSlug]/integrations/index.tsx
@@ -98,7 +98,6 @@ export async function getServerSideProps({
 				title: `Integrations | ${product.name}`,
 				// description: `TODO`,
 			},
-			productSlug: product.slug,
 			integrations,
 			sidebarNavDataLevels,
 			breadcrumbLinks,

--- a/src/pages/[productSlug]/integrations/index.tsx
+++ b/src/pages/[productSlug]/integrations/index.tsx
@@ -92,6 +92,7 @@ export async function getServerSideProps({ params }) {
 				title: `Integrations | ${product.name}`,
 				// description: `TODO`,
 			},
+			productSlug: product.slug,
 			integrations,
 			sidebarNavDataLevels,
 			breadcrumbLinks,

--- a/src/views/product-integrations-landing/index.tsx
+++ b/src/views/product-integrations-landing/index.tsx
@@ -8,7 +8,7 @@ import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/compon
 import { type SidebarProps } from 'components/sidebar'
 import { type BreadcrumbLink } from 'components/breadcrumb-bar'
 
-interface ViewProps {
+export interface ViewProps {
 	integrations: Array<Integration>
 	sidebarNavDataLevels: Array<SidebarProps>
 	breadcrumbLinks: Array<BreadcrumbLink>

--- a/src/views/product-integrations-landing/index.tsx
+++ b/src/views/product-integrations-landing/index.tsx
@@ -4,7 +4,6 @@ import { IntegrationsSearchProvider } from './contexts/integrations-search-conte
 import { type Integration } from 'lib/integrations-api-client/integration'
 
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
-import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/components'
 import { type SidebarProps } from 'components/sidebar'
 import { type BreadcrumbLink } from 'components/breadcrumb-bar'
 
@@ -12,23 +11,19 @@ export interface ViewProps {
 	integrations: Array<Integration>
 	sidebarNavDataLevels: Array<SidebarProps>
 	breadcrumbLinks: Array<BreadcrumbLink>
-	productSlug: string
 }
 
 export default function ProductIntegrationsLanding({
 	integrations,
 	sidebarNavDataLevels,
 	breadcrumbLinks,
-	productSlug,
 }: ViewProps) {
 	return (
 		<IntegrationsSearchProvider integrations={integrations}>
 			<SidebarSidecarLayout
 				sidebarNavDataLevels={sidebarNavDataLevels}
 				breadcrumbLinks={breadcrumbLinks}
-				sidecarSlot={
-					<TryHcpCalloutSidecarPlacement productSlug={productSlug} />
-				}
+				sidecarSlot={<></>}
 			>
 				<div className={s.mainArea}>
 					<SearchableIntegrationsList className={s.searchList} />

--- a/src/views/product-integrations-landing/index.tsx
+++ b/src/views/product-integrations-landing/index.tsx
@@ -12,19 +12,23 @@ interface ViewProps {
 	integrations: Array<Integration>
 	sidebarNavDataLevels: Array<SidebarProps>
 	breadcrumbLinks: Array<BreadcrumbLink>
+	productSlug: string
 }
 
 export default function ProductIntegrationsLanding({
 	integrations,
 	sidebarNavDataLevels,
 	breadcrumbLinks,
+	productSlug,
 }: ViewProps) {
 	return (
 		<IntegrationsSearchProvider integrations={integrations}>
 			<SidebarSidecarLayout
 				sidebarNavDataLevels={sidebarNavDataLevels}
 				breadcrumbLinks={breadcrumbLinks}
-				sidecarSlot={<TryHcpCalloutSidecarPlacement productSlug="waypoint" />}
+				sidecarSlot={
+					<TryHcpCalloutSidecarPlacement productSlug={productSlug} />
+				}
 			>
 				<div className={s.mainArea}>
 					<SearchableIntegrationsList className={s.searchList} />

--- a/src/views/product-integrations-landing/index.tsx
+++ b/src/views/product-integrations-landing/index.tsx
@@ -4,6 +4,7 @@ import { IntegrationsSearchProvider } from './contexts/integrations-search-conte
 import { type Integration } from 'lib/integrations-api-client/integration'
 
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/components'
 import { type SidebarProps } from 'components/sidebar'
 import { type BreadcrumbLink } from 'components/breadcrumb-bar'
 
@@ -23,7 +24,7 @@ export default function ProductIntegrationsLanding({
 			<SidebarSidecarLayout
 				sidebarNavDataLevels={sidebarNavDataLevels}
 				breadcrumbLinks={breadcrumbLinks}
-				sidecarSlot={<></>}
+				sidecarSlot={<TryHcpCalloutSidecarPlacement productSlug="waypoint" />}
 			>
 				<div className={s.mainArea}>
 					<SearchableIntegrationsList className={s.searchList} />


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

For products with an HCP offering, adds a `Try HCP` callout to the sidecar of integration pages.

## 🛠️ How

- Implements a new `TryHcpCalloutSidecarPlacement` component
    - This component accepts a `productSlug`, and handles the logic of whether to render the HCP callout, and what content to show
- Adds `TryHcpCalloutSidecarPlacement` to integrations views
    - Adds to `ProductIntegrationLayout`, which covers the majority of integration pages
    - ~Adds to~ Does not add to `ProductIntegrationsLanding`, as this is not in designs

## 📸 Design Screenshots

| View | Before | After |
| - | - | - | 
| [ReadmeView][/waypoint/integrations/aws-ami] | ![readme-before](https://user-images.githubusercontent.com/4624598/212408370-42c7cd1a-3c8f-48a2-814b-fc5afeeef2a3.png) | ![readme-after](https://user-images.githubusercontent.com/4624598/212408375-d5059cf8-2e26-46ab-a68f-4088cf03d582.png) |
| [ComponentView][/waypoint/integrations/aws-ami/latest/components/builder] | ![component-before](https://user-images.githubusercontent.com/4624598/212408362-5f683894-1289-4681-8c96-038f2db08582.png) | ![component-after](https://user-images.githubusercontent.com/4624598/212408373-8f345853-a223-4600-ad8a-1c01c79e0d51.png) |

## 🧪 Testing

> **Note**: The logic to display the HCP callout only for products that have HCP offerings has been tested in #1376. Vault and Waypoint are the only products that currently have integrations pages, so are the only integrations sections we can test at the moment. 

- [ ] Visit each of the views listed in the section above, for [Vault][/vault/integrations] and [Waypoint][/waypoint/integrations]
    - Each view should show a Try HCP callout in the sidecar
    - The product theme of the Try HCP callout should match as expected
    - The Try HCP callout should link to the expected location

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsintegrations-hcp-callout-in-sidecar-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1202097197789424/1203709011206839/f
[/waypoint/integrations]: https://dev-portal-git-zsintegrations-hcp-callout-in-sidecar-hashicorp.vercel.app/waypoint/integrations
[/vault/integrations]: https://dev-portal-git-zsintegrations-hcp-callout-in-sidecar-hashicorp.vercel.app/vault/integrations
[/waypoint/integrations/aws-ami/latest/components/builder]: https://dev-portal-git-zsintegrations-hcp-callout-in-sidecar-hashicorp.vercel.app/waypoint/integrations/aws-ami/latest/components/builder
[/waypoint/integrations/aws-ami]: https://dev-portal-git-zsintegrations-hcp-callout-in-sidecar-hashicorp.vercel.app/waypoint/integrations/aws-ami