### PR TITLE
patch: hcp callout svg safari

### DIFF
--- a/src/components/try-hcp-callout/components/try-hcp-callout-compact/img/try-hcp-callout-compact-background.svg
+++ b/src/components/try-hcp-callout/components/try-hcp-callout-compact/img/try-hcp-callout-compact-background.svg
@@ -36,6 +36,10 @@
 <stop offset="0.140625" stop-color="#1FBCFF" stop-opacity="0.9"/>
 <stop offset="0.776042" stop-color="#BE87FF" stop-opacity="0"/>
 </radialGradient>
+<linearGradient id="paint3_linear_14_11369" x1="283.574" y1="280.929" x2="150.927" y2="272.788" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
 <clipPath id="clip0_14_11369">
 <rect width="326" height="440" fill="white"/>
 </clipPath>

--- a/src/components/try-hcp-callout/components/try-hcp-callout/img/try-hcp-callout-background.svg
+++ b/src/components/try-hcp-callout/components/try-hcp-callout/img/try-hcp-callout-background.svg
@@ -12,10 +12,18 @@
 <stop offset="0.520833" stop-color="#A457FF" stop-opacity="0"/>
 <stop offset="0.666667" stop-color="#00B1FF" stop-opacity="0.63"/>
 </radialGradient>
+<radialGradient id="paint1_radial_7_11007" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(255.355 574.948) rotate(-90) scale(345.299 777.362)">
+<stop offset="0.151042" stop-color="#1FBCFF" stop-opacity="0.47"/>
+<stop offset="0.828125" stop-color="#BE87FF" stop-opacity="0"/>
+</radialGradient>
 <radialGradient id="paint2_radial_7_11007" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(361.32 522.264) rotate(-90) scale(345.299 777.362)">
 <stop offset="0.302083" stop-color="#1FBCFF" stop-opacity="0.9"/>
 <stop offset="0.682292" stop-color="#BE87FF" stop-opacity="0"/>
 </radialGradient>
+<linearGradient id="paint3_linear_7_11007" x1="962.269" y1="131.587" x2="908.453" y2="259.983" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
 <clipPath id="clip0_7_11007">
 <rect width="1000" height="420" fill="white"/>
 </clipPath>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-hcp-svg-safari-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Safari didn't like the svg edits we made in https://github.com/hashicorp/dev-portal/pull/1753. This fixes those for light mode.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksfix-hcp-svg-safari-hashicorp.vercel.app/packer) in light mode **in safari**, ensure the hcp callouts don't have an odd dark background. 
- [look at install page](https://dev-portal-git-ksfix-hcp-svg-safari-hashicorp.vercel.app/)

## 💭 Anything else?

I'll need to follow up and adjust the approach for dark mode on the compact one and there's still a slight white glare on the main one, since its still off with this change. Will do that in a follow up PR / may need to rethink the svg approach to make it happy with safari.

<img width="428" alt="Screenshot 2023-03-22 at 2 13 57 PM" src="https://user-images.githubusercontent.com/36613477/227040045-68009adc-1976-434e-a70a-03d9af7a64b0.png">


