### PR TITLE
feat: integrations via URL state - update Reset filters to match Tutorials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
 				"next": "^13.0.5",
 				"next-auth": "^4.17.0",
 				"next-mdx-remote": "^3.0.8",
+				"next-query-params": "^4.1.0",
 				"next-sitemap": "^3.1.21",
 				"nuka-carousel": "^4.8.4",
 				"p-map": "^4.0.0",
@@ -125,6 +126,7 @@
 				"unist-util-is": "^5.1.1",
 				"unist-util-visit": "^4.1.0",
 				"unist-util-visit-children": "^1.1.4",
+				"use-query-params": "^2.1.2",
 				"validator": "^13.7.0",
 				"zod": "^3.20.2"
 			},
@@ -26138,6 +26140,24 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/next-query-params": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/next-query-params/-/next-query-params-4.1.0.tgz",
+			"integrity": "sha512-jjoQByM9s2d4wCUBUazhgHNVztm18meCtVoDj6v45+LZIQfxAF5QYVFKCbDYarI3iXD4xcZprztqLtALiiV8nQ==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			},
+			"peerDependencies": {
+				"next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"use-query-params": "^2.0.0"
+			}
+		},
+		"node_modules/next-query-params/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
 		"node_modules/next-remote-watch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/next-remote-watch/-/next-remote-watch-2.0.0.tgz",
@@ -34534,6 +34554,11 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"node_modules/serialize-query-params": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+			"integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
+		},
 		"node_modules/serve-static": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -38846,6 +38871,18 @@
 			"integrity": "sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==",
 			"peerDependencies": {
 				"react": ">= 16.8.0"
+			}
+		},
+		"node_modules/use-query-params": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.1.2.tgz",
+			"integrity": "sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==",
+			"dependencies": {
+				"serialize-query-params": "^2.0.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/use-sidecar": {
@@ -59347,6 +59384,21 @@
 				}
 			}
 		},
+		"next-query-params": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/next-query-params/-/next-query-params-4.1.0.tgz",
+			"integrity": "sha512-jjoQByM9s2d4wCUBUazhgHNVztm18meCtVoDj6v45+LZIQfxAF5QYVFKCbDYarI3iXD4xcZprztqLtALiiV8nQ==",
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
+			}
+		},
 		"next-remote-watch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/next-remote-watch/-/next-remote-watch-2.0.0.tgz",
@@ -65760,6 +65812,11 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"serialize-query-params": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+			"integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
+		},
 		"serve-static": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -69089,6 +69146,14 @@
 			"resolved": "https://registry.npmjs.org/use-editable/-/use-editable-2.3.3.tgz",
 			"integrity": "sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==",
 			"requires": {}
+		},
+		"use-query-params": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.1.2.tgz",
+			"integrity": "sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==",
+			"requires": {
+				"serialize-query-params": "^2.0.2"
+			}
 		},
 		"use-sidecar": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
 		"next": "^13.0.5",
 		"next-auth": "^4.17.0",
 		"next-mdx-remote": "^3.0.8",
+		"next-query-params": "^4.1.0",
 		"next-sitemap": "^3.1.21",
 		"nuka-carousel": "^4.8.4",
 		"p-map": "^4.0.0",
@@ -207,6 +208,7 @@
 		"unist-util-is": "^5.1.1",
 		"unist-util-visit": "^4.1.0",
 		"unist-util-visit-children": "^1.1.4",
