### PR TITLE
Fixing mobileMenuButton class colors

### DIFF
--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -58,13 +58,13 @@
 	background-color: transparent;
 	border-radius: 5px;
 	border: 1px solid transparent;
-	color: var(--token-color-foreground-strong);
+	color: var(--token-color-foreground-high-contrast);
 	display: flex;
 	justify-content: center;
 	padding: 5px;
 
 	&:hover {
-		border: 1px solid var(--token-color-border-strong);
+		border: 1px solid var(--token-color-palette-neutral-200);
 	}
 
 	@media (--dev-dot-hide-mobile-menu) {


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the colors used in the `.mobileMenuButton` class

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- In some dark mode work, these colors were updated in such a way that made the mobile menu button look invisible:

  <img width="830" alt="image" src="https://user-images.githubusercontent.com/43934258/224440702-09e5ea16-9e68-45d7-a5ea-d0d5ab6362ac.png">

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] Change your viewport to `923px` or smaller
- [ ] The mobile menu button should be visible
