### PR TITLE
[link rewrite plugins] Update to no longer rewrite .io home page links in content

### DIFF
--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-docs-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-docs-link.test.ts
@@ -20,6 +20,7 @@ const testEachCase = (cases: TestCase[]) => {
 describe('rewriteExternalDocsLink', () => {
 	describe('when the URL is not to an external docs site', () => {
 		testEachCase([
+			{ input: '/', expected: undefined },
 			{ input: '/vault/api', expected: undefined },
 			{ input: '/waypoint/docs', expected: undefined },
 			{ input: '/vault/tutorials', expected: undefined },

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-docs-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-docs-link.test.ts
@@ -48,11 +48,11 @@ describe('rewriteExternalDocsLink', () => {
 		])
 	})
 
-	describe('docs site home pages are rewritten to product landing pages', () => {
+	describe('docs site home pages are *not* rewritten', () => {
 		testEachCase(
 			Object.keys(productSlugsToHostNames).map((productSlug: ProductSlug) => {
-				const input = `https://${productSlugsToHostNames[productSlug]}`
-				const expected = `/${productSlug}`
+				const input = `https://${productSlugsToHostNames[productSlug]}/`
+				const expected = input
 				return { input, expected }
 			})
 		)

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -108,6 +108,17 @@ describe('rewriteTutorialLinks remark plugin', () => {
 		expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
 	})
 
+	test('Links to `/` are not rewritten', async () => {
+		const input = '[home page](/)'
+		const contentsWithoutPlugin = await remark().process(input)
+
+		const contentsWithPlugin = await remark()
+			.use(rewriteTutorialLinksPlugin)
+			.process(input)
+
+		expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
+	})
+
 	describe('Links to .io home pages are not rewritten', () => {
 		const testInputs: string[] = productSlugs.map((productSlug: string) => {
 			const dotIoHostname = productSlugsToHostNames[productSlug]

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 import remark from 'remark'
 import { rewriteTutorialLinksPlugin } from 'lib/remark-plugins/rewrite-tutorial-links'
-import { productSlugs } from 'lib/products'
+import { productSlugs, productSlugsToHostNames } from 'lib/products'
 
 // HELPERS ------------------------------------------------------
 
@@ -106,6 +106,21 @@ describe('rewriteTutorialLinks remark plugin', () => {
 			.process(TEST_MD_LINKS.nonLearnLink)
 
 		expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
+	})
+
+	describe('Links to .io home pages are not rewritten', () => {
+		const testInputs: string[] = productSlugs.map((productSlug: string) => {
+			const dotIoHostname = productSlugsToHostNames[productSlug]
+			return `[${productSlug} .io home page](https://${dotIoHostname}/)`
+		})
+
+		test.each(testInputs)('%s', async (testInput: string) => {
+			const contentsWithoutPlugin = await remark().process(testInput)
+			const contentsWithPlugin = await remark()
+				.use(rewriteTutorialLinksPlugin)
+				.process(testInput)
+			expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
+		})
 	})
 
 	test("Local anchor links aren't rewritten", async () => {

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-docs-link.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/rewrite-external-docs-link.ts
@@ -12,11 +12,11 @@ import { getIsRewriteableDocsLink } from './get-is-rewriteable-docs-link'
  *
  * Examples:
  *
- *   https://vaultproject.io/												--> /vault
+ *   https://vaultproject.io/												--> https://vaultproject.io/
  *   https://vaultproject.io/api										--> /vault/api-docs
  *   https://vaultproject.io/api/index.html					--> /waypoint/api-docs
  *   https://waypointproject.io/community						--> undefined
- *   https://waypointproject.io/										-->	/waypoint
+ *   https://waypointproject.io/										-->	https://waypointproject.io/
  *   https://waypointproject.io/docs								-->	/waypoint/docs
  *   https://waypointproject.io/docs/some-doc.html	--> /waypoint/docs/some-doc
  *   https://waypointproject.io/community						--> undefined
@@ -48,10 +48,10 @@ export function rewriteExternalDocsLink(urlObject: URL) {
 	) as ProductSlug
 
 	/**
-	 * If there is no `basePath`, then rewrite link to the product's landing page.
+	 * If there is no `basePath`, it's a .io home page and do *not* rewrite.
 	 */
 	if (basePath === '') {
-		return `/${productSlug}${search}${hash}`
+		return urlObject.toString()
 	}
 
 	/**

--- a/src/views/docs-view/__tests__/multiple-remark-plugins.test.ts
+++ b/src/views/docs-view/__tests__/multiple-remark-plugins.test.ts
@@ -41,8 +41,12 @@ describe('multiple remark plugins', () => {
 
 		testEachCase(productUrlAdjuster, [
 			{
+				input: '/',
+				expected: 'https://waypointproject.io/',
+			},
+			{
 				input: 'https://waypointproject.io/',
-				expected: '/waypoint',
+				expected: 'https://waypointproject.io/',
 			},
 			{
 				input: '/waypoint',

--- a/src/views/docs-view/__tests__/multiple-remark-plugins.test.ts
+++ b/src/views/docs-view/__tests__/multiple-remark-plugins.test.ts
@@ -42,7 +42,7 @@ describe('multiple remark plugins', () => {
 		testEachCase(productUrlAdjuster, [
 			{
 				input: '/',
-				expected: 'https://waypointproject.io/',
+				expected: '/',
 			},
 			{
 				input: 'https://waypointproject.io/',

--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -69,12 +69,14 @@ describe('rewriteDocsUrl', () => {
 
 			// Test `rewriteDocsUrl` for each product data object
 			describe(`under ${productSlug} content`, () => {
-				// build up test cases array
+				test('does not rewrite `/`', () => {
+					expect(rewriteDocsUrl('/', productData)).toBe('/')
+				})
+
+				// build up other test cases array
 				const testCases = hostnames.map((dotIoHostName: string) => {
 					const url = `https://${dotIoHostName}`
-					const input = { productData, url }
-					const expected = url
-					return { input, expected }
+					return { input: { productData, url }, expected: url }
 				})
 
 				// execute each test

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -111,6 +111,12 @@ export function rewriteDocsUrl(
 		return inputUrl
 	}
 
+	// If it goes to the home page (`/`), return the inputUrl unmodified
+	const urlObject = new URL(inputUrl, 'https://developer.hashicorp.com')
+	if (urlObject.pathname === '/') {
+		return inputUrl
+	}
+
 	// Prefix docs URLs. "/docs/some-path" becomes "/waypoint/docs/some-path"
 	const isCurrentProductDocsUrl = currentProduct.basePaths.some(
 		(basePath: string) => inputUrl.startsWith(`/${basePath}`)


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1202114367927919/1203750517664204/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds test cases for both `rewriteTutorialLinksPlugin`- and `remarkPluginAdjustLinkUrls`- related logic to:
  - not rewrite .io home page links
  - also not rewrite `/` links (which were previously rewritten to .io home page links by `rewriteDocsUrl`)
- Updates the logic to no longer rewrite .io home page links to developer product landing pages

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

To retain the marketing abilities that come with linking to .io home pages
