### PR TITLE
Removing enable_global_search flag and references ✂️

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -44,7 +44,6 @@
 		"enable_datadog": true,
 		"enable_io_beta_cta": true,
 		"enable_product_docs_search": true,
-		"enable_global_search": true,
 		"enable_dark_mode": true,
 		"enable_home_page_redesign": false
 	}

--- a/config/base.json
+++ b/config/base.json
@@ -43,7 +43,7 @@
 	"flags": {
 		"enable_datadog": true,
 		"enable_io_beta_cta": true,
-		"enable_product_docs_search": true,
+		"enable_product_docs_search": false,
 		"enable_dark_mode": true,
 		"enable_home_page_redesign": false
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,6 @@
 		"max_static_paths": 1
 	},
 	"flags": {
-		"enable_global_search": true,
 		"enable_home_page_redesign": true
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,7 +4,6 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_global_search": true,
 		"enable_home_page_redesign": true
 	}
 }

--- a/src/components/command-bar/index.tsx
+++ b/src/components/command-bar/index.tsx
@@ -25,8 +25,6 @@ import {
 	SupportedCommand,
 } from './types'
 
-const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
-
 const DEFAULT_CONTEXT_STATE: CommandBarContextState = {
 	currentCommand: commands.search,
 	currentInputValue: '',
@@ -127,10 +125,6 @@ const CommandBarProvider = ({ children }: CommandBarProviderProps) => {
 	 * Set up the cmd/ctrl + k keydown listener.
 	 */
 	useEffect(() => {
-		if (!GLOBAL_SEARCH_ENABLED) {
-			return
-		}
-
 		const handleKeyDown = (e: KeyboardEvent) => {
 			const { ctrlKey, metaKey, key } = e
 			if (key === 'k' && (ctrlKey || metaKey)) {

--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -26,8 +26,6 @@ import { NavigationHeaderItem } from './types'
 import { HomePageHeaderContent, ProductPageHeaderContent } from './components'
 import s from './navigation-header.module.css'
 
-const GLOBAL_SEARCH_ENABLED = __config.flags.enable_global_search
-
 /**
  * The header content displayed to the far right of the window. This content is
  * the same for every page in the app.
@@ -104,12 +102,10 @@ const NavigationHeader = () => {
 				<LeftSideHeaderContent />
 			</div>
 			<div className={s.rightSide}>
-				{GLOBAL_SEARCH_ENABLED ? (
-					<CommandBarActivator
-						leadingIcon={<IconSearch16 />}
-						visualLabel="Search"
-					/>
-				) : null}
+				<CommandBarActivator
+					leadingIcon={<IconSearch16 />}
+					visualLabel="Search"
+				/>
 				{__config.flags.enable_dark_mode ? <ThemeSwitch /> : null}
 				<AuthenticationControls />
 				<MobileMenuButton />

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -50,9 +50,7 @@ const DocsView = ({
 	const { compiledSource, scope } = mdxSource
 	const docsMdxComponents = getDocsMdxComponents(currentProduct.slug)
 	const shouldRenderSearch =
-		!__config.flags.enable_global_search &&
-		!hideSearch &&
-		__config.flags.enable_product_docs_search
+		!hideSearch && __config.flags.enable_product_docs_search
 
 	const Layout = layouts[metadata?.layout?.name] ?? DefaultLayout
 

--- a/src/views/product-root-docs-path-landing/index.tsx
+++ b/src/views/product-root-docs-path-landing/index.tsx
@@ -28,9 +28,7 @@ const ProductRootDocsPathLanding = ({
 	outlineItems,
 }: ProductRootDocsPathLandingProps) => {
 	const { pageSubtitle, marketingContentBlocks } = pageContent
-	const showProductDocsSearch =
-		!__config.flags.enable_global_search &&
-		__config.flags.enable_product_docs_search
+	const showProductDocsSearch = __config.flags.enable_product_docs_search
 
 	let mdxSlot: ReactElement
 	if (mdxSource) {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/0/1204295268139181/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes the `enable_global_search` feature flag & cleans up references
- Turns off the `enable_product_docs_search` flag

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Feature flag is no longer needed! 🎉
- The `enable_product_docs_search` was coupled to this one, so I've only flipped that off here for ease of reviewing

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] On several different pages:
  - [ ] Make sure the `CommandBarActivator` element always renders
  - [ ] Make sure the `cmd/ctrl` + `k` keyboard shortcut always opens `CommandBar`
- [ ] On several `/${productSlug}/docs` landing pages, make sure there is no search input above the page title
- [ ] On several `/${productSlug}/${docsBasePath}/*` docs content pages, make sure there is no search input above the page title 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- [Clean up `enable_product_docs_search` feature flag](https://app.asana.com/0/0/1204295268139188/f) is coming in https://github.com/hashicorp/dev-portal/pull/1798!


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204295268139181