### PR TITLE
fix: hcp color inherit

### DIFF
--- a/src/components/product-icon/index.tsx
+++ b/src/components/product-icon/index.tsx
@@ -29,7 +29,11 @@ const productSlugsToIcons = {
 
 const ProductIcon = ({ productSlug, ...rest }: ProductIconProps) => {
 	const Icon = productSlugsToIcons[productSlug]
-	const brandColorSlug = productSlug === 'hcp' ? 'hashicorp' : productSlug
+	// Color should inherit from parent for hcp
+	const color =
+		productSlug === 'hcp'
+			? undefined
+			: `var(--token-color-${productSlug}-brand)`
 
 	if (!Icon) {
 		return null
@@ -39,7 +43,7 @@ const ProductIcon = ({ productSlug, ...rest }: ProductIconProps) => {
 	 * color and then set the product brand color since all the product icons
 	 * have a single fill color.
 	 */
-	return <Icon {...rest} color={`var(--token-color-${brandColorSlug}-brand)`} />
+	return <Icon {...rest} color={color} />
 }
 
 export type { ProductIconProps }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Hcp was set to use `hashicorp-brand` but this should inherit from the parent context instead. 

Bug: 
<img width="837" alt="Screenshot 2023-03-22 at 1 49 48 PM" src="https://user-images.githubusercontent.com/36613477/227034744-4e3384cc-34e0-4ea7-8b87-b5b05fc344f7.png">

Should be:
<img width="1153" alt="Screenshot 2023-03-22 at 1 50 13 PM" src="https://user-images.githubusercontent.com/36613477/227034842-065dda98-5475-4a9c-ba23-81a0697d3e1d.png">


## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksfix-hcp-logo-hashicorp.vercel.app/hcp/docs)
- Ensure the logo tile looks okay in both dark and light mode for the hcp icon

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
