### PR TITLE
patch: fix waf search links

### DIFF
--- a/src/components/command-bar/commands/search/components/tutorials-tab-contents/tutorial-hit.tsx
+++ b/src/components/command-bar/commands/search/components/tutorials-tab-contents/tutorial-hit.tsx
@@ -2,6 +2,7 @@ import { productSlugsToNames } from 'lib/products'
 import { ProductOption } from 'lib/learn-client/types'
 import { CommandBarLinkListItem } from 'components/command-bar/components'
 import { TutorialHitObject, TutorialHitProps } from './types'
+import { getTutorialSlug } from 'views/collection-view/helpers'
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
@@ -43,11 +44,7 @@ const TutorialHit = ({ hit }: TutorialHitProps) => {
 	const badges = products?.map(
 		(productSlug: ProductOption) => productSlugsToNames[productSlug]
 	)
-	const [productSlug, collectionSlug] = defaultContext.slug.split('/')
-	const [, tutorialSlug] = slug.split('/')
-	const resultUrl = `/${
-		productSlug === 'cloud' ? 'hcp' : productSlug
-	}/tutorials/${collectionSlug}/${tutorialSlug}`
+	const resultUrl = getTutorialSlug(slug, defaultContext.slug)
 
 	return (
 		<CommandBarLinkListItem


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-waf-search-link-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203869159927664) 🎟️

## 🗒️ What

Fixes an issue where waf search hits had '/tutorials' in the path. I refactored to use the `getTutorialSlug` function that should handle all edge case logic with waf. 

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksfix-waf-search-link-hashicorp.vercel.app), search for a waf tutorial, make sure the path resolves
- Test for other tutorial paths, make sure they resolve properly as well


