### PR TITLE
fix: inline link size in var descrips

### DIFF
--- a/src/views/product-integration/component-view/components/variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/variable-group-list/index.tsx
@@ -4,7 +4,11 @@ import Badge from 'components/badge'
 import MdxHeadingPermalink from 'components/dev-dot-content/mdx-components/mdx-heading-permalink'
 import { getVariableSlug } from '../../helpers'
 import DevDotContent from 'components/dev-dot-content'
-import { MdxInlineCode, MdxP } from 'components/dev-dot-content/mdx-components'
+import {
+	MdxA,
+	MdxInlineCode,
+	MdxP,
+} from 'components/dev-dot-content/mdx-components'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import s from './style.module.css'
 
@@ -14,7 +18,8 @@ import s from './style.module.css'
  */
 const smallDescriptionMdxComponents = {
 	inlineCode: (props) => <MdxInlineCode {...props} size="100" />,
-	p: (props) => <MdxP {...props} size="200" />,
+	p: (props) => <MdxP {...props} size={200} />,
+	a: (props) => <MdxA {...props} textSize={200} />,
 }
 
 export interface Variable {

--- a/src/views/product-integration/component-view/helpers/get-processed-variables-markdown.ts
+++ b/src/views/product-integration/component-view/helpers/get-processed-variables-markdown.ts
@@ -26,10 +26,7 @@ export async function getProcessedVariablesMarkdown(
 			const uniqueKey = `${variable_group_id}.${key}`
 			processedVariablesMarkdown[uniqueKey] = {}
 			if (description !== null) {
-				const mdxSource = await serializeIntegrationMarkdown(
-					`Here's an [inline link](https://dev.hashicorp.com/waypoint). Also the original description: ` +
-						description
-				)
+				const mdxSource = await serializeIntegrationMarkdown(description)
 				processedVariablesMarkdown[uniqueKey] = { description: mdxSource }
 			}
 		}

--- a/src/views/product-integration/component-view/helpers/get-processed-variables-markdown.ts
+++ b/src/views/product-integration/component-view/helpers/get-processed-variables-markdown.ts
@@ -26,7 +26,10 @@ export async function getProcessedVariablesMarkdown(
 			const uniqueKey = `${variable_group_id}.${key}`
 			processedVariablesMarkdown[uniqueKey] = {}
 			if (description !== null) {
-				const mdxSource = await serializeIntegrationMarkdown(description)
+				const mdxSource = await serializeIntegrationMarkdown(
+					`Here's an [inline link](https://dev.hashicorp.com/waypoint). Also the original description: ` +
+						description
+				)
 				processedVariablesMarkdown[uniqueKey] = { description: mdxSource }
 			}
 		}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-zsvar-description-link-size-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1203792701577283/1203894339506160/f) 🎟️

## 🗒️ What

Fixes an issue where inline links were not sized correctly in integrations variable descriptions.

## 📸 Design Screenshots

### Before

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/4624598/217074214-e06bcf19-2529-4991-9b10-3bce216138f4.png">

### After

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/4624598/217074231-3aabc1a2-6312-4c87-8e9c-426d8ed12c87.png">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203894339506160