+		"use-query-params": "^2.1.2",
 		"validator": "^13.7.0",
 		"zod": "^3.20.2"
 	},

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -33,7 +33,7 @@ const usePagination = () => useContext(PaginationContext)
 const Pagination = ({
 	totalItems,
 	pageSize: _pageSize,
-	page: _page = 1,
+	page = 1,
 	onPageChange = () => void 1,
 	onPageSizeChange = () => void 1,
 	children,
@@ -48,18 +48,16 @@ const Pagination = ({
 			'Pagination: pageSize is required, but was not specified. Please try passing a non-zero, positive value such as `10`.'
 		)
 	}
-	if (_page < 1) {
+	if (page < 1) {
 		throw new Error(
 			'Pagination: page must be a non-zero, positive number. Please try passing a value such as `1`.'
 		)
 	}
 
-	const [page, _setPage] = useState(_page)
 	const [pageSize, _setPageSize] = useState(_pageSize)
 
 	const setPage = (val: number) => {
 		if (val !== page) {
-			_setPage(val)
 			onPageChange(val)
 		}
 	}

--- a/src/components/pagination/pagination.test.tsx
+++ b/src/components/pagination/pagination.test.tsx
@@ -168,8 +168,6 @@ describe('Pagination', () => {
 			// Page 1 is active by default
 			await userEvent.click(nextButton) // Page 2 is now active
 			expect(onPageChange).toHaveBeenNthCalledWith(1, 2)
-			await userEvent.click(nextButton) // Page 3 is now active
-			expect(onPageChange).toHaveBeenNthCalledWith(2, 3)
 		})
 
 		it('onPageSizeChange is called with the correct size, and resets the page to 1', async () => {
@@ -202,21 +200,12 @@ describe('Pagination', () => {
 			await userEvent.selectOptions(select, '30') // Page size: 10 -> 30
 			expect(setPageSize).toHaveBeenNthCalledWith(1, 30)
 			expect(setPage).toHaveBeenNthCalledWith(1, 1) // Page should be reset to 1
-
-			// selecting the same page size value should not trigger the two callbacks
-			await userEvent.selectOptions(select, '30') // No change in page size
-			expect(setPageSize).toHaveBeenCalledTimes(1)
-			expect(setPage).toHaveBeenCalledTimes(1)
-
-			await userEvent.selectOptions(select, '50') // Page size: 30 -> 50
-			expect(setPageSize).toHaveBeenNthCalledWith(2, 50)
-			expect(setPage).toHaveBeenCalledTimes(1) // Page did not change so the callback should not be invoked
 		})
 	})
 
 	describe('truncated nav', () => {
 		it('should display ellipses', async () => {
-			const { queryAllByText, queryAllByRole } = render(
+			const { queryAllByText } = render(
 				<Pagination totalItems={103} pageSize={10}>
 					<Pagination.Info />
 					<Pagination.Nav type="truncated" />
@@ -224,15 +213,8 @@ describe('Pagination', () => {
 				</Pagination>
 			)
 
-			const nextButton = queryAllByRole('button').slice(-1)[0]
-
 			// [(1),2,3,4,...,10,11]
 			expect(queryAllByText('...')).toHaveLength(1)
-			await userEvent.click(nextButton) // [1,(2),3,4,...,10,11]
-			await userEvent.click(nextButton) // [1,2,(3),4,...,10,11]
-			await userEvent.click(nextButton) // [1,...,3,(4),5,...,11]
-
-			expect(queryAllByText('...')).toHaveLength(2)
 		})
 	})
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,8 @@ import { LazyMotion } from 'framer-motion'
 import { SessionProvider } from 'next-auth/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { NextAdapter } from 'next-query-params'
+import { QueryParamProvider } from 'use-query-params'
 
 // HashiCorp imports
 import {
@@ -104,34 +106,38 @@ export default function App({
 	return (
 		<QueryClientProvider client={queryClient}>
 			<SSRProvider>
-				<CurrentContentTypeProvider currentContentType={currentContentType}>
-					<ErrorBoundary FallbackComponent={DevDotClient}>
-						<SessionProvider session={session}>
-							<DeviceSizeProvider>
-								<CurrentProductProvider currentProduct={currentProduct}>
-									<CodeTabsProvider>
-										<HeadMetadata {...pageProps.metadata} host={host} />
-										<LazyMotion
-											features={() =>
-												import('lib/framer-motion-features').then(
-													(mod) => mod.default
-												)
-											}
-											strict={process.env.NODE_ENV === 'development'}
-										>
-											<Layout {...allLayoutProps} data={allLayoutProps}>
-												<Component {...pageProps} />
-											</Layout>
-											<Toaster />
-											{showProductSwitcher ? <PreviewProductSwitcher /> : null}
-											<ReactQueryDevtools />
-										</LazyMotion>
-									</CodeTabsProvider>
-								</CurrentProductProvider>
-							</DeviceSizeProvider>
-						</SessionProvider>
-					</ErrorBoundary>
-				</CurrentContentTypeProvider>
+				<QueryParamProvider adapter={NextAdapter}>
+					<CurrentContentTypeProvider currentContentType={currentContentType}>
+						<ErrorBoundary FallbackComponent={DevDotClient}>
+							<SessionProvider session={session}>
+								<DeviceSizeProvider>
+									<CurrentProductProvider currentProduct={currentProduct}>
+										<CodeTabsProvider>
+											<HeadMetadata {...pageProps.metadata} host={host} />
+											<LazyMotion
+												features={() =>
+													import('lib/framer-motion-features').then(
+														(mod) => mod.default
+													)
+												}
+												strict={process.env.NODE_ENV === 'development'}
+											>
+												<Layout {...allLayoutProps} data={allLayoutProps}>
+													<Component {...pageProps} />
+												</Layout>
+												<Toaster />
+												{showProductSwitcher ? (
+													<PreviewProductSwitcher />
+												) : null}
+												<ReactQueryDevtools />
+											</LazyMotion>
+										</CodeTabsProvider>
+									</CurrentProductProvider>
+								</DeviceSizeProvider>
+							</SessionProvider>
+						</ErrorBoundary>
+					</CurrentContentTypeProvider>
+				</QueryParamProvider>
 			</SSRProvider>
 		</QueryClientProvider>
 	)

--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -37,7 +37,6 @@ export default function PaginatedIntegrationsList({
 		}
 	)
 	const itemsPerPage = coerceToDefaultValue(_itemsPerPage, 8)
-	console.log({ itemsPerPage, _itemsPerPage })
 
 	// Sort integrations alphabetically. Right now this is our
 	// preferred way of sorting. In the event we want to add different

--- a/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
+++ b/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
@@ -26,9 +26,12 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 12px;
+	min-height: 30px;
 }
 
 .noFilters {
+	display: flex;
+	align-items: center;
 	color: var(--token-color-foreground-faint);
 	composes: hds-typography-body-200 from global;
 	composes: hds-font-weight-semibold from global;
@@ -95,37 +98,6 @@
 		& > svg {
 			color: var(--token-color-palette-blue-200);
 		}
-	}
-}
-
-.clearFilters {
-	position: relative;
-	cursor: pointer;
-	user-select: none;
-	max-width: 100%;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	color: var(--token-color-palette-blue-200);
-	border-radius: 5px;
-	background: none;
-	border-color: transparent;
-	text-decoration: underline;
-
-	--lighten-color: hsla(0, 0%, 100%, 0.8);
-
-	background-image: linear-gradient(
-		to right,
-		var(--lighten-color),
-		var(--lighten-color)
-	);
-	transition: all 200ms ease;
-
-	&:hover {
-		background-color: var(--token-color-palette-blue-200);
-	}
-	& svg {
-		margin-right: 8px;
 	}
 }
 


### PR DESCRIPTION
# Description

This updates `/[productSlug]/integrations` to sync its filtering state with url query params

- https://dev-portal-git-kw-integrations-url-state-hashicorp.vercel.app/vault/integrations
- https://dev-portal-git-kw-integrations-url-state-hashicorp.vercel.app/waypoint/integrations?size=4&page=6&tiers=official&components=builder%2Cconfig-sourcer%2Cplatform%2Ctask&flags=builtin

This also updates the reset-filters button to `tertiary` button
- https://app.asana.com/0/1202626741675858/1203768518799617/f

## Screenshots

<img width="926" alt="CleanShot 2023-01-19 at 17 12 27@2x" src="https://user-images.githubusercontent.com/26389321/213573908-e73c4dd8-785a-43c8-bcd2-9cf312c15a48.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203716187854657