### PR TITLE
fix: search compact tabs bg color

### DIFF
--- a/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
+++ b/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
@@ -59,6 +59,7 @@ Styles for each tab button.
 
 	/* In nested tabs, use a thick bottom border, visible when active */
 	&.isNested {
+		background-color: transparent;
 		border: none;
 		border-bottom: 2px solid transparent;
 		padding: 8px 12px 6px 12px;
@@ -73,6 +74,7 @@ Styles for each tab button.
 	}
 
 	&.variant--compact {
+		background-color: transparent;
 		border: none;
 		padding-bottom: 6px;
 		padding-left: 12px;


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-search-tabs-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1203652232454021/1204188684910240) 🎟️

## 🗒️ What

A bug was introduced with #1750, this adds back in the transparent background for the 'compact' search tab buttons. 

<img width="816" alt="Screenshot 2023-03-17 at 9 58 17 AM" src="https://user-images.githubusercontent.com/36613477/225969948-f4ce5165-aeb3-4535-8d64-8f8f50cfe06d.png">


## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

 - visit the preview, open search, type in something. Ensure that the background color of the tab button is not blue. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
