### PR TITLE
fix: display logic for api-docs version select

### DIFF
--- a/src/views/api-docs-view/index.tsx
+++ b/src/views/api-docs-view/index.tsx
@@ -43,6 +43,11 @@ function ApiDocsView({
 	 */
 	const pageHeadingTag = serviceData ? 'p' : 'h1'
 
+	/**
+	 * We only show the version switcher if we have at least 2 options.
+	 */
+	const showVersionSwitcher = versionSwitcherData?.options?.length > 1
+
 	return (
 		<SidebarSidecarLayout
 			breadcrumbLinks={layoutProps.breadcrumbLinks}
@@ -59,7 +64,7 @@ function ApiDocsView({
 					/>
 				}
 				versionSelectorSlot={
-					versionSwitcherData ? (
+					showVersionSwitcher ? (
 						<VersionSwitcher
 							label={versionSwitcherData.label}
 							options={versionSwitcherData.options}


### PR DESCRIPTION
This PR fixes up the display logic for the `/hcp/api-docs/packer` version selector.

## 🧪 Testing

- [Upstream][upstream/hcp/api-docs/packer], the version select dropdown is shown even though there is only one version of the docs to display, resulting in an empty dropdown
- In this PR, at [/hcp/api-docs/packer], the version select dropdown should not be shown

| Before | After |
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/87587e2d-819f-4969-b8a3-1f3b3bd12092) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/d420d77f-c930-47fe-8bf5-08e6d101adc6) | 

[preview]: https://dev-portal-git-zspatch-api-docs-version-select-hashicorp.vercel.app/
[upstream/hcp/api-docs/packer]: https://developer.hashicorp.com/hcp/api-docs/packer
[/hcp/api-docs/packer]: https://dev-portal-git-zspatch-api-docs-version-select-hashicorp.vercel.app/hcp/api-docs/packer