### PR TITLE
chore: adds heading anchors to certifications accordions

### DIFF
--- a/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
@@ -1,3 +1,9 @@
+/** 
+* The permalink icon focus / hover styles should reflect 
+* the same behavior as the mdx-heading-permalink component
+* /src/components/dev-dot-content/mdx-components/mdx-heading-permalink
+**/
+
 .heading {
 	composes: hds-typography-display-400 from global;
 	composes: g-offset-scroll-margin-top from global;
@@ -28,11 +34,6 @@
 		}
 	}
 }
-
-/** 
-* These styles should reflect the same behavior as 
-* the mdx-heading-permalink component
-**/
 
 .icon {
 	width: 24px;

--- a/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
@@ -1,0 +1,53 @@
+.heading {
+	composes: hds-typography-display-400 from global;
+	composes: g-offset-scroll-margin-top from global;
+	font-weight: var(--token-typography-font-weight-bold);
+	color: var(--token-color-foreground-strong);
+	margin: 40px 0 32px 0;
+
+	&:hover {
+		& .icon {
+			color: var(--token-color-foreground-action-hover);
+			opacity: 1;
+		}
+	}
+}
+
+.anchorLink {
+	composes: g-focus-ring-from-box-shadow from global;
+	border-radius: 6px;
+	color: inherit;
+	display: flex;
+	align-items: center;
+
+	&:focus {
+		& .icon {
+			color: var(--token-color-foreground-action-active);
+			background: var(--token-color-surface-faint);
+			opacity: 1;
+		}
+	}
+}
+
+/** 
+* These styles should reflect the same behavior as 
+* the mdx-heading-permalink component
+**/
+
+.icon {
+	width: 24px;
+	height: 24px;
+	border-radius: 6px;
+	margin-left: 8px;
+	opacity: 0;
+	color: var(--token-color-foreground-action);
+	padding: 4px;
+
+	@media (prefers-reduced-motion: no-preference) {
+		transition: opacity 0.2s ease;
+	}
+
+	&:hover {
+		box-shadow: var(--token-surface-mid-box-shadow);
+	}
+}

--- a/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/heading-permalink.module.css
@@ -10,6 +10,7 @@
 	font-weight: var(--token-typography-font-weight-bold);
 	color: var(--token-color-foreground-strong);
 	margin: 40px 0 32px 0;
+	width: fit-content;
 
 	&:hover {
 		& .icon {

--- a/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
@@ -1,8 +1,10 @@
 import slugify from 'slugify'
 import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
 import s from './heading-permalink.module.css'
+
 // Future thought: refactor this to use a shared `HeadingPermalink`
 // base component that can also be used in the mdx heading component
+
 export function HeadingPermalink({ heading }: { heading: string }) {
 	const id = `${slugify(heading, {
 		lower: true,

--- a/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
@@ -1,7 +1,8 @@
 import slugify from 'slugify'
 import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
 import s from './heading-permalink.module.css'
-
+// Future thought: refactor this to use a shared `HeadingPermalink`
+// base component that can also be used in the mdx heading component
 export function HeadingPermalink({ heading }: { heading: string }) {
 	const id = `${slugify(heading, {
 		lower: true,

--- a/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
+++ b/src/views/certifications/views/[slug]/components/heading-permalink/index.tsx
@@ -1,0 +1,17 @@
+import slugify from 'slugify'
+import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
+import s from './heading-permalink.module.css'
+
+export function HeadingPermalink({ heading }: { heading: string }) {
+	const id = `${slugify(heading, {
+		lower: true,
+	})}`
+	return (
+		<h2 className={s.heading} id={id}>
+			<a className={s.anchorLink} href={`#${id}`}>
+				{heading}
+				<IconLink16 className={s.icon} />
+			</a>
+		</h2>
+	)
+}

--- a/src/views/certifications/views/[slug]/components/index.tsx
+++ b/src/views/certifications/views/[slug]/components/index.tsx
@@ -1,3 +1,4 @@
 export * from './exam-details-card'
 export * from './exam-details-badge-and-title'
 export * from './program-hero'
+export * from './heading-permalink'

--- a/src/views/certifications/views/[slug]/index.tsx
+++ b/src/views/certifications/views/[slug]/index.tsx
@@ -1,6 +1,5 @@
 // Global
 import BaseNewLayout from 'layouts/base-new'
-import slugify from 'slugify'
 // Share certifications
 import {
 	AccordionWithMdxContent,
@@ -8,7 +7,7 @@ import {
 	SignupFormArea,
 } from 'views/certifications/components'
 // Local
-import { ExamDetailsCard, ProgramHero } from './components'
+import { ExamDetailsCard, ProgramHero, HeadingPermalink } from './components'
 import { CertificationProgramViewProps } from './types'
 import s from './program-view.module.css'
 
@@ -32,9 +31,7 @@ function CertificationProgramView({
 							const { title, examCode } = exam
 							const fullTitle = title + (examCode ? ` (${examCode})` : '')
 							const accordionHeading = `${fullTitle} Details`
-							const accordionId = `${slugify(accordionHeading, {
-								lower: true,
-							})}`
+
 							return (
 								<div key={fullTitle}>
 									<ExamDetailsCard
@@ -46,15 +43,7 @@ function CertificationProgramView({
 										versionTested={exam.versionTested}
 										slug={slug}
 									/>
-
-									<h2 className={s.examAccordionHeading} id={accordionId}>
-										<a
-											className={s.examAccordionAnchorLink}
-											href={`#${accordionId}`}
-										>
-											{accordionHeading}
-										</a>
-									</h2>
+									<HeadingPermalink heading={accordionHeading} />
 									<AccordionWithMdxContent items={exam.faqItems} />
 								</div>
 							)

--- a/src/views/certifications/views/[slug]/index.tsx
+++ b/src/views/certifications/views/[slug]/index.tsx
@@ -1,5 +1,7 @@
 // Global
 import BaseNewLayout from 'layouts/base-new'
+import classNames from 'classnames'
+import slugify from 'slugify'
 // Share certifications
 import {
 	AccordionWithMdxContent,
@@ -30,6 +32,10 @@ function CertificationProgramView({
 						{exams.map((exam) => {
 							const { title, examCode } = exam
 							const fullTitle = title + (examCode ? ` (${examCode})` : '')
+							const accordionHeading = `${fullTitle} Details`
+							const accordionId = `${slugify(accordionHeading, {
+								lower: true,
+							})}`
 							return (
 								<div key={fullTitle}>
 									<ExamDetailsCard
@@ -41,8 +47,15 @@ function CertificationProgramView({
 										versionTested={exam.versionTested}
 										slug={slug}
 									/>
-									<h2 className={s.examAccordionHeading}>
-										{`${title}${examCode ? ` ${examCode}` : ''} Details`}
+
+									<h2
+										className={classNames(
+											s.examAccordionHeading,
+											'g-offset-scroll-margin-top'
+										)}
+										id={accordionId}
+									>
+										<a href={`#${accordionId}`}>{accordionHeading}</a>
 									</h2>
 									<AccordionWithMdxContent items={exam.faqItems} />
 								</div>

--- a/src/views/certifications/views/[slug]/index.tsx
+++ b/src/views/certifications/views/[slug]/index.tsx
@@ -55,7 +55,12 @@ function CertificationProgramView({
 										)}
 										id={accordionId}
 									>
-										<a href={`#${accordionId}`}>{accordionHeading}</a>
+										<a
+											className={s.examAccordionAnchorLink}
+											href={`#${accordionId}`}
+										>
+											{accordionHeading}
+										</a>
 									</h2>
 									<AccordionWithMdxContent items={exam.faqItems} />
 								</div>

--- a/src/views/certifications/views/[slug]/index.tsx
+++ b/src/views/certifications/views/[slug]/index.tsx
@@ -1,6 +1,5 @@
 // Global
 import BaseNewLayout from 'layouts/base-new'
-import classNames from 'classnames'
 import slugify from 'slugify'
 // Share certifications
 import {
@@ -48,13 +47,7 @@ function CertificationProgramView({
 										slug={slug}
 									/>
 
-									<h2
-										className={classNames(
-											s.examAccordionHeading,
-											'g-offset-scroll-margin-top'
-										)}
-										id={accordionId}
-									>
+									<h2 className={s.examAccordionHeading} id={accordionId}>
 										<a
 											className={s.examAccordionAnchorLink}
 											href={`#${accordionId}`}

--- a/src/views/certifications/views/[slug]/program-view.module.css
+++ b/src/views/certifications/views/[slug]/program-view.module.css
@@ -10,20 +10,6 @@
 	margin-top: -72px;
 }
 
-.examAccordionHeading {
-	composes: hds-typography-display-400 from global;
-	composes: g-offset-scroll-margin-top from global;
-	font-weight: var(--token-typography-font-weight-bold);
-	color: var(--token-color-foreground-strong);
-	margin: 40px 0 32px 0;
-}
-
-.examAccordionAnchorLink {
-	composes: g-focus-ring-from-box-shadow from global;
-	border-radius: 6px;
-	color: inherit;
-}
-
 .signupForm {
 	margin-top: 72px;
 }

--- a/src/views/certifications/views/[slug]/program-view.module.css
+++ b/src/views/certifications/views/[slug]/program-view.module.css
@@ -15,10 +15,12 @@
 	font-weight: var(--token-typography-font-weight-bold);
 	color: var(--token-color-foreground-strong);
 	margin: 40px 0 32px 0;
+}
 
-	& > a {
-		color: inherit;
-	}
+.examAccordionAnchorLink {
+	composes: g-focus-ring-from-box-shadow from global;
+	border-radius: 6px;
+	color: inherit;
 }
 
 .signupForm {

--- a/src/views/certifications/views/[slug]/program-view.module.css
+++ b/src/views/certifications/views/[slug]/program-view.module.css
@@ -12,6 +12,7 @@
 
 .examAccordionHeading {
 	composes: hds-typography-display-400 from global;
+	composes: g-offset-scroll-margin-top from global;
 	font-weight: var(--token-typography-font-weight-bold);
 	color: var(--token-color-foreground-strong);
 	margin: 40px 0 32px 0;

--- a/src/views/certifications/views/[slug]/program-view.module.css
+++ b/src/views/certifications/views/[slug]/program-view.module.css
@@ -15,6 +15,10 @@
 	font-weight: var(--token-typography-font-weight-bold);
 	color: var(--token-color-foreground-strong);
 	margin: 40px 0 32px 0;
+
+	& > a {
+		color: inherit;
+	}
 }
 
 .signupForm {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadd-anchors-hashicorp.vercel.app/certifications/infrastructure-automation) 🔎
- [Asana task](https://app.asana.com/0/1202801212949828/1203714554456192) 🎟️

## 🗒️ What

Adds anchor links to the accordion headings so the education team can directly link to a specific program details. 

## 🧪 Testing

- Visit a [certifications program page](https://dev-portal-git-ksadd-anchors-hashicorp.vercel.app/certifications/infrastructure-automation)
- Click on an accordion heading, validate that an anchor link renders in your browser tab
- Visit the [anchor link directly](https://dev-portal-git-ksadd-anchors-hashicorp.vercel.app/certifications/infrastructure-automation#terraform-associate-(003)-details) to make sure it works. 

## 💭 Anything else?

We should decide whether we want to render the link icon, similar to how we do anchor links in long form content. 
