### PR TITLE
feat: add version alert for api docs

### DIFF
--- a/src/pages/hcp/api-docs/packer/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/packer/[[...page]].tsx
@@ -65,7 +65,7 @@ function HcpPackerApiDocsView(props: ApiDocsViewProps) {
 export const getStaticPaths: GetStaticPaths<ApiDocsParams> = async () => {
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
 	// TODO: shim to demo multiple stable releases
-	versionData[0].releaseStage = 'stable'
+	versionData[1].releaseStage = 'stable'
 	return await getApiDocsStaticPaths(PRODUCT_SLUG, versionData)
 }
 
@@ -82,7 +82,7 @@ export const getStaticProps: GetStaticProps<
 	// Fetch all version data, based on remote `stable` & `preview` subfolders
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
 	// TODO: shim to demo multiple stable releases
-	versionData[0].releaseStage = 'stable'
+	versionData[1].releaseStage = 'stable'
 	// If we can't find any version data at all, render a 404 page.
 	if (!versionData) {
 		return { notFound: true }

--- a/src/pages/hcp/api-docs/packer/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/packer/[[...page]].tsx
@@ -64,6 +64,8 @@ function HcpPackerApiDocsView(props: ApiDocsViewProps) {
  */
 export const getStaticPaths: GetStaticPaths<ApiDocsParams> = async () => {
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
+	// TODO: shim to demo multiple stable releases
+	versionData[1].releaseStage = 'stable'
 	return await getApiDocsStaticPaths(PRODUCT_SLUG, versionData)
 }
 
@@ -79,6 +81,8 @@ export const getStaticProps: GetStaticProps<
 > = async ({ params }: { params: ApiDocsParams }) => {
 	// Fetch all version data, based on remote `stable` & `preview` subfolders
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
+	// TODO: shim to demo multiple stable releases
+	versionData[1].releaseStage = 'stable'
 	// If we can't find any version data at all, render a 404 page.
 	if (!versionData) {
 		return { notFound: true }

--- a/src/pages/hcp/api-docs/packer/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/packer/[[...page]].tsx
@@ -65,7 +65,7 @@ function HcpPackerApiDocsView(props: ApiDocsViewProps) {
 export const getStaticPaths: GetStaticPaths<ApiDocsParams> = async () => {
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
 	// TODO: shim to demo multiple stable releases
-	versionData[1].releaseStage = 'stable'
+	versionData[0].releaseStage = 'stable'
 	return await getApiDocsStaticPaths(PRODUCT_SLUG, versionData)
 }
 
@@ -82,7 +82,7 @@ export const getStaticProps: GetStaticProps<
 	// Fetch all version data, based on remote `stable` & `preview` subfolders
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
 	// TODO: shim to demo multiple stable releases
-	versionData[1].releaseStage = 'stable'
+	versionData[0].releaseStage = 'stable'
 	// If we can't find any version data at all, render a 404 page.
 	if (!versionData) {
 		return { notFound: true }

--- a/src/pages/hcp/api-docs/packer/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/packer/[[...page]].tsx
@@ -64,8 +64,6 @@ function HcpPackerApiDocsView(props: ApiDocsViewProps) {
  */
 export const getStaticPaths: GetStaticPaths<ApiDocsParams> = async () => {
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
-	// TODO: shim to demo multiple stable releases
-	versionData[1].releaseStage = 'stable'
 	return await getApiDocsStaticPaths(PRODUCT_SLUG, versionData)
 }
 
@@ -81,8 +79,6 @@ export const getStaticProps: GetStaticProps<
 > = async ({ params }: { params: ApiDocsParams }) => {
 	// Fetch all version data, based on remote `stable` & `preview` subfolders
 	const versionData = await fetchCloudApiVersionData(GITHUB_SOURCE_DIRECTORY)
-	// TODO: shim to demo multiple stable releases
-	versionData[1].releaseStage = 'stable'
 	// If we can't find any version data at all, render a 404 page.
 	if (!versionData) {
 		return { notFound: true }

--- a/src/views/api-docs-view/components/api-docs-version-alert/api-docs-version-alert.module.css
+++ b/src/views/api-docs-view/components/api-docs-version-alert/api-docs-version-alert.module.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	padding-left: 24px;
+	padding-right: 24px;
+}
+
+.versionAlertLink {
+	/* Note: !important seems necessary here to ensure the color is applied
+	   to all states. @TODO: update InlineLink to better support theming. */
+	color: var(--token-color-foreground-primary) !important;
+}

--- a/src/views/api-docs-view/components/api-docs-version-alert/index.tsx
+++ b/src/views/api-docs-view/components/api-docs-version-alert/index.tsx
@@ -20,17 +20,20 @@ function ApiDocsVersionAlert({
 	}
 
 	/**
+	 * If this is a versioned URL, but it's the same content as the latest URL,
+	 * we also won't show a version alert.
+	 */
+	if (latestStableVersion.versionId === currentVersion.versionId) {
+		return null
+	}
+
+	/**
 	 * Otherwise, build a message and link, and show the version alert.
 	 */
 	const latestLinkUrl = '/hcp/api-docs/packer'
-	let latestLinkText = 'View latest version'
+	const latestLinkText = 'View latest version'
 	let versionMessage: string
-	if (latestStableVersion.versionId === currentVersion.versionId) {
-		// May be the latest stable version at an "explicit version" URL
-		versionMessage =
-			'You are viewing the latest documentation at a versioned URL.'
-		latestLinkText = `View at the latest URL`
-	} else if (currentVersion.releaseStage === 'preview') {
+	if (currentVersion.releaseStage === 'preview') {
 		// May be a preview version
 		versionMessage = `You are viewing documentation for the preview version ${currentVersion.versionId}.`
 	} else {

--- a/src/views/api-docs-view/components/api-docs-version-alert/index.tsx
+++ b/src/views/api-docs-view/components/api-docs-version-alert/index.tsx
@@ -1,0 +1,85 @@
+import { IconInfo16 } from '@hashicorp/flight-icons/svg-react/info-16'
+import InlineLink from 'components/inline-link'
+import PageAlert from 'components/page-alert'
+import type { ApiDocsVersionAlertProps } from './types'
+import s from './api-docs-version-alert.module.css'
+
+/**
+ * Display a version alert for API documentation
+ */
+function ApiDocsVersionAlert({
+	isVersionedUrl,
+	currentVersion,
+	latestStableVersion,
+}: ApiDocsVersionAlertProps) {
+	/**
+	 * If this isn't a versioned URL, we won't show a version alert.
+	 */
+	if (!isVersionedUrl) {
+		return null
+	}
+
+	/**
+	 * Otherwise, build a message and link, and show the version alert.
+	 */
+	const latestLinkUrl = '/hcp/api-docs/packer'
+	let latestLinkText = 'View latest version'
+	let versionMessage: string
+	if (latestStableVersion.versionId === currentVersion.versionId) {
+		// May be the latest stable version at an "explicit version" URL
+		versionMessage =
+			'You are viewing the latest documentation at a versioned URL.'
+		latestLinkText = `View at the latest URL`
+	} else if (currentVersion.releaseStage === 'preview') {
+		// May be a preview version
+		versionMessage = `You are viewing documentation for the preview version ${currentVersion.versionId}.`
+	} else {
+		// Otherwise, is some other version, such as non-latest table version
+		versionMessage = `You are viewing documentation for version ${currentVersion.versionId}.`
+	}
+
+	return (
+		<VersionAlert
+			message={versionMessage}
+			latestLinkUrl={latestLinkUrl}
+			latestLinkText={latestLinkText}
+		/>
+	)
+}
+
+/**
+ * Display a generic version alert
+ */
+function VersionAlert({
+	message,
+	latestLinkUrl,
+	latestLinkText,
+}: {
+	message: string
+	latestLinkUrl: string
+	latestLinkText: string
+}) {
+	return (
+		<PageAlert
+			className={s.root}
+			description={
+				<>
+					{message}{' '}
+					<InlineLink
+						className={s.versionAlertLink}
+						href={latestLinkUrl}
+						textSize={200}
+						textWeight="medium"
+					>
+						{latestLinkText}
+					</InlineLink>
+					.
+				</>
+			}
+			icon={<IconInfo16 />}
+			type="highlight"
+		/>
+	)
+}
+
+export { ApiDocsVersionAlert }

--- a/src/views/api-docs-view/components/api-docs-version-alert/types.ts
+++ b/src/views/api-docs-view/components/api-docs-version-alert/types.ts
@@ -1,0 +1,7 @@
+import type { ApiDocsVersionData } from 'views/api-docs-view/types'
+
+export interface ApiDocsVersionAlertProps {
+	isVersionedUrl: boolean
+	currentVersion: ApiDocsVersionData
+	latestStableVersion: ApiDocsVersionData
+}

--- a/src/views/api-docs-view/components/index.tsx
+++ b/src/views/api-docs-view/components/index.tsx
@@ -1,2 +1,3 @@
+export * from './api-docs-version-alert'
 export * from './heading-with-badge'
 export * from './path-truncation-aside'

--- a/src/views/api-docs-view/index.tsx
+++ b/src/views/api-docs-view/index.tsx
@@ -10,7 +10,7 @@ import NoIndexTagIfVersioned from 'components/no-index-tag-if-versioned'
 import OperationObject from 'components/open-api-page/partials/operation-object'
 import DocsPageHeading from 'views/docs-view/components/docs-page-heading'
 // Local
-import { HeadingWithBadge } from './components'
+import { ApiDocsVersionAlert, HeadingWithBadge } from './components'
 // Types
 import type { ApiDocsViewProps } from 'views/api-docs-view/types'
 import type { OperationObjectType } from 'components/open-api-page/types'
@@ -30,6 +30,7 @@ function ApiDocsView({
 	massagePathFn = (path: string) => path,
 	renderOperationIntro,
 	isVersionedUrl,
+	versionAlert,
 	versionSwitcherData,
 }: ApiDocsViewProps) {
 	/**
@@ -46,6 +47,7 @@ function ApiDocsView({
 		<SidebarSidecarLayout
 			breadcrumbLinks={layoutProps.breadcrumbLinks}
 			sidebarNavDataLevels={layoutProps.sidebarNavDataLevels}
+			alertBannerSlot={<ApiDocsVersionAlert {...versionAlert} />}
 		>
 			<NoIndexTagIfVersioned isVersioned={isVersionedUrl} />
 			<DocsPageHeading

--- a/src/views/api-docs-view/server/get-api-docs-static-props/index.ts
+++ b/src/views/api-docs-view/server/get-api-docs-static-props/index.ts
@@ -160,6 +160,11 @@ export async function getApiDocsStaticProps({
 			serviceData,
 			isVersionedUrl,
 			versionSwitcherData,
+			versionAlert: {
+				isVersionedUrl,
+				currentVersion,
+				latestStableVersion,
+			},
 		},
 	}
 }

--- a/src/views/api-docs-view/types.ts
+++ b/src/views/api-docs-view/types.ts
@@ -6,6 +6,7 @@ import type { OperationObjectType } from 'components/open-api-page/types'
 import type { SidebarProps } from 'components/sidebar'
 import type { VersionSwitcherOption } from 'components/version-switcher/types'
 import type { ProductData } from 'types/products'
+import { ApiDocsVersionAlertProps } from './components/api-docs-version-alert/types'
 
 /**
  * Params type for `getStaticPaths` and `getStaticProps`.
@@ -107,4 +108,9 @@ export interface ApiDocsViewProps {
 	 * Optional. If set to `true`, a `noindex` tag will be added to the page.
 	 */
 	isVersionedUrl?: boolean
+
+	/**
+	 * Optional. If provided, a version alert will be shown.
+	 */
+	versionAlert?: ApiDocsVersionAlertProps
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds a version alert on non-latest-URL API docs pages.

## 🤷 Why

To more consistently signal to visitors when they're viewing a non-latest version of documentation.

## 📸 Design Screenshots

| Page | Before | After |
| - | - | - |
| [Preview version][/hcp/api-docs/packer/2023-01-01] | <img width="400" alt="before-preview" src="https://user-images.githubusercontent.com/4624598/235529675-5807e21a-25ca-42e1-98b2-ad34ebabfb5b.png" /> | <img width="400" alt="after-preview" src="https://user-images.githubusercontent.com/4624598/235529669-ecf95589-9d84-4e4f-a70c-e6b34091e853.png" /> |
| [Older stable version][/hcp/api-docs/packer/2021-04-30] | <img width="400" alt="before-older-stable" src="https://user-images.githubusercontent.com/4624598/235529673-fb79eb65-8a92-45bd-92de-46a268f95095.png" /> | <img width="400" alt="after-older-stable" src="https://user-images.githubusercontent.com/4624598/235529664-b08d1c39-5b13-4d79-a1a2-b15dbb42eaa5.png" /> |

> **Warning**: we do not actually have any concrete examples of `Older stable version` pages. They're possible however, such as when a newer preview version becomes stable, so they felt worth accounting for. This PR used a shim to pretend that we had multiple stable versions, by manually adjusting version data right after we fetch it. The shim has since been removed.

> **Note**: appearance at latest version URLs, such as [/hcp/api-docs/packer], and at explicit URLs for the latest version such as [/hcp/api-docs/packer/2022-12-02], is unchanged.

## 🧪 Testing

Visit each of the versioned page types, and confirm the version alert appears as expected:

- Latest version (no change): [/hcp/api-docs/packer]
- Preview version:[/hcp/api-docs/packer/2023-01-01]
- Older stable version: [/hcp/api-docs/packer/2021-04-30]
- Latest version at explicitly versioned URL: [/hcp/api-docs/packer/2022-12-02]

## 💭 Anything else?

Not at the moment.

[task]: https://app.asana.com/0/0/1204508086349465/f
[preview]: https://dev-portal-git-zsversioned-api-docs-alert-hashicorp.vercel.app/
[/hcp/api-docs/packer]: https://dev-portal-git-zsversioned-api-docs-alert-hashicorp.vercel.app/hcp/api-docs/packer
[/hcp/api-docs/packer/2021-04-30]: https://dev-portal-git-zsversioned-api-docs-alert-hashicorp.vercel.app/hcp/api-docs/packer/2021-04-30
[/hcp/api-docs/packer/2022-12-02]: https://dev-portal-git-zsversioned-api-docs-alert-hashicorp.vercel.app/hcp/api-docs/packer/2022-12-02
[/hcp/api-docs/packer/2023-01-01]: https://dev-portal-git-zsversioned-api-docs-alert-hashicorp.vercel.app/hcp/api-docs/packer/2023-01-01