### PR TITLE
[rewrite-links.ts] Remove .slice that was used for testing

### DIFF
--- a/scripts/docs-content-link-rewrites/rewrite-links.ts
+++ b/scripts/docs-content-link-rewrites/rewrite-links.ts
@@ -53,7 +53,7 @@ const main = async () => {
 	if (mdxFilesWithLinksToRewrite.length > 0) {
 		// Throw an error if configured to, such as in a legacy link format checker
 		let message = `\n 🔴 Found MDX links to rewrite in ${mdxFilesWithLinksToRewrite.length} files:`
-		mdxFilesWithLinksToRewrite.slice(0, 5).forEach((file, index) => {
+		mdxFilesWithLinksToRewrite.forEach((file, index) => {
 			message += `\n\n  File #${index + 1}: "${file}"`
 
 			const linksForFile = mdxLinksToRewrite[file]


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes a `.slice` that was used to reduce the output of the `rewrite-links` script, for testing purposes while working on #1579
