### PR TITLE
[CommandBar] Enable input & tab pre-population on open

### DIFF
--- a/src/views/homepage/components/featured-content-grid/featured-content-grid.module.css
+++ b/src/views/homepage/components/featured-content-grid/featured-content-grid.module.css
@@ -31,6 +31,7 @@
 .searchCard {
 	background-color: var(--token-color-foreground-strong);
 	border-radius: 10px;
+	border: 1px solid magenta; /* TODO: remove; denotes WIP */
 	box-shadow: none;
 	padding-bottom: 18px;
 	padding-left: 24px;
@@ -45,14 +46,8 @@
 	margin-bottom: 20px;
 }
 
-.searchCardCarousel {
-	border-radius: 8px;
-	background-color: #222429; /* TODO */
-	height: 125px;
-	width: 100%;
-}
-
 .card {
 	background-color: var(--token-color-foreground-strong);
+	border: 1px solid magenta; /* TODO: remove; denotes WIP */
 	height: 100%;
 }

--- a/src/views/homepage/components/featured-content-grid/index.tsx
+++ b/src/views/homepage/components/featured-content-grid/index.tsx
@@ -1,9 +1,12 @@
 import Card from 'components/card'
+import { useCommandBar } from 'components/command-bar'
 import Heading from 'components/heading'
 import Text from 'components/text'
 import s from './featured-content-grid.module.css'
 
 const FeaturedContentGrid = () => {
+	const { setCurrentInputValue, toggleIsOpen } = useCommandBar()
+
 	return (
 		<div className={s.root}>
 			<div className={s.gridAreaA}>
@@ -18,7 +21,17 @@ const FeaturedContentGrid = () => {
 							on a wide range of topics.
 						</Text>
 					</div>
-					<div className={s.searchCardCarousel} />
+					<div className={s.searchCardCarousel}>
+						{/* @TODO */}
+						<button
+							onClick={() => {
+								setCurrentInputValue('TEST')
+								toggleIsOpen()
+							}}
+						>
+							open search
+						</button>
+					</div>
 				</Card>
 			</div>
 			<div className={s.gridAreaB}>

--- a/src/views/homepage/components/featured-content-grid/index.tsx
+++ b/src/views/homepage/components/featured-content-grid/index.tsx
@@ -4,6 +4,14 @@ import Heading from 'components/heading'
 import Text from 'components/text'
 import s from './featured-content-grid.module.css'
 
+const FEATURED_SEARCH_TERMS = [
+	'Consul Kubernetes Helm Chart',
+	'Vault AppRole Auth Method',
+	'Nomad Service Discovery',
+	'Terraform Variables',
+	'Cloud Operating Model',
+]
+
 const FeaturedContentGrid = () => {
 	const { setCurrentInputValue, toggleIsOpen } = useCommandBar()
 
@@ -22,15 +30,20 @@ const FeaturedContentGrid = () => {
 						</Text>
 					</div>
 					<div className={s.searchCardCarousel}>
-						{/* @TODO */}
-						<button
-							onClick={() => {
-								setCurrentInputValue('TEST')
-								toggleIsOpen()
-							}}
-						>
-							open search
-						</button>
+						<ul>
+							{FEATURED_SEARCH_TERMS.map((featuredSearchTerm: string) => (
+								<li key={featuredSearchTerm}>
+									<button
+										onClick={() => {
+											setCurrentInputValue(featuredSearchTerm)
+											toggleIsOpen()
+										}}
+									>
+										{featuredSearchTerm}
+									</button>
+								</li>
+							))}
+						</ul>
 					</div>
 				</Card>
 			</div>

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -136,6 +136,13 @@ function HomePageView({ content }: HomePageProps): ReactElement {
 	)
 }
 
+/**
+ * `contentType` is set to "tutorials" so that all of the featured Search
+ * options will show the Tutorials tab by default. If we decide to feature
+ * Search terms that should show other tabs on click, then CommandBar will need
+ * to have functionality added to do so.
+ */
+HomePageView.contentType = 'tutorials'
 HomePageView.layout = BaseNewLayout
 HomePageView.theme = GlobalThemeOption.light
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambcb-settings-on-open-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/0/1204131825828256/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds basic `<button>`s to the featured search card
  - The featured search terms are defined in the attached task
  - These buttons leverage the `setCurrentInputValue` and `toggleIsOpen` helpers exposed by `CommandBar`
- Sets the `contentType` of the `HomePageView` to `'tutorials'`
  - This makes `CommandBar` show the `"Tutorials"` tab by default
  - Added a comment with explicit context, since we previously had this page use the `"global"` `contentType`
- Adds a magenta border around WIP cards, since this page is starting to shape up and may look official/done/broken otherwise

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [the home page](https://dev-portal-git-ambcb-settings-on-open-hashicorp.vercel.app/) on the preview
- [ ] For each `<button>` in the `"Search with ease"` featured card:
  - [ ] Activate the button
  - [ ] CommandBar should open
  - [ ] The input text should match the button's text
  - [ ] The Tutorials tab should be selected

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- This PR does not style these new buttons. That will come in a separate task currently scheduled for next week: [Style & animate SearchCard](https://app.asana.com/0/0/1204200670480305/f).
- There's a slight delay/flash when `CommandBar` is opened with these buttons. This is because `SearchCommandBarDialogBody` waits to send off search queries for `300ms` after the text input is finished changes, and because of the search results loading delay. This isn't ideal, and I'm thinking through a couple of options for optimizing this before release. This PR will not optimize this.
  - Expose the `setSearchQuery` helper from `SearchCommandBarDialogBody`. This doesn't feel super ideal because it's not intended to be used as a utility, it's still a feasible and low-effort option. However, it will only remove the 300ms before the search query is sent off. It will not help the results loading delay (an existing issue).
  - Pre-load the search results for these buttons on render, and put the results in the React Query cache. Since we currently rely solely on Algolia's UI components/contexts to invoke search results fetching, I'm not sure how feasible this idea is. I'll do some digging and see if Algolia exposes any prefetching utilities though!
