### PR TITLE
fix: use narrow width for WAF

### DIFF
--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -52,6 +52,7 @@ export default function WellArchitectedFrameworkTutorialView({
 					headings={layoutProps.headings}
 					breadcrumbLinks={layoutProps.breadcrumbLinks}
 					sidebarNavDataLevels={layoutProps.navLevels}
+					mainWidth="narrow"
 				>
 					<TutorialMeta
 						heading={{ slug: slug, text: name }}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where the revised grid layout from #1412 was not applied to tutorial pages with [/well-architected-framework][/well-architected-framework] (WAF).

## 🧪 Testing

- [ ] Visit a WAF tutorial page, such as [/well-architected-framework/com/cloud-operating-model][/well-architected-framework/com/cloud-operating-model]
    - The main area content width should be slightly narrower, matching other tutorials pages, such as [/waypoint/tutorials/get-started-docker/get-started-intro][/waypoint/tutorials/get-started-docker/get-started-intro]

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202801212949828/1203848628599302/f
[preview]: https://dev-portal-git-zswaf-layout-tweak-hashicorp.vercel.app/
[/well-architected-framework]: https://dev-portal-git-zswaf-layout-tweak-hashicorp.vercel.app/well-architected-framework
[/well-architected-framework/com/cloud-operating-model]: https://dev-portal-git-zswaf-layout-tweak-hashicorp.vercel.app/well-architected-framework/com/cloud-operating-model
[/waypoint/tutorials/get-started-docker/get-started-intro]: https://dev-portal-git-zswaf-layout-tweak-hashicorp.vercel.app/waypoint/tutorials/get-started-docker/get-started-intro