### PR TITLE
[ThemeSelect] Auto generating aria-label when no id

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -82,7 +82,7 @@ function Footer({
 					opensInNewTab={true}
 					className={s.feedbackButton}
 				/>
-				{shouldRenderThemeSwitcher ? <ThemeSelect ariaLabel="theme" /> : null}
+				{shouldRenderThemeSwitcher ? <ThemeSelect /> : null}
 			</span>
 			<ul className={s.links}>
 				{FOOTER_ITEMS.map((item: FooterItem, index: number) => {
@@ -148,7 +148,7 @@ function Footer({
 				</li>
 				{shouldRenderThemeSwitcher ? (
 					<li className={classNames(s.actionDesktop, s.linkListItem)}>
-						<ThemeSelect ariaLabel="theme" />
+						<ThemeSelect />
 					</li>
 				) : null}
 			</ul>

--- a/src/components/theme-switcher/index.tsx
+++ b/src/components/theme-switcher/index.tsx
@@ -7,24 +7,41 @@ import { IconCaret16 } from '@hashicorp/flight-icons/svg-react/caret-16'
 import { IconMonitor16 } from '@hashicorp/flight-icons/svg-react/monitor-16'
 import { IconMoon16 } from '@hashicorp/flight-icons/svg-react/moon-16'
 import { IconSun16 } from '@hashicorp/flight-icons/svg-react/sun-16'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, ReactElement } from 'react'
 import { useTheme } from 'next-themes'
 
 import { GlobalThemeOption } from 'styles/themes/types'
 import s from './theme-switcher.module.css'
 
+interface ThemeConfig {
+	icon: ReactElement
+	label: string
+	value: string
+}
+
+const THEME_CONFIGS: { [key in GlobalThemeOption]: ThemeConfig } = {
+	[GlobalThemeOption.dark]: {
+		icon: <IconMoon16 />,
+		label: 'Dark',
+		value: 'dark',
+	},
+	[GlobalThemeOption.light]: {
+		icon: <IconSun16 />,
+		label: 'Light',
+		value: 'light',
+	},
+	[GlobalThemeOption.system]: {
+		icon: <IconMonitor16 />,
+		label: 'System',
+		value: 'system',
+	},
+}
+
 interface ThemeSelectProps {
 	id?: string
-	ariaLabel?: string
 }
 
-const ThemeIcons = {
-	[GlobalThemeOption.system]: <IconMonitor16 />,
-	[GlobalThemeOption.dark]: <IconMoon16 />,
-	[GlobalThemeOption.light]: <IconSun16 />,
-}
-
-export default function ThemeSelect({ id, ariaLabel }: ThemeSelectProps) {
+export default function ThemeSelect({ id }: ThemeSelectProps) {
 	const [mounted, setMounted] = useState(false)
 	const { theme, setTheme } = useTheme()
 
@@ -38,15 +55,16 @@ export default function ThemeSelect({ id, ariaLabel }: ThemeSelectProps) {
 		return null
 	}
 
-	if (id && ariaLabel) {
-		throw new Error(
-			'[ThemeSelect]: Please only pass one of "id" or "ariaLabel", but not both'
-		)
+	// If no `id` is given, generate an `aria-label` that matches selected option
+	let ariaLabel
+	const hasId = id?.length > 0
+	if (!hasId) {
+		ariaLabel = THEME_CONFIGS[theme].label
 	}
 
 	return (
 		<div className={s.root}>
-			<span className={s.themeIcon}>{ThemeIcons[theme]}</span>
+			<span className={s.themeIcon}>{THEME_CONFIGS[theme].icon}</span>
 			<select
 				aria-label={ariaLabel}
 				className={s.select}
@@ -54,9 +72,11 @@ export default function ThemeSelect({ id, ariaLabel }: ThemeSelectProps) {
 				value={theme}
 				onChange={(e) => setTheme(e.target.value)}
 			>
-				<option value="system">System</option>
-				<option value="dark">Dark</option>
-				<option value="light">Light</option>
+				{Object.values(THEME_CONFIGS).map(({ label, value }: ThemeConfig) => (
+					<option key={value} value={value}>
+						{label}
+					</option>
+				))}
 			</select>
 			<span className={s.trailingIcon}>
 				<IconCaret16 />


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Branching off of #1811, updates `ThemeSelect` to auto generate the rendered `<select>`'s `aria-label`
- Also lifts up a `THEME_CONFIGS` constant that stores each theme's `icon`, `label`, and `text`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- The `aria-label` originally proposed in #1811 poses an issue for speech recognition users: the text is not visible, so not intuitive for these users to know how to interact with the element
- We can't totally omit `aria-label` in this case because `<select>` elements do not set their Accessible Name based on their content. This contrasts how `DropdownDisclosure` works, which uses a `<button>` under the hood.
- These changes emulate how `DropdownDisclosure` would behave if we used it here, which is that the Accessible Name becomes the text of the currently selected theme.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to a themed page on the preview URL
- [ ] Scroll to the footer of the site
- [ ] Inspect the `ThemeSelect` in your browser devtools
- [ ] Open the Accessibility tab to view the accessibility tree
- [ ] Confirm the Accessible Name for the element matches the text of the currently selected theme

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- Worth noting this backlog task regarding `DropdownDisclosure` for posterity: [Reconsider updating the ThemeSwitcher to use a dropdown instead of native select](https://app.asana.com/0/1203652232454021/1204284168518969/f)
