### PR TITLE
[preAdjustUrl] Fix how dot-slash URLs in content are adjusted

### DIFF
--- a/src/lib/remark-plugins/remark-plugin-adjust-link-urls/__tests__/remark-plugin-adjust-link-urls.test.ts
+++ b/src/lib/remark-plugins/remark-plugin-adjust-link-urls/__tests__/remark-plugin-adjust-link-urls.test.ts
@@ -53,15 +53,19 @@ describe('remarkPluginAdjustLinkUrls', () => {
 
 		describe('pre-adjusts folder-relative urls starting with `./`', () => {
 			const testCases = [
+				// Example of test case:
+				// https://github.com/hashicorp/waypoint/blob/63d5149a2aa63214f6f5fa41e825cb1a13783b9e/website/content/plugins/aws-ecs.mdx?plain=1#L17
 				{
-					input: './configuration',
-					expected: '/docs/disks/configuration',
-					currentPath: '/docs/disks',
+					input: './pack',
+					expected: '/plugins/pack',
+					currentPath: '/plugins/aws-ecs',
 				},
+				// Example of test case:
+				// https://github.com/hashicorp/terraform-plugin-sdk/blob/8058e8060ef488d9881645ad9cad0872cdff3094/website/docs/plugin/sdkv2/logging/index.mdx?plain=1#L25
 				{
-					input: './hyperv/common-issues',
-					expected: '/docs/disks/hyperv/common-issues',
-					currentPath: '/docs/disks',
+					input: './logging/http-transport',
+					expected: '/plugin/sdkv2/logging/http-transport',
+					currentPath: '/plugin/sdkv2/logging',
 				},
 			]
 			testEachCase(testCases)

--- a/src/lib/remark-plugins/remark-plugin-adjust-link-urls/helpers.ts
+++ b/src/lib/remark-plugins/remark-plugin-adjust-link-urls/helpers.ts
@@ -65,17 +65,20 @@ const handleDotDotFolderRelativeUrl = ({
  * path.
  */
 const handleDotSlashFolderRelativeUrl = ({
-	currentPath,
+	currentPathParts,
 	url,
 }: {
-	currentPath: string
+	currentPathParts: string[]
 	url: string
 }) => {
 	// Remove the leading dot-slash from the url
 	const urlWithOutDotSlash = url.slice('./'.length)
 
+	// Remove the last part of the currentPath
+	const currentPathWithoutLastPart = currentPathParts.slice(0, -1).join('/')
+
 	// Concatenate the current path and url (without the dot-slash)
-	const newUrl = path.join(currentPath, urlWithOutDotSlash)
+	const newUrl = path.join(currentPathWithoutLastPart, urlWithOutDotSlash)
 
 	// Return the new url
 	return newUrl
@@ -113,7 +116,7 @@ const preAdjustUrl = ({ currentPath, url }): string => {
 
 	// Handle folder-relative URL that is linking downwards
 	if (url.startsWith('./')) {
-		return handleDotSlashFolderRelativeUrl({ currentPath, url })
+		return handleDotSlashFolderRelativeUrl({ currentPathParts, url })
 	}
 
 	// Search for first part of url within currentPath


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes how dot-slash links (start with `./`) are adjusted by `remarkPluginAdjustLinkUrls`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- We ignored folder-relative URLs until https://github.com/hashicorp/dev-portal/pull/1518, where this bug was introduced because of some incorrect test cases

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [`/waypoint/plugins/aws-ecs#builders`](https://dev-portal-git-ambfix-dot-slash-urls-hashicorp.vercel.app/waypoint/plugins/aws-ecs#builders) on the preview URL
- [ ] The "Docker" link should go to `/waypoint/plugins/docker`
  - compare to [staging](https://dev-portal-git-staging-hashicorp.vercel.app/waypoint/plugins/aws-ecs#builders)
- [ ] The "Cloud Native Buildpacks" link should go to `/waypoint/plugins/pack`
  - compare to [staging](https://dev-portal-git-staging-hashicorp.vercel.app/waypoint/plugins/aws-ecs#builders)
- [ ] Go to [`/terraform/plugin/sdkv2/logging#log-http-transactions`](https://dev-portal-git-ambfix-dot-slash-urls-hashicorp.vercel.app/terraform/plugin/sdkv2/logging#log-http-transactions) on the preview URL
- [ ] The "set up the Logging HTTP Transport" link should go to `/terraform/plugin/sdkv2/logging/http-transport`
  - compare to [staging](https://dev-portal-git-staging-hashicorp.vercel.app/terraform/plugin/sdkv2/logging#log-http-transactions)
