### PR TITLE
fix: add missing margin to docs landing-hero

### DIFF
--- a/src/components/landing-hero/landing-hero.module.css
+++ b/src/components/landing-hero/landing-hero.module.css
@@ -7,6 +7,7 @@
 	align-items: center;
 	display: flex;
 	gap: 16px;
+	margin-bottom: 32px;
 
 	&.hasSubtitle {
 		align-items: flex-start;


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes a bug where there was no spacing between the "landing hero" on docs landing pages, and the content of those pages.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/4624598/223557598-5f88b1db-c986-40fb-8676-fd6bf6c622cd.png) | ![after](https://user-images.githubusercontent.com/4624598/223557588-25220b34-70e3-4871-bcf9-600456585ec8.png) |

## 🧪 Testing

- [ ] Visit a docs landing page, such as [/terraform/language][/terraform/language]
    - There should be spacing between the landing hero (`h1` with icon next to it) and the main content of the page

[task]: https://app.asana.com/0/1202097197789424/1204130762580102/f
[preview]: https://dev-portal-git-zsfix-docs-hero-spacing-hashicorp.vercel.app/
[/terraform/language]: https://dev-portal-git-zsfix-docs-hero-spacing-hashicorp.vercel.app/terraform/language