### PR TITLE
style: update tab tokens

### DIFF
--- a/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
+++ b/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
@@ -33,7 +33,7 @@ the correct elements, roles, states, and properties are being set in the markup.
 Styles for each tab button.
 */
 .tabButton[role='tab'] {
-	background-color: var(--token-color-surface-primary);
+	background-color: transparent;
 	border-radius: 5px;
 	border: 1px solid transparent;
 	color: var(--token-color-foreground-faint);
@@ -59,7 +59,6 @@ Styles for each tab button.
 
 	/* In nested tabs, use a thick bottom border, visible when active */
 	&.isNested {
-		background-color: transparent;
 		border: none;
 		border-bottom: 2px solid transparent;
 		padding: 8px 12px 6px 12px;
@@ -74,7 +73,6 @@ Styles for each tab button.
 	}
 
 	&.variant--compact {
-		background-color: transparent;
 		border: none;
 		padding-bottom: 6px;
 		padding-left: 12px;
@@ -84,7 +82,7 @@ Styles for each tab button.
 
 		&[aria-selected='true'] {
 			&::after {
-				background-color: var(--token-color-palette-blue-200);
+				background-color: var(--token-color-foreground-action);
 				border-radius: 3px;
 				bottom: -1px;
 				content: '';


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksupdate-tabs-background-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204108582255288) 🎟️

## 🗒️ What

Updates the background of the tab action button to be transparent to blend in with the background on dark mode where its not always white. 

<img width="1023" alt="Screenshot 2023-03-16 at 10 50 49 AM" src="https://user-images.githubusercontent.com/36613477/225709017-a60982cd-64cf-44f5-be7f-8267380e3e1d.png">


## 🧪 Testing

- Test light mode fully in the [swingset page](https://dev-portal-git-ksupdate-tabs-background-hashicorp.vercel.app/swingset/components/tabs). Ensure that it matches upstream.
- Test dark mode on the preview [install view](https://dev-portal-git-ksupdate-tabs-background-hashicorp.vercel.app/packer/downloads), ensure that the tab buttons now blend in with the accordion disclosure background, as opposed to [current staging upstream.](https://dev-portal-git-staging-hashicorp.vercel.app/packer/downloads)
- See another example in the [hcp packer api docs](https://dev-portal-git-ksupdate-tabs-background-hashicorp.vercel.app/hcp/api-docs/packer), open an endpoint and checkout 'response' tabs to see the background color now blending in.
- Visit a tutorial page [with tabs](https://dev-portal-git-ksupdate-tabs-background-hashicorp.vercel.app/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy#deploy-consul-datacenter). Validate that everything looks okay in both dark and light mode. (There should be no change on these views from [staging upstream](https://dev-portal-git-staging-hashicorp.vercel.app/packer/downloads) currently, as the background was using 'primary' previously, which matches the sidebar-sidecar layout background.)

## 💭 Anything else?

Mobile should be unaffected by this change since the active mobile state uses the blue 'action' color for the background.
