### PR TITLE
hotfix: Fixes z-index of mobile menu on home page

### DIFF
--- a/src/layouts/base-new/base-new-layout.module.css
+++ b/src/layouts/base-new/base-new-layout.module.css
@@ -40,7 +40,7 @@ Asana task: https://app.asana.com/0/1202114367927919/1202316169578550/f
 
 .mobileMenuContainer {
 	padding: 24px;
-	z-index: 2;
+	z-index: 4;
 }
 
 .mobileMenuNavList {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambmobile-menu-hotfix-hashicorp.vercel.app/) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the `z-index` value for the mobile menu container on the home page

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Some of the absolutely positioned elements of the home page were on top of the mobile menu container

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the home page on the preview
- [ ] Open the mobile menu
- [ ] No home page elements should render on top of the mobile menu contents
