### PR TITLE
[docs-content-check-legacy-links-format] Skip steps if no PR number found; set VERCEL_URL to prod

### DIFF
--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -38,9 +38,15 @@ jobs:
               repo: process.env.REPO,
               commit_sha: process.env.COMMIT_SHA
             })
-            return data[0].number
+            const prNumber = data && data[0] && data[0].number
+            if (prNumber) {
+              return prNumber
+            } else {
+              return false
+            }
 
       - name: Get list of PR files
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         id: get-lists-of-pr-files
         uses: actions/github-script@v6
         env:
@@ -98,20 +104,24 @@ jobs:
             return result
 
       - name: Checkout dev-portal
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         uses: actions/checkout@v3
         with:
           repository: 'hashicorp/dev-portal'
 
       - name: Install dev-portal dependencies
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         run: npm ci
 
       - name: Check out branch with content changes
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         uses: actions/checkout@v3
         with:
           path: 'content-repo'
           repository: '${{ inputs.repo-owner }}/${{ inputs.repo-name }}'
 
       - name: Get target_url hostname
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         id: get-target-url-hostname
         uses: actions/github-script@v6
         env:
@@ -123,6 +133,7 @@ jobs:
             return hostname
 
       - name: Run rewrite-docs-content-links script
+        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         id: run-rewrite-docs-content-links-script
         env:
           MDX_FILE_PATH_PREFIX: 'content-repo/${{ inputs.mdx-directory }}'

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -120,18 +120,6 @@ jobs:
           path: 'content-repo'
           repository: '${{ inputs.repo-owner }}/${{ inputs.repo-name }}'
 
-      - name: Get target_url hostname
-        if: ${{ steps.get-pr-number.outputs.result != 'false' }}
-        id: get-target-url-hostname
-        uses: actions/github-script@v6
-        env:
-          DEPLOYMENT_STATUS_TARGET_URL: ${{ github.event.deployment_status.target_url }}
-        with:
-          script: |
-            const { DEPLOYMENT_STATUS_TARGET_URL } = process.env
-            const { hostname } = new URL(DEPLOYMENT_STATUS_TARGET_URL)
-            return hostname
-
       - name: Run rewrite-docs-content-links script
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         id: run-rewrite-docs-content-links-script
@@ -140,4 +128,4 @@ jobs:
           NAV_DATA_FILE_PATH_PREFIX: 'content-repo/${{ inputs.nav-data-directory }}'
           RELEVANT_CHANGED_FILES: ${{ steps.get-lists-of-pr-files.outputs.result }}
           ERROR_IF_LINKS_TO_REWRITE: 'true'
-        run: VERCEL_URL=${{ steps.get-target-url-hostname.outputs.result }} npm run rewrite-docs-content-links
+        run: VERCEL_URL="developer.hashicorp.com" npm run rewrite-docs-content-links

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -28,17 +28,6 @@ jobs:
       REPO: ${{ inputs.repo-name }}
       COMMIT_SHA: ${{ inputs.commit-sha }}
     steps:
-      - name: Get target_url hostname
-        id: get-target-url-hostname
-        uses: actions/github-script@v6
-        env:
-          DEPLOYMENT_STATUS_TARGET_URL: ${{ github.event.deployment_status.target_url }}
-        with:
-          script: |
-            const { DEPLOYMENT_STATUS_TARGET_URL } = process.env
-            const { hostname } = new URL(DEPLOYMENT_STATUS_TARGET_URL)
-            return hostname
-
       - name: Get PR number
         id: get-pr-number
         uses: actions/github-script@v6
@@ -121,6 +110,17 @@ jobs:
         with:
           path: 'content-repo'
           repository: '${{ inputs.repo-owner }}/${{ inputs.repo-name }}'
+
+      - name: Get target_url hostname
+        id: get-target-url-hostname
+        uses: actions/github-script@v6
+        env:
+          DEPLOYMENT_STATUS_TARGET_URL: ${{ github.event.deployment_status.target_url }}
+        with:
+          script: |
+            const { DEPLOYMENT_STATUS_TARGET_URL } = process.env
+            const { hostname } = new URL(DEPLOYMENT_STATUS_TARGET_URL)
+            return hostname
 
       - name: Run rewrite-docs-content-links script
         id: run-rewrite-docs-content-links-script

--- a/.github/workflows/docs-content-link-rewrites-e2e.yml
+++ b/.github/workflows/docs-content-link-rewrites-e2e.yml
@@ -45,7 +45,7 @@ jobs:
               repo: process.env.REPO,
               commit_sha: process.env.COMMIT_SHA
             })
-            return data && data[0].head.ref === "docs/amb.migrate-link-formats"
+            return data && data[0]?.head?.ref === "docs/amb.migrate-link-formats"
 
       - name: Check out dev-portal repo
         uses: actions/checkout@v3

--- a/.github/workflows/docs-content-link-rewrites-e2e.yml
+++ b/.github/workflows/docs-content-link-rewrites-e2e.yml
@@ -45,7 +45,7 @@ jobs:
               repo: process.env.REPO,
               commit_sha: process.env.COMMIT_SHA
             })
-            return data && data[0]?.head?.ref === "docs/amb.migrate-link-formats"
+            return data && data[0].head.ref === "docs/amb.migrate-link-formats"
 
       - name: Check out dev-portal repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## 🗒️ What/Why

<!--
Briefly list out the changes proposed in this PR.
-->

- Replaces the `get-target-url-hostname` step with a hardcoded value for `VERCEL_URL` in the `run-rewrite-docs-content-links-script` step
- Changes the return value of `get-pr-number` when no PR is found to `false`
- Updates all subsequent steps to `get-pr-number` to only run if the return value was not false, so the workflow doesn't fail if a commit has been pushed up but does not have an associated PR yet

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Testing with [hashicorp/cloud.hashicorp.com#593](https://github.com/hashicorp/cloud.hashicorp.com/pull/593):

- [ ] See that the steps are skipped in this workflow run because no PR number was found: [cloud.hashicorp.com run #118](https://github.com/hashicorp/cloud.hashicorp.com/actions/runs/3991278846/jobs/6845904473)
- [ ] See that the `"Run rewrite-docs-content-links script"` step is successful and passes the right value for VERCEL_URL in this run: [cloud.hashicorp.com run #119](https://github.com/hashicorp/cloud.hashicorp.com/actions/runs/3991293595/jobs/6845939853#step:7:1)
