### PR TITLE
fix: gradient pixel leak on waypoint.io landing

### DIFF
--- a/src/components/_proxied-dot-io/waypoint/homepage/hero/style.module.css
+++ b/src/components/_proxied-dot-io/waypoint/homepage/hero/style.module.css
@@ -76,6 +76,9 @@
 		rgba(89, 220, 228, 0.8) 0.25%,
 		rgba(99, 208, 255, 0.5) 95.01%
 	);
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 100% 95%;
 	z-index: -1;
 
 	@media (--medium-up) {

--- a/src/components/_proxied-dot-io/waypoint/homepage/hero/style.module.css
+++ b/src/components/_proxied-dot-io/waypoint/homepage/hero/style.module.css
@@ -76,6 +76,10 @@
 		rgba(89, 220, 228, 0.8) 0.25%,
 		rgba(99, 208, 255, 0.5) 95.01%
 	);
+
+  /* Size and position ensures bluish background
+  does not leak out from behind the layered SVG,
+  which has wavy white mask-like shapes */
 	background-repeat: no-repeat;
 	background-position: center;
 	background-size: 100% 95%;


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task](https://app.asana.com/0/1202791227659279/1203962669700281/f) 🎟️

## 🗒️ What

Fixes a background pixel row leak issue in Safari.

## 📸 Design Screenshots

| Before | After |
| - | - | 
| <img width="1552" alt="before" src="https://user-images.githubusercontent.com/4624598/218243290-3d50bccf-40fa-4de4-8802-3a7c2ed32d39.png"> | <img width="1552" alt="after" src="https://user-images.githubusercontent.com/4624598/218243286-667f1861-bdd2-4e64-8d48-f307a1593331.png"> |

## 🧪 Testing

- [ ] Open [the preview link][preview], switch to Waypoint dot-io mode
    - Visit the home page in Safari
    - The pixel artifact seen in the `Before` picture above should no longer be there
    - The page should look as expected when browser zoom is applied, and should continue to look as expected across all viewport sizes.

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsfix-waypoint-pixel-bug-hashicorp.vercel.app/