### PR TITLE
Update the integration header’s title to be to be a span instead of a h1

### DIFF
--- a/src/components/content-header-card/content-header-card.module.css
+++ b/src/components/content-header-card/content-header-card.module.css
@@ -181,3 +181,7 @@
 		}
 	}
 }
+
+.title {
+	composes: hds-typography-display-300 from global, hds-font-weight-bold from global;
+}

--- a/src/components/content-header-card/index.tsx
+++ b/src/components/content-header-card/index.tsx
@@ -10,7 +10,6 @@ import Card from 'components/card'
 import DropdownDisclosure, {
 	DropdownDisclosureLinkItem,
 } from 'components/dropdown-disclosure'
-import Heading from 'components/heading'
 import IconTileLogo from 'components/icon-tile-logo'
 import StandaloneLink from 'components/standalone-link'
 import Text from 'components/text'
@@ -57,9 +56,7 @@ export default function ContentHeaderCard({
 						)}
 						<div className={s.left}>
 							<div className={s.titleWrap}>
-								<Heading size={300} weight="bold" level={1} className={s.title}>
-									{title}
-								</Heading>
+								<span className={s.title}>{title}</span>
 								{attribution && (
 									<Text size={100} weight="medium" className={s.attribution}>
 										{attribution}


### PR DESCRIPTION
We do not want this integration header to be the H1 of the page, as it remains consistent beween subpages (with different page titles). In a [slack discussion](https://hashicorp.slack.com/archives/C03RZAF1XS8/p1680542560922859) it was brought up that there are two `h1`'s on the integration pages, due to the Header component having a H1, and also due to the template having a H1.

The header component always refers to the integration, and is not the source of the page title, so I'm updating this component to be driven via a `span`.

I was considering adjusting this to be another header (like a h2), but realized that it does not fall within the header hierarchy at all.

Let's wait on merging this one until we have https://github.com/hashicorp/dev-portal/pull/1805 deployed & in.