### PR TITLE
feat: add vscode config for cssVariables extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"csstools.postcss",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
-		"stylelint.vscode-stylelint"
+		"stylelint.vscode-stylelint",
+		"vunguyentuan.vscode-css-variables"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,12 @@
 	"eslint.codeActionsOnSave.rules": ["curly"],
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
-	}
+	},
+	"cssVariables.lookupFiles": [
+		"**/*.css",
+		"node_modules/@hashicorp/mktg-global-styles/style.css",
+		"node_modules/@hashicorp/design-system-tokens/dist/devdot/css/tokens.css",
+		"node_modules/@hashicorp/design-system-tokens/dist/devdot/css/helpers/elevation.css",
+		"node_modules/@hashicorp/design-system-tokens/dist/devdot/css/helpers/typography.css"
+	]
 }


### PR DESCRIPTION
## 🗒️ What

This adds local `.vscode` config for the `vunguyentuan.vscode-css-variables` extension
- https://marketplace.visualstudio.com/items?itemName=vunguyentuan.vscode-css-variables

This enables intellisense/cmd-click'ing to see definitions of variables definite in various `@hashicorp` node_modules


https://user-images.githubusercontent.com/26389321/214897986-7145a391-ae87-4e74-b754-72b10a83bf3e.mp4


## 🤷 Why

Improved DX for anyone using the `vunguyentuan.vscode-css-variables` extension!

