### PR TITLE
fixes broken links and style guide inconsistencies

### DIFF
--- a/src/content/consul/docs-landing.json
+++ b/src/content/consul/docs-landing.json
@@ -1,24 +1,24 @@
 {
-	"pageSubtitle": "Consul is a multi-networking tool that offers a fully-featured service mesh solution that solves the networking and security challenges of operating microservices and cloud infrastructure (multi-cloud and hybrid cloud). This documentation covers the main concepts of Consul, what problems it can solve, and contains a quick start for using Consul.",
+	"pageSubtitle": "Consul is a multi-networking tool that offers a fully-featured service mesh solution. It solves the networking and security challenges of operating microservices and cloud infrastructure in multi-cloud and hybrid cloud environments. This documentation describes Consul concepts, the problems it solves, and contains quick-start tutorials for using Consul.",
 	"marketingContentBlocks": [
 		{
 			"type": "section-heading",
-			"title": "Use Cases"
+			"title": "Use cases"
 		},
 		{
 			"type": "card-grid",
-			"title": "Service Mesh",
-			"description": "Consul Service Mesh provides service-to-service connection authorization and encryption using mutual Transport Layer Security (TLS).",
+			"title": "Service mesh",
+			"description": "Consul service mesh provides service-to-service connection authorization and encryption using mutual transport layer security (TLS).",
 			"cards": [
 				{
 					"title": "Register mesh services",
-					"description": "Use configuration files to define and register services with Consul and associate services with health checks.",
-					"url": "/consul/docs/discovery/services"
+					"description": "Define and register services with Consul and associate them with health checks.",
+					"url": "/consul/docs/services/services"
 				},
 				{
 					"title": "Configure mesh behavior",
 					"description": "The exported services configuration entry enables you to export services from a single file.",
-					"url": "/consul/docs/connect/config-entries"
+					"url": "/consul/docs/connect/config-entries/exported-services"
 				},
 				{
 					"title": "Manage mesh traffic",
@@ -26,8 +26,8 @@
 					"url": "/consul/docs/connect/gateways"
 				},
 				{
-					"title": "Setup API Gateway",
-					"description": "Using Consul API gateway functionality.",
+					"title": "Control ingress traffic",
+					"description": "Deploy a Consul API gateway to manage north-south network traffic .",
 					"url": "/consul/docs/api-gateway"
 				}
 			]
@@ -35,25 +35,25 @@
 		{
 			"type": "card-grid",
 			"title": "Kubernetes",
-			"description": "Consul has many integrations with Kubernetes. You can deploy Consul to Kubernetes using the Helm chart or Consul K8s CLI, sync services between Consul and Kubernetes, run Consul Service Mesh, and more.",
+			"description": "Consul has many integrations with Kubernetes. You can deploy Consul to Kubernetes using the Helm chart or Consul K8s CLI, sync services between Consul and Kubernetes, run Consul service mesh, and more.",
 			"cards": [
 				{
 					"title": "Install Consul on Kubernetes",
-					"description": "Consul can run directly on Kubernetes, both in server or client mode. For pure Kubernetes workloads, this enables Consul to also exist purely within Kubernetes. For heterogeneous workloads, Consul agents can join a server running inside or outside of Kubernetes.",
+					"description": "Consul runs directly on Kubernetes to support pure K8s workloads. You can also join workloads to Consul servers outside of Kubernetes to support mixed environments.",
 					"url": "/consul/docs/k8s/installation/install"
 				},
 				{
-					"title": "Consul Service Mesh on Kubernetes",
-					"description": "Consul service mesh enables automatic service to service authorization and connection encryption across your Consul services. Use Consul to secure pod communication with other services.",
-					"url": "/consul/docs/k8s/connect"
+					"title": "Simplify service mesh on Kubernetes with Consul Dataplane",
+					"description": "Consul Dataplane manages proxies but leaves responsibility for other functions to the orchestrator, removing the need to run client agents on every node.",
+					"url": "/consul/docs/connect/dataplane"
 				},
 				{
-					"title": "Multi-Cluster",
+					"title": "Connect services deployed to multiple Kubernetes clusters",
 					"description": "Install and federate Consul on multiple Kubernetes clusters.",
-					"url": "/consul/docs/k8s/installation/multi-cluster"
+					"url": "/consul/docs/k8s/deployment-configurations/multi-cluster"
 				},
 				{
-					"title": "Syncing Kubernetes and Consul Services",
+					"title": "Sync Kubernetes and Consul services",
 					"description": "Automatically sync your Kubernetes and Consul services to seamlessly secure communications between your Kubernetes and Consul services.",
 					"url": "/consul/docs/k8s/service-sync"
 				}
@@ -61,21 +61,21 @@
 		},
 		{
 			"type": "card-grid",
-			"title": "Network Infrastructure Automation",
+			"title": "Network infrastructure automation",
 			"description": "Consul-Terraform-Sync (CTS) enables dynamic updates to network infrastructure devices triggered by service changes.",
 			"cards": [
 				{
-					"title": "Install and Configure CTS",
+					"title": "Install and configure the CTS",
 					"description": "Install the CTS binary.",
 					"url": "/consul/docs/nia/installation/install"
 				},
 				{
-					"title": "Define Dynamic Updates",
+					"title": "Define dynamic updates",
 					"description": "Configure CTS Tasks to automatically update network infrastructure when your Consul services change.",
 					"url": "/consul/docs/nia/tasks"
 				},
 				{
-					"title": "Create a Terraform Module",
+					"title": "Create a Terraform module",
 					"description": "Automatically execute Terraform modules for network infrastructure automation with CTS.",
 					"url": "/consul/docs/nia/terraform-modules"
 				}
@@ -84,7 +84,7 @@
 		{
 			"type": "card-grid",
 			"title": "Platforms",
-			"description": "Consul can be integrated with several other platforms and products. Learn more about Consul integrations and how to enable them.",
+			"description": "Consul integrates with several platforms and products. Learn more about Consul integrations and how to enable them.",
 			"cards": [
 				{
 					"title": "Nomad",
@@ -117,22 +117,22 @@
 			"cards": [
 				{
 					"iconName": "connection",
-					"text": "Envoy Integration",
+					"text": "Envoy integration",
 					"url": "/consul/docs/connect/proxies/envoy"
 				},
 				{
 					"iconName": "api",
-					"text": "HTTP API Structure",
+					"text": "HTTP API structure",
 					"url": "/consul/api-docs"
 				},
 				{
 					"iconName": "download",
-					"text": "Download Consul Tools",
-					"url": "/consul/docs/download-tools"
+					"text": "Download Consul tools",
+					"url": "/consul/docs/integrate/download-tools"
 				},
 				{
 					"iconName": "terminal",
-					"text": "GitHub Samples",
+					"text": "GitHub samples",
 					"url": "https://github.com/hashicorp?q=learn-consul&type=public&language=&sort=stargazers"
 				}
 			]


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-98rz5umo6-hashicorp.vercel.app/consul/docs) 🔎

## 🗒️ What

We noticed some broken links on the docs landing page as a result of some content refactoring. This PR fixes the broken links and updates some of the existing content for consistency with the style guide. 

I also swapped out one of the Kubernetes cards for a link to Consul Dataplane. I figured it was new and something we would want to promote on the docs landing page.
