### PR TITLE
[rewrite-links] Fix script argument parsing for CI

### DIFF
--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -108,8 +108,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'hashicorp/dev-portal'
-          # TODO REMOVE BEFORE MERGING (just for testing script changes)
-          ref: 'amb.fix-script-arg-parsing'
 
       - name: Install dev-portal dependencies
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -108,6 +108,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'hashicorp/dev-portal'
+          # TODO REMOVE BEFORE MERGING (just for testing script changes)
+          ref: 'amb.fix-script-arg-parsing'
 
       - name: Install dev-portal dependencies
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}

--- a/scripts/docs-content-link-rewrites/helpers/get-rewrite-links-script-arguments.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-rewrite-links-script-arguments.ts
@@ -51,16 +51,20 @@ const getScriptArgumentsForCi = () => {
 		RELEVANT_CHANGED_FILES
 	)
 
+	// Concatenate cwd() with given file path prefixes
+	const mdxFilesPrefix = path.join(process.cwd(), MDX_FILE_PATH_PREFIX)
+	const navDataFilesPrefix = path.join(process.cwd(), NAV_DATA_FILE_PATH_PREFIX)
+
 	// Return the shaped-up arguments
 	return {
 		changedMdxFiles: changedMdxFiles.map((filePath) =>
-			path.join(process.cwd(), MDX_FILE_PATH_PREFIX, filePath)
+			path.join(mdxFilesPrefix, filePath)
 		),
 		changedNavDataJsonFiles: changedNavDataJsonFiles.map((filePath) =>
-			path.join(process.cwd(), NAV_DATA_FILE_PATH_PREFIX, filePath)
+			path.join(navDataFilesPrefix, filePath)
 		),
-		mdxFilesPrefix: MDX_FILE_PATH_PREFIX,
-		navDataFilesPrefix: NAV_DATA_FILE_PATH_PREFIX,
+		mdxFilesPrefix,
+		navDataFilesPrefix,
 		repo: REPO,
 	}
 }


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the `mdxFilesPrefix` and `navDataFilesPrefix` values returned by `getScriptArgumentsForCi`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- The script expects `mdxFilesPrefix` and `navDataFilesPrefix` to be full paths from the root of the machine that's running the script, and the values included periods in them to denote relative paths.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

- I ran the following locally (the `` and `` values are where the content lives local to my copy of `dev-portal`)

```
CI=1 REPO="packer" MDX_FILE_PATH_PREFIX="../content-repos/packer/website/content" NAV_DATA_FILE_PATH_PREFIX="../content-repos/packer/website/data" RELEVANT_CHANGED_FILES='{"changedMdxFiles":["/community-tools.mdx"],"changedNavDataJsonFiles":[]}' npx hc-tools ./scripts/docs-content-link-rewrites/rewrite-links.ts
```

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

I tested this locally, and "live" by:

- Temporarily passing a `ref` to the reuseable workflow's checkout of `dev-portal`
- [Opened a draft PR in packer](https://github.com/hashicorp/packer/pull/12230/files) to reference this branch's version of the workflow, and with a change to the file we've been seeing issues with
- Waited for the action to pass here: https://github.com/hashicorp/packer/actions/workflows/check-legacy-links-format.yml?query=branch%3Adocs%2Famb.test-workflow
