### PR TITLE
Switch the Integration page <h1> to be {integration.name} rather than `README`

### DIFF
--- a/src/views/product-integration/readme-view/index.tsx
+++ b/src/views/product-integration/readme-view/index.tsx
@@ -38,7 +38,7 @@ export default function ProductIntegrationReadmeView({
 
 	return (
 		<ProductIntegrationLayout
-			title="README"
+			title={integration.name}
 			className={s.readmeView}
 			breadcrumbLinks={breadcrumbLinks}
 			currentProduct={product}


### PR DESCRIPTION
Adjusting the Integration page H1 to be driven by the `{integration.name}`.

Previously, the title of this page was `README`, and our guidance to integration authors was that they incorporate the {integration.name} as the first H2 of the top level integration README.  We've adjusted this guidance in our documentation for authors [here](https://github.com/hashicorp/integration-template/blob/main/INTEGRATION_README.md).

Right now, Waypoint integrations are the only remote integrations, and I've adjusted those in this PR: https://github.com/hashicorp/waypoint/pull/4610.  We'll be sure to sync that content before merging this PR to ensure there is no duplication of Titles.

- [Preview link...](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1203792704477775/1203295231021660) 🎟️