### PR TITLE
refactor: non-themed routes to config

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -29,6 +29,7 @@
 			"/certifications",
 			"/certifications/[slug]"
 		],
+		"non_themed_paths": ["/", "/sign-up"],
 		"datadog_config": {
 			"scriptUrl": "https://www.datadoghq-browser-agent.com/datadog-rum-v4.js",
 			"applicationId": "40a2019f-88ad-4076-ab52-ffd074064eed",

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -13,6 +13,7 @@ import Text from 'components/text'
 import { FEEDBACK_FORM_URL } from 'constants/feedback-form'
 import { ThemeSwitcherWithLabel } from 'components/theme-switcher'
 import Link from 'components/link'
+import isThemedPath from 'lib/isThemedPath'
 import { FooterItem, FooterProps } from './types'
 import s from './footer.module.css'
 
@@ -69,7 +70,7 @@ function Footer({
 	className,
 }: FooterProps): React.ReactElement {
 	const { pathname } = useRouter()
-	const shouldRenderThemeSwitcher = pathname !== '/' && pathname !== 'sign-up'
+	const shouldRenderThemeSwitcher = isThemedPath(pathname)
 
 	return (
 		<footer

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -7,6 +7,7 @@ import { IconChevronDown24 } from '@hashicorp/flight-icons/svg-react/chevron-dow
 import { useRouter } from 'next/router'
 import { getUserMeta } from 'lib/auth/user'
 import isAbsoluteUrl from 'lib/is-absolute-url'
+import isThemedPath from 'lib/isThemedPath'
 import Disclosure, {
 	DisclosureActivator,
 	DisclosureContent,
@@ -17,7 +18,6 @@ import { UserDropdownDisclosureItem } from 'components/user-dropdown-disclosure'
 import UserDropdownDisclosureThemeSwitcher from 'components/theme-switcher/user-dropdown-switcher'
 import { MobileUserDisclosureProps } from './types'
 import s from './mobile-user-disclosure.module.css'
-import isThemedPath from 'lib/isThemedPath'
 
 /**
  * Handles rendering a list item for `MobileUserDisclosure`.

--- a/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
+++ b/src/components/mobile-menu-container/components/mobile-user-disclosure/index.tsx
@@ -17,6 +17,7 @@ import { UserDropdownDisclosureItem } from 'components/user-dropdown-disclosure'
 import UserDropdownDisclosureThemeSwitcher from 'components/theme-switcher/user-dropdown-switcher'
 import { MobileUserDisclosureProps } from './types'
 import s from './mobile-user-disclosure.module.css'
+import isThemedPath from 'lib/isThemedPath'
 
 /**
  * Handles rendering a list item for `MobileUserDisclosure`.
@@ -65,7 +66,6 @@ const MobileUserDisclosure = ({
 }: MobileUserDisclosureProps) => {
 	const { icon, label, description } = getUserMeta(user)
 	const { pathname } = useRouter()
-	const shouldRenderThemeSwitcher = pathname !== '/'
 
 	return (
 		<Disclosure containerClassName={s.root} initialOpen={initialOpen}>
@@ -86,7 +86,7 @@ const MobileUserDisclosure = ({
 				</Text>
 				<ul className={s.list}>
 					{items.map(renderItem)}
-					{shouldRenderThemeSwitcher ? (
+					{isThemedPath(pathname) ? (
 						<UserDropdownDisclosureThemeSwitcher />
 					) : null}
 				</ul>

--- a/src/components/user-dropdown-disclosure/index.tsx
+++ b/src/components/user-dropdown-disclosure/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import { IconUser24 } from '@hashicorp/flight-icons/svg-react/user-24'
 import { getUserMeta } from 'lib/auth/user'
 import isAbsoluteUrl from 'lib/is-absolute-url'
+import isThemedPath from 'lib/isThemedPath'
 import DropdownDisclosure, {
 	DropdownDisclosureButtonItem,
 	DropdownDisclosureDescriptionItem,
@@ -70,7 +71,6 @@ const UserDropdownDisclosure = ({
 	user,
 }: UserDropdownDisclosureProps) => {
 	const { pathname } = useRouter()
-	const shouldRenderThemeSwitcher = pathname !== '/' && pathname !== 'sign-up'
 
 	let userMeta
 	if (user) {
@@ -97,9 +97,7 @@ const UserDropdownDisclosure = ({
 				</>
 			) : null}
 			{items.map(renderItem)}
-			{shouldRenderThemeSwitcher ? (
-				<UserDropdownDisclosureThemeSwitcher />
-			) : null}
+			{isThemedPath(pathname) ? <UserDropdownDisclosureThemeSwitcher /> : null}
 		</DropdownDisclosure>
 	)
 }

--- a/src/layouts/core-dev-dot-layout/index.tsx
+++ b/src/layouts/core-dev-dot-layout/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router'
 import { ThemeProvider } from 'next-themes'
 import { DatadogHeadTag, DatadogScriptTag } from 'lib/datadog'
 import { makeDarkModeToast } from 'lib/toast/make-dark-mode-notification'
+import isThemedPath from 'lib/isThemedPath'
 import { MobileMenuProvider } from 'contexts'
 import TabProvider from 'components/tabs/provider'
 import { GlobalThemeOption } from 'styles/themes/types'
@@ -20,11 +21,7 @@ const CoreDevDotLayout = ({ children }: CoreDevDotLayoutProps) => {
 	const { asPath, pathname, isReady } = router
 
 	const isSwingset = asPath.startsWith('/swingset')
-	const isToastPath =
-		pathname !== '/' &&
-		pathname !== '/sign-up' &&
-		pathname !== '/_error' &&
-		!isSwingset
+	const isToastPath = isThemedPath(pathname) && !isSwingset
 
 	useEffect(() => {
 		if (isReady && isToastPath) {

--- a/src/lib/isThemedPath.ts
+++ b/src/lib/isThemedPath.ts
@@ -1,7 +1,3 @@
 export default function isThemedPath(currentPath: string): boolean {
-	return (
-		__config.dev_dot.non_themed_paths.findIndex(
-			(nonThemedPath: string) => nonThemedPath === currentPath
-		) === -1
-	)
+	return !__config.dev_dot.non_themed_paths.includes(currentPath)
 }

--- a/src/lib/isThemedPath.ts
+++ b/src/lib/isThemedPath.ts
@@ -1,0 +1,7 @@
+export default function isThemedPath(currentPath: string): boolean {
+	return (
+		__config.dev_dot.non_themed_paths.findIndex(
+			(nonThemedPath: string) => nonThemedPath === currentPath
+		) === -1
+	)
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksthemed-product-icon-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204323512217789) 🎟️

## 🗒️ What

So we can control the non-themed paths from one spot. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

I added a utility for checking whether the current path is _themed_ and used that where we render theming UI. 

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksthemed-product-icon-hashicorp.vercel.app/)
- Validate that the themed ui (user nav dropdown, mobile nav, & footer) shows up on all routes except the homepage and the sign up path

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
