### PR TITLE
chore: removes enableAuth flag

### DIFF
--- a/src/components/tutorial-card/helpers/with-auth-elements.tsx
+++ b/src/components/tutorial-card/helpers/with-auth-elements.tsx
@@ -1,5 +1,4 @@
 import { useTutorialProgress } from 'hooks/progress'
-import { useFlags } from 'flags/client'
 import { progressStatusToAriaLabel } from 'lib/learn-client/api/progress'
 import { TutorialProgressStatus } from 'lib/learn-client/types'
 import { TutorialCardBookmarkButton } from 'components/bookmark-button'
@@ -18,7 +17,6 @@ export function TutorialCardWithAuthElements({
 	BookmarkButtonComponent = TutorialCardBookmarkButton,
 	...restProps
 }: TutorialCardPropsWithId) {
-	const { flags } = useFlags()
 	/**
 	 * Get tutorial progress. Will be undefined if not authenticated.
 	 * Note as well that useTutorialProgress depends on AUTH_ENABLED.
@@ -55,12 +53,9 @@ export function TutorialCardWithAuthElements({
 					) : (
 						<CardEyebrowText>{restProps.duration}</CardEyebrowText>
 					)}
-					{/** Hide from prod until auth is enabled */}
-					{flags?.enableAuth ? (
-						<BookmarkButtonComponent
-							tutorial={{ id: tutorialId, name: restProps.heading }}
-						/>
-					) : null}
+					<BookmarkButtonComponent
+						tutorial={{ id: tutorialId, name: restProps.heading }}
+					/>
 				</>
 			}
 		/>

--- a/src/components/tutorial-card/index.test.tsx
+++ b/src/components/tutorial-card/index.test.tsx
@@ -12,12 +12,6 @@ const mockTutorialCardData = {
 	productsUsed: [],
 }
 
-jest.mock('flags/client', () => ({
-	flags: {
-		enableAuth: false,
-	},
-}))
-
 describe('Tutorial Card eyebrow slot', () => {
 	it('Shows base read time', () => {
 		const { queryByText } = render(<TutorialCard {...mockTutorialCardData} />)

--- a/src/flags/config.ts
+++ b/src/flags/config.ts
@@ -3,7 +3,6 @@ import type { Configuration } from '@happykit/flags/config'
 // You can replace this with your exact flag types
 export type AppFlags = {
 	[key: string]: boolean | number | string | null
-	enableAuth: boolean
 }
 
 export const config: Configuration<AppFlags> = {
@@ -13,6 +12,5 @@ export const config: Configuration<AppFlags> = {
 	defaultFlags: {
 		testFlag: false,
 		ioHomeHeroAlt: true,
-		enableAuth: false,
 	},
 }

--- a/src/views/product-landing/helpers/__tests__/make-heading-slug-scope.test.ts
+++ b/src/views/product-landing/helpers/__tests__/make-heading-slug-scope.test.ts
@@ -1,11 +1,5 @@
 import { makeHeadingSlugScope } from '../'
 
-jest.mock('flags/client', () => ({
-	flags: {
-		enableAuth: false,
-	},
-}))
-
 describe('makeHeadingSlugScope', () => {
 	test('returns already-unique headings unmodified', () => {
 		const makeHeadingSlug = makeHeadingSlugScope()


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksremove-enable-auth-flag-hashicorp.vercel.app/consul/tutorials) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203869159979404) 🎟️

## 🗒️ What

Cleanup an old flag! 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

Visit a page with[ tutorial cards,](https://dev-portal-git-ksremove-enable-auth-flag-hashicorp.vercel.app/consul/tutorials) there should be no changes, the bookmark icon should always render.

## 💭 Anything else?

- [ ]  Remove from happykit after this is merged

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203869159979404