### PR TITLE
[StandaloneLinkContents] Fixing how color prop is handled

### DIFF
--- a/src/components/standalone-link/index.tsx
+++ b/src/components/standalone-link/index.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { ReactElement } from 'react'
 import classNames from 'classnames'
 import Link from 'components/link'
 import {
@@ -12,21 +11,18 @@ import {
 } from './types'
 import s from './standalone-link.module.css'
 
+const DEFAULT_COLOR_VARIANT = 'primary'
+
 const StandaloneLinkContents = ({
 	className,
-	color,
+	color = DEFAULT_COLOR_VARIANT,
 	icon,
 	iconPosition,
 	size,
 	text,
 	textClassName,
 }: StandaloneLinkContentsProps) => {
-	const containerClasses = classNames(
-		s.contents,
-		s[`color-${color}`],
-		s[size],
-		className
-	)
+	const containerClasses = classNames(s.contents, s[size], s[color], className)
 	const textClasses = classNames(s.text, textClassName)
 
 	return (
@@ -41,8 +37,8 @@ const StandaloneLinkContents = ({
 const StandaloneLink = ({
 	ariaLabel,
 	className,
+	color = DEFAULT_COLOR_VARIANT,
 	'data-heap-track': dataHeapTrack,
-	color = 'primary',
 	download,
 	href,
 	icon,
@@ -52,8 +48,8 @@ const StandaloneLink = ({
 	size = 'medium',
 	text,
 	textClassName,
-}: StandaloneLinkProps): ReactElement => {
-	const classes = classNames(s.root, className)
+}: StandaloneLinkProps) => {
+	const classes = classNames(s.root, s[color], className)
 	const rel = opensInNewTab ? 'noreferrer noopener' : undefined
 
 	return (
@@ -68,7 +64,6 @@ const StandaloneLink = ({
 			opensInNewTab={opensInNewTab}
 		>
 			<StandaloneLinkContents
-				color={color}
 				icon={icon}
 				iconPosition={iconPosition}
 				size={size}

--- a/src/components/standalone-link/index.tsx
+++ b/src/components/standalone-link/index.tsx
@@ -5,6 +5,7 @@
 
 import classNames from 'classnames'
 import Link from 'components/link'
+import { ToastColor, developmentToast } from 'components/toast'
 import {
 	type StandaloneLinkContentsProps,
 	type StandaloneLinkProps,
@@ -15,14 +16,29 @@ const DEFAULT_COLOR_VARIANT = 'primary'
 
 const StandaloneLinkContents = ({
 	className,
-	color = DEFAULT_COLOR_VARIANT,
+	color,
 	icon,
 	iconPosition,
+	inheritColor = false,
 	size,
 	text,
 	textClassName,
 }: StandaloneLinkContentsProps) => {
-	const containerClasses = classNames(s.contents, s[size], s[color], className)
+	if (color && inheritColor) {
+		developmentToast({
+			color: ToastColor.warning,
+			title: 'Warning in `StandaloneLinkContents`',
+			description:
+				'`StandaloneLinkContents` does not accept both `color` and `inheritColor`; `inheritColor` takes precedence.',
+		})
+	}
+
+	const containerClasses = classNames(
+		s.standaloneLinkContents,
+		s[size],
+		!inheritColor && s[color ?? DEFAULT_COLOR_VARIANT],
+		className
+	)
 	const textClasses = classNames(s.text, textClassName)
 
 	return (
@@ -49,7 +65,7 @@ const StandaloneLink = ({
 	text,
 	textClassName,
 }: StandaloneLinkProps) => {
-	const classes = classNames(s.root, s[color], className)
+	const classes = classNames(s.standaloneLink, s[color], className)
 	const rel = opensInNewTab ? 'noreferrer noopener' : undefined
 
 	return (
@@ -66,6 +82,7 @@ const StandaloneLink = ({
 			<StandaloneLinkContents
 				icon={icon}
 				iconPosition={iconPosition}
+				inheritColor
 				size={size}
 				text={text}
 				textClassName={textClassName}

--- a/src/components/standalone-link/standalone-link.module.css
+++ b/src/components/standalone-link/standalone-link.module.css
@@ -15,10 +15,7 @@
 	text-decoration: none;
 	width: fit-content;
 
-	&:active {
-		text-decoration: underline;
-	}
-
+	&:active,
 	&:hover {
 		text-decoration: underline;
 	}
@@ -31,6 +28,14 @@
 		text-decoration: none;
 		margin: -5px;
 		padding: 5px;
+	}
+
+	/*
+  When rendered inside of `StandaloneLink`, prevent `StandaloneLinkContents`
+  from setting its own color.
+  */
+	& .contents {
+		color: inherit !important;
 	}
 }
 
@@ -58,22 +63,25 @@
 ***
 */
 
-.color-primary {
+.primary {
 	color: var(--token-color-foreground-action);
 
-	&:active {
+	/* only change color on active for <a href> */
+	&[href]:active {
 		color: var(--token-color-foreground-action-active);
 	}
 
-	&:hover {
+	/* only change color on active for <a href> */
+	&[href]:hover {
 		color: var(--token-color-foreground-action-hover);
 	}
 }
 
-.color-secondary {
+.secondary {
 	color: var(--token-color-foreground-strong);
 
-	&:active {
+	/* only change color on active for <a href> */
+	&[href]:active {
 		color: var(--token-color-foreground-primary);
 	}
 }

--- a/src/components/standalone-link/standalone-link.module.css
+++ b/src/components/standalone-link/standalone-link.module.css
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.root {
+.standaloneLink {
 	/* composition */
 	composes: g-focus-ring-from-box-shadow from global;
 
@@ -29,17 +29,9 @@
 		margin: -5px;
 		padding: 5px;
 	}
-
-	/*
-  When rendered inside of `StandaloneLink`, prevent `StandaloneLinkContents`
-  from setting its own color.
-  */
-	& .contents {
-		color: inherit !important;
-	}
 }
 
-.contents {
+.standaloneLinkContents {
 	align-items: center;
 	display: flex;
 	gap: 6px;
@@ -66,13 +58,11 @@
 .primary {
 	color: var(--token-color-foreground-action);
 
-	/* only change color on active for <a href> */
-	&[href]:active {
+	&.standaloneLink:active {
 		color: var(--token-color-foreground-action-active);
 	}
 
-	/* only change color on active for <a href> */
-	&[href]:hover {
+	&.standaloneLink:hover {
 		color: var(--token-color-foreground-action-hover);
 	}
 }
@@ -80,8 +70,7 @@
 .secondary {
 	color: var(--token-color-foreground-strong);
 
-	/* only change color on active for <a href> */
-	&[href]:active {
+	&.standaloneLink:active {
 		color: var(--token-color-foreground-primary);
 	}
 }

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -6,29 +6,7 @@
 import { ReactElement } from 'react'
 import { LinkProps } from 'components/link'
 
-type InheritedLinkProps = Pick<
-	LinkProps,
-	'className' | 'download' | 'href' | 'onClick' | 'opensInNewTab'
->
-
-interface StandaloneLinkProps
-	extends StandaloneLinkContentsProps,
-		InheritedLinkProps {
-	/**
-	 * A non-visible label presented by screen readers. Passed directly to the
-	 * internal link element as the `aria-label` prop.
-	 *
-	 * ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
-	 */
-	ariaLabel?: LinkProps['aria-label']
-
-	/**
-	 * A data-heap-track string to add to the <a /> element.
-	 */
-	'data-heap-track'?: string
-}
-
-interface StandaloneLinkContentsProps {
+interface SharedBaseProps {
 	/**
 	 * A string of one or more classnames. Is appended to list of classnames
 	 * passed to the container element.
@@ -83,5 +61,27 @@ interface StandaloneLinkContentsProps {
 	 */
 	textClassName?: string
 }
+
+type InheritedLinkProps = Pick<
+	LinkProps,
+	'className' | 'download' | 'href' | 'onClick' | 'opensInNewTab'
+>
+
+interface StandaloneLinkProps extends SharedBaseProps, InheritedLinkProps {
+	/**
+	 * A non-visible label presented by screen readers. Passed directly to the
+	 * internal link element as the `aria-label` prop.
+	 *
+	 * ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
+	 */
+	ariaLabel?: LinkProps['aria-label']
+
+	/**
+	 * A data-heap-track string to add to the <a /> element.
+	 */
+	'data-heap-track'?: string
+}
+
+type StandaloneLinkContentsProps = SharedBaseProps
 
 export type { StandaloneLinkContentsProps, StandaloneLinkProps }

--- a/src/components/standalone-link/types.ts
+++ b/src/components/standalone-link/types.ts
@@ -82,6 +82,15 @@ interface StandaloneLinkProps extends SharedBaseProps, InheritedLinkProps {
 	'data-heap-track'?: string
 }
 
-type StandaloneLinkContentsProps = SharedBaseProps
+interface StandaloneLinkContentsProps extends SharedBaseProps {
+	/**
+	 * Optional boolean for specifying if `StandaloneLinkContents` should inherit
+	 * its container's color properties. When `true`, does not apply the helper
+	 * classes associated with the `color` prop.
+	 *
+	 * Default: `false`.
+	 */
+	inheritColor?: boolean
+}
 
 export type { StandaloneLinkContentsProps, StandaloneLinkProps }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambfix-standalone-link-contents-hashicorp.vercel.app/) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Updates `StandaloneLinkContents`'s `.contents` class to inherit it's `color` when nested inside of `StandaloneLink`
- Adds `DEFAULT_COLOR_VARIANT` since it's needed in 2 places in the file now
- Simplifies the classname associated with `StandaloneLink`'s `color` prop (easier to maintain 2 references to)
- Fixes the color classes to only apply a color change on active/hover if the element it's applied to has an `href` property

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to [the `StandaloneLink` Swingset page](https://dev-portal-git-ambfix-standalone-link-contents-hashicorp.vercel.app/swingset/components/standalonelink)
- [ ] The `StandaloneLink` examples should behave as expected when hovered
- [ ] The `StandaloneLink` examples should behave as expected when active
- [ ] The `StandaloneLinkContents` examples should behave as expected when hovered
- [ ] The `StandaloneLinkContents` examples should behave as expected when active
