### PR TITLE
chore: fix vagrant icon import

### DIFF
--- a/src/components/product-icon/index.tsx
+++ b/src/components/product-icon/index.tsx
@@ -9,7 +9,7 @@ import { IconHcp16 } from '@hashicorp/flight-icons/svg-react/hcp-16'
 import { IconNomad16 } from '@hashicorp/flight-icons/svg-react/nomad-16'
 import { IconPacker16 } from '@hashicorp/flight-icons/svg-react/packer-16'
 import { IconTerraform16 } from '@hashicorp/flight-icons/svg-react/terraform-16'
-import { IconVagrant16 } from '@hashicorp/flight-icons/svg-react/vagrant-16'
+import { IconVagrantColor16 } from '@hashicorp/flight-icons/svg-react/vagrant-color-16'
 import { IconVault16 } from '@hashicorp/flight-icons/svg-react/vault-16'
 import { IconWaypoint16 } from '@hashicorp/flight-icons/svg-react/waypoint-16'
 import { ProductIconProps } from './types'
@@ -22,7 +22,7 @@ const productSlugsToIcons = {
 	packer: IconPacker16,
 	sentinel: null,
 	terraform: IconTerraform16,
-	vagrant: IconVagrant16,
+	vagrant: IconVagrantColor16, // Vagrant's logo has 'shadows' so has to be 'color', also stays the same between themes
 	vault: IconVault16,
 	waypoint: IconWaypoint16,
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-vagrant-logo-hashicorp.vercel.app/vagrant) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

For theming, we updated the product icons to dynamically set their fill color associated with the brand since brand colors can shift between themes. Since vagrant doesn't shift and also is '3d' with shadows, we still need to import the color version. 

### Bug
<img width="281" alt="Screenshot 2023-03-24 at 10 27 27 AM" src="https://user-images.githubusercontent.com/36613477/227597766-62ee79b2-bf71-441e-994b-73509abb1e93.png">


### Fix
<img width="344" alt="Screenshot 2023-03-24 at 10 28 15 AM" src="https://user-images.githubusercontent.com/36613477/227598005-f11368c8-79a6-4331-b0c4-ea0f5b95ba5a.png">

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [visit vagrant in preview](https://dev-portal-git-ksfix-vagrant-logo-hashicorp.vercel.app/vagrant), validate that the logo shoes highlights / shadows.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
