### PR TITLE
chore: fix focus style

### DIFF
--- a/src/components/command-bar/components/activator/command-bar-activator.module.css
+++ b/src/components/command-bar/components/activator/command-bar-activator.module.css
@@ -11,7 +11,7 @@
 	align-items: center;
 	background-color: transparent;
 	border-radius: 5px;
-	border: none;
+	border: 1px solid var(--token-color-palette-neutral-400);
 	display: flex;
 	gap: 16px;
 	justify-content: space-between;
@@ -20,10 +20,6 @@
 	padding-right: 12px;
 	padding-top: 8px;
 	width: fit-content;
-
-	/* TODO is there a better value for this? */
-	box-shadow: inset 0 0 0 1px rgba(222, 223, 227, 0.3),
-		inset 0 1px 2px 1px rgba(222, 223, 227, 0.1);
 
 	/* Show icon-only starting at 1071px and narrower */
 	@media only screen and (max-width: 1071px) {
@@ -39,19 +35,6 @@
 
 		& .right {
 			display: none;
-		}
-	}
-
-	@nest html[data-theme='dark'] & {
-		border: 1px solid var(--token-color-border-strong);
-
-		/* TODO update the light version with a token instead of manual box shadow */
-		box-shadow: unset;
-
-		/* Ensures the g-focus-ring-from-box-shadow-dark styles aren't overridden */
-		&:focus-visible {
-			box-shadow: var(--custom-token-focus-ring-action-box-shadow-dark);
-			outline: transparent;
 		}
 	}
 }

--- a/src/components/command-bar/components/activator/command-bar-activator.module.css
+++ b/src/components/command-bar/components/activator/command-bar-activator.module.css
@@ -47,6 +47,12 @@
 
 		/* TODO update the light version with a token instead of manual box shadow */
 		box-shadow: unset;
+
+		/* Ensures the g-focus-ring-from-box-shadow-dark styles aren't overridden */
+		&:focus-visible {
+			box-shadow: var(--custom-token-focus-ring-action-box-shadow-dark);
+			outline: transparent;
+		}
 	}
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfixup-focus-ring-hashicorp.vercel.app/waypoint) 🔎
- [Asana task](https://app.asana.com/0/1203652232454021/1204304009719187) 🎟️

## 🗒️ What

This fixes up the focus ring styles that were being overridden by the dark override styles for the `box-shadow`. 

<img width="455" alt="Screenshot 2023-03-30 at 5 15 57 PM" src="https://user-images.githubusercontent.com/36613477/228991904-4c3ee49a-8071-4ffa-8b6e-9f5ff1e6f698.png">

## 🧪 Testing

- [Visit the preview ](https://dev-portal-git-ksfixup-focus-ring-hashicorp.vercel.app/waypoint), enable dark theme and tab through the nav. The command bar activator input should have focus styles that match light mode. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
