### PR TITLE
Adding merchandisingSlot on /nomad/downloads

### DIFF
--- a/src/pages/nomad/downloads/index.tsx
+++ b/src/pages/nomad/downloads/index.tsx
@@ -2,8 +2,31 @@ import nomadData from 'data/nomad.json'
 import { ProductData } from 'types/products'
 import ProductDownloadsView from 'views/product-downloads-view'
 import { generateGetStaticProps } from 'views/product-downloads-view/server'
+import Card from 'components/card'
+import InlineLink from 'components/inline-link'
+import Text from 'components/text'
+import s from './style.module.css'
+
+const NomadDownloadsPage = (props) => {
+	return (
+		<ProductDownloadsView
+			{...props}
+			merchandisingSlot={
+				<Card className={s.card} elevation="base">
+					<Text asElement="span">
+						A beta for Nomad v1.5.0 is available! The release can be{' '}
+						<InlineLink href="https://releases.hashicorp.com/nomad/1.5.0-beta.1/">
+							downloaded here
+						</InlineLink>
+						.
+					</Text>
+				</Card>
+			}
+		/>
+	)
+}
 
 const getStaticProps = generateGetStaticProps(nomadData as ProductData)
 
 export { getStaticProps }
-export default ProductDownloadsView
+export default NomadDownloadsPage

--- a/src/pages/nomad/downloads/style.module.css
+++ b/src/pages/nomad/downloads/style.module.css
@@ -1,0 +1,5 @@
+.card {
+	background-color: var(--token-color-surface-faint);
+	border-color: var(token-color-border-strong);
+	color: var(--token-color-foreground-primary);
+}


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Passes an `InlineAlert`-type of element into the `merchandisingSlot` of Nomad's downloads page

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This is an extension of #1628

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [`/nomad/downloads`](https://dev-portal-git-amb-nomad-150-beta1-download-box-hashicorp.vercel.app/nomad/downloads) on the preview
- [ ] Scroll below the "Operating System" card
- [ ] The following message should be below the card:
  <img width="939" alt="CleanShot 2023-02-08 at 16 17 24@2x" src="https://user-images.githubusercontent.com/43934258/217652897-a502851c-e611-4cd5-be58-a32bcc28f86d.png">
- [ ] The link should point to `https://releases.hashicorp.com/nomad/1.5.0-beta.1/`

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- I've created a ticket for considering a new feature on downloads views: [[ProductDownloadsView] Add support for custom PageAlerts](https://app.asana.com/0/1202801212949828/1203933033786126/f)
