### PR TITLE
feat: revise param and outputs to sections

### DIFF
--- a/src/components/filter-input/filter-input.module.css
+++ b/src/components/filter-input/filter-input.module.css
@@ -10,7 +10,6 @@
 	--input-padding: 8px;
 
 	height: var(--input-height);
-	margin-bottom: 16px;
 	position: relative;
 	display: flex;
 	align-items: center;

--- a/src/layouts/product-integration-layout/index.tsx
+++ b/src/layouts/product-integration-layout/index.tsx
@@ -5,7 +5,9 @@ import {
 	generateTopLevelSidebarNavData,
 } from 'components/sidebar/helpers'
 import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/components'
-import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import SidebarSidecarLayout, {
+	SidebarSidecarLayoutProps,
+} from 'layouts/sidebar-sidecar'
 import { Integration } from 'lib/integrations-api-client/integration'
 import { Release, ReleaseComponent } from 'lib/integrations-api-client/release'
 import {
@@ -29,6 +31,7 @@ interface ProductIntegrationLayoutProps {
 	// should be redirected to.
 	getVersionChangedURL: (version: string) => string
 	children: React.ReactNode
+	sidecarSlot?: SidebarSidecarLayoutProps['sidecarSlot']
 }
 
 /**
@@ -45,6 +48,7 @@ export default function ProductIntegrationLayout({
 	breadcrumbLinks,
 	getVersionChangedURL,
 	children,
+	sidecarSlot,
 }: ProductIntegrationLayoutProps) {
 	// Determine if we're on the latest version, as that will slightly adjust the URLs
 	const onLatestVersion = integration.versions[0] === activeRelease.version
@@ -107,9 +111,7 @@ export default function ProductIntegrationLayout({
 			// @ts-ignore
 			sidebarNavDataLevels={sidebarNavDataLevels}
 			breadcrumbLinks={breadcrumbLinks}
-			sidecarSlot={
-				<TryHcpCalloutSidecarPlacement productSlug={currentProduct.slug} />
-			}
+			sidecarSlot={sidecarSlot}
 		>
 			{!onLatestVersion && (
 				<HashiHead>

--- a/src/views/product-integration/component-view/components/mdx-heading-outside-mdx/index.tsx
+++ b/src/views/product-integration/component-view/components/mdx-heading-outside-mdx/index.tsx
@@ -1,0 +1,55 @@
+import {
+	MdxH1,
+	MdxH2,
+	MdxH3,
+	MdxH4,
+	MdxH5,
+	MdxH6,
+} from 'components/dev-dot-content/mdx-components'
+import MdxHeadingPermalink from 'components/dev-dot-content/mdx-components/mdx-heading-permalink'
+import { HeadingProps } from 'components/heading'
+
+/**
+ * Map from a heading level to a specific MDX heading component.
+ */
+const mdxHeadingMap: Record<
+	HeadingProps['level'],
+	(props: $TSFixMe) => JSX.Element
+> = {
+	1: MdxH1,
+	2: MdxH2,
+	3: MdxH3,
+	4: MdxH4,
+	5: MdxH5,
+	6: MdxH6,
+}
+
+/**
+ * Render a heading that matches how headings are rendered in MDX,
+ * including our MDX-style permalink component.
+ */
+export function MdxHeadingOutsideMdx({
+	id,
+	title,
+	level,
+}: {
+	id: string
+	title: string
+	level: HeadingProps['level']
+}) {
+	const Component = mdxHeadingMap[level]
+	return (
+		<Component id={id}>
+			<MdxHeadingPermalink
+				/* Note: the `__permalink-h` class is needed for correct hover styles,
+			   as our MdxHeadings use a `:global` selector that targets it.
+				 TODO: consider alternatives, eg parent selector or useHover hook. */
+				className="__permalink-h"
+				href={`#${id}`}
+				level={level}
+				ariaLabel={title}
+			/>
+			{title}
+		</Component>
+	)
+}

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -1,4 +1,5 @@
 import { IconSearch16 } from '@hashicorp/flight-icons/svg-react/search-16'
+import FilterInput from 'components/filter-input'
 import { CheckboxField } from 'components/form/field-controls'
 import { useState } from 'react'
 import { Variable, VariableGroupList } from '../variable-group-list'
@@ -60,10 +61,12 @@ export default function SearchableVariableGroupList({
 	return (
 		<div>
 			<div className={s.searchRow}>
-				<SearchBar
-					groupName={groupName}
-					searchQuery={searchQuery}
-					onChange={(e) => setSearchQuery(e.target.value)}
+				<FilterInput
+					className={s.filterInputMarginReset}
+					placeholder={`Search ${groupName}`}
+					value={searchQuery}
+					onChange={(value: string) => setSearchQuery(value)}
+					IconComponent={IconSearch16}
 				/>
 				{isRequiredRelevant ? (
 					<div className={s.checkboxContainer}>
@@ -79,20 +82,6 @@ export default function SearchableVariableGroupList({
 				{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
 			</p>
 			<VariableGroupList variables={matchesWithAncestors} />
-		</div>
-	)
-}
-
-function SearchBar({ groupName, searchQuery, onChange }) {
-	return (
-		<div className={s.searchBar}>
-			<IconSearch16 />
-			<input
-				type="text"
-				placeholder={`Search ${groupName}`}
-				value={searchQuery}
-				onChange={onChange}
-			/>
 		</div>
 	)
 }

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -62,7 +62,6 @@ export default function SearchableVariableGroupList({
 		<div>
 			<div className={s.searchRow}>
 				<FilterInput
-					className={s.filterInputMarginReset}
 					placeholder={`Search ${groupName}`}
 					value={searchQuery}
 					onChange={(value: string) => setSearchQuery(value)}

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/style.module.css
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/style.module.css
@@ -13,31 +13,11 @@
 	}
 }
 
-/* TODO: this is duplicated from searchable-integrations-list */
-.searchBar {
-	background-color: var(--white);
-	border-radius: 2px;
-	box-shadow: 0 0 0 1px var(--gray-5);
-	height: 45px;
-	position: relative;
-
-	& > svg {
-		position: absolute;
-		top: calc(50% - 10px);
-		left: 16px;
-		height: 20px;
-		width: auto;
-		color: var(--gray-3);
-		pointer-events: none;
-	}
-
-	& > input {
-		background-color: transparent;
-		border-width: 0;
-		width: 100%;
-		height: 100%;
-		padding-left: calc(16px * 2 + 20px);
-	}
+/* TODO: It might be ideal for anything in src/components to _not_ set
+   margin around the exported component. This way, in cases where the
+	 consumer's layout needs differ, a margin reset would not be necessary */
+.filterInputMarginReset {
+	margin-bottom: 0;
 }
 
 .results {

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/style.module.css
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/style.module.css
@@ -13,13 +13,6 @@
 	}
 }
 
-/* TODO: It might be ideal for anything in src/components to _not_ set
-   margin around the exported component. This way, in cases where the
-	 consumer's layout needs differ, a margin reset would not be necessary */
-.filterInputMarginReset {
-	margin-bottom: 0;
-}
-
 .results {
 	color: var(--gray-3);
 	font-size: 12px;

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -1,5 +1,5 @@
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
-import Tabs, { Tab } from 'components/tabs'
+import { MdxH2 } from 'components/dev-dot-content/mdx-components'
 import ProductIntegrationLayout from 'layouts/product-integration-layout'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import { getIntegrationComponentUrl } from 'lib/integrations'
@@ -59,34 +59,29 @@ export default function ProductIntegrationComponentView({
 			)}
 			{component.variable_groups.length ? (
 				<div className={s.variableGroups}>
-					<Tabs variant="compact">
-						{component.variable_groups.map((variableGroup: VariableGroup) => {
-							return (
-								<Tab
-									key={variableGroup.id}
-									heading={variableGroup.variable_group_config.name}
-								>
-									<SearchableVariableGroupList
-										groupName={variableGroup.variable_group_config.name}
-										variables={variableGroup.variables.map(
-											(variable: ApiVariable): Variable => {
-												return {
-													key: variable.key,
-													type: variable.type,
-													description: variable.description,
-													required: variable.required,
-												}
+					{component.variable_groups.map((variableGroup: VariableGroup) => {
+						return (
+							<div key={variableGroup.id}>
+								{/* Note: using MDX heading here to match adjacent content */}
+								<MdxH2>{variableGroup.variable_group_config.name}</MdxH2>
+								<SearchableVariableGroupList
+									groupName={variableGroup.variable_group_config.name}
+									variables={variableGroup.variables.map(
+										(variable: ApiVariable): Variable => {
+											return {
+												key: variable.key,
+												type: variable.type,
+												description: variable.description,
+												required: variable.required,
 											}
-										)}
-									/>
-								</Tab>
-							)
-						})}
-					</Tabs>
+										}
+									)}
+								/>
+							</div>
+						)
+					})}
 				</div>
-			) : (
-				<></>
-			)}
+			) : null}
 		</ProductIntegrationLayout>
 	)
 }

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -1,6 +1,10 @@
+import slugify from 'slugify'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
-import { MdxH2 } from 'components/dev-dot-content/mdx-components'
+import { MdxHeadingOutsideMdx } from './components/mdx-heading-outside-mdx'
 import ProductIntegrationLayout from 'layouts/product-integration-layout'
+import TableOfContents, {
+	TableOfContentsHeading,
+} from 'layouts/sidebar-sidecar/components/table-of-contents'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import { getIntegrationComponentUrl } from 'lib/integrations'
 import { Integration } from 'lib/integrations-api-client/integration'
@@ -33,6 +37,19 @@ export default function ProductIntegrationComponentView({
 	serializedREADME,
 	breadcrumbLinks,
 }: ProductIntegrationComponentViewProps) {
+	const { variable_groups } = component
+	/**
+	 * Build variable group headings, which are used for both
+	 * the table of contents and to render the headings themselves
+	 */
+	const variableGroupHeadings: TableOfContentsHeading[] = variable_groups.map(
+		(variableGroup: VariableGroup) => {
+			const title = variableGroup.variable_group_config.name
+			const slug = slugify(title, { lower: true })
+			return { title: title, slug: slug, level: 2 }
+		}
+	)
+
 	return (
 		<ProductIntegrationLayout
 			className={s.integrationComponentView}
@@ -46,6 +63,7 @@ export default function ProductIntegrationComponentView({
 					version === integration.versions[0] ? 'latest' : version
 				return getIntegrationComponentUrl(integration, component, versionString)
 			}}
+			sidecarSlot={<TableOfContents headings={variableGroupHeadings} />}
 		>
 			{serializedREADME ? (
 				<div className={s.mdxWrapper}>
@@ -57,13 +75,19 @@ export default function ProductIntegrationComponentView({
 			) : (
 				<></>
 			)}
-			{component.variable_groups.length ? (
+			{variable_groups.length ? (
 				<div className={s.variableGroups}>
-					{component.variable_groups.map((variableGroup: VariableGroup) => {
+					{variable_groups.map((variableGroup: VariableGroup, idx: number) => {
+						const headingData = variableGroupHeadings[idx]
+
 						return (
 							<div key={variableGroup.id}>
 								{/* Note: using MDX heading here to match adjacent content */}
-								<MdxH2>{variableGroup.variable_group_config.name}</MdxH2>
+								<MdxHeadingOutsideMdx
+									id={headingData.slug}
+									title={headingData.title}
+									level={headingData.level}
+								/>
 								<SearchableVariableGroupList
 									groupName={variableGroup.variable_group_config.name}
 									variables={variableGroup.variables.map(

--- a/src/views/product-integration/readme-view/index.tsx
+++ b/src/views/product-integration/readme-view/index.tsx
@@ -1,4 +1,5 @@
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
+import { TryHcpCalloutSidecarPlacement } from 'components/try-hcp-callout/components'
 import ProductIntegrationLayout from 'layouts/product-integration-layout'
 import defaultMdxComponents from 'layouts/sidebar-sidecar/utils/_local_platform-docs-mdx'
 import { getIntegrationUrl } from 'lib/integrations'
@@ -37,6 +38,7 @@ export default function ProductIntegrationReadmeView({
 					? getIntegrationUrl(integration)
 					: getIntegrationUrl(integration, version)
 			}}
+			sidecarSlot={<TryHcpCalloutSidecarPlacement productSlug={product.slug} />}
 		>
 			<MDXRemote {...serializedREADME} components={defaultMdxComponents({})} />
 		</ProductIntegrationLayout>

--- a/src/views/product-integrations-landing/components/searchable-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/searchable-integrations-list/index.tsx
@@ -204,6 +204,7 @@ export default function SearchableIntegrationsList({
 		<div className={classNames(s.searchableIntegrationsList, className)}>
 			<div className={s.header}>
 				<FilterInput
+					className={s.filterInput}
 					IconComponent={IconSearch16}
 					value={filterQuery}
 					onChange={(v: string) => {

--- a/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
+++ b/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
@@ -46,6 +46,10 @@
 	}
 }
 
+.filterInput {
+	margin-bottom: 16px;
+}
+
 .selectStack {
 	display: flex;
 	flex-direction: row;

--- a/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
+++ b/src/views/product-integrations-landing/components/searchable-integrations-list/style.module.css
@@ -46,42 +46,6 @@
 	}
 }
 
-.searchBar {
-	background-color: var(--white);
-	border-radius: 2px;
-	box-shadow: 0 0 0 1px var(--gray-5);
-	height: 45px;
-	position: relative;
-	margin-bottom: 20px;
-
-	& > svg {
-		position: absolute;
-		top: calc(50% - 10px);
-		left: 16px;
-		height: 20px;
-		width: auto;
-		color: var(--gray-3);
-		pointer-events: none;
-	}
-
-	& > input {
-		background-color: transparent;
-		border-width: 0;
-		width: 100%;
-		height: 100%;
-		padding-left: calc(16px * 2 + 20px);
-	}
-}
-
-.filterBarInput {
-	appearance: none; /* "reset" some user stylesheet styles */
-	font-size: 1rem; /* TODO replace with real value */
-}
-
-.filterButton {
-	margin-top: 12px;
-}
-
 .selectStack {
 	display: flex;
 	flex-direction: row;

--- a/src/views/tutorial-library/tutorial-library.module.css
+++ b/src/views/tutorial-library/tutorial-library.module.css
@@ -10,7 +10,6 @@
 
 	& .input {
 		flex-grow: 1;
-		margin-bottom: 0;
 	}
 
 	@media (--dev-dot-tablet-down) {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana][task-destructure] 🎟️

## 🗒️ What

> **Note**: "variable groups" generally refers to Parameters and Outputs

On integration component views:

- Moves "variable groups" out of `Tabs` and into dedicated sections
- Updates the sidecar to show a table of contents linking to "variable groups"

## 🛠️ How

- Render "variable groups" as sections rather than `Tabs`
- Tangent fix: Update variables groups to use `FilterInput` for consistency
- Tangent chore: clean up some unused styles
- Tangent chore: remove margin from shared FilterInput component
- Refactor: slight refactor so `ProductIntegrationsLayout` can render more varied sidecar content, instead of always rendering a `TryHCPCallout` and nothing else
- Implement a table of contents for "variable groups" on component views

## 📸 Design Screenshots

🎨 [Figma file][figma]

| Design | Before | After |
| - | - | - |
| ![design](https://user-images.githubusercontent.com/4624598/215202052-5ed4be06-1f54-405a-9679-dae3769a886b.png) | ![before](https://user-images.githubusercontent.com/4624598/215202048-2594ace8-da3c-453f-aef0-404fb02f8fe0.png) | ![after](https://user-images.githubusercontent.com/4624598/215206199-50a6894b-e313-4f4f-bb99-7f6a4fdaa7a0.png) |

## 🧪 Testing

- [ ] Visit an integrations component page, such as [/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder][/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder]
    - Parameters and Outputs should now be in sections, headed by `h2` elements, rather than within `Tabs`
    - The `<h2 />` elements for Parameters and Outputs should be deep-linkable, showing a permalink icon on hover (similar to headings in MDX)
    - The sidecar should display a table of contents, with `Parameters` and `Outputs`
    - "Deep links" to variable groups, such as [/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder#outputs][/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder#outputs], should work as expected, jumping the page to the appropriate section

## 💭 Anything else?

> **Note**: this PR adds a table of contents that links to variable groups only. We do _not_ currently include headings from the readme contents itself. This would likely be worth splitting into a separate task, if it's something we want to implement. This might make sense to tackle around the same time as 🎟 [Ensure component params/outputs descriptions get remark-plugin processing](https://app.asana.com/0/1203792701577283/1203697277089836/f), as it'll be in roughly the same vein (we'll need our `remark` headings plugin to run on README contents, in order to extract headings for our table of contents).

[task-deeplink]: https://app.asana.com/0/1203792701577283/1203767402020112/f
[task-destructure]: https://app.asana.com/0/1202097197789424/1203703363880003/f
[figma]: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=17236%3A219695&t=kSTqRZPQfS1nH4HT-1
[preview]: https://dev-portal-git-zsparams-outputs-sections-hashicorp.vercel.app
[/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder]: https://dev-portal-git-zsparams-outputs-sections-hashicorp.vercel.app/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder
[/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder#outputs]: https://dev-portal-git-zsparams-outputs-sections-hashicorp.vercel.app/waypoint/integrations/BrandonRomano/aws-ami/latest/components/builder#outputs