### PR TITLE
fix: fix api-docs issues from handling circular json

### DIFF
--- a/src/components/open-api-page/server/index.ts
+++ b/src/components/open-api-page/server/index.ts
@@ -24,9 +24,31 @@ import {
  * @param {*} params
  * @returns
  */
-function getPropsForPage(schema, params) {
+function getPropsForPage(
+	/**
+	 * Open API schema object
+	 */
+	schema,
+	/**
+	 * Parameters from getStaticProps.
+	 */
+	params,
+	/**
+	 * The Waypoint API docs have circular references.
+	 * We manually try to deal with those. This is a band-aid solution,
+	 * it seems to have unintended side-effects when applied to other
+	 * products' API docs, and almost certainly merits further investigation.
+	 *
+	 * Asana task:
+	 * https://app.asana.com/0/1202097197789424/1203989531295664/f
+	 */
+	mayHaveCircularReferences: boolean = false
+) {
 	// parse the data we'll show to the user from the schema
-	const operationObjects = getOperationObjects(schema)
+	const operationObjects = getOperationObjects(
+		schema,
+		mayHaveCircularReferences
+	)
 	const serviceIds = getServiceIds(operationObjects)
 	// info and sidenav data are needed on all pages
 	const info = schema.info
@@ -78,9 +100,19 @@ function getPropsForPage(schema, params) {
  * @param {*} schema
  * @returns
  */
-function getPathsFromSchema(schema) {
+function getPathsFromSchema(
+	schema,
+	/**
+	 * Band-aid solution for circular references in Waypoint API docs. Task:
+	 * https://app.asana.com/0/1202097197789424/1203989531295664/f
+	 */
+	mayHaveCircularReferences: boolean = false
+) {
 	// Assign each operation category to a URL using its slug-ified ID
-	const operationObjects = getOperationObjects(schema)
+	const operationObjects = getOperationObjects(
+		schema,
+		mayHaveCircularReferences
+	)
 	const slugs = getServiceIds(operationObjects).map(getServicePathSlug)
 	// If this is a single service, just return an index page
 	const isSingleService = slugs.length === 1

--- a/src/components/open-api-page/utils/remove-circular-references.js
+++ b/src/components/open-api-page/utils/remove-circular-references.js
@@ -42,7 +42,22 @@ function safeStringifyJson(obj, indent = 2) {
  * should likely address and resolve that intentionally.
  */
 function removeCircularReferences(obj) {
-	return JSON.parse(safeStringifyJson(obj))
+	try {
+		/**
+		 * Try to stringify the object. If it has circular references,
+		 * we'll get an error. If there's no error in making the JSON string,
+		 * there's no need to modify the object, so we return it as-is.
+		 */
+		JSON.stringify(obj)
+		return obj
+	} catch (e) {
+		/**
+		 * If we got an error, we need to somehow deal with circular references.
+		 * The `safeStringifyJson` function does this, but not perfectly.
+		 * We avoid using it unless we have to.
+		 */
+		return JSON.parse(safeStringifyJson(obj))
+	}
 }
 
 export { removeCircularReferences }

--- a/src/components/open-api-page/utils/remove-circular-references.js
+++ b/src/components/open-api-page/utils/remove-circular-references.js
@@ -42,22 +42,7 @@ function safeStringifyJson(obj, indent = 2) {
  * should likely address and resolve that intentionally.
  */
 function removeCircularReferences(obj) {
-	try {
-		/**
-		 * Try to stringify the object. If it has circular references,
-		 * we'll get an error. If there's no error in making the JSON string,
-		 * there's no need to modify the object, so we return it as-is.
-		 */
-		JSON.stringify(obj)
-		return obj
-	} catch (e) {
-		/**
-		 * If we got an error, we need to somehow deal with circular references.
-		 * The `safeStringifyJson` function does this, but not perfectly.
-		 * We avoid using it unless we have to.
-		 */
-		return JSON.parse(safeStringifyJson(obj))
-	}
+	return JSON.parse(safeStringifyJson(obj))
 }
 
 export { removeCircularReferences }

--- a/src/pages/waypoint/api-docs/[[...page]].tsx
+++ b/src/pages/waypoint/api-docs/[[...page]].tsx
@@ -60,7 +60,8 @@ export async function getStaticPaths() {
 	}
 
 	if (schema) {
-		paths = getPathsFromSchema(schema)
+		const mayHaveCircularReferences = true
+		paths = getPathsFromSchema(schema, mayHaveCircularReferences)
 	}
 
 	return { paths, fallback: false }
@@ -76,7 +77,21 @@ export async function getStaticProps({ params }) {
 	}
 
 	// API page data
-	const apiPageProps = getPropsForPage(schema, params)
+	/**
+	 * Note: the Waypoint API docs have circular references.
+	 * We manually try to deal with those. This is a band-aid solution,
+	 * it seems to have unintended side-effects when applied to other
+	 * products' API docs, and almost certainly merits further investigation.
+	 *
+	 * Asana task:
+	 * https://app.asana.com/0/1202097197789424/1203989531295664/f
+	 */
+	const mayHaveCircularReferences = true
+	const apiPageProps = getPropsForPage(
+		schema,
+		params,
+		mayHaveCircularReferences
+	)
 
 	// Product data
 	const productData = cachedGetProductData(productSlug)


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Fixes an issue where some information does not render in Boundary API docs.

## 🛠️ How

As method for dealing with circular references was introduced in #1654, as it was necessary for `/waypoint/api-docs` to render. This method unknowingly removed some information from Boundary API docs (information that was falsely identified by the method as being a circular reference).

Updates to only apply the method of dealing with circular references in operation objects to `/waypoint/api-docs`.

## 🧪 Testing

- [ ] Visit the Boundary API docs, at [/boundary/api-docs]
    - The docs should look & function as they do upstread, except...
    - Some operations which previously displayed incomplete information should now be fixed. For example, the `Create Host` operation under [/boundary/api-docs/host-service] should display `Request` parameter information.

Other instances of open API docs pages should continue to render as they do upstream:

- [ ] Visit the Waypoint API docs, at [/waypoint/api-docs]
- [ ] Visit the HCP Packer API docs, at [/hcp/api-docs/packer]

## 💭 Anything else?

We'd like to follow up on improving our handling of Waypoint's API docs. Task: 🎟️ [[api-docs] investigate circular references in Waypoint API docs](https://app.asana.com/0/1202097197789424/1203989531295664/f)

[preview]: https://dev-portal-git-zspatch-boundary-api-docs-hashicorp.vercel.app/
[/waypoint/api-docs]: https://dev-portal-git-zspatch-boundary-api-docs-hashicorp.vercel.app/waypoint/api-docs
[/hcp/api-docs/packer]: https://dev-portal-git-zspatch-boundary-api-docs-hashicorp.vercel.app/hcp/api-docs/packer
[/boundary/api-docs]: https://dev-portal-git-zspatch-boundary-api-docs-hashicorp.vercel.app/boundary/api-docs
[/boundary/api-docs/host-service]: https://dev-portal-git-zspatch-boundary-api-docs-hashicorp.vercel.app/boundary/api-docs/host-service