### PR TITLE
feat: optional sidecarSlot on integrations landing

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -107,9 +107,15 @@ const SidebarSidecarLayoutContent = ({
 	} else {
 		SidecarContent = null
 	}
+	// We'll include the sidecar only if `SidecarContent` is not null
+	const includesSidecar = SidecarContent !== null
 
 	return (
-		<div className={classNames(s.root, s[`mainWidth-${mainWidth}`])}>
+		<div
+			className={classNames(s.root, s[`mainWidth-${mainWidth}`], {
+				[s.includesSidecar]: includesSidecar,
+			})}
+		>
 			<MobileMenuContainer className={s.mobileMenuContainer} ref={sidebarRef}>
 				<div className={s.sidebarContentWrapper}>
 					<MobileAuthenticationControls />
@@ -153,7 +159,7 @@ const SidebarSidecarLayoutContent = ({
 							/>
 						)}
 					</main>
-					{SidecarContent !== null ? (
+					{includesSidecar ? (
 						<div className={s.sidecarWrapper}>
 							<SidecarContent />
 						</div>

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -92,14 +92,20 @@ const SidebarSidecarLayoutContent = ({
 		sidebarContent = <Sidebar {...sidebarProps} />
 	}
 
-	const SidecarContent = (): ReactElement => {
-		if (typeof sidecarSlot !== 'undefined') {
-			return sidecarSlot
-		}
-
-		return (
+	/**
+	 * Optionally render sidecar content. If no sidecar content is provided,
+	 * the main content will not have sidecar space rendered alongside it.
+	 */
+	let SidecarContent: () => ReactElement | null
+	if (typeof sidecarSlot !== 'undefined') {
+		SidecarContent = () => sidecarSlot
+	} else if (typeof headings !== 'undefined') {
+		// eslint-disable-next-line react/display-name
+		SidecarContent = () => (
 			<TableOfContents headings={filterTableOfContentsHeadings(headings)} />
 		)
+	} else {
+		SidecarContent = null
 	}
 
 	return (
@@ -147,9 +153,11 @@ const SidebarSidecarLayoutContent = ({
 							/>
 						)}
 					</main>
-					<div className={s.sidecarWrapper}>
-						<SidecarContent />
-					</div>
+					{SidecarContent !== null ? (
+						<div className={s.sidecarWrapper}>
+							<SidecarContent />
+						</div>
+					) : null}
 				</div>
 				{showScrollProgress ? (
 					<ScrollProgressBar progress={scrollYProgress} />

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -22,6 +22,14 @@ for further details.
   navigation-header component, in order to match alignment in design specs. */
 	--main-area-padding-right: 24px;
 
+	/* We want space between the main area and the sidecar... and we need
+	   to know this spacing metric when rendering the layout without the
+		 sidecar, so that we can align with layouts that do have the sidecar */
+	--sidecar-spacing: 48px;
+	@media (min-width: 1440px) {
+		--sidecar-spacing: 64px;
+	}
+
 	/*
   We want our footer to have a top border which spans
   across both the main content and sidecar.
@@ -48,6 +56,13 @@ for further details.
 	&.mainWidth-wide {
 		--main-element-max-width: 896px;
 		--sidecar-width: 220px;
+
+		/* If sidecar is not included, let the main content area eat up the space */
+		&:not(.includesSidecar) {
+			--main-element-max-width: calc(
+				896px + var(--sidecar-width) + var(--sidecar-spacing)
+			);
+		}
 	}
 
 	&.mainWidth-narrow {
@@ -124,14 +139,10 @@ for further details.
 		display: block;
 		flex-shrink: 0;
 		height: fit-content;
-		margin-left: 48px;
+		margin-left: var(--sidecar-spacing);
 		position: sticky;
 		top: calc(var(--sticky-bars-height) + var(--main-area-padding-top));
 		width: var(--sidecar-width);
-	}
-
-	@media (min-width: 1440px) {
-		margin-left: 64px;
 	}
 }
 

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -22,9 +22,11 @@ interface BaseProps {
 
 /**
  * `PropsForSidecar` defines the properties that represent `Sidecar` behavior.
- * This approach allows us to require either (not both) `headings` and
+ *
+ * This approach allows us to require either (but not both) `headings` and
  * `sidecarSlot` since providing both of these props is not a case that this
- * component handles.
+ * component handles. We also handle if neither of these props are provided,
+ * in which case we render main content only, with no sidecar space.
  */
 type PropsForSidecar =
 	| {
@@ -33,7 +35,7 @@ type PropsForSidecar =
 	  }
 	| {
 			headings?: never
-			sidecarSlot: ReactElement | null
+			sidecarSlot?: ReactElement | null
 	  }
 
 /**

--- a/src/views/product-integrations-landing/index.tsx
+++ b/src/views/product-integrations-landing/index.tsx
@@ -27,7 +27,6 @@ export default function ProductIntegrationsLanding({
 			<SidebarSidecarLayout
 				sidebarNavDataLevels={sidebarNavDataLevels}
 				breadcrumbLinks={breadcrumbLinks}
-				sidecarSlot={<></>}
 			>
 				<div className={s.mainArea}>
 					<BrandedHeaderCard


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates the integration landing view to remove blank space where the sidecar would be. This increases the space available for the main content area.

## 🤷 Why

To better match design specs, and avoid an off-centered main content area.

## 🛠️ How

- In `SidebarSidecarLayout`, update the `sidecarSlot` prop to be truly optional (can be omitted from props, rather than passing `null` or `<></>`)
- Use this new capability for the `ProductIntegrationsLanding` view

## 📸 Design Screenshots

🎨 [Figma link][figma]

### Design

<img width="1919" alt="CleanShot 2023-01-18 at 10 57 09@2x" src="https://user-images.githubusercontent.com/4624598/213223475-4a929fe2-18b0-4bf1-a154-5ed3cf8d4249.png">

### Implementation

#### Before

https://user-images.githubusercontent.com/4624598/213223147-05240e69-e3fa-4207-b742-bacb0f0838ca.mp4

#### After

https://user-images.githubusercontent.com/4624598/213288686-b61a0a56-48f0-44f1-8f44-5fc461f1c914.mp4

## 🧪 Testing

- [ ] Visit an integrations landing page, such as [/vault/integrations][/vault/integrations]
    - There should _not_ be a blank column-ish space where the sidecar usually is (compare to [upstream][upstream/vault/integrations])
    - When toggling between pages with and without a sidecar, such as between [/vault][/vault] and [/vault/integrations][/vault/integrations], the main content area should be right-aligned regardless of whether the sidecar is shown

## 💭 Anything else?

Not at the moment!

<details>
<summary>Previously `max-width` in this PR didn't match spec, but have since updated 👍</summary>

In this PR, we've used the same `main` content area max-width as in all other `SidebarSidecarLayout` instances. This differs from the max-width in Figma designs, which looks to be `1024px` (rather than the current `896px`). If implementing the wider `1024px` max-width is a strict requirement, we could either:

1. Add another option to our `mainWidth` prop (currently either `wide / 896px` or `narrow / 680px`), which would be low-effort but doesn't feel like a great solution long term, or
2. Refactor `SidebarSidecarLayout` for better composability, which would be higher effort (since our existing component has a few things we'd need to detangle)

For now I've gone with the third option of not worrying to hard about the exact pixel value of the `main` area max-width - especially considering we had recent pushes to reduce the main area width for readability, it seems like `1024px` wide cards might be slightly less readable than `896px` wide cards anyways.

</details>


[preview]: https://dev-portal-git-zsrm-sidecar-space-from-landing-hashicorp.vercel.app
[task]: https://app.asana.com/0/1202626741675858/1203746230354963/f
[figma]: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=17267%3A218514&t=JYmt6p7PplivfYHF-4
[/vault/integrations]:  https://dev-portal-git-zsrm-sidecar-space-from-landing-hashicorp.vercel.app/vault/integrations
[upstream/vault/integrations]:  https://dev-portal-git-product-integrations-hashicorp.vercel.app/vault/integrations

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203746230354963