### PR TITLE
Enable integrations in top nav if page active

### DIFF
--- a/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
@@ -18,11 +18,6 @@ describe('getNavItems', () => {
 					name: 'CLI',
 					path: 'commands',
 				},
-				{
-					iconName: 'plug',
-					name: 'Plugins',
-					path: 'plugins',
-				},
 			],
 		} as ProductData
 		expect(getNavItems(testWaypointData)).toMatchInlineSnapshot(`
@@ -44,8 +39,8 @@ describe('getNavItems', () => {
 		    "url": "/waypoint/commands",
 		  },
 		  Object {
-		    "label": "Plugins",
-		    "url": "/waypoint/plugins",
+		    "label": "Integrations",
+		    "url": "/waypoint/integrations",
 		  },
 		  Object {
 		    "label": "Try Cloud",

--- a/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
@@ -1,12 +1,8 @@
 import { NavigationHeaderIcon } from 'components/navigation-header/types'
-import {
-	getDocsNavHasItems,
-	getDocsNavItems,
-} from 'lib/docs/get-docs-nav-items'
-import { NavItem } from './types'
+import { getDocsNavItems } from 'lib/docs/get-docs-nav-items'
+import { getIsEnabledProductIntegrations } from 'lib/integrations/get-is-enabled-product-integrations'
 import { ProductData } from 'types/products'
-import { PrimaryNavLinkProps } from '../../primary-nav-link'
-import { PrimaryNavSubmenuProps } from '../../primary-nav-submenu'
+import { NavItem } from './types'
 
 const TRY_CLOUD_ITEM_PRODUCT_SLUGS = [
 	'boundary',
@@ -148,6 +144,11 @@ export function getNavItems(currentProduct: ProductData): NavItem[] {
 			label: 'Registry',
 			url: 'https://registry.terraform.io/',
 			opensInNewTab: true,
+		})
+	} else if (getIsEnabledProductIntegrations(currentProduct.slug)) {
+		items.push({
+			label: 'Integrations',
+			url: `/${currentProduct.slug}/integrations`,
 		})
 	}
 


### PR DESCRIPTION
🎟️ [Add 'Integrations' to top level product nav](https://app.asana.com/0/1203792701577283/1203869159927655)

## Has Integrations in Nav
https://dev-portal-git-brintegrations-in-nav-hashicorp.vercel.app/vault
![CleanShot 2023-02-03 at 14 14 28@2x](https://user-images.githubusercontent.com/2105067/216721156-3f3c1cc0-6956-4cc2-aaf3-b27337d70861.png)

https://dev-portal-git-brintegrations-in-nav-hashicorp.vercel.app/waypoint (here on Preview)
![CleanShot 2023-02-03 at 14 14 50@2x](https://user-images.githubusercontent.com/2105067/216721202-44949236-7967-4485-8459-f139a2e593de.png)

## No Integrations in Nav

https://dev-portal-git-brintegrations-in-nav-hashicorp.vercel.app/nomad (and all other products)
<img width="1235" alt="CleanShot 2023-02-03 at 14 15 05@2x" src="https://user-images.githubusercontent.com/2105067/216721247-3919cc8f-d53a-47be-9085-0f7802053d93.png">