### PR TITLE
fix: ISR settings for integrations

### DIFF
--- a/src/views/product-integration/component-view/server.ts
+++ b/src/views/product-integration/component-view/server.ts
@@ -184,6 +184,7 @@ async function getStaticProps({
 	)
 
 	return {
+		revalidate: __config.dev_dot.revalidate,
 		props: {
 			metadata: {
 				title: `${integration.name} ${releaseComponent.component.name}${titleVersion} | Integrations`,

--- a/src/views/product-integration/readme-view/server.ts
+++ b/src/views/product-integration/readme-view/server.ts
@@ -84,7 +84,7 @@ async function getStaticPaths(): Promise<GetStaticPathsResult<PathParams>> {
 		.flat()
 		.map((params: PathParams) => ({ params }))
 	// Return static paths
-	return { paths, fallback: false }
+	return { paths, fallback: 'blocking' }
 }
 
 /**

--- a/src/views/product-integrations-landing/server.ts
+++ b/src/views/product-integrations-landing/server.ts
@@ -82,6 +82,7 @@ export async function getStaticProps({
 	]
 
 	return {
+		revalidate: __config.dev_dot.revalidate,
 		props: {
 			metadata: {
 				title: `Integrations`,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR updates `getStaticProps` & `getStaticPaths` settings to allow [incremental static regeneration](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) of integrations-related pages.

## 🛠️ How

For all of the below changes, we've used our config value `__config.dev_dot.revalidate` for regeneration timing. This setting is in seconds, and is currently set to `360`, so pages will be regenerated at most every 6 minutes.

- For `/<product>/integrations` landing views, we add `revalidate: __config.dev_dot.revalidate` return value to `getStaticProps`.
    - This means new integrations can be added between deploys, and will show up in search results on the product integrations landing pages.
    - Note: we leave `fallback: false` in `getStaticPaths`, as we don't expect changes to the integrations API content alone to merit starting to render new product landing pages.
- For integration "readme" views on the latest version, we add `fallback: "blocking"` to `getStaticPaths`.
    - We already had this setting for the versioned `getStaticPaths`, since we don't want to statically render all versions of all integrations.
    - Adding `fallback: "blocking"` to the "latest" views means that new integrations can now be added in between deploys.
- For integration "component" views, we add `revalidate: __config.dev_dot.revalidate` to the return value of `getStaticProps`.
    - Ensures new integration components can be added between deploys

[task]: https://app.asana.com/0/1203792701577283/1203870024661482/f
[preview]: https://dev-portal-git-zsintegrations-isr-hashicorp.vercel.app/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203870024661482