### PR TITLE
fix: user dropdown disclosure active bg-color

### DIFF
--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -111,6 +111,12 @@
 		border-color: var(--token-color-palette-neutral-200);
 	}
 
+	@nest html[data-theme='light'] & {
+		&:active {
+			background-color: var(--token-color-foreground-primary);
+		}
+	}
+
 	@nest html[data-theme='dark'] & {
 		color: var(--token-color-foreground-strong);
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-background-user-button-hashicorp.vercel.app/) 🔎

## 🗒️ What

Fixes an issue where the user dropdown disclosure active background color was off on light-themed pages. I connected with @braydenlove to figure out what this color should be. We chose to do an override this this only affects light themed user dropdown disclosure in the navigation.

<img width="305" alt="Screenshot 2023-05-15 at 3 24 25 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/628f3b6c-6a6d-4d55-a609-a4df8d39ba19">

## 🧪 Testing

- [Visit the homepage](https://dev-portal-git-ksfix-background-user-button-hashicorp.vercel.app/), click the user dropdown disclosure, ensure that on `active` the component background color isn't too light. Compare with production. 
- Visit a [page with theming](https://dev-portal-git-ksfix-background-user-button-hashicorp.vercel.app/waypoint), switch between light and dark theme and ensure the contrast on the active background color is adequate. The dark theme activator bg-color shouldn't be affected.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
