### PR TITLE
Remove Override from Integration Header

### DIFF
--- a/src/components/content-header-card/content-header-card.module.css
+++ b/src/components/content-header-card/content-header-card.module.css
@@ -127,16 +127,18 @@
 				&:not(:first-of-type) {
 					margin-left: 12px;
 				}
-				& > * {
-					/* TODO: Rather than override our existing link component, 
-					we should eject or build in support for what we're trying
-					to do here. These styles assume the StandaloneLink styles
-					are part of its contract, but they are not and are subject
-					to change */
-					text-decoration: underline;
-					color: var(--token-color-foreground-primary);
-					&:hover {
-						color: var(--token-color-foreground-strong);
+				& > a {
+					& > * {
+						/* TODO: Rather than override our existing link component,
+						we should eject or build in support for what we're trying
+						to do here. These styles assume the StandaloneLink styles
+						are part of its contract, but they are not and are subject
+						to change */
+						text-decoration: underline;
+						color: var(--token-color-foreground-primary);
+						&:hover {
+							color: var(--token-color-foreground-strong);
+						}
 					}
 				}
 			}

--- a/src/components/content-header-card/content-header-card.module.css
+++ b/src/components/content-header-card/content-header-card.module.css
@@ -127,20 +127,6 @@
 				&:not(:first-of-type) {
 					margin-left: 12px;
 				}
-				& > a {
-					& > * {
-						/* TODO: Rather than override our existing link component,
-						we should eject or build in support for what we're trying
-						to do here. These styles assume the StandaloneLink styles
-						are part of its contract, but they are not and are subject
-						to change */
-						text-decoration: underline;
-						color: var(--token-color-foreground-primary);
-						&:hover {
-							color: var(--token-color-foreground-strong);
-						}
-					}
-				}
 			}
 		}
 

--- a/src/components/content-header-card/index.tsx
+++ b/src/components/content-header-card/index.tsx
@@ -108,6 +108,7 @@ export default function ContentHeaderCard({
 											href={link.href}
 											opensInNewTab={!link.href.startsWith('/')}
 											iconPosition="leading"
+											color="secondary"
 										/>
 									</li>
 								)


### PR DESCRIPTION
An issue cropped up which was hot-fixed via https://github.com/hashicorp/dev-portal/pull/1825, which addressed an issue where the styles were no longer targeting the right element (leading to the links in this header component to be incorrect).

This PR removes the Override from the integrations header. After some discussion with Design, we landed on the fact that we are OK not including the permanent underline, in favor of using the StandaloneLink as designed.

[🔍 Preview](https://dev-portal-git-brintegration-header-remove-override-hashicorp.vercel.app/waypoint/integrations/hashicorp/aws-ami). 

> There is an outstanding bug right now, unrelated to this PR, where underlines are displaying the incorrect color, which is being worked on currently.