### PR TITLE
fix: scroll to page top on pagination change

### DIFF
--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -58,6 +58,8 @@ export default function PaginatedIntegrationsList({
 		if (isFirstRender.current) {
 			isFirstRender.current = false
 		} else {
+			// Scroll to the top of the page
+			window.scrollTo(0, 0)
 			// Try to find the first result link, and focus it
 			const targetElement = containerRef.current?.querySelector('a')
 			if (targetElement) {

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -1,4 +1,5 @@
 import { Integration } from 'lib/integrations-api-client/integration'
+import getFullNavHeaderHeight from 'lib/get-full-nav-header-height'
 import { useEffect, useRef, useState } from 'react'
 import IntegrationsList from '../integrations-list'
 import s from './style.module.css'
@@ -58,12 +59,18 @@ export default function PaginatedIntegrationsList({
 		if (isFirstRender.current) {
 			isFirstRender.current = false
 		} else {
-			// Scroll to the top of the page
-			window.scrollTo(0, 0)
 			// Try to find the first result link, and focus it
 			const targetElement = containerRef.current?.querySelector('a')
 			if (targetElement) {
-				targetElement.focus()
+				targetElement.focus({ forceVisible: true })
+				/**
+				 * We need to scroll up a bit, as the focused item may be slightly
+				 * hidden behind the top navigation bar. Note this approach is slightly
+				 * brittle, as --navigationHeader. We also add an extra 64px,
+				 * which makes it more clear we've scrolled to the top of results.
+				 */
+				const navScrollCompensation = getFullNavHeaderHeight() + 64
+				window.scrollBy(0, navScrollCompensation * -1)
 			}
 		}
 	}, [currentPage])

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -1,5 +1,5 @@
 import { Integration } from 'lib/integrations-api-client/integration'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import IntegrationsList from '../integrations-list'
 import s from './style.module.css'
 import Pagination from 'components/pagination'
@@ -11,6 +11,7 @@ interface PaginatedIntegrationsListProps {
 export default function PaginatedIntegrationsList({
 	integrations,
 }: PaginatedIntegrationsListProps) {
+	const containerRef = useRef(null)
 	const [itemsPerPage, setItemsPerPage] = useState(8)
 	// Sort integrations alphabetically. Right now this is our
 	// preferred way of sorting. In the event we want to add different
@@ -40,13 +41,26 @@ export default function PaginatedIntegrationsList({
 		setCurrentPage(1)
 	}, [sortedIntegrations])
 
+	/**
+	 * If our pagination page changes, scroll up to the top of the wrapper.
+	 *
+	 * We also focus the search input, since otherwise, keyboard users would
+	 * be scrolled to the top of the page (due to scrollTo), and then
+	 * immediately scrolled to the bottom of the page (since )
+	 */
 	function setPageWithScrollReset(page: number) {
-		setCurrentPage(1)
+		setCurrentPage(page)
+		// Scroll to the top of the page
 		window.scrollTo(0, 0)
+		// Try to find the first result link, and focus it
+		const targetElement = containerRef.current?.querySelector('a')
+		if (targetElement) {
+			targetElement.focus({ focusVisible: true })
+		}
 	}
 
 	return (
-		<div className={s.paginatedIntegrationsList}>
+		<div className={s.paginatedIntegrationsList} ref={containerRef}>
 			<IntegrationsList integrations={currentPageIntegrations} />
 			{/* It's possible that all integrations display on a single page
       in that case, just don't even show the paginator. */}

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -12,6 +12,7 @@ interface PaginatedIntegrationsListProps {
 export default function PaginatedIntegrationsList({
 	integrations,
 }: PaginatedIntegrationsListProps) {
+	const isFirstRender = useRef(true)
 	const containerRef = useRef(null)
 	const [itemsPerPage, setItemsPerPage] = useState(8)
 	// Sort integrations alphabetically. Right now this is our
@@ -49,16 +50,17 @@ export default function PaginatedIntegrationsList({
 	 * be scrolled to the top of the page (due to scrollTo), and then
 	 * immediately scrolled to the bottom of the page (since )
 	 */
-	function setPageWithScrollReset(page: number) {
-		setCurrentPage(page)
-		// Scroll to the top of the page
-		window.scrollTo(0, 0)
-		// Try to find the first result link, and focus it
-		const targetElement = containerRef.current?.querySelector('a')
-		if (targetElement) {
-			targetElement.focus()
+	useEffect(() => {
+		if (isFirstRender.current) {
+			isFirstRender.current = false
+		} else {
+			// Try to find the first result link, and focus it
+			const targetElement = containerRef.current?.querySelector('a')
+			if (targetElement) {
+				targetElement.focus()
+			}
 		}
-	}
+	}, [currentPage])
 
 	const { isDesktop, isMobile, isTablet } = useDeviceSize()
 
@@ -73,7 +75,7 @@ export default function PaginatedIntegrationsList({
 						totalItems={integrations.length}
 						pageSize={itemsPerPage}
 						page={currentPage}
-						onPageChange={setPageWithScrollReset}
+						onPageChange={setCurrentPage}
 						onPageSizeChange={setItemsPerPage}
 					>
 						{(isDesktop || isTablet) && <Pagination.Info />}

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -1,5 +1,5 @@
 import { Integration } from 'lib/integrations-api-client/integration'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import IntegrationsList from '../integrations-list'
 import s from './style.module.css'
 import Pagination from 'components/pagination'
@@ -11,7 +11,6 @@ interface PaginatedIntegrationsListProps {
 export default function PaginatedIntegrationsList({
 	integrations,
 }: PaginatedIntegrationsListProps) {
-	const isFirstRender = useRef(true)
 	const [itemsPerPage, setItemsPerPage] = useState(8)
 	// Sort integrations alphabetically. Right now this is our
 	// preferred way of sorting. In the event we want to add different
@@ -41,17 +40,10 @@ export default function PaginatedIntegrationsList({
 		setCurrentPage(1)
 	}, [sortedIntegrations])
 
-	/**
-	 * If our pagination page changes, scroll up to the top of the wrapper
-	 * However, don't scroll to the wrapper if this is the first render.
-	 */
-	useEffect(() => {
-		if (isFirstRender.current) {
-			isFirstRender.current = false
-		} else {
-			window.scrollTo(0, 0)
-		}
-	}, [currentPage])
+	function setPageWithScrollReset(page: number) {
+		setCurrentPage(1)
+		window.scrollTo(0, 0)
+	}
 
 	return (
 		<div className={s.paginatedIntegrationsList}>
@@ -64,7 +56,7 @@ export default function PaginatedIntegrationsList({
 						totalItems={integrations.length}
 						pageSize={8}
 						page={1}
-						onPageChange={setCurrentPage}
+						onPageChange={setPageWithScrollReset}
 						onPageSizeChange={setItemsPerPage}
 					>
 						<Pagination.Info />

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -48,7 +48,11 @@ export default function PaginatedIntegrationsList({
 	 *
 	 * We also focus the search input, since otherwise, keyboard users would
 	 * be scrolled to the top of the page (due to scrollTo), and then
-	 * immediately scrolled to the bottom of the page (since )
+	 * immediately scrolled to the bottom of the page.
+	 *
+	 * TODO: consider hooking into <Pagination/>'s `onPageChange`.
+	 * This might be more clear than a separate effect (but for now, would
+	 * not result in the same focus behaviour on the first result link.)
 	 */
 	useEffect(() => {
 		if (isFirstRender.current) {

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -55,7 +55,7 @@ export default function PaginatedIntegrationsList({
 		// Try to find the first result link, and focus it
 		const targetElement = containerRef.current?.querySelector('a')
 		if (targetElement) {
-			targetElement.focus({ focusVisible: true })
+			targetElement.focus()
 		}
 	}
 

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -1,5 +1,5 @@
 import { Integration } from 'lib/integrations-api-client/integration'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import IntegrationsList from '../integrations-list'
 import s from './style.module.css'
 import Pagination from 'components/pagination'
@@ -11,6 +11,7 @@ interface PaginatedIntegrationsListProps {
 export default function PaginatedIntegrationsList({
 	integrations,
 }: PaginatedIntegrationsListProps) {
+	const isFirstRender = useRef(true)
 	const [itemsPerPage, setItemsPerPage] = useState(8)
 	// Sort integrations alphabetically. Right now this is our
 	// preferred way of sorting. In the event we want to add different
@@ -39,6 +40,18 @@ export default function PaginatedIntegrationsList({
 	useEffect(() => {
 		setCurrentPage(1)
 	}, [sortedIntegrations])
+
+	/**
+	 * If our pagination page changes, scroll up to the top of the wrapper
+	 * However, don't scroll to the wrapper if this is the first render.
+	 */
+	useEffect(() => {
+		if (isFirstRender.current) {
+			isFirstRender.current = false
+		} else {
+			window.scrollTo(0, 0)
+		}
+	}, [currentPage])
 
 	return (
 		<div className={s.paginatedIntegrationsList}>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates the `PaginatedIntegrationsList` to scroll to the top of the page when pages are changed.

## 🛠️ How

- Adds a `useEffect` hook that calls `window.scrollTo(0, 0)` when `currentPage` changes after the initial render

## 🧪 Testing

- [ ] Visit a page with `PaginatedIntegrationsList`, such as [/waypoint/integrations][/waypoint/integrations]
    - On initial render, scroll position should not change. For example, if you scroll partway down the page, and then reload the page, the browser behaviour of remembering your scroll position should still work.
    - When interacting with the pagination bar, if the current page is changed, the window should scroll back up to the top

## 💭 Anything else?

### Note on positioning

This PR implements scrolling to the very top of the page. If we'd prefer to scroll to a different position, such as the top of the paginated results, we could add a `ref` that we tack onto a target element, and call `ref.current.scrollIntoView()` rather than `window.scrollTo(0, 0)`.

### Thought on alternative approach

In implementing and testing this, I found the behaviour after the change to still feel a bit jarring. Another option that might address the same concern as the original issue could be to move the pagination controls to _above_ the results, rather than below.

<details>
<summary>📺 ⬇️ Demo of pagination at bottom, with scroll reset <em>(this PR)</em></summary>

https://user-images.githubusercontent.com/4624598/213020247-88c849b3-ea44-49b6-a5d7-80dd83b3ebdf.mp4

</details>


<details>
<summary>📺 ⬆️ Demo of pagination at top, without scroll reset<em>(potential alternate approach)</em></summary>

https://user-images.githubusercontent.com/4624598/213020239-37465ee6-c184-4d38-87b6-51dfb18d7227.mp4

</details>

As a related thought, which might be helpful with pagination controls above or below the results list, we could reconsider the default number of items per page - or perhaps even make the default number of items per page dynamically adjust based on viewport height, such that all results on a "page" can be viewed within one viewport height. This could help alleviate the relatively cumbersome process of `scroll → change page → scroll → ... etc` when page results are too tall to be viewed in a single viewport height.

[preview]: https://dev-portal-git-zsintegrations-paginator-scroll-reset-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1202626741675858/1203717383445373/f
[/waypoint/integrations]: https://dev-portal-git-zsintegrations-paginator-scroll-reset-hashicorp.vercel.app/waypoint/integrations

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203717383445373