### PR TITLE
fix: add theme provider forced light - sign up page

### DIFF
--- a/src/views/sign-up-view/index.tsx
+++ b/src/views/sign-up-view/index.tsx
@@ -5,6 +5,7 @@
 
 // Third-party imports
 import { useRouter } from 'next/router'
+import { ThemeProvider } from 'next-themes'
 
 // HashiCorp imports
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
@@ -53,67 +54,69 @@ const SignUpView = () => {
 	}
 
 	return (
-		<div className={s.root}>
-			<main className={s.main}>
-				<div>
-					<Link aria-label="HashiCorp Developer" href="/">
-						<InlineSvg
-							className={s.logo}
-							src={require('./img/logo-black.svg?include')}
-						/>
-					</Link>
-					<Heading className={s.heading} level={1} size={500} weight="bold">
-						{TITLE}
-					</Heading>
-					<ul className={s.list}>
-						{DETAILS.map((detail: string, index: number) => {
-							return (
-								// eslint-disable-next-line react/no-array-index-key
-								<li key={index} className={s.listItem}>
-									<IconCheckCircle16 className={s.detailIcon} />
-									<Text asElement="span" size={200} weight="regular">
-										{detail}
-									</Text>
-								</li>
-							)
-						})}
-					</ul>
-					<Button
-						icon={<IconUserPlus16 />}
-						iconPosition="trailing"
-						size="medium"
-						text={SIGN_UP_BUTTON_TEXT}
-						onClick={() => signUp()}
-					/>
-					<div className={s.signInContainer}>
-						<Text size={200} weight="regular">
-							{SIGN_IN_HINT_TEXT}
-						</Text>
+		<ThemeProvider forcedTheme="light">
+			<div className={s.root}>
+				<main className={s.main}>
+					<div>
+						<Link aria-label="HashiCorp Developer" href="/">
+							<InlineSvg
+								className={s.logo}
+								src={require('./img/logo-black.svg?include')}
+							/>
+						</Link>
+						<Heading className={s.heading} level={1} size={500} weight="bold">
+							{TITLE}
+						</Heading>
+						<ul className={s.list}>
+							{DETAILS.map((detail: string, index: number) => {
+								return (
+									// eslint-disable-next-line react/no-array-index-key
+									<li key={index} className={s.listItem}>
+										<IconCheckCircle16 className={s.detailIcon} />
+										<Text asElement="span" size={200} weight="regular">
+											{detail}
+										</Text>
+									</li>
+								)
+							})}
+						</ul>
 						<Button
-							color="tertiary"
-							icon={<IconArrowRight16 />}
+							icon={<IconUserPlus16 />}
 							iconPosition="trailing"
-							onClick={() => signIn()}
 							size="medium"
-							text={SIGN_IN_BUTTON_TEXT}
+							text={SIGN_UP_BUTTON_TEXT}
+							onClick={() => signUp()}
+						/>
+						<div className={s.signInContainer}>
+							<Text size={200} weight="regular">
+								{SIGN_IN_HINT_TEXT}
+							</Text>
+							<Button
+								color="tertiary"
+								icon={<IconArrowRight16 />}
+								iconPosition="trailing"
+								onClick={() => signIn()}
+								size="medium"
+								text={SIGN_IN_BUTTON_TEXT}
+							/>
+						</div>
+					</div>
+				</main>
+				<aside className={s.aside}>
+					<div className={s.asideGradient} />
+					<div className={s.asideGraphicContainer}>
+						<InlineSvg
+							className={s.asideGraphic}
+							/**
+							 * Replace with real graphic when it's available
+							 * ref: https://app.asana.com/0/1202097197789424/1202683836858983/f
+							 */
+							src={require('./img/aside-graphic.svg?include')}
 						/>
 					</div>
-				</div>
-			</main>
-			<aside className={s.aside}>
-				<div className={s.asideGradient} />
-				<div className={s.asideGraphicContainer}>
-					<InlineSvg
-						className={s.asideGraphic}
-						/**
-						 * Replace with real graphic when it's available
-						 * ref: https://app.asana.com/0/1202097197789424/1202683836858983/f
-						 */
-						src={require('./img/aside-graphic.svg?include')}
-					/>
-				</div>
-			</aside>
-		</div>
+				</aside>
+			</div>
+		</ThemeProvider>
 	)
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksforce-light-sign-up-hashicorp.vercel.app/sign-up) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204138604242158) 🎟️

## 🗒️ What

This PR adds the theme provider to the sign up page and forces this view to always be 'light' theme. There was an issue where the dark color palette tokens would carry over into this view, even though there isn't theming (see video in ticket). 

This view should remain consistent despite dark and light theming due to the hybrid design. 

[✨ **View diff without whitespace** ✨ ](https://github.com/hashicorp/dev-portal/pull/1751/files?diff=split&w=1)

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksforce-light-sign-up-hashicorp.vercel.app/), select 'dark' for the theme
- Visit the [sign up page](https://dev-portal-git-ksforce-light-sign-up-hashicorp.vercel.app/sign-up), ensure it is the same as upstream
- Test with light for good measure. 

## 💭 Anything else?

To see the issue, visit [staging](https://dev-portal-git-staging-hashicorp.vercel.app/) and select dark mode and then visit the [sign up page](https://dev-portal-git-staging-hashicorp.vercel.app/sign-up). Note that the behavior is inconsistent, but you can see the issue in the [video posted on the ticket. ](https://app.asana.com/0/1199634971449915/1204138604242158)
