### PR TITLE
fix: width bug in sidebar-sidecar layout

### DIFF
--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -124,7 +124,11 @@ for further details.
 /* .mainAndSidecar spans the padded area, and lays out main + sidecar. */
 .mainAndSidecar {
 	display: flex;
-	max-width: 100%;
+	max-width: calc(
+		var(--main-element-max-width) + var(--sidecar-spacing) +
+			var(--sidecar-width)
+	);
+	width: 100%;
 }
 
 /* .main handles the max-width and sizing for the main area. */


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes a layout bug, which mainly affects Open API docs pages.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/4624598/222510272-d414ef15-7eec-4532-a496-86111ffcfb8b.png) | ![after](https://user-images.githubusercontent.com/4624598/222510275-cbed2975-7923-4ac0-af38-905a19c8ebe3.png) |

## 🧪 Testing

- [ ] Visit a page where the layout is broken upstream, such as [/boundary/api-docs/worker-service][/boundary/api-docs/worker-service]
    - The layout should now be fixed - the main content should be aligned with the breadcrumb bar, and the API docs should occupy a similar width as a main container on other docs pages (note: is in intentionally a little wider).
- [ ] Visit other pages that use `SidebarSidecarLayout` to confirm they're still working, such as [/vault/api-docs/auth/aws][/vault/api-docs/auth/aws]

[task]: https://app.asana.com/0/1202097197789424/1204090899347066/f
[preview]: https://dev-portal-git-zsfix-layout-bug-hashicorp.vercel.app/
[/boundary/api-docs/worker-service]: https://dev-portal-git-zsfix-layout-bug-hashicorp.vercel.app/boundary/api-docs/worker-service
[/vault/api-docs/auth/aws]: https://dev-portal-git-zsfix-layout-bug-hashicorp.vercel.app/vault/api-docs/auth/aws