### PR TITLE
Adding role=status on results count text

### DIFF
--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -75,7 +75,11 @@ export default function SearchableVariableGroupList({
 					</div>
 				) : null}
 			</div>
-			<p className={s.results}>
+			{/**
+			 * Technique ARIA22: Using role=status to present status messages
+			 * https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22
+			 */}
+			<p className={s.results} role="status">
 				{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
 			</p>
 			<VariableGroupList variables={matchesWithAncestors} />

--- a/src/views/product-integrations-landing/components/searchable-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/searchable-integrations-list/index.tsx
@@ -270,10 +270,13 @@ export default function SearchableIntegrationsList({
 							})}
 						</DropdownDisclosure>
 					</div>
-					<span className={classNames(s.results, s.tablet_up)}>
+					{/**
+					 * Technique ARIA22: Using role=status to present status messages
+					 * https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22
+					 */}
+					<span className={classNames(s.results, s.tablet_up)} role="status">
 						{resultText}
 					</span>
-
 					{/* mobile_only */}
 					<div className={classNames(s.row, s.mobile_only)}>
 						<Button


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambresults-aria-live-hashicorp.vercel.app/vault/integrations) 🔎
- [Asana task](https://app.asana.com/0/1203792610600085/1203776130786803/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `role="status"` to:
  - the `<span>` that contains the "XX results found" text on `/${productSlug}/integrations`
  - the `<p>` that contains the "XX Results" text in `SearchableVariableGroupList`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This satisfies [SC 4.1.3: Status Messages (Level AA)](https://www.w3.org/WAI/WCAG22/Understanding/status-messages), to provide an update to AT users when the page state changes without moving browser focus from where it currently sits 

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- [Technique ARIA22: Using role=status to present status messages](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [`/vault/integrations`](https://dev-portal-git-ambresults-aria-live-hashicorp.vercel.app/vault/integrations) on the preview URL
- [ ] Enable VoiceOver (`cmd`+`F5`)
- [ ] Focus the filter `<input />` element
- [ ] Type 2 characters
- [ ] VoiceOver should announce "XX results found" where XX matches the value shown in the text
