### PR TITLE
feat: anchor links for variables

### DIFF
--- a/src/components/dev-dot-content/mdx-components/mdx-heading-permalink/mdx-heading-permalink.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-heading-permalink/mdx-heading-permalink.module.css
@@ -24,7 +24,7 @@
 		}
 	}
 
-	&:focus {
+	&:focus-visible {
 		opacity: 1;
 		background: var(--token-color-surface-faint);
 

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -80,7 +80,10 @@ export default function SearchableVariableGroupList({
 			<p className={s.results}>
 				{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
 			</p>
-			<VariableGroupList variables={matchesWithAncestors} />
+			<VariableGroupList
+				groupName={groupName}
+				variables={matchesWithAncestors}
+			/>
 		</div>
 	)
 }

--- a/src/views/product-integration/component-view/components/variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/variable-group-list/index.tsx
@@ -1,7 +1,9 @@
 import { IconCornerDownRight16 } from '@hashicorp/flight-icons/svg-react/corner-down-right-16'
 import classNames from 'classnames'
 import Badge from 'components/badge'
+import MdxHeadingPermalink from 'components/dev-dot-content/mdx-components/mdx-heading-permalink'
 import ReactMarkdown from 'react-markdown'
+import { getVariableSlug } from '../../helpers'
 import s from './style.module.css'
 
 export interface Variable {
@@ -19,6 +21,7 @@ export interface VariableGroup {
 }
 
 export interface VariableGroupListProps {
+	groupName: string
 	variables: Array<Variable>
 	unflatten?: boolean // Users should never set this to false, needed for recursive nesting
 	isNested?: boolean
@@ -28,6 +31,7 @@ export function VariableGroupList({
 	variables,
 	unflatten = true,
 	isNested = false,
+	groupName,
 }: VariableGroupListProps) {
 	const vars: Array<Variable> = unflatten
 		? unflattenVariables(variables)
@@ -36,6 +40,10 @@ export function VariableGroupList({
 	return (
 		<ul className={s.variableGroupList}>
 			{vars.map((variable: Variable) => {
+				/**
+				 * Construct a permalink slug for this specific variable
+				 */
+				const permalinkId = getVariableSlug(groupName, variable.key)
 				return (
 					<li
 						key={variable.key}
@@ -53,7 +61,9 @@ export function VariableGroupList({
 						<div className={s.indentedContent}>
 							<div className={s.topRow}>
 								<span className={s.left}>
-									<code className={s.key}>{variable.key}</code>
+									<code id={permalinkId} className={s.key}>
+										{variable.key}
+									</code>
 									{variable.required != null && (
 										<span
 											className={classNames(s.required, {
@@ -63,6 +73,11 @@ export function VariableGroupList({
 											{variable.required ? 'Required' : 'Optional'}
 										</span>
 									)}
+									<MdxHeadingPermalink
+										className={s.permalink}
+										level={4}
+										href={`#${permalinkId}`}
+									/>
 								</span>
 								{variable.type ? (
 									<Badge
@@ -87,6 +102,7 @@ export function VariableGroupList({
 
 							{variable.variables?.length > 0 && (
 								<VariableGroupList
+									groupName={groupName}
 									unflatten={false}
 									variables={variable.variables}
 									isNested={true}

--- a/src/views/product-integration/component-view/components/variable-group-list/style.module.css
+++ b/src/views/product-integration/component-view/components/variable-group-list/style.module.css
@@ -39,15 +39,6 @@
 				align-items: center;
 			}
 
-			& .key {
-				border: 1px solid var(--token-color-border-primary);
-				border-radius: 5px;
-				padding: 2px 4px 3px;
-				background: var(--token-color-palette-neutral-50);
-				font-size: 16px;
-				color: var(--token-color-foreground-strong);
-			}
-
 			& .required {
 				font-size: 13px;
 				color: var(--token-color-foreground-faint);
@@ -88,5 +79,21 @@
 				}
 			}
 		}
+	}
+}
+
+.key {
+	composes: g-offset-scroll-margin-top from global;
+	border: 1px solid var(--token-color-border-primary);
+	border-radius: 5px;
+	padding: 2px 4px 3px;
+	background: var(--token-color-palette-neutral-50);
+	font-size: 16px;
+	color: var(--token-color-foreground-strong);
+}
+
+.permalink {
+	@nest .topRow:hover & {
+		opacity: 1;
 	}
 }

--- a/src/views/product-integration/component-view/helpers/index.ts
+++ b/src/views/product-integration/component-view/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './variable-group-slug-from-name'

--- a/src/views/product-integration/component-view/helpers/variable-group-slug-from-name.ts
+++ b/src/views/product-integration/component-view/helpers/variable-group-slug-from-name.ts
@@ -1,0 +1,19 @@
+import slugify from 'slugify'
+
+/**
+ * Return a slugified version of the provided variable group name
+ */
+export function getVariableGroupSlug(name: string) {
+	return slugify(name, { lower: true })
+}
+
+/**
+ * Given a unique variable group name, and a variable key,
+ * Return a slug identifier for the variable
+ */
+export function getVariableSlug(
+	groupName: string,
+	variableKey: string
+): string {
+	return `${getVariableGroupSlug(groupName)}.${variableKey}`.replace(/\./g, '-')
+}

--- a/src/views/product-integration/component-view/helpers/variable-group-slug-from-name.ts
+++ b/src/views/product-integration/component-view/helpers/variable-group-slug-from-name.ts
@@ -15,5 +15,5 @@ export function getVariableSlug(
 	groupName: string,
 	variableKey: string
 ): string {
-	return `${getVariableGroupSlug(groupName)}.${variableKey}`.replace(/\./g, '-')
+	return `${getVariableGroupSlug(groupName)}.${variableKey}`
 }

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -1,4 +1,3 @@
-import slugify from 'slugify'
 import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import { MdxHeadingOutsideMdx } from './components/mdx-heading-outside-mdx'
 import ProductIntegrationLayout from 'layouts/product-integration-layout'
@@ -18,6 +17,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { ProductData } from 'types/products'
 import SearchableVariableGroupList from './components/searchable-variable-group-list'
 import { Variable } from './components/variable-group-list'
+import { getVariableGroupSlug } from './helpers'
 import s from './style.module.css'
 
 export interface ProductIntegrationComponentViewProps {
@@ -44,9 +44,9 @@ export default function ProductIntegrationComponentView({
 	 */
 	const variableGroupHeadings: TableOfContentsHeading[] = variable_groups.map(
 		(variableGroup: VariableGroup) => {
-			const title = variableGroup.variable_group_config.name
-			const slug = slugify(title, { lower: true })
-			return { title: title, slug: slug, level: 2 }
+			const groupName = variableGroup.variable_group_config.name
+			const slug = getVariableGroupSlug(groupName)
+			return { title: groupName, slug, level: 2 }
 		}
 	)
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR implements permalinks for individual variables within variable groups. These variable groups appear on integrations component pages.

## 🛠️ How

- Generates an ID for each variable with the format `<groupSlug>.<variable.key>`
- Uses the shared `MdxHeadingPermalink` component to implement the link
- Tangent fix: uses focus-visible for mdx-heading-permalink, to prevent focus styles lingering after click

## 📸 Design Screenshots

🎨 [Figma][figma]

<img width="1419" alt="CleanShot 2023-01-30 at 12 03 16@2x" src="https://user-images.githubusercontent.com/4624598/215544471-3332befe-621b-4e92-aa02-efa2d059c37b.png">

## 🧪 Testing

- [ ] Visit a page that shows `VariableGroup`s, such as [/waypoint/integrations/BrandonRomano/aws-ecs/latest/components/platform][/waypoint/integrations/BrandonRomano/aws-ecs/latest/components/platform]
    - By default, everything should look as it did before
    - When hovering the name of any variable, or nested property, a "permalink" icon should appear directly after the variable key
    - When clicking the "permalink" icon, the page URL should change to include the permalink. As well, the page should jump to the correct anchor link position. The anchor link target should _not_ be hidden by the top nav.

## 💭 Anything else?

### On copy-to-clipboard

> **Note**: we also want to implement copying permalinks to the clipboard when they're clicked. It seems like this would not be an integrations specific change, and would be something we can ship immediately for other uses of `MdxHeadingPermalink`, so seems best to approach as a separate task and PR onto `main`. EDIT: made a task for this at 🎟 [Implement copy-to-clipboard for permalinks](https://app.asana.com/0/1202097197789424/1203859285380463/f)

### On permalink icon styling

> **Note**: existing styles for `MdxHeadingPermalink` differ slightly from what we have in the design spec. In the design spec, the icon is gray on hover of related content; and blue when hovered directly. In the existing implementation, the icon is blue on hover of related content; and a border is shown around the icon when hovered directly. Based on related feedback in [#1511 (comment)](https://github.com/hashicorp/dev-portal/pull/1511#issuecomment-1377907672), I think what we have in implementation is acceptable, and the intent is _not_ to update all instances of `MdxHeadingPermalink`, but rather to keep the existing implementation as-is.

[figma]: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=17788%3A228540&t=NWZ9acM6VzSB1Hwm-0
[task]: https://app.asana.com/0/1202097197789424/1203767402020112/f
[preview]: https://dev-portal-git-zsdeeplink-vars-hashicorp.vercel.app/
[/waypoint/integrations/BrandonRomano/aws-ecs/latest/components/platform]: https://dev-portal-git-zsdeeplink-vars-hashicorp.vercel.app/waypoint/integrations/BrandonRomano/aws-ecs/latest/components/platform
