### PR TITLE
ubuntu: use gpg -o instead of tee for getting gpg key

### DIFF
--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -43,7 +43,7 @@ export const generateDefaultPackageManagers = (
 		{
 			label: 'Ubuntu/Debian',
 			commands: [
-				`wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
+				`wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
 				`echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list`,
 				`sudo apt update && sudo apt install ${productSlug}`,
 			],
@@ -104,7 +104,7 @@ export function generateEnterprisePackageManagers(
 		{
 			label: 'Ubuntu/Debian',
 			commands: [
-				`wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
+				`wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
 				`echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list`,
 				`sudo apt update && sudo apt install ${productSlug}-enterprise`,
 			],


### PR DESCRIPTION
Second attempt at https://github.com/hashicorp/dev-portal/pull/797

This time using `gpg -o` as suggested by @phinze 

Attaching a screenshot of what happens when users follow the instructiosn as-is. Your terminal turns into an unusable mess. It's an awful UX.

![Screenshot from 2023-03-14 11-19-27](https://user-images.githubusercontent.com/394887/225074549-6dc44953-d237-4b8e-b22b-a800fcd1a7fd.png)

