### PR TITLE
fix: hcp wordmark color

### DIFF
--- a/src/components/try-hcp-callout/components/hcp-logo-heading/hcp-logo-heading.module.css
+++ b/src/components/try-hcp-callout/components/hcp-logo-heading/hcp-logo-heading.module.css
@@ -8,5 +8,10 @@
 		display: block;
 		height: 28px;
 		width: auto;
+
+		/** For theming, paths need to have a token fill **/
+		& path {
+			fill: var(--token-color-foreground-strong);
+		}
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-hcp-wordmark-hashicorp.vercel.app/hcp) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204240152820189) 🎟️

## 🗒️ What

This fixes an issue where the HCP wordmark wasn't 'flipping' for dark mode since its using `mktg-logos` that don't inherit the `currentColor`

### Upstream
<img width="985" alt="Screenshot 2023-03-23 at 11 35 01 AM" src="https://user-images.githubusercontent.com/36613477/227314287-3adc85b8-cfe5-4a3a-859f-3bda772191e1.png">

### This branch
<img width="689" alt="Screenshot 2023-03-23 at 11 34 35 AM" src="https://user-images.githubusercontent.com/36613477/227314195-3850f674-820a-4266-8c42-2013fdc793af.png">
<img width="711" alt="Screenshot 2023-03-23 at 11 34 52 AM" src="https://user-images.githubusercontent.com/36613477/227314249-b62ab580-4575-40c9-81a0-088a33f013eb.png">

## 🧪 Testing

- Visit the hcp landing page. Checkout the HCP callout. Verify that in both light and dark mode the logo renders as expected. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
