### PR TITLE
[link format checker] Adding check for VERCEL_URL

### DIFF
--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -13,9 +13,6 @@ on:
       commit-sha:
         required: true
         type: string
-      vercel-url:
-        required: true
-        type: string
       mdx-directory:
         required: true
         type: string
@@ -30,8 +27,18 @@ jobs:
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
-      VERCEL_URL: '${{ inputs.vercel-url }}'
     steps:
+      - name: Get target_url hostname
+        id: get-target-url-hostname
+        uses: actions/github-script@v6
+        env:
+          DEPLOYMENT_STATUS_TARGET_URL: ${{ github.event.deployment_status.target_url }}
+        with:
+          script: |
+            const { DEPLOYMENT_STATUS_TARGET_URL } = process.env
+            const { hostname } = new URL(DEPLOYMENT_STATUS_TARGET_URL)
+            return hostname
+
       - name: Get PR number
         id: get-pr-number
         uses: actions/github-script@v6
@@ -118,6 +125,7 @@ jobs:
       - name: Run rewrite-docs-content-links script
         id: run-rewrite-docs-content-links-script
         env:
+          VERCEL_URL: ${{ steps.get-target-url-hostname.outputs.result }}
           MDX_FILE_PATH_PREFIX: 'content-repo/${{ inputs.mdx-directory }}'
           NAV_DATA_FILE_PATH_PREFIX: 'content-repo/${{ inputs.nav-data-directory }}'
           RELEVANT_CHANGED_FILES: ${{ steps.get-lists-of-pr-files.outputs.result }}

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -125,9 +125,8 @@ jobs:
       - name: Run rewrite-docs-content-links script
         id: run-rewrite-docs-content-links-script
         env:
-          VERCEL_URL: ${{ steps.get-target-url-hostname.outputs.result }}
           MDX_FILE_PATH_PREFIX: 'content-repo/${{ inputs.mdx-directory }}'
           NAV_DATA_FILE_PATH_PREFIX: 'content-repo/${{ inputs.nav-data-directory }}'
           RELEVANT_CHANGED_FILES: ${{ steps.get-lists-of-pr-files.outputs.result }}
           ERROR_IF_LINKS_TO_REWRITE: 'true'
-        run: npm run rewrite-docs-content-links
+        run: VERCEL_URL=${{ steps.get-target-url-hostname.outputs.result }} npm run rewrite-docs-content-links

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -13,6 +13,9 @@ on:
       commit-sha:
         required: true
         type: string
+      vercel-url:
+        required: true
+        type: string
       mdx-directory:
         required: true
         type: string
@@ -27,12 +30,8 @@ jobs:
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
-      VERCEL_URL: '${{ github.event.deployment_status.target_url }}'
+      VERCEL_URL: ${{ inputs.vercel-url }}
     steps:
-      - name: Fail workflow if no "github.event.deployment_status.target_url"
-        shell: bash
-        run: if [ "$VERCEL_URL" == "" ]; then exit 1; fi
-
       - name: Get PR number
         id: get-pr-number
         uses: actions/github-script@v6

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -30,7 +30,7 @@ jobs:
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
-      VERCEL_URL: ${{ inputs.vercel-url }}
+      VERCEL_URL: '${{ inputs.vercel-url }}'
     steps:
       - name: Get PR number
         id: get-pr-number

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -27,7 +27,12 @@ jobs:
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
+      VERCEL_URL: ${{ github.event.deployment_status.target_url }}
     steps:
