### PR TITLE
Update TA cert page to reflect that TA003 exam is live

### DIFF
--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -1,10 +1,9 @@
 <!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
 
 ## Exam Availability Dates
-- **Today:** Terraform Associate **002** certification is available to schedule
-- **April 5:** Terraform Associate **003** becomes available to schedule. Both versions will be available
-- **May 5:** Last day to schedule or reschedule an appointment to take the Terraform Associate 002 exam
-    - Scheduling subject to appointment availability until May 19
+- **April 5:** Terraform Associate **003** is available to schedule. Both versions are available.
+- **May 5:** Last day to schedule or reschedule an appointment to take the Terraform Associate 002 exam.
+    - Scheduling subject to appointment availability until May 19.
 
 ## Which Exam to Take
 

--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -2,11 +2,11 @@
 	"title": "Infrastructure Automation",
 	"summary": {
 		"heading": "Infrastructure<br />Automation Certifications",
-		"description": "Verify your infrastructure automation skills. If you have a Terraform Associate certification, wait until the new version comes out in March 2023 to recertify. Your Terraform Associate badge’s expiration date has been extended, check Credly.com for your updated expiration date."
+		"description": "Verify your infrastructure automation skills."
 	},
 	"hero": {
 		"heading": "Infrastructure<br />Automation Certifications",
-		"description": "You will be able to use either version of the Terraform Associate certification to verify your basic infrastructure automation skills."
+		"description": "You will be able to use either version of the Terraform Associate certification to verify your basic infrastructure automation skills until May 2023."
 	},
 	"exams": [
 		{
@@ -14,7 +14,7 @@
 			"examCode": "002",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
-			"description": "The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with Terraform open source. This includes understanding which enterprise features exist and what can and cannot be done using the open source offering. You should have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"description": "The Terraform Associate 002 exam will be available until May 2023, subject to appointment availability. The objective differences between the exam versions focus on reorganization and rewording of objectives to cover recent and future Terraform product growth.",
 			"links": {
 				"prepare": "/terraform/tutorials/certification",
 				"register": "https://cp.certmetrics.com/hashicorp/en/login"
@@ -26,7 +26,7 @@
 			"examCode": "003",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
-			"description": "Starting in March 2023, the Terraform Associate 003 will begin to replace the Terraform Associate 002 certification. The objective differences between the exam versions focus on reorganization and rewording of objectives to cover recent and future Terraform product growth.",
+			"description": "The Terraform Associate 003 is now live. The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with Terraform open source. This includes understanding which enterprise features exist and what can and cannot be done using the open source offering. You should have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may be sufficient.",
 			"links": {
 				"prepare": "/terraform/tutorials/certification-003"
 			},

--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -11,6 +11,17 @@
 	"exams": [
 		{
 			"title": "Terraform Associate",
+			"examCode": "003",
+			"productSlug": "terraform",
+			"versionTested": "Terraform 1.0 or higher",
+			"description": "The Terraform Associate 003 is now live. The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with Terraform open source. This includes understanding which enterprise features exist and what can and cannot be done using the open source offering. You should have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"links": {
+				"prepare": "/terraform/tutorials/certification-003"
+			},
+			"faqSlug": "terraform-associate-003"
+		},
+		{
+			"title": "Terraform Associate",
 			"examCode": "002",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.0 or higher",
@@ -20,17 +31,6 @@
 				"register": "https://cp.certmetrics.com/hashicorp/en/login"
 			},
 			"faqSlug": "terraform-associate-002"
-		},
-		{
-			"title": "Terraform Associate",
-			"examCode": "003",
-			"productSlug": "terraform",
-			"versionTested": "Terraform 1.0 or higher",
-			"description": "The Terraform Associate 003 is now live. The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with Terraform open source. This includes understanding which enterprise features exist and what can and cannot be done using the open source offering. You should have professional experience using Terraform in production, but performing the exam objectives in a personal demo environment may be sufficient.",
-			"links": {
-				"prepare": "/terraform/tutorials/certification-003"
-			},
-			"faqSlug": "terraform-associate-003"
-		}
+		}	
 	]
 }


### PR DESCRIPTION
## 🔗 Relevant links
- [Preview link](https://dev-portal-git-certta003-live-on-cert-pages-hashicorp.vercel.app/certifications/infrastructure-automation) 🔎
- [Asana task](https://app.asana.com/0/1202910531801828/1204283654992281/f) 🎟️

## 🗒️ What

Made updates to https://developer.hashicorp.com/certifications/infrastructure-automation page to call out that TA003 exam is now live.

## 🤷 Why

Because TA 003 exam is now live

## 🧪 Testing
- [ ] View deploy review
- [x] TA003 is on top on infrastructure-automation page
- [x] TA003 is on top on certifications page
- [x] New copy is live and correct
- [x] Dates in FAQ are updated
