### PR TITLE
Removing css extension from prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@ _temp-migrations/
 .git-blame-ignore-revs
 .next
 .vercel
-*.css
 node_modules
 out
 playwright-report/


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Removes the `*.css` line from `.prettierignore`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- `.css` files haven't been getting auto formatted on save
- This is likely a remnant from the `SPACE` > `TAB` migration many, many months ago
