### PR TITLE
[Pagination] Fix cross-browser font sizing

### DIFF
--- a/src/components/pagination/pagination.module.css
+++ b/src/components/pagination/pagination.module.css
@@ -64,6 +64,8 @@
 
 .control {
 	composes: g-focus-ring-from-box-shadow from global;
+	composes: hds-typography-body-100 from global;
+	appearance: none; /* "reset" some user stylesheet styles */
 	color: inherit;
 	border-radius: 5px;
 	font-weight: var(--token-typography-font-weight-medium);


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1203792701577283/1203752857375375/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the differing font sizes cross browser with `appearance: none` and an explicit font size setting

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] View the "Basic" Swingset example in Safari and Chrome: [/swingset/components/pagination](https://dev-portal-git-ambfix-pagination-font-safari-hashicorp.vercel.app/swingset/components/pagination)
- [ ] The font size should not differ between browsers
