### PR TITLE
[Home Page Redesign] Implementing swipe interaction on featured search card

### DIFF
--- a/src/hooks/use-on-swipe.ts
+++ b/src/hooks/use-on-swipe.ts
@@ -10,7 +10,9 @@ interface UseOnSwipeOptions {
 const DEFAULT_CLIENT_X_DIFF_THRESHOLD = 20
 
 /**
- * @TODO document
+ * Given a ref associated with a swipeable HTML element and callback functions
+ * swiping left and swiping right, invokes the appropriate callback when a swipe
+ * is detected.
  */
 const useOnSwipe = ({
 	diffThreshold = DEFAULT_CLIENT_X_DIFF_THRESHOLD,
@@ -32,7 +34,8 @@ const useOnSwipe = ({
 			const changedTouch = event.changedTouches.item(0)
 			const clientXDiff = clientX.current - changedTouch.clientX
 
-			if (Math.abs(clientXDiff) <= diffThreshold) {
+			// If the diff is negligble, then the swipe was too small to be meaningful
+			if (clientXDiff === 0 || Math.abs(clientXDiff) <= diffThreshold) {
 				return
 			}
 
@@ -53,4 +56,5 @@ const useOnSwipe = ({
 	}, [diffThreshold, onSwipeLeft, onSwipeRight, ref])
 }
 
+export type { UseOnSwipeOptions }
 export { useOnSwipe }

--- a/src/hooks/use-on-swipe.ts
+++ b/src/hooks/use-on-swipe.ts
@@ -1,0 +1,56 @@
+import { MutableRefObject, useEffect, useRef } from 'react'
+
+interface UseOnSwipeOptions {
+	diffThreshold?: number
+	onSwipeLeft: () => void
+	onSwipeRight: () => void
+	ref: MutableRefObject<HTMLElement>
+}
+
+const DEFAULT_CLIENT_X_DIFF_THRESHOLD = 20
+
+/**
+ * @TODO document
+ */
+const useOnSwipe = ({
+	diffThreshold = DEFAULT_CLIENT_X_DIFF_THRESHOLD,
+	onSwipeLeft,
+	onSwipeRight,
+	ref,
+}: UseOnSwipeOptions): void => {
+	const clientX = useRef<number>()
+
+	useEffect(() => {
+		const elementWithListeners = ref.current
+
+		const handleTouchStart = (event: TouchEvent) => {
+			const firstTouch = event.touches.item(0)
+			clientX.current = firstTouch.clientX
+		}
+
+		const handleTouchEnd = (event: TouchEvent) => {
+			const changedTouch = event.changedTouches.item(0)
+			const clientXDiff = clientX.current - changedTouch.clientX
+
+			if (Math.abs(clientXDiff) <= diffThreshold) {
+				return
+			}
+
+			if (clientXDiff < 0) {
+				onSwipeLeft()
+			} else {
+				onSwipeRight()
+			}
+		}
+
+		elementWithListeners.addEventListener('touchstart', handleTouchStart)
+		elementWithListeners.addEventListener('touchend', handleTouchEnd)
+
+		return () => {
+			elementWithListeners.removeEventListener('touchstart', handleTouchStart)
+			elementWithListeners.removeEventListener('touchend', handleTouchEnd)
+		}
+	}, [diffThreshold, onSwipeLeft, onSwipeRight, ref])
+}
+
+export { useOnSwipe }

--- a/src/hooks/use-on-swipe.ts
+++ b/src/hooks/use-on-swipe.ts
@@ -13,6 +13,12 @@ const DEFAULT_CLIENT_X_DIFF_THRESHOLD = 20
  * Given a ref associated with a swipeable HTML element and callback functions
  * swiping left and swiping right, invokes the appropriate callback when a swipe
  * is detected.
+ *
+ * Note: if we find the need to listen for more than touch events in the future,
+ * React Aria's useMove hook may be something we can leverage. At the time of
+ * writing, we do not yet have a need for all of its functionality.
+ *
+ * https://react-spectrum.adobe.com/react-aria/useMove.html
  */
 const useOnSwipe = ({
 	diffThreshold = DEFAULT_CLIENT_X_DIFF_THRESHOLD,

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { KeyboardEvent, useEffect, useRef, useState } from 'react'
+import { KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
 import deriveKeyEventState from 'lib/derive-key-event-state'
@@ -36,34 +36,38 @@ const SearchFeaturedCard = () => {
 		setCurrentInputValue: setCommandBarSearchValue,
 		toggleIsOpen: toggleCommandBar,
 	} = useCommandBar()
+	const scrollableAreaRef = useRef<HTMLDivElement>()
 	const [currentIndex, setCurrentIndex] = useState(
 		INITIALLY_CENTERED_TERM_INDEX
 	)
-	const scrollableAreaRef = useRef<HTMLDivElement>()
 
-	/**
-	 * @TODO document
-	 */
+	// Callback for incrementing currentIndex and wrapping back to the first index
+	const incrementIndex = useCallback(() => {
+		setCurrentIndex((prevIndex: number) => {
+			if (prevIndex === FEATURED_SEARCH_TERMS.length - 1) {
+				return 0
+			} else {
+				return prevIndex + 1
+			}
+		})
+	}, [])
+
+	// Callback for decrementing currentIndex and wrapping back to the last index
+	const decrementIndex = useCallback(() => {
+		setCurrentIndex((prevIndex: number) => {
+			if (prevIndex === 0) {
+				return FEATURED_SEARCH_TERMS.length - 1
+			} else {
+				return prevIndex - 1
+			}
+		})
+	}, [])
+
+	// Handline incrementing or decrementing currentIndex when a user swipes
 	useOnSwipe({
 		ref: scrollableAreaRef,
-		onSwipeLeft: () => {
-			setCurrentIndex((prevIndex: number) => {
-				if (prevIndex === 0) {
-					return FEATURED_SEARCH_TERMS.length - 1
-				} else {
-					return prevIndex - 1
-				}
-			})
-		},
-		onSwipeRight: () => {
-			setCurrentIndex((prevIndex: number) => {
-				if (prevIndex === FEATURED_SEARCH_TERMS.length - 1) {
-					return 0
-				} else {
-					return prevIndex + 1
-				}
-			})
-		},
+		onSwipeLeft: () => decrementIndex(),
+		onSwipeRight: () => incrementIndex(),
 	})
 
 	/**
@@ -139,14 +143,7 @@ const SearchFeaturedCard = () => {
 		let interval: NodeJS.Timer
 		if (isAutoScrollEnabled) {
 			interval = setInterval(() => {
-				setCurrentIndex((prev: number) => {
-					const isLastIndex = FEATURED_SEARCH_TERMS.length - 1
-					if (prev === isLastIndex) {
-						return 0
-					} else {
-						return prev + 1
-					}
-				})
+				incrementIndex()
 			}, 4000)
 		}
 
@@ -162,7 +159,12 @@ const SearchFeaturedCard = () => {
 			)
 			clearInterval(interval)
 		}
-	}, [isAutoScrollEnabled, isCommandBarOpen, prefersReducedMotion])
+	}, [
+		incrementIndex,
+		isAutoScrollEnabled,
+		isCommandBarOpen,
+		prefersReducedMotion,
+	])
 
 	/**
 	 * When `currentIndex` changes, check if the button at that index is centered.

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
@@ -3,20 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {
-	KeyboardEvent,
-	MutableRefObject,
-	useEffect,
-	useRef,
-	useState,
-} from 'react'
+import { KeyboardEvent, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { IconArrowRight16 } from '@hashicorp/flight-icons/svg-react/arrow-right-16'
 import deriveKeyEventState from 'lib/derive-key-event-state'
 import usePrefersReducedMotion from 'lib/hooks/usePrefersReducedMotion'
+import { useOnSwipe } from 'hooks/use-on-swipe'
 import Card from 'components/card'
 import { useCommandBar } from 'components/command-bar'
-import Heading from 'components/heading'
 import { StandaloneLinkContents } from 'components/standalone-link'
 import Text from 'components/text'
 import s from './search-featured-card.module.css'
@@ -31,56 +25,6 @@ const FEATURED_SEARCH_TERMS = [
 
 // Starting the animation from the center, as requested from Design
 const INITIALLY_CENTERED_TERM_INDEX = 2
-
-/**
- * @TODO
- *
- * - move to own file
- * - document
- */
-const useSwipeDectector = ({
-	ref,
-	onSwipeLeft,
-	onSwipeRight,
-}: {
-	ref: MutableRefObject<HTMLElement>
-	onSwipeLeft: () => void
-	onSwipeRight: () => void
-}): void => {
-	const clientX = useRef<number>()
-
-	useEffect(() => {
-		const elementWithListeners = ref.current
-
-		const handleTouchStart = (event: TouchEvent) => {
-			const firstTouch = event.touches.item(0)
-			clientX.current = firstTouch.clientX
-		}
-
-		const handleTouchMove = (event: TouchEvent) => {
-			const changedTouch = event.changedTouches.item(0)
-			const clientXDiff = clientX.current - changedTouch.clientX
-
-			if (Math.abs(clientXDiff) < 20) {
-				return
-			}
-
-			if (clientXDiff < 0) {
-				onSwipeLeft()
-			} else {
-				onSwipeRight()
-			}
-		}
-
-		elementWithListeners.addEventListener('touchstart', handleTouchStart)
-		elementWithListeners.addEventListener('touchend', handleTouchMove)
-
-		return () => {
-			elementWithListeners.removeEventListener('touchstart', handleTouchStart)
-			elementWithListeners.removeEventListener('touchend', handleTouchMove)
-		}
-	}, [ref, onSwipeLeft, onSwipeRight])
-}
 
 const SearchFeaturedCard = () => {
 	const prefersReducedMotion = usePrefersReducedMotion()
@@ -100,7 +44,7 @@ const SearchFeaturedCard = () => {
 	/**
 	 * @TODO document
 	 */
-	useSwipeDectector({
+	useOnSwipe({
 		ref: scrollableAreaRef,
 		onSwipeLeft: () => {
 			setCurrentIndex((prevIndex: number) => {

--- a/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
+++ b/src/views/homepage/components/featured-content-grid/search-featured-card.tsx
@@ -43,11 +43,10 @@ const useSwipeDectector = ({
 	onSwipeLeft,
 	onSwipeRight,
 }: {
-	// @TODO let `HTMLDivElement` be passed in
-	ref: MutableRefObject<HTMLDivElement>
+	ref: MutableRefObject<HTMLElement>
 	onSwipeLeft: () => void
 	onSwipeRight: () => void
-}) => {
+}): void => {
 	const clientX = useRef<number>()
 
 	useEffect(() => {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ambhp-search-card-swipe-hashicorp.vercel.app/) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds new `useOnSwipe` hook
- Leverages the new hook in `SearchFeaturedCard`
- Abstracts 2 new `incrementIndex` and `decrementIndex` callbacks in `SearchFeaturedCard`

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] On a mobile device, go [the home page](https://dev-portal-git-ambhp-search-card-swipe-hashicorp.vercel.app/) on the preview
- [ ] When the first button is centered and you swipe right, the last button should become centered
- [ ] When the last button is centered and you swipe left, the first button should become centered
- [ ] When swiping left on other buttons, the next button should become centered
- [ ] When swiping right on other buttons, the previous button should become centered

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- The [React Aria `useMove`](useMove) was raised as a potential solution for this functionality, but I decided not to leverage it here since we only need to listen for touch events in this case. However, I did leave a note in the code comments about the hook in case we find it's additional functionality necessary in the future.
