### PR TITLE
Add pre-release info on version alert banner

### DIFF
--- a/src/components/version-alert-banner/index.tsx
+++ b/src/components/version-alert-banner/index.tsx
@@ -26,14 +26,11 @@ export default function VersionAlertBanner({
 	releaseStage?: string
 	latestVersionUrl: string
 }) {
-	function determineVersionMessage() {
-		if (typeof releaseStage !== 'undefined' && releaseStage !== 'stable') {
-			return 'You are viewing pre-released documentation for version'
-		}
-		return 'You are viewing documentation for version'
-	}
+	let versionMessage = 'You are viewing documentation for version'
 
-	const versionMessage = determineVersionMessage()
+	if (typeof releaseStage !== 'undefined' && releaseStage !== 'stable') {
+		versionMessage = 'You are viewing pre-released documentation for version'
+	}
 
 	return (
 		<PageAlert

--- a/src/components/version-alert-banner/index.tsx
+++ b/src/components/version-alert-banner/index.tsx
@@ -29,7 +29,7 @@ export default function VersionAlertBanner({
 	let versionMessage = 'You are viewing documentation for version'
 
 	if (typeof releaseStage !== 'undefined' && releaseStage !== 'stable') {
-		versionMessage = 'You are viewing pre-released documentation for version'
+		versionMessage = `You are viewing documentation for pre-release version`
 	}
 
 	return (

--- a/src/components/version-alert-banner/index.tsx
+++ b/src/components/version-alert-banner/index.tsx
@@ -19,17 +19,28 @@ import s from './version-alert-banner.module.css'
  */
 export default function VersionAlertBanner({
 	currentVersion,
+	releaseStage,
 	latestVersionUrl,
 }: {
 	currentVersion: string
+	releaseStage?: string
 	latestVersionUrl: string
 }) {
+	function determineVersionMessage() {
+		if (typeof releaseStage !== 'undefined' && releaseStage !== 'stable') {
+			return 'You are viewing pre-released documentation for version'
+		}
+		return 'You are viewing documentation for version'
+	}
+
+	const versionMessage = determineVersionMessage()
+
 	return (
 		<PageAlert
 			className={s.root}
 			description={
 				<>
-					You are viewing documentation for version {currentVersion}.{' '}
+					{versionMessage} {currentVersion}.{' '}
 					<InlineLink
 						className={s.versionAlertLink}
 						href={latestVersionUrl}

--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -7,6 +7,7 @@ import { getVersionFromPath } from 'lib/get-version-from-path'
 import { removeVersionFromPath } from 'lib/remove-version-from-path'
 import useCurrentPath from 'hooks/use-current-path'
 import VersionAlertBanner from 'components/version-alert-banner'
+import { VersionSelectItem } from '@hashicorp/react-docs-page/server/loaders/remote-content'
 
 /**
  * Renders an alert banner if the current URL indicates a non-latest version,
@@ -14,19 +15,31 @@ import VersionAlertBanner from 'components/version-alert-banner'
  *
  * Note that the logic here is based specifically on docs URL structures.
  */
-function DocsVersionAlertBanner() {
+function DocsVersionAlertBanner({
+	versions,
+}: {
+	versions: VersionSelectItem[]
+}) {
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
-	const currentlyViewedVersion = getVersionFromPath(currentPath)
+	const versionFromPath = getVersionFromPath(currentPath)
+	const isLatestVersion = !versionFromPath
 
 	// If we're viewing the latest version, we don't need an alert banner
-	if (!currentlyViewedVersion) {
+	if (isLatestVersion) {
 		return null
 	}
+
+	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
+	const { releaseStage } = versions.find(
+		(currentVersion: VersionSelectItem) =>
+			currentVersion.version === versionFromPath
+	)
 
 	// Otherwise, render a version alert banner
 	return (
 		<VersionAlertBanner
-			currentVersion={currentlyViewedVersion}
+			releaseStage={releaseStage}
+			currentVersion={versionFromPath}
 			latestVersionUrl={removeVersionFromPath(currentPath)}
 		/>
 	)

--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -29,17 +29,16 @@ function DocsVersionAlertBanner({
 		return null
 	}
 
-	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
-	const { releaseStage } = versions.find(
+	// find curent version in list of versions, to give VersionAlertBanner access to VersionSelectItem's releaseStage and label
+	const { releaseStage, label } = versions.find(
 		(currentVersion: VersionSelectItem) =>
 			currentVersion.version === versionFromPath
 	)
 
-	// Otherwise, render a version alert banner
 	return (
 		<VersionAlertBanner
 			releaseStage={releaseStage}
-			currentVersion={versionFromPath}
+			currentVersion={label}
 			latestVersionUrl={removeVersionFromPath(currentPath)}
 		/>
 	)

--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -23,7 +23,7 @@ function DocsVersionAlertBanner({
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 	const versionFromPath = getVersionFromPath(currentPath)
 
-	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
+	// find curent version in list of versions
 	const { releaseStage, isLatest } = versions.find(
 		(currentVersion: VersionSelectItem) =>
 			currentVersion.version === versionFromPath

--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -22,19 +22,18 @@ function DocsVersionAlertBanner({
 }) {
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 	const versionFromPath = getVersionFromPath(currentPath)
-
-	// find curent version in list of versions
-	const { releaseStage, isLatest } = versions.find(
-		(currentVersion: VersionSelectItem) =>
-			currentVersion.version === versionFromPath
-	)
-
-	const isLatestVersion = !versionFromPath || isLatest
+	const isLatestVersion = !versionFromPath
 
 	// If we're viewing the latest version, we don't need an alert banner
 	if (isLatestVersion) {
 		return null
 	}
+
+	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
+	const { releaseStage } = versions.find(
+		(currentVersion: VersionSelectItem) =>
+			currentVersion.version === versionFromPath
+	)
 
 	// Otherwise, render a version alert banner
 	return (

--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -22,18 +22,19 @@ function DocsVersionAlertBanner({
 }) {
 	const currentPath = useCurrentPath({ excludeHash: true, excludeSearch: true })
 	const versionFromPath = getVersionFromPath(currentPath)
-	const isLatestVersion = !versionFromPath
+
+	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
+	const { releaseStage, isLatest } = versions.find(
+		(currentVersion: VersionSelectItem) =>
+			currentVersion.version === versionFromPath
+	)
+
+	const isLatestVersion = !versionFromPath || isLatest
 
 	// If we're viewing the latest version, we don't need an alert banner
 	if (isLatestVersion) {
 		return null
 	}
-
-	// find curent version in list of versions, to give VersionAlertBanner access to `releaseStage`
-	const { releaseStage } = versions.find(
-		(currentVersion: VersionSelectItem) =>
-			currentVersion.version === versionFromPath
-	)
 
 	// Otherwise, render a version alert banner
 	return (

--- a/src/layouts/docs-view-layout/index.tsx
+++ b/src/layouts/docs-view-layout/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { VersionSelectItem } from '@hashicorp/react-docs-page/server/loaders/remote-content'
 import { OutlineNavWithActive } from 'components/outline-nav/components'
 import { OutlineLinkItem } from 'components/outline-nav/types'
 import SidebarSidecarLayout, {
@@ -16,8 +17,12 @@ import { DocsVersionAlertBanner } from './components'
  */
 const DocsViewLayout = ({
 	outlineItems,
+	versions,
 	...layoutProps
-}: SidebarSidecarLayoutProps & { outlineItems: OutlineLinkItem[] }) => {
+}: SidebarSidecarLayoutProps & {
+	outlineItems: OutlineLinkItem[]
+	versions?: VersionSelectItem[]
+}) => {
 	return (
 		<SidebarSidecarLayout
 			{...layoutProps}
@@ -42,7 +47,7 @@ const DocsViewLayout = ({
 			 * https://app.asana.com/0/1202097197789424/1204098852315293/f
 			 */
 			sidecarSlot={<OutlineNavWithActive items={outlineItems.slice(0)} />}
-			alertBannerSlot={<DocsVersionAlertBanner />}
+			alertBannerSlot={<DocsVersionAlertBanner versions={versions} />}
 		/>
 	)
 }

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -26,5 +26,5 @@ export interface SidebarSidecarLayoutProps {
 	/**
 	 * Optionally render an alert banner before the main content area.
 	 */
-	alertBannerSlot?: React.ReactNode
+	alertBannerSlot?: ReactNode
 }

--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -50,7 +50,11 @@ const DocsView = ({
 	const Layout = layouts[metadata?.layout?.name] ?? DefaultLayout
 
 	return (
-		<DocsViewLayout {...layoutProps} outlineItems={outlineItems}>
+		<DocsViewLayout
+			{...layoutProps}
+			outlineItems={outlineItems}
+			versions={versions}
+		>
 			<div className={classNames(versions && s.contentWithVersions)}>
 				{versions ? (
 					<div className={s.versionSwitcherWrapper}>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-napre-release-version-alert-hashicorp.vercel.app) 🔎
- [Asana task](https://app.asana.com/0/1203347061500809/1203374761617819) 🎟️

## 🗒️ What

This PR changes the message on the `VersionAlertBanner` when a pre-released or non-stable version is selected. 

**Pre-release Version Message:**  You are viewing pre-released documentation for version __
**Stable Version Message (unchanged):**  You are viewing documentation for version __

## 🤷 Why

This will get allow the user to know that the docs version they are currently looking at is not a stable version

## 🛠️ How

To achieve this I passed `versions` from `DocsViewProps` (`views > docs-view > server.ts > getStaticProps()`) through `DocsView`, into `DocsViewLayout`, ultimately into `DocsVersionAlertBanner`. 

From there, I find the `VersionSelectItem` that matches the version in the URL, and pass 'releaseStage' into a optional prop that I added to `VersionAlertBanner`. 

In the `VersionAlertBanner` component I check if the passed in `releaseStage` prop is `!== stable`, and re-assign the default message to a pre-release specific message.

Handling the logic this way allows for a non-breaking change for `VersionAlertBanner`.

