### PR TITLE
refactor: disclosure list item icon placement to right

### DIFF
--- a/src/components/dropdown-disclosure/components/list-item/index.tsx
+++ b/src/components/dropdown-disclosure/components/list-item/index.tsx
@@ -97,10 +97,10 @@ const DropdownDisclosureButtonItem = ({
 					toggleDisclosure()
 				}}
 			>
-				{icon}
 				<Text asElement="span" size={200} weight="medium">
 					{children}
 				</Text>
+				{icon}
 			</button>
 		</DropdownDisclosureListItem>
 	)
@@ -119,10 +119,10 @@ const DropdownDisclosureLinkItem = ({
 	return (
 		<DropdownDisclosureListItem>
 			<Link className={s.link} href={href} rel={rel} target={target}>
-				{icon}
 				<Text asElement="span" size={200} weight="medium">
 					{children}
 				</Text>
+				{icon}
 			</Link>
 		</DropdownDisclosureListItem>
 	)

--- a/src/components/dropdown-disclosure/components/list-item/list-item.module.css
+++ b/src/components/dropdown-disclosure/components/list-item/list-item.module.css
@@ -22,6 +22,7 @@
 	padding: 8px 10px 8px 16px;
 	position: relative;
 	text-decoration: none;
+	justify-content: space-between;
 
 	& span {
 		display: block;

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -39,15 +39,15 @@ const renderItem = (
 	if (href) {
 		content = (
 			<Link href={href} className={s.link} opensInNewTab={isExternal} rel={rel}>
-				{icon}
 				{labelElement}
+				{icon}
 			</Link>
 		)
 	} else if (onClick) {
 		content = (
 			<button className={s.button} onClick={onClick}>
-				{icon}
 				{labelElement}
+				{icon}
 			</button>
 		)
 	}

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/mobile-user-disclosure.module.css
@@ -121,4 +121,5 @@
 	padding-right: 16px;
 	padding-top: 8px;
 	width: 100%;
+	justify-content: space-between;
 }

--- a/src/lib/auth/user.tsx
+++ b/src/lib/auth/user.tsx
@@ -5,6 +5,7 @@
 
 import { Session } from 'next-auth'
 import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
+import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import useAuthentication from 'hooks/use-authentication'
 import { UserDropdownDisclosureProps } from 'components/user-dropdown-disclosure'
 
@@ -41,6 +42,7 @@ const getUserMenuItems = ({
 		{
 			label: 'Account settings',
 			href: 'https://portal.cloud.hashicorp.com/account-settings',
+			icon: <IconExternalLink16 />,
 		},
 		{
 			label: 'Sign out',


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksrefactor-mobile-menu-icon-placement-hashicorp.vercel.app/boundary) 🔎
- [Asana task](https://app.asana.com/0/1203652232454021/1204303889362367) 🎟️
- [Figma](https://www.figma.com/file/v0Hyqvjdf6QJAvRkdIBV24/Dark-Mode?node-id=815-40857&t=BLzfEIgRtHWvgFn3-0) 🎨 

## 🗒️ What

This PR refactors the placement of the dropdown disclosure item icon to the right hand side. 

<img width="326" alt="Screenshot 2023-04-03 at 5 58 52 PM" src="https://user-images.githubusercontent.com/36613477/229659160-ac64272d-c58d-47ae-aa9e-aff7086fde48.png">
<img width="478" alt="Screenshot 2023-04-03 at 5 59 04 PM" src="https://user-images.githubusercontent.com/36613477/229659180-2ce98274-09e5-452d-9fe3-1318ec5c95d8.png">

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksrefactor-mobile-menu-icon-placement-hashicorp.vercel.app/boundary)
- Sign in
- Test the desktop dropdown disclosure placement
- Test the tablet / mobile view

## 💭 Anything else?

We've removed all the icons from the menus except the external link icon. [This is a follow up task.](https://github.com/hashicorp/dev-portal/pull/1793#issuecomment-1491047999)
