### PR TITLE
Adding LandingPageBlocks component, abstracting components from /${productSlug}/docs views

### DIFF
--- a/src/components/callout-card/index.tsx
+++ b/src/components/callout-card/index.tsx
@@ -87,5 +87,6 @@ function CalloutCard({
 	)
 }
 
+export type { CalloutCardProps }
 export { CalloutCard }
 export default CalloutCard

--- a/src/components/card/components/index.ts
+++ b/src/components/card/components/index.ts
@@ -1,9 +1,10 @@
-import CardDescription from './card-description'
+import CardDescription, { CardDescriptionProps } from './card-description'
 import CardEyebrow, { CardEyebrowText } from './card-eyebrow'
 import CardFooter from './card-footer'
 import CardLogo from './card-logo'
-import CardTitle from './card-title'
+import CardTitle, { CardTitleProps } from './card-title'
 
+export type { CardDescriptionProps, CardTitleProps }
 export {
 	CardDescription,
 	CardEyebrow,

--- a/src/components/icon-card-link-grid-list/index.tsx
+++ b/src/components/icon-card-link-grid-list/index.tsx
@@ -1,6 +1,6 @@
 import CardsGridList from 'components/cards-grid-list'
 import IconCardLink from 'components/icon-card-link'
-import { IconCardLinkGridListProps, IconCard } from './types'
+import { IconCardLinkGridListProps, IconCardLinkGridListCard } from './types'
 
 function IconCardLinkGridList({
 	cards,
@@ -10,7 +10,7 @@ function IconCardLinkGridList({
 }: IconCardLinkGridListProps) {
 	return (
 		<CardsGridList gridGap={gridGap} fixedColumns={fixedColumns}>
-			{cards.map((iconCard: IconCard, key: number) => {
+			{cards.map((iconCard: IconCardLinkGridListCard, key: number) => {
 				return (
 					<IconCardLink
 						// eslint-disable-next-line react/no-array-index-key
@@ -26,5 +26,5 @@ function IconCardLinkGridList({
 	)
 }
 
-export type { IconCardLinkGridListProps }
+export type { IconCardLinkGridListProps, IconCardLinkGridListCard }
 export default IconCardLinkGridList

--- a/src/components/icon-card-link-grid-list/types.ts
+++ b/src/components/icon-card-link-grid-list/types.ts
@@ -2,13 +2,13 @@ import { CardsGridListProps } from 'components/cards-grid-list'
 import { IconCardLinkProps } from 'components/icon-card-link'
 import { ProductSlug } from 'types/products'
 
-export type IconCard = Pick<
+export type IconCardLinkGridListCard = Pick<
 	IconCardLinkProps,
 	'icon' | 'productSlug' | 'text' | 'url'
 >
 
 export interface IconCardLinkGridListProps
 	extends Pick<CardsGridListProps, 'gridGap' | 'fixedColumns'> {
-	cards: IconCard[]
+	cards: IconCardLinkGridListCard[]
 	productSlug?: ProductSlug
 }

--- a/src/components/landing-page-blocks/components/autosized-heading-block/autosized-heading-block.module.css
+++ b/src/components/landing-page-blocks/components/autosized-heading-block/autosized-heading-block.module.css
@@ -1,0 +1,12 @@
+.root {
+	composes: g-offset-scroll-margin-top from global;
+	color: var(--token-color-foreground-strong);
+
+	&.h2 {
+		margin-bottom: 24px;
+	}
+
+	&.h3 {
+		margin-bottom: 4px;
+	}
+}

--- a/src/components/landing-page-blocks/components/autosized-heading-block/index.tsx
+++ b/src/components/landing-page-blocks/components/autosized-heading-block/index.tsx
@@ -1,0 +1,32 @@
+import classNames from 'classnames'
+import Heading, { HeadingProps } from 'components/heading'
+import { AutosizedHeadingBlockProps } from './types'
+import s from './autosized-heading-block.module.css'
+
+const AutosizedHeadingBlock = ({
+	className,
+	id,
+	level,
+	text,
+}: AutosizedHeadingBlockProps) => {
+	const levelsToSize = {
+		2: 400,
+		3: 300,
+	}
+	const classes = classNames(s.root, s[`h${level}`], className)
+
+	return (
+		<Heading
+			className={classes}
+			id={id}
+			level={level}
+			size={levelsToSize[level] as HeadingProps['size']}
+			weight="bold"
+		>
+			{text}
+		</Heading>
+	)
+}
+
+export type { AutosizedHeadingBlockProps }
+export { AutosizedHeadingBlock }

--- a/src/components/landing-page-blocks/components/autosized-heading-block/types.ts
+++ b/src/components/landing-page-blocks/components/autosized-heading-block/types.ts
@@ -1,0 +1,8 @@
+interface AutosizedHeadingBlockProps {
+	className?: string
+	id: string
+	level: 2 | 3
+	text: string
+}
+
+export type { AutosizedHeadingBlockProps }

--- a/src/components/landing-page-blocks/components/callout-card-block/index.tsx
+++ b/src/components/landing-page-blocks/components/callout-card-block/index.tsx
@@ -1,0 +1,21 @@
+import CalloutCard from 'components/callout-card'
+import { CalloutCardBlockProps } from './types'
+
+const CalloutCardBlock = ({
+	body,
+	ctas,
+	heading,
+	headingSlug,
+}: CalloutCardBlockProps) => {
+	return (
+		<CalloutCard
+			body={body}
+			ctas={ctas}
+			heading={heading}
+			headingSlug={headingSlug}
+		/>
+	)
+}
+
+export type { CalloutCardBlockProps }
+export { CalloutCardBlock }

--- a/src/components/landing-page-blocks/components/callout-card-block/types.ts
+++ b/src/components/landing-page-blocks/components/callout-card-block/types.ts
@@ -1,0 +1,5 @@
+import { CalloutCardProps } from 'components/callout-card'
+
+type CalloutCardBlockProps = CalloutCardProps
+
+export type { CalloutCardBlockProps }

--- a/src/components/landing-page-blocks/components/card-grid-block/card-grid-block.module.css
+++ b/src/components/landing-page-blocks/components/card-grid-block/card-grid-block.module.css
@@ -1,0 +1,12 @@
+.root {
+	margin-bottom: 48px;
+}
+
+.description {
+	color: var(--token-color-foreground-primary);
+	margin-bottom: 16px;
+}
+
+.cardsGridListCardLink {
+	height: 100%;
+}

--- a/src/components/landing-page-blocks/components/card-grid-block/index.tsx
+++ b/src/components/landing-page-blocks/components/card-grid-block/index.tsx
@@ -1,0 +1,51 @@
+import { CardTitle, CardDescription } from 'components/card/components'
+import CardLink from 'components/card-link'
+import CardsGridList from 'components/cards-grid-list'
+import Text from 'components/text'
+import { AutosizedHeadingBlock } from '..'
+import { CardGridBlockCard, CardGridBlockProps } from './types'
+import s from './card-grid-block.module.css'
+
+const CardGridBlock = ({
+	cards,
+	description,
+	title,
+	headingId,
+	headingLevel,
+}: CardGridBlockProps) => {
+	const hasTitle = Boolean(title)
+	const hasDescription = Boolean(description)
+
+	return (
+		<div className={s.root}>
+			{hasTitle && (
+				<AutosizedHeadingBlock
+					level={headingLevel}
+					id={headingId}
+					text={title}
+				/>
+			)}
+			{hasDescription && (
+				<Text className={s.description} size={300} weight="regular">
+					{description}
+				</Text>
+			)}
+			<CardsGridList>
+				{cards.map(({ description, title, url }: CardGridBlockCard) => (
+					<CardLink
+						key={url}
+						ariaLabel={title}
+						className={s.cardsGridListCardLink}
+						href={url}
+					>
+						<CardTitle text={title} />
+						<CardDescription text={description} />
+					</CardLink>
+				))}
+			</CardsGridList>
+		</div>
+	)
+}
+
+export type { CardGridBlockCard, CardGridBlockProps }
+export { CardGridBlock }

--- a/src/components/landing-page-blocks/components/card-grid-block/types.ts
+++ b/src/components/landing-page-blocks/components/card-grid-block/types.ts
@@ -1,0 +1,21 @@
+import {
+	CardTitleProps,
+	CardDescriptionProps,
+} from 'components/card/components'
+import { AutosizedHeadingBlockProps } from '..'
+
+interface CardGridBlockCard {
+	description: CardDescriptionProps['text']
+	title: CardTitleProps['text']
+	url: string
+}
+
+interface CardGridBlockProps {
+	cards: CardGridBlockCard[]
+	description: string
+	title: AutosizedHeadingBlockProps['text']
+	headingId: AutosizedHeadingBlockProps['id']
+	headingLevel: AutosizedHeadingBlockProps['level']
+}
+
+export type { CardGridBlockCard, CardGridBlockProps }

--- a/src/components/landing-page-blocks/components/icon-card-grid-block/index.tsx
+++ b/src/components/landing-page-blocks/components/icon-card-grid-block/index.tsx
@@ -1,0 +1,19 @@
+import { SUPPORTED_ICONS } from 'content/supported-icons'
+import IconCardLinkGridList from 'components/icon-card-link-grid-list'
+import { IconCardGridBlockCard, IconCardGridBlockProps } from './types'
+
+const IconCardGridBlock = ({ cards, productSlug }: IconCardGridBlockProps) => {
+	return (
+		<IconCardLinkGridList
+			cards={cards.map(({ iconName, text, url }: IconCardGridBlockCard) => ({
+				icon: SUPPORTED_ICONS[iconName],
+				text,
+				url,
+			}))}
+			productSlug={productSlug}
+		/>
+	)
+}
+
+export type { IconCardGridBlockCard, IconCardGridBlockProps }
+export { IconCardGridBlock }

--- a/src/components/landing-page-blocks/components/icon-card-grid-block/types.ts
+++ b/src/components/landing-page-blocks/components/icon-card-grid-block/types.ts
@@ -1,0 +1,16 @@
+import { ProductSlug } from 'types/products'
+import { SUPPORTED_ICONS } from 'content/supported-icons'
+import { IconCardLinkGridListCard } from 'components/icon-card-link-grid-list'
+
+interface IconCardGridBlockCard {
+	iconName: keyof typeof SUPPORTED_ICONS
+	text: IconCardLinkGridListCard['text']
+	url: IconCardLinkGridListCard['url']
+}
+
+interface IconCardGridBlockProps {
+	cards: IconCardGridBlockCard[]
+	productSlug: ProductSlug
+}
+
+export type { IconCardGridBlockCard, IconCardGridBlockProps }

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,0 +1,1 @@
+export * from './paragraph-block'

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,1 +1,2 @@
+export * from './autosized-heading-block'
 export * from './paragraph-block'

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,3 +1,4 @@
 export * from './autosized-heading-block'
+export * from './icon-card-grid-block'
 export * from './paragraph-block'
 export * from './section-heading-block'

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,2 +1,3 @@
 export * from './autosized-heading-block'
 export * from './paragraph-block'
+export * from './section-heading-block'

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,4 +1,5 @@
 export * from './autosized-heading-block'
+export * from './callout-card-block'
 export * from './card-grid-block'
 export * from './icon-card-grid-block'
 export * from './paragraph-block'

--- a/src/components/landing-page-blocks/components/index.ts
+++ b/src/components/landing-page-blocks/components/index.ts
@@ -1,4 +1,5 @@
 export * from './autosized-heading-block'
+export * from './card-grid-block'
 export * from './icon-card-grid-block'
 export * from './paragraph-block'
 export * from './section-heading-block'

--- a/src/components/landing-page-blocks/components/paragraph-block/index.tsx
+++ b/src/components/landing-page-blocks/components/paragraph-block/index.tsx
@@ -1,0 +1,10 @@
+import { MDXRemote } from 'next-mdx-remote'
+import { MdxA, MdxP } from 'components/dev-dot-content/mdx-components'
+import { ParagraphBlockProps } from './types'
+
+const ParagraphBlock = ({ mdxSource }: ParagraphBlockProps) => {
+	return <MDXRemote {...mdxSource} components={{ a: MdxA, p: MdxP }} />
+}
+
+export type { ParagraphBlockProps }
+export { ParagraphBlock }

--- a/src/components/landing-page-blocks/components/paragraph-block/types.ts
+++ b/src/components/landing-page-blocks/components/paragraph-block/types.ts
@@ -1,0 +1,7 @@
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+
+interface ParagraphBlockProps {
+	mdxSource: MDXRemoteSerializeResult
+}
+
+export type { ParagraphBlockProps }

--- a/src/components/landing-page-blocks/components/section-heading-block/index.tsx
+++ b/src/components/landing-page-blocks/components/section-heading-block/index.tsx
@@ -1,0 +1,17 @@
+import { AutosizedHeadingBlock } from '../autosized-heading-block'
+import { SectionHeadingBlockProps } from './types'
+import s from './section-heading-block.module.css'
+
+const SectionHeadingBlock = ({ level, id, text }: SectionHeadingBlockProps) => {
+	return (
+		<AutosizedHeadingBlock
+			className={s.root}
+			id={id}
+			level={level}
+			text={text}
+		/>
+	)
+}
+
+export type { SectionHeadingBlockProps }
+export { SectionHeadingBlock }

--- a/src/components/landing-page-blocks/components/section-heading-block/section-heading-block.module.css
+++ b/src/components/landing-page-blocks/components/section-heading-block/section-heading-block.module.css
@@ -1,0 +1,7 @@
+.root {
+	margin-top: 48px;
+
+	&:first-child {
+		margin-top: 0;
+	}
+}

--- a/src/components/landing-page-blocks/components/section-heading-block/types.ts
+++ b/src/components/landing-page-blocks/components/section-heading-block/types.ts
@@ -1,0 +1,9 @@
+import { AutosizedHeadingBlockProps } from '../autosized-heading-block'
+
+interface SectionHeadingBlockProps {
+	level: AutosizedHeadingBlockProps['level']
+	id: AutosizedHeadingBlockProps['id']
+	text: AutosizedHeadingBlockProps['text']
+}
+
+export type { SectionHeadingBlockProps }

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,0 +1,7 @@
+import { ParagraphBlock } from './components'
+
+const LandingPageBlocks = () => null
+
+export default Object.assign(LandingPageBlocks, {
+	ParagraphBlock,
+})

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,5 +1,6 @@
 import {
 	AutosizedHeadingBlock,
+	CardGridBlock,
 	IconCardGridBlock,
 	ParagraphBlock,
 	SectionHeadingBlock,
@@ -9,6 +10,7 @@ const LandingPageBlocks = () => null
 
 export default Object.assign(LandingPageBlocks, {
 	AutosizedHeadingBlock,
+	CardGridBlock,
 	IconCardGridBlock,
 	ParagraphBlock,
 	SectionHeadingBlock,

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,5 +1,6 @@
 import {
 	AutosizedHeadingBlock,
+	CalloutCardBlock,
 	CardGridBlock,
 	IconCardGridBlock,
 	ParagraphBlock,
@@ -10,6 +11,7 @@ const LandingPageBlocks = () => null
 
 export default Object.assign(LandingPageBlocks, {
 	AutosizedHeadingBlock,
+	CalloutCardBlock,
 	CardGridBlock,
 	IconCardGridBlock,
 	ParagraphBlock,

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,5 +1,6 @@
 import {
 	AutosizedHeadingBlock,
+	IconCardGridBlock,
 	ParagraphBlock,
 	SectionHeadingBlock,
 } from './components'
@@ -8,6 +9,7 @@ const LandingPageBlocks = () => null
 
 export default Object.assign(LandingPageBlocks, {
 	AutosizedHeadingBlock,
+	IconCardGridBlock,
 	ParagraphBlock,
 	SectionHeadingBlock,
 })

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,8 +1,13 @@
-import { AutosizedHeadingBlock, ParagraphBlock } from './components'
+import {
+	AutosizedHeadingBlock,
+	ParagraphBlock,
+	SectionHeadingBlock,
+} from './components'
 
 const LandingPageBlocks = () => null
 
 export default Object.assign(LandingPageBlocks, {
 	AutosizedHeadingBlock,
 	ParagraphBlock,
+	SectionHeadingBlock,
 })

--- a/src/components/landing-page-blocks/index.tsx
+++ b/src/components/landing-page-blocks/index.tsx
@@ -1,7 +1,8 @@
-import { ParagraphBlock } from './components'
+import { AutosizedHeadingBlock, ParagraphBlock } from './components'
 
 const LandingPageBlocks = () => null
 
 export default Object.assign(LandingPageBlocks, {
+	AutosizedHeadingBlock,
 	ParagraphBlock,
 })

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -3,7 +3,6 @@ import slugify from 'slugify'
 
 // Global imports
 import { useCurrentProduct } from 'contexts'
-import CalloutCard from 'components/callout-card'
 import LandingPageBlocks from 'components/landing-page-blocks'
 
 // Local imports
@@ -58,11 +57,11 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 
 				if (block.type === 'getting-started-card') {
 					return (
-						<CalloutCard
-							heading={GETTING_STARTED_CARD_HEADING}
-							headingSlug={GETTING_STARTED_CARD_HEADING_SLUG}
+						<LandingPageBlocks.CalloutCardBlock
 							body={block.description}
 							ctas={[block.callToAction]}
+							heading={GETTING_STARTED_CARD_HEADING}
+							headingSlug={GETTING_STARTED_CARD_HEADING_SLUG}
 							key={index}
 						/>
 					)

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -12,10 +12,10 @@ import CardsGridList from 'components/cards-grid-list'
 import Heading, { HeadingProps } from 'components/heading'
 import IconCardLinkGridList from 'components/icon-card-link-grid-list'
 import Text from 'components/text'
+import LandingPageBlocks from 'components/landing-page-blocks'
 
 // Local imports
 import s from './marketing-content.module.css'
-import { ParagraphBlock } from '../paragraph-block'
 
 const GETTING_STARTED_CARD_HEADING = 'Getting Started'
 const GETTING_STARTED_CARD_HEADING_SLUG = slugify(GETTING_STARTED_CARD_HEADING)
@@ -125,7 +125,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 		<div className={s.root}>
 			{blocks.map((block, index) => {
 				if (block.type === 'paragraph') {
-					return <ParagraphBlock {...block} key={index} />
+					return <LandingPageBlocks.ParagraphBlock {...block} key={index} />
 				}
 
 				if (block.type === 'section-heading') {

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -2,13 +2,11 @@
 import slugify from 'slugify'
 
 // Global imports
-import { SUPPORTED_ICONS } from 'content/supported-icons'
 import { useCurrentProduct } from 'contexts'
 import CalloutCard from 'components/callout-card'
 import { CardDescription, CardTitle } from 'components/card/components'
 import CardLink from 'components/card-link'
 import CardsGridList from 'components/cards-grid-list'
-import IconCardLinkGridList from 'components/icon-card-link-grid-list'
 import Text from 'components/text'
 import LandingPageBlocks from 'components/landing-page-blocks'
 
@@ -17,22 +15,6 @@ import s from './marketing-content.module.css'
 
 const GETTING_STARTED_CARD_HEADING = 'Getting Started'
 const GETTING_STARTED_CARD_HEADING_SLUG = slugify(GETTING_STARTED_CARD_HEADING)
-
-/**
- * @TODO move to a different folder/file & document
- */
-const IconCardGrid = ({ cards, productSlug }) => {
-	return (
-		<IconCardLinkGridList
-			cards={cards.map(({ iconName, text, url }) => ({
-				icon: SUPPORTED_ICONS[iconName],
-				text,
-				url,
-			}))}
-			productSlug={productSlug}
-		/>
-	)
-}
 
 /**
  * @TODO move to a different folder/file & document
@@ -95,7 +77,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 
 				if (block.type === 'icon-card-grid') {
 					return (
-						<IconCardGrid
+						<LandingPageBlocks.IconCardGridBlock
 							cards={block.cards}
 							productSlug={currentProduct.slug}
 							key={index}

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -1,5 +1,4 @@
 // Third-party imports
-import classNames from 'classnames'
 import slugify from 'slugify'
 
 // Global imports
@@ -9,7 +8,6 @@ import CalloutCard from 'components/callout-card'
 import { CardDescription, CardTitle } from 'components/card/components'
 import CardLink from 'components/card-link'
 import CardsGridList from 'components/cards-grid-list'
-import Heading, { HeadingProps } from 'components/heading'
 import IconCardLinkGridList from 'components/icon-card-link-grid-list'
 import Text from 'components/text'
 import LandingPageBlocks from 'components/landing-page-blocks'
@@ -22,44 +20,10 @@ const GETTING_STARTED_CARD_HEADING_SLUG = slugify(GETTING_STARTED_CARD_HEADING)
 
 /**
  * @TODO move to a different folder/file & document
- * @TODO make Heading have default size instead of this abstraction?
- */
-const AutosizedHeading = ({
-	className,
-	id,
-	level,
-	text,
-}: {
-	className?: string
-	id: string
-	level: 2 | 3
-	text: string
-}) => {
-	const levelsToSize = {
-		2: 400,
-		3: 300,
-	}
-	const classes = classNames(s.heading, s[`h${level}`], className)
-
-	return (
-		<Heading
-			className={classes}
-			id={id}
-			level={level}
-			size={levelsToSize[level] as HeadingProps['size']}
-			weight="bold"
-		>
-			{text}
-		</Heading>
-	)
-}
-
-/**
- * @TODO move to a different folder/file & document
  */
 const SectionHeading = ({ level, id, text }) => {
 	return (
-		<AutosizedHeading
+		<LandingPageBlocks.AutosizedHeadingBlock
 			className={s.sectionHeading}
 			id={id}
 			level={level}
@@ -67,7 +31,6 @@ const SectionHeading = ({ level, id, text }) => {
 		/>
 	)
 }
-
 /**
  * @TODO move to a different folder/file & document
  */
@@ -94,7 +57,11 @@ const CardGrid = ({ cards, description, title, headingId, headingLevel }) => {
 	return (
 		<div className={s.cardGridWrapper}>
 			{hasTitle && (
-				<AutosizedHeading level={headingLevel} id={headingId} text={title} />
+				<LandingPageBlocks.AutosizedHeadingBlock
+					level={headingLevel}
+					id={headingId}
+					text={title}
+				/>
 			)}
 			{hasDescription && (
 				<Text className={s.cardGridDescription} size={300} weight="regular">

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -4,10 +4,6 @@ import slugify from 'slugify'
 // Global imports
 import { useCurrentProduct } from 'contexts'
 import CalloutCard from 'components/callout-card'
-import { CardDescription, CardTitle } from 'components/card/components'
-import CardLink from 'components/card-link'
-import CardsGridList from 'components/cards-grid-list'
-import Text from 'components/text'
 import LandingPageBlocks from 'components/landing-page-blocks'
 
 // Local imports
@@ -15,44 +11,6 @@ import s from './marketing-content.module.css'
 
 const GETTING_STARTED_CARD_HEADING = 'Getting Started'
 const GETTING_STARTED_CARD_HEADING_SLUG = slugify(GETTING_STARTED_CARD_HEADING)
-
-/**
- * @TODO move to a different folder/file & document
- */
-const CardGrid = ({ cards, description, title, headingId, headingLevel }) => {
-	const hasTitle = Boolean(title)
-	const hasDescription = Boolean(description)
-
-	return (
-		<div className={s.cardGridWrapper}>
-			{hasTitle && (
-				<LandingPageBlocks.AutosizedHeadingBlock
-					level={headingLevel}
-					id={headingId}
-					text={title}
-				/>
-			)}
-			{hasDescription && (
-				<Text className={s.cardGridDescription} size={300} weight="regular">
-					{description}
-				</Text>
-			)}
-			<CardsGridList>
-				{cards.map(({ description, title, url }) => (
-					<CardLink
-						key={url}
-						ariaLabel={title}
-						className={s.cardGridCard}
-						href={url}
-					>
-						<CardTitle text={title} />
-						<CardDescription text={description} />
-					</CardLink>
-				))}
-			</CardsGridList>
-		</div>
-	)
-}
 
 const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 	const currentProduct = useCurrentProduct()
@@ -87,7 +45,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 
 				if (block.type === 'card-grid') {
 					return (
-						<CardGrid
+						<LandingPageBlocks.CardGridBlock
 							cards={block.cards}
 							description={block.description}
 							headingLevel={block.headingLevel}

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -21,19 +21,6 @@ const GETTING_STARTED_CARD_HEADING_SLUG = slugify(GETTING_STARTED_CARD_HEADING)
 /**
  * @TODO move to a different folder/file & document
  */
-const SectionHeading = ({ level, id, text }) => {
-	return (
-		<LandingPageBlocks.AutosizedHeadingBlock
-			className={s.sectionHeading}
-			id={id}
-			level={level}
-			text={text}
-		/>
-	)
-}
-/**
- * @TODO move to a different folder/file & document
- */
 const IconCardGrid = ({ cards, productSlug }) => {
 	return (
 		<IconCardLinkGridList
@@ -97,7 +84,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 
 				if (block.type === 'section-heading') {
 					return (
-						<SectionHeading
+						<LandingPageBlocks.SectionHeadingBlock
 							id={block.headingId}
 							level={block.headingLevel}
 							text={block.title}

--- a/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
@@ -1,31 +1,3 @@
 .root {
 	margin-top: 32px;
 }
-
-/*
-***
-* Classes used in the "card-grid" block.
-***
-*/
-
-.cardGridWrapper {
-	margin-bottom: 48px;
-}
-
-.cardGridDescription {
-	color: var(--token-color-foreground-primary);
-	margin-bottom: 16px;
-}
-
-.cardGridCard {
-	height: 100%;
-}
-
-.cardGridCardTitle {
-	color: var(--token-color-foreground-strong);
-}
-
-.cardGridCardDescription {
-	color: var(--token-color-foreground-faint);
-	margin-top: 4px;
-}

--- a/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
@@ -8,19 +8,6 @@
 ***
 */
 
-.heading {
-	composes: g-offset-scroll-margin-top from global;
-	color: var(--token-color-foreground-strong);
-
-	&.h2 {
-		margin-bottom: 24px;
-	}
-
-	&.h3 {
-		margin-bottom: 4px;
-	}
-}
-
 .sectionHeading {
 	margin-top: 48px;
 

--- a/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/marketing-content.module.css
@@ -4,20 +4,6 @@
 
 /*
 ***
-* Classes for styling Heading elements
-***
-*/
-
-.sectionHeading {
-	margin-top: 48px;
-
-	&:first-child {
-		margin-top: 0;
-	}
-}
-
-/*
-***
 * Classes used in the "card-grid" block.
 ***
 */


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203820004767055/f) 🎟️ 

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Abstracts the marketing content block components used in `src/views/product-root-docs-path-landing/components/marketing-content/index.tsx` into a new, reusable `LandingPageBlocks` module/component that lives in `src/components`:
  - `AutosizedHeadingBlock`
  - `CalloutCardBlock`
  - `CardGridBlock`
  - `IconCardGridBlock`
  - `ParagraphBlock`
  - `SectionHeadingBlock`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This is the first step in consolidating the authoring interfaces (JSON files in `src/content`) & components used on our three main landing pages for consistency and lower engineering maintenance

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

The following pages should be unchanged compared to prod:

| Page slug | Preview | Prod |
| - | - | - |
| `/hcp/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/hcp/docs) | [prod url](https://developer.hashicorp.com/hcp/docs) |
| `/terraform/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/terraform/docs) | [prod url](https://developer.hashicorp.com/terraform/docs) |
| `/packer/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/packer/docs) | [prod url](https://developer.hashicorp.com/packer/docs) |
| `/consul/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/consul/docs) | [prod url](https://developer.hashicorp.com/consul/docs) |
| `/vault/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/vault/docs) | [prod url](https://developer.hashicorp.com/vault/docs) |
| `/boundary/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/boundary/docs) | [prod url](https://developer.hashicorp.com/boundary/docs) |
| `/nomad/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/nomad/docs) | [prod url](https://developer.hashicorp.com/nomad/docs) |
| `/waypoint/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/waypoint/docs) | [prod url](https://developer.hashicorp.com/waypoint/docs) |
| `/vagrant/docs` | [preview url](https://dev-portal-git-ambadd-lpb-component-hashicorp.vercel.app/vagrant/docs) | [prod url](https://developer.hashicorp.com/vagrant/docs) |

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- Next up: abstracting components from the blocks from `/${productSlug}` landing pages and/or reusing some components abstracted in this PR
- In a few PRs: documentation will be added for `LandingPageBlocks`. Waiting to fully document until its subcomponents list is more complete and their names are stable.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203820004767057
  