### PR TITLE
Adds a hotfix to fix the integration header link color

### DIFF
--- a/src/components/content-header-card/content-header-card.module.css
+++ b/src/components/content-header-card/content-header-card.module.css
@@ -127,16 +127,18 @@
 				&:not(:first-of-type) {
 					margin-left: 12px;
 				}
-				& > * {
-					/* TODO: Rather than override our existing link component, 
-					we should eject or build in support for what we're trying
-					to do here. These styles assume the StandaloneLink styles
-					are part of its contract, but they are not and are subject
-					to change */
-					text-decoration: underline;
-					color: var(--token-color-foreground-primary);
-					&:hover {
-						color: var(--token-color-foreground-strong);
+				& > a {
+					& > * {
+						/* TODO: Rather than override our existing link component,
+						we should eject or build in support for what we're trying
+						to do here. These styles assume the StandaloneLink styles
+						are part of its contract, but they are not and are subject
+						to change */
+						text-decoration: underline;
+						color: var(--token-color-foreground-primary);
+						&:hover {
+							color: var(--token-color-foreground-strong);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
[🔍 Preview](https://dev-portal-git-brintegration-header-hotfix-hashicorp.vercel.app/waypoint/integrations/hashicorp/aws-ami)

Noticed a visual bug that cropped up on the Integrations component header. This link is supposed to be a different color.

![CleanShot 2023-04-06 at 10 34 05@2x](https://user-images.githubusercontent.com/2105067/230453734-989c9887-ae47-44b0-a07b-b6641462efb2.png)

The comment that's in the code there is _exactly_ what has happened here.

This is a hotfix, and not addressing the root issue, but should at least patch it up for now.  I'll open up a thread of discussion here so we can avoid this class of bug in the future.