### PR TITLE
style: update inline code border and bg color

### DIFF
--- a/src/components/dev-dot-content/dev-dot-content.module.css
+++ b/src/components/dev-dot-content/dev-dot-content.module.css
@@ -34,9 +34,13 @@
 			}
 
 			& :not(pre) > code {
-				background-color: var(--token-color-palette-neutral-0);
+				background-color: var(--token-color-surface-faint);
 				border-radius: 5px;
-				border: var(--themed-border);
+				border: 1px solid var(--token-color-border-primary);
+
+				@nest html[data-theme='dark'] & {
+					background-color: var(--token-color-surface-strong);
+				}
 			}
 
 			&.alert-info {

--- a/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
@@ -6,15 +6,12 @@
 .inlineCode {
 	background-color: var(--token-color-surface-faint);
 	border-radius: 5px;
-	border: 1px solid var(--token-color-palette-alpha-200);
+	border: 1px solid var(--token-color-border-primary);
 	line-height: 1;
 	padding: 2px 4px 3px 4px;
 
 	@nest html[data-theme='dark'] & {
 		background-color: var(--token-color-surface-strong);
-
-		/* --token-color-border-strong */
-		border-color: var(--token-color-border-primary);
 	}
 }
 

--- a/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
@@ -4,11 +4,18 @@
  */
 
 .inlineCode {
-	background-color: var(--token-color-surface-strong);
+	background-color: var(--token-color-surface-faint);
 	border-radius: 5px;
-	border: 1px solid var(--token-color-border-strong);
+	border: 1px solid var(--token-color-palette-alpha-200);
 	line-height: 1;
 	padding: 2px 4px 3px 4px;
+
+	@nest html[data-theme='dark'] & {
+		background-color: var(--token-color-surface-strong);
+
+		/* --token-color-border-strong */
+		border-color: var(--token-color-border-primary);
+	}
 }
 
 .size-100 {

--- a/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-inline-code/mdx-inline-code.module.css
@@ -4,9 +4,9 @@
  */
 
 .inlineCode {
-	background-color: var(--token-color-palette-neutral-50);
+	background-color: var(--token-color-surface-strong);
 	border-radius: 5px;
-	border: 1px solid rgba(101, 106, 118, 0.2);
+	border: 1px solid var(--token-color-border-strong);
 	line-height: 1;
 	padding: 2px 4px 3px 4px;
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksupdate-inline-code-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1203652232454021/1204108582255289) 🎟️
- [Figma File](https://www.figma.com/file/v0Hyqvjdf6QJAvRkdIBV24/Dark-Mode?node-id=302-30801&t=zKEXDsfXxqaz5rY9-0) 🎨 

## 🗒️ What

Updates the inline code background color to be a semantic token instead of the base neutral token. Also adjusts the border to use a token. 

<img width="878" alt="Screenshot 2023-03-16 at 10 25 11 AM" src="https://user-images.githubusercontent.com/36613477/225702538-a66d3269-f2f6-4ca2-9eab-ae879c29a51a.png">



## 🧪 Testing

### Regular inline code
- [Visit a page](https://dev-portal-git-ksupdate-inline-code-hashicorp.vercel.app/terraform/cli/commands/init) with inline code
- [And another](https://dev-portal-git-ksupdate-inline-code-hashicorp.vercel.app/terraform/enterprise/run/cli#excluding-files-from-upload)
- Validate that light mode looks the same as production
- Check dark mode, ensure the background and border colors matches [the spec](https://www.figma.com/file/v0Hyqvjdf6QJAvRkdIBV24/Dark-Mode?node-id=302-30801&t=zKEXDsfXxqaz5rY9-0) 

### Inline code in legacy alerts
- [Visit a page](https://dev-portal-git-ksupdate-inline-code-hashicorp.vercel.app/terraform/enterprise/run/run-environment#state-access-and-authentication) with the legacy alert
- Validate that the background and border colors for the inline code match [the spec](https://www.figma.com/file/v0Hyqvjdf6QJAvRkdIBV24/Dark-Mode?node-id=302-30801&t=zKEXDsfXxqaz5rY9-0) in both dark and light mode. 

## 💭 Anything else?

Waiting on updated blue values to finish this override. 
