### PR TITLE
[docs-content-link-rewrites] Filter out empty hrefs, set retries to 0

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,7 @@ const config: PlaywrightTestConfig = {
 		{
 			name: 'docs-content-link-rewrites',
 			testMatch: 'src/__tests__/e2e/docs-content-link-rewrites.spec.ts',
+			retries: 0,
 		},
 	],
 

--- a/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
+++ b/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
@@ -12,12 +12,20 @@ test.describe.configure({ mode: 'parallel' })
 /**
  * Given a Playwright Locator for anchors, returns an array of hrefs.
  */
-const gatherHrefsFromLocator = async (anchorLocator: Locator) => {
+const gatherHrefsFromLocator = async (
+	anchorLocator: Locator
+): Promise<string[]> => {
 	return anchorLocator.evaluateAll((anchors: HTMLAnchorElement[]) => {
-		return anchors.map((anchor: HTMLAnchorElement) => {
-			const { pathname = '', search = '', hash = '' } = new URL(anchor.href)
-			return `${pathname}${search}${hash}`
-		})
+		return (
+			anchors
+				// filter out anchor elements with empty hrefs (such as ones injected for headings)
+				.filter((anchor: HTMLAnchorElement) => anchor.href?.length > 0)
+				// pull the path, search query string, and anchor string for each non-empty href
+				.map((anchor: HTMLAnchorElement) => {
+					const { pathname = '', search = '', hash = '' } = new URL(anchor.href)
+					return `${pathname}${search}${hash}`
+				})
+		)
 	})
 }
 


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates the `gatherHrefsFromLocator` to filter out `href` properties that are empty, to prevent errors with `new URL(href)`
- Adds a `retries` configuration to the `docs-content-link-rewrites` playwright project, to save time in workflow runs

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out the code locally
- [ ] Run the following to load the data for the tests:
  ```
  REPO=consul npm run test:e2e:linkRewrites:loadData
  ```
- [ ] Run the following to start the tests:
  ```
  MAIN_BRANCH_PREVIEW_URL=https://consul-git-main-hashicorp.vercel.app/ PR_BRANCH_PREVIEW_URL=https://consul-git-docs-ambmigrate-link-formats-hashicorp.vercel.app/ npm run test:e2e:linkRewrites
  ```
- [ ] No tests should fail because of: "locator.evaluateAll: TypeError: Failed to construct 'URL': Invalid URL" (it's okay if tests fail for other reasons, Consul's migration is in-progress)
