### PR TITLE
[integrations] Adding users-16 icon for Community tier

### DIFF
--- a/src/views/product-integrations-landing/components/tag-list/index.tsx
+++ b/src/views/product-integrations-landing/components/tag-list/index.tsx
@@ -3,6 +3,7 @@ import { IconEnterprise16 } from '@hashicorp/flight-icons/svg-react/enterprise-1
 import { IconHandshake16 } from '@hashicorp/flight-icons/svg-react/handshake-16'
 import { IconHashicorp16 } from '@hashicorp/flight-icons/svg-react/hashicorp-16'
 import { IconRocket16 } from '@hashicorp/flight-icons/svg-react/rocket-16'
+import { IconUsers16 } from '@hashicorp/flight-icons/svg-react/users-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
 import classNames from 'classnames'
 import Badge, { BadgeProps } from 'components/badge'
@@ -75,6 +76,7 @@ export function GetIntegrationTags(
 		case Tier.COMMUNITY:
 			tierTag = {
 				name: 'Community',
+				icon: <IconUsers16 />,
 				description:
 					'Community integrations are published by individual maintainers, groups of maintainers, or other members of the HashiCorp community.',
 			}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1203792616809419/1203879534908332/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds the `icon` property for the Community `Badge`s that show on integrations `CardLink`s

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [`/vault/integrations?tiers=community`](https://dev-portal-git-ambadd-community-tier-icon-hashicorp.vercel.app/vault/integrations?tiers=community) on the preview URL
- [ ] See that Community `Badge`s now have the `users-16` icon ([compared to staging](https://dev-portal-git-staging-hashicorp.vercel.app/vault/integrations?tiers=community) where they are not present)
