### PR TITLE
tutorials-preview: Bypass /static_paths endpoint

### DIFF
--- a/src/pages/[productSlug]/tutorials/[...tutorialSlug]/index.tsx
+++ b/src/pages/[productSlug]/tutorials/[...tutorialSlug]/index.tsx
@@ -26,6 +26,15 @@ async function _getStaticPaths(): Promise<
 > {
 	const validPaths = await getTutorialPagePaths()
 
+	// For hashicorp/tutorials PR previews, skip the call to determine paths
+	// from analytics, and statically build all paths.
+	if (process.env.HASHI_ENV === 'tutorials-preview') {
+		return {
+			paths: validPaths,
+			fallback: false,
+		}
+	}
+
 	let paths = []
 
 	try {


### PR DESCRIPTION
# Description

For `HASHI_ENV: 'tutorials-preview'`, bypass the call to our `/static_paths` endpoint, and statically build all **tutorials** pages..