### PR TITLE
feat: integrations nested outline for variable groups

### DIFF
--- a/src/components/outline-nav/utils/highlight-active-items.ts
+++ b/src/components/outline-nav/utils/highlight-active-items.ts
@@ -12,11 +12,11 @@ function highlightActiveItems(
 	currentUrl: string
 ): OutlineLinkItem[] {
 	return items.map((item) => {
+		const isActive = item.url === currentUrl
 		if ('items' in item) {
 			const activeItems = highlightActiveItems(item.items, currentUrl)
-			return { ...item, items: activeItems }
+			return { ...item, items: activeItems, isActive }
 		} else {
-			const isActive = item.url === currentUrl
 			return { ...item, isActive }
 		}
 	})

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -53,10 +53,15 @@ export default function ProductIntegrationComponentView({
 		(variableGroup: VariableGroup) => {
 			const groupName = variableGroup.variable_group_config.name
 			const groupSlug = getVariableGroupSlug(groupName)
-			const nestedItems = variableGroup.variables.map((v) => {
-				const variableSlug = getVariableSlug(groupName, v.key)
-				return { title: v.key, url: `#${variableSlug}` }
-			})
+			const nestedItems = variableGroup.variables
+				.filter((v) => {
+					const isTopLevelVariable = v.key.indexOf('.') === -1
+					return isTopLevelVariable
+				})
+				.map((v) => {
+					const variableSlug = getVariableSlug(groupName, v.key)
+					return { title: v.key, url: `#${variableSlug}` }
+				})
 			return { title: groupName, url: `#${groupSlug}`, items: nestedItems }
 		}
 	)

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -21,7 +21,7 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { ProductData } from 'types/products'
 import SearchableVariableGroupList from './components/searchable-variable-group-list'
 import { Variable } from './components/variable-group-list'
-import { getVariableGroupSlug } from './helpers'
+import { getVariableGroupSlug, getVariableSlug } from './helpers'
 import type { ProcessedVariablesMarkdown } from './helpers/get-processed-variables-markdown'
 import s from './style.module.css'
 import VersionAlertBanner from 'components/version-alert-banner'
@@ -50,13 +50,23 @@ export default function ProductIntegrationComponentView({
 	 * Build variable group headings, which are used for both
 	 * the table of contents and to render the headings themselves
 	 */
-	const variableGroupHeadings: TableOfContentsHeading[] = variable_groups.map(
-		(variableGroup: VariableGroup) => {
+	const variableGroupHeadings: TableOfContentsHeading[] = variable_groups
+		.map((variableGroup: VariableGroup) => {
 			const groupName = variableGroup.variable_group_config.name
+			const variableHeadings = variableGroup.variables.map((v) => {
+				return {
+					title: v.key,
+					slug: getVariableSlug(groupName, v.key),
+					level: 3 as const,
+				}
+			})
 			const slug = getVariableGroupSlug(groupName)
-			return { title: groupName, slug, level: 2 }
-		}
-	)
+			return [
+				{ title: groupName, slug, level: 2 as const },
+				...variableHeadings,
+			]
+		})
+		.flat()
 
 	/**
 	 * Grab the current version string from the activeRelease.

--- a/src/views/product-integration/component-view/index.tsx
+++ b/src/views/product-integration/component-view/index.tsx
@@ -7,8 +7,7 @@ import { BreadcrumbLink } from 'components/breadcrumb-bar'
 import DevDotContent from 'components/dev-dot-content'
 import { MdxHeadingOutsideMdx } from './components/mdx-heading-outside-mdx'
 import ProductIntegrationLayout from 'layouts/product-integration-layout'
-import { TableOfContentsHeading } from 'components/table-of-contents'
-import { OutlineNavFromHeadings } from 'components/outline-nav/components'
+import { OutlineNavWithActive } from 'components/outline-nav/components'
 import { getIntegrationComponentUrl } from 'lib/integrations'
 import { Integration } from 'lib/integrations-api-client/integration'
 import {
@@ -23,6 +22,7 @@ import SearchableVariableGroupList from './components/searchable-variable-group-
 import { Variable } from './components/variable-group-list'
 import { getVariableGroupSlug, getVariableSlug } from './helpers'
 import type { ProcessedVariablesMarkdown } from './helpers/get-processed-variables-markdown'
+import type { OutlineNavProps } from 'components/outline-nav'
 import s from './style.module.css'
 import VersionAlertBanner from 'components/version-alert-banner'
 
@@ -47,26 +47,19 @@ export default function ProductIntegrationComponentView({
 }: ProductIntegrationComponentViewProps) {
 	const { variable_groups } = component
 	/**
-	 * Build variable group headings, which are used for both
-	 * the table of contents and to render the headings themselves
+	 * Build outline nav items for the component variable groups
 	 */
-	const variableGroupHeadings: TableOfContentsHeading[] = variable_groups
-		.map((variableGroup: VariableGroup) => {
+	const outlineNavItems: OutlineNavProps['items'] = variable_groups.map(
+		(variableGroup: VariableGroup) => {
 			const groupName = variableGroup.variable_group_config.name
-			const variableHeadings = variableGroup.variables.map((v) => {
-				return {
-					title: v.key,
-					slug: getVariableSlug(groupName, v.key),
-					level: 3 as const,
-				}
+			const groupSlug = getVariableGroupSlug(groupName)
+			const nestedItems = variableGroup.variables.map((v) => {
+				const variableSlug = getVariableSlug(groupName, v.key)
+				return { title: v.key, url: `#${variableSlug}` }
 			})
-			const slug = getVariableGroupSlug(groupName)
-			return [
-				{ title: groupName, slug, level: 2 as const },
-				...variableHeadings,
-			]
-		})
-		.flat()
+			return { title: groupName, url: `#${groupSlug}`, items: nestedItems }
+		}
+	)
 
 	/**
 	 * Grab the current version string from the activeRelease.
@@ -87,7 +80,7 @@ export default function ProductIntegrationComponentView({
 					version === integration.versions[0] ? 'latest' : version
 				return getIntegrationComponentUrl(integration, component, versionString)
 			}}
-			sidecarSlot={<OutlineNavFromHeadings headings={variableGroupHeadings} />}
+			sidecarSlot={<OutlineNavWithActive items={outlineNavItems} />}
 			alertBannerSlot={
 				isLatestVersion ? null : (
 					<VersionAlertBanner
@@ -111,16 +104,12 @@ export default function ProductIntegrationComponentView({
 			{variable_groups.length ? (
 				<div className={s.variableGroups}>
 					{variable_groups.map((variableGroup: VariableGroup, idx: number) => {
-						const headingData = variableGroupHeadings[idx]
-
+						const groupName = variableGroup.variable_group_config.name
+						const slug = getVariableGroupSlug(groupName)
 						return (
 							<div key={variableGroup.id}>
 								{/* Note: using MDX heading here to match adjacent content */}
-								<MdxHeadingOutsideMdx
-									id={headingData.slug}
-									title={headingData.title}
-									level={headingData.level}
-								/>
+								<MdxHeadingOutsideMdx id={slug} title={groupName} level={2} />
 								<SearchableVariableGroupList
 									groupName={variableGroup.variable_group_config.name}
 									variables={variableGroup.variables.map(


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR implements nested outline links for variable groups on Integrations component pages. Common variable groups include Parameters and Outputs.

## 🤷 Why

To match designs, providing a more detailed outline of component pages.

## 🛠️ How

- Updates business logic to generate nested `outlineNavItems` rather than flat `variableGroupHeadings`
- Swaps out `OutlineNavFromHeadings`, swaps in `OutlineNavWithActive`

## 📸 Design Screenshots

🎨 [Figma file][figma]

### Design

<img width="1449" alt="CleanShot 2023-02-23 at 16 27 13@2x" src="https://user-images.githubusercontent.com/4624598/221034177-6816b554-ed2d-4e1a-8778-2826d4f858bc.png">

### Implementation

<img width="1785" alt="CleanShot 2023-02-23 at 16 28 28@2x" src="https://user-images.githubusercontent.com/4624598/221034455-c3dc1357-8b35-47a0-a2be-a0d0f402127c.png">

## 🧪 Testing

- [ ] Visit a component page, such as [/waypoint/integrations/hashicorp/docker/latest/components/builder][/waypoint/integrations/hashicorp/docker/latest/components/builder]
    - The sidecar should show an `OutlineNav` listing all parameters and outputs
    - Jump links to `Parameters`, `Outputs`, and all nested items should function as expected

## 💭 Anything else?

> **Note**: on integration component pages, we are not yet extracting headings and adding them to the `OutlineNav`. Due to sanitization requirements, this may be a slightly more involved effort, and regardless felt reasonable to treat as a separate task from `Parameters` and `Outputs` nesting. See 🎟 [[discuss] sanitize-friendly heading anchor links for user content](https://app.asana.com/0/1203792616809419/1203896228323108/f) for details.

[task]: https://app.asana.com/0/1203810296555970/1203970622632444/f
[figma]: https://www.figma.com/file/VD7ahvXuXWJApeGnhbW4hv/Developer?node-id=19816%3A232842&t=Rb5wf1DnjDv9sTsf-4
[preview]: https://dev-portal-git-zsint-component-nested-outline-hashicorp.vercel.app/
[/waypoint/integrations/hashicorp/docker/latest/components/builder]: https://dev-portal-git-zsint-component-nested-outline-hashicorp.vercel.app/waypoint/integrations/hashicorp/docker/latest/components/builder