### PR TITLE
Abstracting StandaloneLinkContents

### DIFF
--- a/src/components/standalone-link/docs.mdx
+++ b/src/components/standalone-link/docs.mdx
@@ -33,7 +33,7 @@ const MyComponent = () => {
 ### With a trailing icon
 
 <LiveComponent>
-{`
+	{`
 <StandaloneLink
   href="/"
   icon={<SwingsetTestIcon name="arrow-right" />}
@@ -46,7 +46,7 @@ const MyComponent = () => {
 ### With a leading icon
 
 <LiveComponent>
-{`
+	{`
 <StandaloneLink
   href="/"
   icon={<SwingsetTestIcon name="github" />}
@@ -59,7 +59,7 @@ const MyComponent = () => {
 ### With color set to secondary
 
 <LiveComponent>
-{`
+	{`
 <StandaloneLink
   color="secondary"
   href="/"
@@ -73,7 +73,7 @@ const MyComponent = () => {
 ### With varying size values
 
 <LiveComponent>
-{`
+	{`
 <>
   <StandaloneLink
     href="/"
@@ -98,5 +98,62 @@ const MyComponent = () => {
     text="Get Started"
   />
 </>
+`}
+</LiveComponent>
+
+### `StandaloneLinkContents`
+
+`StandaloneLink` exports a utility component called `StandaloneLinkContents`. This utility is responsible for displaying the inner contents of `StandaloneLink`. It is useful where the _look_ of `StandaloneLink` is needed but no `<a>` link element is needed, such as a call-to-action that is placed inside of a `CardLink`.
+
+<LiveComponent>
+	{`
+<div style={{ display: 'flex', gap: 24 }}>
+  <div>
+    <StandaloneLinkContents
+      color="primary"
+      icon={<SwingsetTestIcon name="github" size={16} />}
+      iconPosition="leading"
+      size="small"
+      text="Get Started"
+    />
+    <StandaloneLinkContents
+      color="primary"
+      icon={<SwingsetTestIcon name="github" size={16} />}
+      iconPosition="leading"
+      size="medium"
+      text="Get Started"
+    />
+    <StandaloneLinkContents
+      color="primary"
+      icon={<SwingsetTestIcon name="github" size={24} />}
+      iconPosition="leading"
+      size="large"
+      text="Get Started"
+    />
+  </div>
+  <div>
+    <StandaloneLinkContents
+      color="secondary"
+      icon={<SwingsetTestIcon name="arrow-right" size={16} />}
+      iconPosition="trailing"
+      size="small"
+      text="Get Started"
+    />
+    <StandaloneLinkContents
+      color="secondary"
+      icon={<SwingsetTestIcon name="arrow-right" size={16} />}
+      iconPosition="trailing"
+      size="medium"
+      text="Get Started"
+    />
+    <StandaloneLinkContents
+      color="secondary"
+      icon={<SwingsetTestIcon name="arrow-right" size={24} />}
+      iconPosition="trailing"
+      size="large"
+      text="Get Started"
+    />
+  </div>
+</div>
 `}
 </LiveComponent>

--- a/src/components/standalone-link/index.tsx
+++ b/src/components/standalone-link/index.tsx
@@ -6,14 +6,43 @@
 import { ReactElement } from 'react'
 import classNames from 'classnames'
 import Link from 'components/link'
-import { StandaloneLinkProps } from './types'
+import {
+	type StandaloneLinkContentsProps,
+	type StandaloneLinkProps,
+} from './types'
 import s from './standalone-link.module.css'
+
+const StandaloneLinkContents = ({
+	className,
+	color,
+	icon,
+	iconPosition,
+	size,
+	text,
+	textClassName,
+}: StandaloneLinkContentsProps) => {
+	const containerClasses = classNames(
+		s.contents,
+		s[`color-${color}`],
+		s[size],
+		className
+	)
+	const textClasses = classNames(s.text, textClassName)
+
+	return (
+		<div className={containerClasses}>
+			{iconPosition === 'leading' && icon}
+			<span className={textClasses}>{text}</span>
+			{iconPosition === 'trailing' && icon}
+		</div>
+	)
+}
 
 const StandaloneLink = ({
 	ariaLabel,
 	className,
-	color = 'primary',
 	'data-heap-track': dataHeapTrack,
+	color = 'primary',
 	download,
 	href,
 	icon,
@@ -24,7 +53,7 @@ const StandaloneLink = ({
 	text,
 	textClassName,
 }: StandaloneLinkProps): ReactElement => {
-	const classes = classNames(s.root, s[`color-${color}`], s[size], className)
+	const classes = classNames(s.root, className)
 	const rel = opensInNewTab ? 'noreferrer noopener' : undefined
 
 	return (
@@ -38,12 +67,18 @@ const StandaloneLink = ({
 			rel={rel}
 			opensInNewTab={opensInNewTab}
 		>
-			{iconPosition === 'leading' && icon}
-			<span className={classNames(s.text, textClassName)}>{text}</span>
-			{iconPosition === 'trailing' && icon}
+			<StandaloneLinkContents
+				color={color}
+				icon={icon}
+				iconPosition={iconPosition}
+				size={size}
+				text={text}
+				textClassName={textClassName}
+			/>
 		</Link>
 	)
 }
 
-export type { StandaloneLinkProps }
+export type { StandaloneLinkContentsProps, StandaloneLinkProps }
+export { StandaloneLinkContents }
 export default StandaloneLink

--- a/src/components/standalone-link/standalone-link.module.css
+++ b/src/components/standalone-link/standalone-link.module.css
@@ -4,12 +4,14 @@
  */
 
 .root {
+	/* composition */
 	composes: g-focus-ring-from-box-shadow from global;
+
+	/* properties */
 	align-items: center;
 	border-radius: 5px;
 	cursor: pointer;
 	display: flex;
-	font-family: var(--token-typography-font-stack-text);
 	text-decoration: none;
 	width: fit-content;
 
@@ -30,21 +32,21 @@
 		margin: -5px;
 		padding: 5px;
 	}
+}
+
+.contents {
+	align-items: center;
+	display: flex;
+	gap: 6px;
+	width: fit-content;
 
 	& svg {
 		flex-shrink: 0;
-
-		&:first-child {
-			margin-right: 6px;
-		}
-
-		&:last-child {
-			margin-left: 6px;
-		}
 	}
 }
 
 .text {
+	font-family: var(--token-typography-font-stack-text);
 	font-size: var(--font-size);
 	font-weight: var(--token-typography-font-weight-medium);
 	line-height: var(--line-height);

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -11,7 +11,9 @@ type InheritedLinkProps = Pick<
 	'className' | 'download' | 'href' | 'onClick' | 'opensInNewTab'
 >
 
-export interface StandaloneLinkProps extends InheritedLinkProps {
+interface StandaloneLinkProps
+	extends StandaloneLinkContentsProps,
+		InheritedLinkProps {
 	/**
 	 * A non-visible label presented by screen readers. Passed directly to the
 	 * internal link element as the `aria-label` prop.
@@ -21,14 +23,22 @@ export interface StandaloneLinkProps extends InheritedLinkProps {
 	ariaLabel?: LinkProps['aria-label']
 
 	/**
-	 * Determines the set of colors to use for various states of the component.
-	 */
-	color?: 'primary' | 'secondary'
-
-	/**
 	 * A data-heap-track string to add to the <a /> element.
 	 */
 	'data-heap-track'?: string
+}
+
+interface StandaloneLinkContentsProps {
+	/**
+	 * A string of one or more classnames. Is appended to list of classnames
+	 * passed to the container element.
+	 */
+	className?: string
+
+	/**
+	 * Determines the set of colors to use for various states of the component.
+	 */
+	color?: 'primary' | 'secondary'
 
 	/**
 	 * An icon from `@hashicorp/flight-icons` to render.
@@ -73,3 +83,5 @@ export interface StandaloneLinkProps extends InheritedLinkProps {
 	 */
 	textClassName?: string
 }
+
+export type { StandaloneLinkContentsProps, StandaloneLinkProps }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambadd-standalone-link-contents-hashicorp.vercel.app/swingset/components/standalonelink) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Abstracts new `StandaloneLinkContents` out of `StandaloneLink`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- We've had to do this as one-offs in a few places, and I'm seeing a need for it in the Home Page Redesign work as well

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the [`StandaloneLink` Swingset page](https://dev-portal-git-ambadd-standalone-link-contents-hashicorp.vercel.app/swingset/components/standalonelink)
- [ ] Make sure the existing examples still render and function the same [as in `staging`](https://dev-portal-git-staging-hashicorp.vercel.app/swingset/components/standalonelink)
- [ ] Make sure the new `StandaloneLinkContents` section renders and functions as expected

## 💭 Anything else?

This PR does not attempt to make use of `StandaloneLinkContents` in other areas of the app to keep this PR small, for faster review purposes since this work will be used in Home Page Redesign PRs.
