### PR TITLE
Fix duplicate product name in title

### DIFF
--- a/src/pages/[productSlug]/integrations/index.tsx
+++ b/src/pages/[productSlug]/integrations/index.tsx
@@ -95,7 +95,7 @@ export async function getServerSideProps({
 	return {
 		props: {
 			metadata: {
-				title: `Integrations | ${product.name}`,
+				title: `Integrations`,
 				// description: `TODO`,
 			},
 			product,


### PR DESCRIPTION
### Before
<img width="243" alt="CleanShot 2023-01-24 at 14 47 23@2x" src="https://user-images.githubusercontent.com/2105067/214438297-0f6c46e0-8b7b-475a-85ba-1cebd7a81a50.png">

### After

<img width="240" alt="CleanShot 2023-01-24 at 14 47 02@2x" src="https://user-images.githubusercontent.com/2105067/214438289-b58b73d9-a13e-4ebf-aa61-1171bdf9a695.png">





- 🎟️ [Duplicated "Vault" in page Title](https://app.asana.com/0/1203792610600085/1203812301614400)