### PR TITLE
Deterministically sort the Tier filters

### DIFF
--- a/src/views/product-integrations-landing/contexts/integrations-search-context.tsx
+++ b/src/views/product-integrations-landing/contexts/integrations-search-context.tsx
@@ -1,13 +1,13 @@
 import {
-	Integration,
-	Tier,
-	IntegrationComponent,
 	Flag,
+	Integration,
+	IntegrationComponent,
+	Tier,
 } from 'lib/integrations-api-client/integration'
 import { createContext, useContext, useMemo } from 'react'
-import { useQueryParam, QueryParamOptions, withDefault } from 'use-query-params'
+import { QueryParamOptions, useQueryParam, withDefault } from 'use-query-params'
 
-import { encodeDelimitedArray, decodeDelimitedArray } from 'use-query-params'
+import { decodeDelimitedArray, encodeDelimitedArray } from 'use-query-params'
 
 /**
  * Uses a comma to delimit entries. e.g. ['a', 'b'] => qp?=a,b
@@ -162,12 +162,8 @@ export const IntegrationsSearchProvider: React.FC<Props> = ({
 	// are no community integrations passed, we simply won't display
 	// that checkbox.
 	const tierOptions = Array.from(
-		new Set(
-			integrations.map((i: Integration) => {
-				return i.tier
-			})
-		)
-	).sort((a, b) => {
+		new Set(integrations.map((i: Integration) => i.tier))
+	).sort((a: Tier, b: Tier) => {
 		if (tierSortVal(a) > tierSortVal(b)) {
 			return 1
 		} else if (tierSortVal(a) < tierSortVal(b)) {

--- a/src/views/product-integrations-landing/contexts/integrations-search-context.tsx
+++ b/src/views/product-integrations-landing/contexts/integrations-search-context.tsx
@@ -143,13 +143,39 @@ export const IntegrationsSearchProvider: React.FC<Props> = ({
 
 	let filteredIntegrations = integrations
 
+	// The logical sort ordering of the Tiers
+	const tierSortVal = (tier: string): number => {
+		console.log(tier)
+		switch (tier) {
+			case Tier.OFFICIAL:
+				return 1
+			case Tier.PARTNER:
+				return 2
+			case Tier.COMMUNITY:
+			default:
+				return 3
+		}
+	}
+
 	// Figure out the list of tiers we want to display as filters
 	// based off of the integrations list that we are passed. If there
 	// are no community integrations passed, we simply won't display
 	// that checkbox.
 	const tierOptions = Array.from(
-		new Set(integrations.map((i: Integration) => i.tier))
-	)
+		new Set(
+			integrations.map((i: Integration) => {
+				return i.tier
+			})
+		)
+	).sort((a, b) => {
+		if (tierSortVal(a) > tierSortVal(b)) {
+			return 1
+		} else if (tierSortVal(a) < tierSortVal(b)) {
+			return -1
+		} else {
+			return 0
+		}
+	})
 
 	// Calculate the number of integrations that match each tier
 	const matchingOfficial = integrations.filter(


### PR DESCRIPTION
Tiers were being sorted arbitrarily depending on what the state of the data was.  Sort this deterministically; Official > Partner > Community.

[🎟️ Asana Ticket](https://app.asana.com/0/1203792610600085/1203793680296866)
[🔍 Preview](https://dev-portal-git-brtier-ordering-hashicorp.vercel.app/vault/integrations)