### PR TITLE
Point Get Certified section to new 003 exam

### DIFF
--- a/src/content/terraform/product-landing.json
+++ b/src/content/terraform/product-landing.json
@@ -102,8 +102,8 @@
 		{
 			"type": "collection_cards",
 			"collectionSlugs": [
-				"terraform/certification",
-				"terraform/certification-associate-tutorials"
+				"terraform/certification-003",
+				"terraform/certification-associate-tutorials-003"
 			]
 		}
 	]


### PR DESCRIPTION
Terraform Associate 003 exam launched today. We want to make sure potential candidates are pointed at the right study materials.

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-ta003-get-certified-updates-hashicorp.vercel.app/terraform) 🔎
- [Asana task](https://app.asana.com/0/1202910531801828/1204283654992281/f) 🎟️

## 🗒️ What

Changed the links in the "Get Certified" section to point to Terraform 003 materials, instead of 002, because 003 launched today.


## 🤷 Why

Because 003 exam launched today.

## 🧪 Testing

- [x] View the deploy preview
- [x] Click the Get Certified tiles on the TF landing page to make sure they go to the 003 pages


