### PR TITLE
[rewrite-links] Replace accidental returns with continues

### DIFF
--- a/scripts/docs-content-link-rewrites/helpers/get-mdx-links-to-rewrite.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-mdx-links-to-rewrite.ts
@@ -20,7 +20,7 @@ const getMdxLinksToRewrite = async ({
 	for (let i = 0; i < filePaths.length; i++) {
 		const filePath = filePaths[i]
 		if (!filePath.endsWith('.mdx')) {
-			return
+			continue
 		}
 
 		const filePathWithoutPrefix = filePath.replace(filePathPrefix, '')
@@ -36,7 +36,7 @@ const getMdxLinksToRewrite = async ({
 		 */
 		const isAtContentRoot = !currentPath.slice(1).includes('/')
 		if (isAtContentRoot) {
-			return
+			continue
 		}
 
 		const fileContent = fs.readFileSync(filePath, 'utf-8')


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Replaces 2 `return`s in a `for` loop with `continue`s

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- I've written so many loops like this with `.forEach` that I forgot `continue` is what you want when trying to skip an iteration 😅 🤣 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Check out this branch locally
- [ ] Run this script on the latest `main` under packer
- [ ] There should be 0 files to rewrite (as opposed to 1 identified in [a recent workflow run](https://github.com/hashicorp/packer/actions/runs/4027597813/jobs/6924059518#step:7:28))