+      - name: Fail workflow if no "github.event.deployment_status.target_url"
+        shell: bash
+        run: if [ "$VERCEL_URL" == "" ]; then exit 1; fi
+
       - name: Get PR number
         id: get-pr-number
         uses: actions/github-script@v6

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -27,7 +27,7 @@ jobs:
       OWNER: ${{ inputs.repo-owner }}
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
-      VERCEL_URL: ${{ github.event.deployment_status.target_url }}
+      VERCEL_URL: '${{ github.event.deployment_status.target_url }}'
     steps:
       - name: Fail workflow if no "github.event.deployment_status.target_url"
         shell: bash

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -9,7 +9,6 @@ export async function getTutorialMap() {
 	const baseUrl = process.env.VERCEL_URL
 		? `https://${process.env.VERCEL_URL}`
 		: 'http://localhost:3000'
-	console.log('[getTutorialMap] baseUrl:', baseUrl)
 	const apiRoute = new URL('api/tutorials-map', baseUrl)
 
 	/**

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -5,10 +5,17 @@ import { withTiming } from 'lib/with-timing'
 
 export async function getTutorialMap() {
 	let result = {}
+
+	// Set `baseUrl`, allowing VERCEL_URL to be a full URL or just a hostname
+	const { VERCEL_URL } = process.env
+	let baseUrl = 'http://localhost:3000'
+	if (VERCEL_URL) {
+		baseUrl = VERCEL_URL.startsWith('http')
+			? VERCEL_URL
+			: `https://${VERCEL_URL}`
+	}
+
 	const isDuringBuild = process.env.VERCEL && process.env.CI
-	const baseUrl = process.env.VERCEL_URL
-		? `https://${process.env.VERCEL_URL}`
-		: 'http://localhost:3000'
 	const apiRoute = new URL('api/tutorials-map', baseUrl)
 
 	/**

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -1,7 +1,10 @@
+import path from 'path'
 import fetch from 'node-fetch'
 import moize, { Options } from 'moize'
 import { generateTutorialMap } from 'pages/api/tutorials-map'
 import { withTiming } from 'lib/with-timing'
+
+const API_PATH = 'api/tutorials-map'
 
 export async function getTutorialMap() {
 	let result = {}
@@ -16,7 +19,7 @@ export async function getTutorialMap() {
 	}
 
 	const isDuringBuild = process.env.VERCEL && process.env.CI
-	const apiRoute = new URL('api/tutorials-map', baseUrl)
+	const apiRoute = path.join(baseUrl, API_PATH)
 
 	/**
 	 * For statically generated pages, we can cache the tutorial

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -1,25 +1,15 @@
-import path from 'path'
 import fetch from 'node-fetch'
 import moize, { Options } from 'moize'
 import { generateTutorialMap } from 'pages/api/tutorials-map'
 import { withTiming } from 'lib/with-timing'
 
-const API_PATH = 'api/tutorials-map'
-
 export async function getTutorialMap() {
 	let result = {}
-
-	// Set `baseUrl`, allowing VERCEL_URL to be a full URL or just a hostname
-	const { VERCEL_URL } = process.env
-	let baseUrl = 'http://localhost:3000'
-	if (VERCEL_URL) {
-		baseUrl = VERCEL_URL.startsWith('http')
-			? VERCEL_URL
-			: `https://${VERCEL_URL}`
-	}
-
 	const isDuringBuild = process.env.VERCEL && process.env.CI
-	const apiRoute = path.join(baseUrl, API_PATH)
+	const baseUrl = process.env.VERCEL_URL
+		? `https://${process.env.VERCEL_URL}`
+		: 'http://localhost:3000'
+	const apiRoute = new URL('api/tutorials-map', baseUrl)
 
 	/**
 	 * For statically generated pages, we can cache the tutorial

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -9,6 +9,7 @@ export async function getTutorialMap() {
 	const baseUrl = process.env.VERCEL_URL
 		? `https://${process.env.VERCEL_URL}`
 		: 'http://localhost:3000'
+	console.log('[getTutorialMap] baseUrl:', baseUrl)
 	const apiRoute = new URL('api/tutorials-map', baseUrl)
 
 	/**


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `"Get target_url hostname"` step to pull `hostname` from `github.event.deployment_status.target_url`
- Updates `.github/workflows/docs-content-check-legacy-links-format.yml` workflow to set `VERCEL_URL` inline when it runs `npm run rewrite-docs-content-links`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Since refactoring the link rewrite script in https://github.com/hashicorp/dev-portal/pull/1525, the script calls `getTutorialMap` which relies on a VERCEL_URL, or defaults the baseUrl for the api endpoint to `http://localhost:3000`. The latest runs for this workflow aren't setting VERCEL_URL, so the default is being used. Since no local server is running, an error happens when trying to fetch the tutorial map.

## 🧪 Testing

- [ ] Go to the test run of this workflow in HCP: https://github.com/hashicorp/cloud.hashicorp.com/actions/runs/3990754564/jobs/6844770507
- [ ] The run should no longer error with `ECONNREFUSED`
  - It's OK if the workflow fails because old link formats were detected

## 💭 Anything else?

Once this PR is merged, I will update the workflows that call this one to:

- Be triggered with `on: [deployment_status]`
- Only run the job `if: github.event.deployment_status.state == 'success'`
- Have the latest commit hash in the `uses` line
