### PR TITLE
style: fixup apple logo import

### DIFF
--- a/src/views/product-downloads-view/boundary/components/operating-system-icons.tsx
+++ b/src/views/product-downloads-view/boundary/components/operating-system-icons.tsx
@@ -5,7 +5,7 @@
 
 // Icons
 import { IconDownload16 } from '@hashicorp/flight-icons/svg-react/download-16'
-import { IconAppleColor16 } from '@hashicorp/flight-icons/svg-react/apple-color-16'
+import { IconApple16 } from '@hashicorp/flight-icons/svg-react/apple-16'
 import { IconMicrosoftColor16 } from '@hashicorp/flight-icons/svg-react/microsoft-color-16'
 /* Note: linux icon should be added to HDS Flight Icons soon */
 import { IconLinuxColor16 } from 'views/product-downloads-view/boundary/components'
@@ -17,7 +17,7 @@ import { OperatingSystem } from 'lib/fetch-release-data'
  * Map an operating system to its associated 16px color icon.
  */
 export const operatingSystemIcons: Record<OperatingSystem, ReactElement> = {
-	darwin: <IconAppleColor16 />,
+	darwin: <IconApple16 />,
 	linux: <IconLinuxColor16 />,
 	windows: <IconMicrosoftColor16 />,
 	/**


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksupdate-apple-icon-hashicorp.vercel.app/boundary/downloads) 🔎
- [Asana task](https://app.asana.com/0/1203652232454021/1204240152820178) 🎟️

## 🗒️ What

Adjusts the import for the apple logo to not be color, so that the color is inherited from the parent context and can shift with themes. 

### Before
<img width="984" alt="Screenshot 2023-03-23 at 1 38 40 PM" src="https://user-images.githubusercontent.com/36613477/227350922-3de08245-725f-4d85-afbc-2e77cce71d8a.png">

### After
<img width="972" alt="Screenshot 2023-03-23 at 1 40 35 PM" src="https://user-images.githubusercontent.com/36613477/227352231-24eb45ba-8030-49e9-90f1-c971f39e31e7.png">

## 🧪 Testing

- Visit the [boundary downloads page](https://dev-portal-git-ksupdate-apple-icon-hashicorp.vercel.app/boundary/downloads), validate that the apple logo switches properly between light and dark. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
