### PR TITLE
[Home Page Redesign] Implement search card auto scroll with transition on `transform: translateX()` property

### DIFF
--- a/src/views/homepage/components/featured-content-grid/search-featured-card.module.css
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.module.css
@@ -4,6 +4,8 @@
  */
 
 .root {
+	--auto-scroll-transition-length: 400ms;
+
 	background-color: var(--token-color-foreground-strong);
 	background-position: center top;
 	background-repeat: no-repeat;
@@ -100,32 +102,29 @@
 	}
 }
 
-.buttonContainer {
+.buttonsContainer {
 	align-items: center;
 	display: flex;
-	gap: 24px;
-	max-width: 100%;
-	overflow: hidden;
+	left: 100vw;
 	padding-bottom: 38px;
 	padding-top: 38px;
 	position: relative;
 
-	/* 500px with 16px base font */
-	@media screen and (max-width: 31.25rem) {
-		gap: 12px;
-	}
-
 	/* Only enable animation if query is supported and value is no-preference */
 	@media (prefers-reduced-motion: no-preference) {
-		scroll-behavior: smooth;
+		transition: left var(--auto-scroll-transition-length) ease-in-out;
 	}
+}
 
-	/* spacers that enable the first/last buttons to be centered */
-	&::before,
-	&::after {
-		content: '';
-		min-height: 1px;
-		min-width: 300px;
+.buttonContainer {
+	padding-left: 12px;
+	padding-right: 12px;
+	z-index: 1;
+
+	/* 500px with 16px base font */
+	@media screen and (max-width: 31.25rem) {
+		padding-left: 6px;
+		padding-right: 6px;
 	}
 }
 
@@ -153,7 +152,6 @@
 	color: var(--token-color-palette-neutral-0);
 	opacity: 0.5;
 	padding: 1px 0;
-	z-index: 1;
 
 	/* 500px with 16px base font */
 	@media screen and (max-width: 31.25rem) {
@@ -167,7 +165,7 @@
 
 	/* Only enable animation if query is supported and value is no-preference */
 	@media (prefers-reduced-motion: no-preference) {
-		transition: opacity 120ms ease-in-out;
+		transition: opacity var(--auto-scroll-transition-length) ease-in-out;
 	}
 
 	&:focus,
@@ -235,7 +233,8 @@
 
 	/* Only enable animation if query is supported and value is no-preference */
 	@media (prefers-reduced-motion: no-preference) {
-		transition: width 120ms ease-in-out, color 120ms ease-in-out;
+		transition: width var(--auto-scroll-transition-length) ease-in-out,
+			color var(--auto-scroll-transition-length) ease-in-out;
 	}
 
 	&.currentPositionIndicator {

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.module.css
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.module.css
@@ -93,7 +93,7 @@
 	position: absolute;
 	right: 0;
 	top: 0;
-	z-index: 2;
+	z-index: 3;
 
 	/* 500px with 16px base font */
 	@media (max-width: 31.25rem) {
@@ -105,14 +105,15 @@
 .buttonsContainer {
 	align-items: center;
 	display: flex;
-	left: 100vw;
 	padding-bottom: 38px;
 	padding-top: 38px;
 	position: relative;
+	transform: translateX(100vw);
+	z-index: 2;
 
 	/* Only enable animation if query is supported and value is no-preference */
 	@media (prefers-reduced-motion: no-preference) {
-		transition: left var(--auto-scroll-transition-length) ease-in-out;
+		transition: transform var(--auto-scroll-transition-length) ease-in-out;
 	}
 }
 
@@ -172,7 +173,7 @@
 	&:focus-visible,
 	&.currentButton {
 		opacity: 1;
-		z-index: 3;
+		z-index: 4;
 	}
 }
 

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
@@ -167,9 +167,10 @@ const SearchFeaturedCard = () => {
 			}
 		)
 
+		const newXPosition = sumPreviousButtonsWidths - buttonLeftToContainerLeft
 		scrollableAreaRef.current.style.setProperty(
-			'left',
-			`calc(-1 * ${sumPreviousButtonsWidths - buttonLeftToContainerLeft}px)`
+			'transform',
+			`translateX(calc(-1 * ${newXPosition}px))`
 		)
 	}, [currentIndex])
 

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
@@ -10,7 +10,6 @@ import deriveKeyEventState from 'lib/derive-key-event-state'
 import usePrefersReducedMotion from 'lib/hooks/usePrefersReducedMotion'
 import Card from 'components/card'
 import { useCommandBar } from 'components/command-bar'
-import Heading from 'components/heading'
 import { StandaloneLinkContents } from 'components/standalone-link'
 import Text from 'components/text'
 import s from './search-featured-card.module.css'
@@ -144,20 +143,34 @@ const SearchFeaturedCard = () => {
 	 * If it's not, then center it.
 	 */
 	useEffect(() => {
-		const { left: containerLeft, width: containerWidth } =
-			scrollableAreaRef.current.getBoundingClientRect()
-		const { left: buttonLeft, width: buttonWidth } =
-			scrollableAreaRef.current.children
-				.item(currentIndex)
-				.getBoundingClientRect()
+		// Pull overall container and current button container elements into variables
+		const buttonsContainer = scrollableAreaRef.current
+		const buttonContainerToCenter = buttonsContainer.children.item(currentIndex)
 
-		const widthDifference = containerWidth - buttonWidth
-		const buttonLeftWhenCentered = containerLeft + widthDifference / 2
+		// Pull element widths into variables
+		const containerWidth = buttonsContainer.clientWidth
+		const buttonContainerWidth = buttonContainerToCenter.clientWidth
 
-		const buttonOffsetFromCenter = buttonLeft - buttonLeftWhenCentered
-		if (Math.abs(buttonOffsetFromCenter) > 10) {
-			scrollableAreaRef.current.scrollBy(buttonOffsetFromCenter, 0)
-		}
+		// Get distance from left button container edge to overall container's left edge
+		const widthDifference = containerWidth - buttonContainerWidth
+		const buttonLeftToContainerLeft = widthDifference / 2
+
+		let sumPreviousButtonsWidths = 0
+		Array.from(buttonsContainer.childNodes).find(
+			(buttonElement: HTMLButtonElement, index: number) => {
+				if (index === currentIndex) {
+					return true
+				} else {
+					sumPreviousButtonsWidths += buttonElement.clientWidth
+					return false
+				}
+			}
+		)
+
+		scrollableAreaRef.current.style.setProperty(
+			'left',
+			`calc(-1 * ${sumPreviousButtonsWidths - buttonLeftToContainerLeft}px)`
+		)
 	}, [currentIndex])
 
 	return (
@@ -170,7 +183,7 @@ const SearchFeaturedCard = () => {
 			<div className={s.carousel}>
 				<div className={s.blurredBackground} />
 				<div className={s.fadedBackground} />
-				<div className={s.buttonContainer} ref={scrollableAreaRef}>
+				<div className={s.buttonsContainer} ref={scrollableAreaRef}>
 					{FEATURED_SEARCH_TERMS.map((term: string, index: number) => {
 						const id = `search-term-${index}`
 						const isCurrent = index === currentIndex
@@ -190,30 +203,31 @@ const SearchFeaturedCard = () => {
 						}
 
 						return (
-							<button
-								id={id}
-								key={id}
-								className={classNames(s.button, isCurrent && s.currentButton)}
-								onClick={handleClick}
-								onKeyUp={handleKeyUp}
-							>
-								<div className={s.buttonContent}>
-									<Text
-										asElement="span"
-										className={s.buttonText}
-										size={200}
-										weight="semibold"
-									>
-										{term}
-									</Text>
-									<StandaloneLinkContents
-										color="primary"
-										icon={<IconArrowRight16 />}
-										iconPosition="trailing"
-										text="Explore"
-									/>
-								</div>
-							</button>
+							<div className={s.buttonContainer} key={id}>
+								<button
+									id={id}
+									className={classNames(s.button, isCurrent && s.currentButton)}
+									onClick={handleClick}
+									onKeyUp={handleKeyUp}
+								>
+									<div className={s.buttonContent}>
+										<Text
+											asElement="span"
+											className={s.buttonText}
+											size={200}
+											weight="semibold"
+										>
+											{term}
+										</Text>
+										<StandaloneLinkContents
+											color="primary"
+											icon={<IconArrowRight16 />}
+											iconPosition="trailing"
+											text="Explore"
+										/>
+									</div>
+								</button>
+							</div>
 						)
 					})}
 				</div>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambhp-safari-autoscroll-hashicorp.vercel.app/) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Replaces the `scrollBy` autoscroll implementation with programmatically setting the `transform: translateX()` property in JS

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Autoscroll was not working consistently in macOs or iOS Safari

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] The "Search with ease" card autoscroll should work smoothly in:
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari

## 💭 Anything else?

- My first attempt at this tried to animate against the `left` CSS property. When testing it in Safari, it was jittery/laggy. Shout out to @BRKalow for a resource about this and the suggestion to use `translate: transformX()` instead! The resource is: [Stick to Compositor-Only Properties and Manage Layer Count](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204484002819134