### PR TITLE
Removing manual focus management from integrations pagination

### DIFF
--- a/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/paginated-integrations-list/index.tsx
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { useRef } from 'react'
+import { useQueryParam, NumberParam, withDefault } from 'use-query-params'
 import { Integration } from 'lib/integrations-api-client/integration'
-import getFullNavHeaderHeight from 'lib/get-full-nav-header-height'
-import { useEffect, useRef } from 'react'
+import { useDeviceSize } from 'contexts/device-size'
+import Pagination from 'components/pagination'
 import IntegrationsList from '../integrations-list'
 import s from './style.module.css'
-import Pagination from 'components/pagination'
-import { useDeviceSize } from 'contexts/device-size'
-import { useQueryParam, NumberParam, withDefault } from 'use-query-params'
 
 interface PaginatedIntegrationsListProps {
 	integrations: Array<Integration>
@@ -28,11 +27,14 @@ function coerceToDefaultValue(value: number, init: number): number {
 	return value
 }
 
+/**
+ * @TODO handle focus management on page & page size changes, if needed.
+ * https://app.asana.com/0/1202097197789424/1203752518527704/f
+ */
 export default function PaginatedIntegrationsList({
 	integrations,
 	onClearFiltersClicked,
 }: PaginatedIntegrationsListProps) {
-	const isFirstRender = useRef(true)
 	const containerRef = useRef(null)
 	const [_itemsPerPage, setItemsPerPage] = useQueryParam(
 		'size',
@@ -77,37 +79,6 @@ export default function PaginatedIntegrationsList({
 		(currentPage - 1) * itemsPerPage,
 		currentPage * itemsPerPage
 	)
-
-	/**
-	 * If our pagination page changes, scroll up to the top of the wrapper.
-	 *
-	 * We also focus the search input, since otherwise, keyboard users would
-	 * be scrolled to the top of the page (due to scrollTo), and then
-	 * immediately scrolled to the bottom of the page.
-	 *
-	 * TODO: consider hooking into <Pagination/>'s `onPageChange`.
-	 * This might be more clear than a separate effect (but for now, would
-	 * not result in the same focus behaviour on the first result link.)
-	 */
-	useEffect(() => {
-		if (isFirstRender.current) {
-			isFirstRender.current = false
-		} else {
-			// Try to find the first result link, and focus it
-			const targetElement = containerRef.current?.querySelector('a')
-			if (targetElement) {
-				targetElement.focus({ forceVisible: true })
-				/**
-				 * We need to scroll up a bit, as the focused item may be slightly
-				 * hidden behind the top navigation bar. Note this approach is slightly
-				 * brittle, as --navigationHeader. We also add an extra 64px,
-				 * which makes it more clear we've scrolled to the top of results.
-				 */
-				const navScrollCompensation = getFullNavHeaderHeight() + 64
-				window.scrollBy(0, navScrollCompensation * -1)
-			}
-		}
-	}, [currentPage])
 
 	const { isDesktop, isMobile, isTablet } = useDeviceSize()
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambintegrations-pagination-hashicorp.vercel.app/vault/integrations) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1204131002305968/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes manual focus management from `PaginatedIntegrationsList` that happened when `page` changed
- We have an Asana task for getting guidance from the Design Systems team on focus management in filter views, so removing this functionality for now rather than make it more complex feels like the right move

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This behavior was causing browser focus to move from the filter input to the first result while a user was typing, if the current page number was not 1

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to /vault/integrations
- [ ] Change the page number
- [ ] Type a few characters into the filter input
- [ ] The browser focus should not move away from the input
