### PR TITLE
refactor: use badges in tag list

### DIFF
--- a/src/layouts/product-integration-layout/components/header/index.tsx
+++ b/src/layouts/product-integration-layout/components/header/index.tsx
@@ -12,7 +12,7 @@ import TruncateMaxLines from 'components/truncate-max-lines'
 import { useDeviceSize } from 'contexts'
 import { Integration, Flag } from 'lib/integrations-api-client/integration'
 import { Release } from 'lib/integrations-api-client/release'
-import {
+import TagList, {
 	GetIntegrationTags,
 	Tag,
 } from 'views/product-integrations-landing/components/tag-list'
@@ -117,20 +117,7 @@ export default function Header({
 				) : null}
 			</div>
 			<div className={s.lower}>
-				<ul className={s.tagList}>
-					{tags.map((tag: Tag) => (
-						<li key={tag.name} className={s.tag}>
-							<Tooltip label={tag.description}>
-								<Badge
-									icon={tag.icon as React.ReactElement}
-									text={tag.name}
-									type="outlined"
-									size="small"
-								/>
-							</Tooltip>
-						</li>
-					))}
-				</ul>
+				<TagList tags={tags} type="outlined" />
 				{shouldShowInstallButton && (
 					<Button
 						size={isMobile ? 'medium' : 'small'}

--- a/src/layouts/product-integration-layout/components/header/style.module.css
+++ b/src/layouts/product-integration-layout/components/header/style.module.css
@@ -98,15 +98,3 @@
 		margin-top: 0;
 	}
 }
-
-.tagList {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	display: flex;
-}
-
-.tag {
-	margin-right: 8px;
-	line-height: 0;
-}

--- a/src/views/product-integrations-landing/components/integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/integrations-list/index.tsx
@@ -65,6 +65,7 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
 					<TagList
 						className={s.tagList}
 						tags={GetIntegrationTags(integration, false)}
+						size="medium"
 					/>
 					<span className={s.viewDetails}>
 						View Details

--- a/src/views/product-integrations-landing/components/tag-list/index.tsx
+++ b/src/views/product-integrations-landing/components/tag-list/index.tsx
@@ -5,6 +5,7 @@ import { IconHashicorp16 } from '@hashicorp/flight-icons/svg-react/hashicorp-16'
 import { IconRocket16 } from '@hashicorp/flight-icons/svg-react/rocket-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
 import classNames from 'classnames'
+import Badge, { BadgeProps } from 'components/badge'
 import Tooltip from 'components/tooltip'
 import {
 	Flag,
@@ -13,43 +14,32 @@ import {
 } from 'lib/integrations-api-client/integration'
 import s from './style.module.css'
 
-export type Size = 'small' | 'medium'
-
 export interface Tag {
 	name: string
-	icon?: React.ReactNode
+	icon?: React.ReactElement
 	description: string
 }
 
 interface TagListProps {
 	tags: Array<Tag>
 	className?: string
-	size?: Size
+	size?: BadgeProps['size']
+	type?: BadgeProps['type']
 }
-
-/**
- * @TODO refactor this to render a list of `Badge` components
- */
 
 export default function TagList({
 	tags,
 	className,
 	size = 'small',
+	type = 'filled',
 }: TagListProps) {
 	return (
-		<ul
-			className={classNames(s.tagList, className, {
-				[s.medium]: size === 'medium',
-			})}
-		>
+		<ul className={classNames(s.tagList, className)}>
 			{tags.map((tag: Tag) => {
 				return (
-					<li key={tag.name}>
+					<li key={tag.name} className={s.tag}>
 						<Tooltip label={tag.description}>
-							<div className={s.tagContent}>
-								{tag.icon && <span className={s.icon}>{tag.icon}</span>}
-								<span>{tag.name}</span>
-							</div>
+							<Badge icon={tag.icon} text={tag.name} type={type} size={size} />
 						</Tooltip>
 					</li>
 				)
@@ -94,7 +84,7 @@ export function GetIntegrationTags(
 	return [
 		...(tierFirst ? [tierTag] : []),
 		...integration.flags.map((flag: Flag) => {
-			let icon: React.ReactNode = undefined
+			let icon = undefined
 			switch (flag.slug) {
 				case 'builtin':
 					icon = <IconWrench16 />

--- a/src/views/product-integrations-landing/components/tag-list/style.module.css
+++ b/src/views/product-integrations-landing/components/tag-list/style.module.css
@@ -5,36 +5,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+}
 
-	& > li {
-		z-index: 1;
-
-		& .tagContent {
-			display: flex;
-			align-items: center;
-			background: var(--token-color-surface-strong);
-			border-radius: var(--token-form-control-border-radius);
-			padding: 4px 8px;
-			font-weight: var(--font-weight-medium);
-			font-size: 13px;
-			color: var(--token-color-foreground-primary);
-
-			& .icon {
-				display: flex;
-				margin-right: 4px;
-			}
-		}
-	}
-
-	&.medium {
-		gap: 10px;
-		& > li {
-			& .tagContent {
-				font-size: 16px;
-			}
-			& .icon {
-				margin-right: 6px;
-			}
-		}
-	}
+.tag {
+	z-index: 1;
+	line-height: 0;
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksrefactor-tag-list-hashicorp.vercel.app/waypoint/integrations) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1203841143367699) 🎟️

## 🗒️ What

This PR refactors the `TagList` component used in integrations landing pages to use the [`Badge` component](https://developer.hashicorp.com/swingset/components/badge) and updates the integration header to use the same component ([follow-up](https://github.com/hashicorp/dev-portal/pull/1574/files#diff-fd02c7c956695e4750e0e5fe224383932153a78535df653f9a947e09d8cd0b57R31)). 

## 🧪 Testing

- [Visit this page](https://dev-portal-git-ksrefactor-tag-list-hashicorp.vercel.app/waypoint/integrations), ensure the tag list renders as expected
- [Visit this page](https://dev-portal-git-ksrefactor-tag-list-hashicorp.vercel.app/waypoint/integrations/BrandonRomano/aws-ami), ensure the tag list hasn't changed. 

## 💭 Anything else?

- Is there a design spec somewhere so I can make sure these tag styles match? 
