### PR TITLE
Aligning UserDropdownDisclosure focus ring for consistency

### DIFF
--- a/src/components/dropdown-disclosure/index.tsx
+++ b/src/components/dropdown-disclosure/index.tsx
@@ -35,6 +35,7 @@ const handleError = (message: string) => {
 }
 
 const DropdownDisclosure = ({
+	activatorClassName,
 	'aria-label': ariaLabel,
 	children,
 	className,
@@ -89,7 +90,7 @@ const DropdownDisclosure = ({
 		>
 			<DropdownDisclosureActivator
 				aria-label={ariaLabel}
-				className={s.activator}
+				className={classNames(s.activator, activatorClassName)}
 				color={color}
 				hideChevron={hideChevron}
 			>

--- a/src/components/dropdown-disclosure/types.ts
+++ b/src/components/dropdown-disclosure/types.ts
@@ -25,6 +25,12 @@ interface DropdownDisclosureProps
 	extends PickedDropdownDisclosureActivatorProps,
 		PickedDisclosureProps {
 	/**
+	 * An optional `className` that is passed to the internally rendered
+	 * `DropdownDisclosureActivator`.
+	 */
+	activatorClassName?: string
+
+	/**
 	 * Text that should be announced by a screen reader when the activator
 	 * `<button>` comes into focus. Should only be provided in two cases:
 	 *

--- a/src/components/navigation-header/index.tsx
+++ b/src/components/navigation-header/index.tsx
@@ -57,7 +57,7 @@ const AuthenticationControls = () => {
 	return (
 		<div className={s.authenticationControls}>
 			<UserDropdownDisclosure
-				className={s.userDropdownDisclosure}
+				activatorClassName={s.userDropdownDisclosureActivator}
 				listPosition="right"
 				items={
 					user

--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -99,7 +99,11 @@
 	}
 }
 
-.userDropdownDisclosure button[aria-expanded] {
+.userDropdownDisclosureActivator {
+	/* composition */
+	composes: g-focus-ring-from-box-shadow-dark from global;
+
+	/* properties */
 	background-color: transparent;
 	color: var(--token-color-foreground-high-contrast);
 

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -62,6 +62,7 @@ const renderItem = (
  * both authenticated and unauthenticated users.
  */
 const UserDropdownDisclosure = ({
+	activatorClassName,
 	className,
 	items,
 	listPosition,
@@ -74,6 +75,7 @@ const UserDropdownDisclosure = ({
 
 	return (
 		<DropdownDisclosure
+			activatorClassName={activatorClassName}
 			aria-label="User menu"
 			className={className}
 			icon={user ? userMeta.icon : <IconUser24 />}

--- a/src/components/user-dropdown-disclosure/types.ts
+++ b/src/components/user-dropdown-disclosure/types.ts
@@ -24,10 +24,13 @@ type UserDropdownDisclosureItem =
 			onClick: DropdownDisclosureButtonItemProps['onClick']
 	  }
 
-interface UserDropdownDisclosureProps {
-	className?: DropdownDisclosureProps['className']
+type PickedDropdownDisclosureProps = Pick<
+	DropdownDisclosureProps,
+	'activatorClassName' | 'className' | 'listPosition'
+>
+
+interface UserDropdownDisclosureProps extends PickedDropdownDisclosureProps {
 	items: UserDropdownDisclosureItem[]
-	listPosition?: DropdownDisclosureProps['listPosition']
 	user: Session['user']
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-user-dropdown-focus-ring-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202114367927919/1204304009719193/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `activatorClassName` prop to `DropdownDisclosure`
- Adds `activatorClassName` prop to `UserDropdownDisclosure`, inherited directly from `DropdownDisclosure`
- Renames the `userDropdownDisclosure` class to `userDropdownDisclosureActivator`
- Updates the same class to compose `g-focus-ring-from-box-shadow-dark`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- This element was the only one in the nav header that did not compose `g-focus-ring-from-box-shadow-dark` for the focus ring styles

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to any page in the app
- [ ] Check that the `focus-visible` style of `UserDropdownDisclosure` matches the other elements in the nav header

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- Not directly related to this PR, but a Dark Mode question for @kendallstrautman & @braydenlove: Does the `--custom-token-focus-ring-action-box-shadow-dark` variable that the `g-focus-ring-from-box-shadow-dark` global class uses need to be swapped at all when the theme switches?
