### PR TITLE
feat: variants button list

### DIFF
--- a/src/components/tutorial-meta/components/index.ts
+++ b/src/components/tutorial-meta/components/index.ts
@@ -5,3 +5,4 @@
 
 export * from './badges'
 export * from './badges/helpers'
+export * from './variant-list'

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -33,7 +33,10 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 								aria-current={activeVariantOption.slug === option.slug}
 							>
 								<ButtonLink
-									className={classNames(!isActiveOption && s.linkBorderColor)}
+									className={classNames(
+										s.linkOverrides,
+										!isActiveOption && s.secondaryLinkOverrides
+									)}
 									size="small"
 									color={isActiveOption ? 'primary' : 'secondary'}
 									text={option.name}

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -11,7 +11,7 @@ import {
 import { useRouter } from 'next/router'
 import s from './variant-list.module.css'
 
-export default function VariantList({ variant }: { variant: TutorialVariant }) {
+export function VariantList({ variant }: { variant: TutorialVariant }) {
 	// @TODO hook this into a useVariants hook
 	const activeVariantOption = variant.options[0]
 	const VARIANT_LIST_ID = 'variant-list-label'

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -1,5 +1,6 @@
 // @TODO uncomment when enabling cookies
 // import Cookies from 'js-cookie'
+import Link from 'next/link'
 import classNames from 'classnames'
 import {
 	TutorialVariant,
@@ -7,7 +8,6 @@ import {
 	getVariantParam,
 	getVariantPath,
 } from 'views/tutorial-view/utils/variants'
-import ButtonLink from 'components/button-link'
 import { useRouter } from 'next/router'
 import s from './variant-list.module.css'
 
@@ -32,14 +32,11 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 								key={option.slug}
 								aria-current={activeVariantOption.slug === option.slug}
 							>
-								<ButtonLink
+								<Link
 									className={classNames(
-										s.linkOverrides,
-										!isActiveOption && s.secondaryLinkOverrides
+										s.link,
+										isActiveOption ? s.activeLink : s.inActiveLink
 									)}
-									size="small"
-									color={isActiveOption ? 'primary' : 'secondary'}
-									text={option.name}
 									href={getVariantPath(asPath, variantParam)}
 									onClick={() => {
 										// @TODO add this in when we have real data to check against
@@ -49,7 +46,9 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 										// 	Cookies.set(variant.id, variantParam)
 										// }
 									}}
-								/>
+								>
+									{option.name}
+								</Link>
 							</li>
 						)
 					})}

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -1,6 +1,6 @@
 // @TODO uncomment when enabling cookies
 // import Cookies from 'js-cookie'
-import Link from 'next/link'
+import Link from 'components/link'
 import classNames from 'classnames'
 import {
 	TutorialVariant,
@@ -28,16 +28,14 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 						const variantParam = getVariantParam(variant.slug, option.slug)
 						const isActiveOption = activeVariantOption.slug === option.slug
 						return (
-							<li
-								key={option.slug}
-								aria-current={activeVariantOption.slug === option.slug}
-							>
+							<li key={option.slug}>
 								<Link
 									className={classNames(
 										s.link,
 										isActiveOption ? s.activeLink : s.inActiveLink
 									)}
 									href={getVariantPath(asPath, variantParam)}
+									aria-current={isActiveOption ? 'page' : false}
 									onClick={() => {
 										// @TODO add this in when we have real data to check against
 										// const variantCookie = Cookies.get(variant.slug)

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -1,5 +1,6 @@
 // @TODO uncomment when enabling cookies
 // import Cookies from 'js-cookie'
+import classNames from 'classnames'
 import {
 	TutorialVariant,
 	TutorialVariantOption,
@@ -25,18 +26,16 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 				<ul aria-labelledby={VARIANT_LIST_ID} className={s.list}>
 					{variant.options.map((option: TutorialVariantOption) => {
 						const variantParam = getVariantParam(variant.slug, option.slug)
+						const isActiveOption = activeVariantOption.slug === option.slug
 						return (
 							<li
 								key={option.slug}
 								aria-current={activeVariantOption.slug === option.slug}
 							>
 								<ButtonLink
+									className={classNames(!isActiveOption && s.linkBorderColor)}
 									size="small"
-									color={
-										activeVariantOption.slug === option.slug
-											? 'primary'
-											: 'secondary'
-									}
+									color={isActiveOption ? 'primary' : 'secondary'}
 									text={option.name}
 									href={getVariantPath(asPath, variantParam)}
 									onClick={() => {

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -23,34 +23,34 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 			</label>
 			<nav>
 				<ul aria-labelledby={VARIANT_LIST_ID} className={s.list}>
-					{variant.options.map((option: TutorialVariantOption) => (
-						<li
-							key={option.slug}
-							aria-current={activeVariantOption.slug === option.slug}
-						>
-							<ButtonLink
-								size="small"
-								color={
-									activeVariantOption.slug === option.slug
-										? 'primary'
-										: 'secondary'
-								}
-								text={option.name}
-								href={getVariantPath(
-									asPath,
-									getVariantParam(variant.slug, option.slug)
-								)}
-								onClick={() => {
-									// @TODO add this in when we have real data to check against
-									// const variantCookie = Cookies.get(variant.id)
-									// // if it exists and its not already set with the same value
-									// if (!variantCookie || variantCookie !== option.id) {
-									// 	Cookies.set(variant.id, option.id)
-									// }
-								}}
-							/>
-						</li>
-					))}
+					{variant.options.map((option: TutorialVariantOption) => {
+						const variantParam = getVariantParam(variant.slug, option.slug)
+						return (
+							<li
+								key={option.slug}
+								aria-current={activeVariantOption.slug === option.slug}
+							>
+								<ButtonLink
+									size="small"
+									color={
+										activeVariantOption.slug === option.slug
+											? 'primary'
+											: 'secondary'
+									}
+									text={option.name}
+									href={getVariantPath(asPath, variantParam)}
+									onClick={() => {
+										// @TODO add this in when we have real data to check against
+										// const variantCookie = Cookies.get(variant.slug)
+										// // if it exists and its not already set with the same value
+										// if (!variantCookie || variantCookie !== variantParam) {
+										// 	Cookies.set(variant.id, variantParam)
+										// }
+									}}
+								/>
+							</li>
+						)
+					})}
 				</ul>
 			</nav>
 		</div>

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -1,4 +1,5 @@
-import Cookies from 'js-cookie'
+// @TODO uncomment when enabling cookies
+// import Cookies from 'js-cookie'
 import {
 	TutorialVariant,
 	TutorialVariantOption,
@@ -17,15 +18,18 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 
 	return (
 		<div className={s.root}>
-			<label id={VARIANT_LIST_ID}>{variant.slug}</label>
+			<label id={VARIANT_LIST_ID} className={s.label}>
+				{variant.name}
+			</label>
 			<nav>
-				<ul aria-labelledby={VARIANT_LIST_ID}>
+				<ul aria-labelledby={VARIANT_LIST_ID} className={s.list}>
 					{variant.options.map((option: TutorialVariantOption) => (
 						<li
 							key={option.slug}
 							aria-current={activeVariantOption.slug === option.slug}
 						>
 							<ButtonLink
+								size="small"
 								color={
 									activeVariantOption.slug === option.slug
 										? 'primary'
@@ -34,14 +38,15 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 								text={option.name}
 								href={getVariantPath(
 									asPath,
-									getVariantParam(variant.slug, activeVariantOption.slug)
+									getVariantParam(variant.slug, option.slug)
 								)}
 								onClick={() => {
-									const variantCookie = Cookies.get(variant.id)
-									// if it exists and its not already set with the same value
-									if (!variantCookie || variantCookie !== option.id) {
-										Cookies.set(variant.id, option.id)
-									}
+									// @TODO add this in when we have real data to check against
+									// const variantCookie = Cookies.get(variant.id)
+									// // if it exists and its not already set with the same value
+									// if (!variantCookie || variantCookie !== option.id) {
+									// 	Cookies.set(variant.id, option.id)
+									// }
 								}}
 							/>
 						</li>

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -30,10 +30,7 @@ export function VariantList({ variant }: { variant: TutorialVariant }) {
 						return (
 							<li key={option.slug}>
 								<Link
-									className={classNames(
-										s.link,
-										isActiveOption ? s.activeLink : s.inActiveLink
-									)}
+									className={classNames(s.link)}
 									href={getVariantPath(asPath, variantParam)}
 									aria-current={isActiveOption ? 'page' : undefined}
 									onClick={() => {

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -35,7 +35,7 @@ export default function VariantList({ variant }: { variant: TutorialVariant }) {
 										isActiveOption ? s.activeLink : s.inActiveLink
 									)}
 									href={getVariantPath(asPath, variantParam)}
-									aria-current={isActiveOption ? 'page' : false}
+									aria-current={isActiveOption ? 'page' : undefined}
 									onClick={() => {
 										// @TODO add this in when we have real data to check against
 										// const variantCookie = Cookies.get(variant.slug)

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -1,0 +1,53 @@
+import Cookies from 'js-cookie'
+import {
+	TutorialVariant,
+	TutorialVariantOption,
+	getVariantParam,
+	getVariantPath,
+} from 'views/tutorial-view/utils/variants'
+import ButtonLink from 'components/button-link'
+import { useRouter } from 'next/router'
+import s from './variant-list.module.css'
+
+export default function VariantList({ variant }: { variant: TutorialVariant }) {
+	// @TODO hook this into a useVariants hook
+	const activeVariantOption = variant.options[0]
+	const VARIANT_LIST_ID = 'variant-list-label'
+	const { asPath } = useRouter()
+
+	return (
+		<div className={s.root}>
+			<label id={VARIANT_LIST_ID}>{variant.slug}</label>
+			<nav>
+				<ul aria-labelledby={VARIANT_LIST_ID}>
+					{variant.options.map((option: TutorialVariantOption) => (
+						<li
+							key={option.slug}
+							aria-current={activeVariantOption.slug === option.slug}
+						>
+							<ButtonLink
+								color={
+									activeVariantOption.slug === option.slug
+										? 'primary'
+										: 'secondary'
+								}
+								text={option.name}
+								href={getVariantPath(
+									asPath,
+									getVariantParam(variant.slug, activeVariantOption.slug)
+								)}
+								onClick={() => {
+									const variantCookie = Cookies.get(variant.id)
+									// if it exists and its not already set with the same value
+									if (!variantCookie || variantCookie !== option.id) {
+										Cookies.set(variant.id, option.id)
+									}
+								}}
+							/>
+						</li>
+					))}
+				</ul>
+			</nav>
+		</div>
+	)
+}

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -1,0 +1,3 @@
+.root {
+	color: red;
+}

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -28,9 +28,36 @@
 }
 
 /** 
-* Subtle override here for the border color to adjust the button link
-* within the container background color
+* 🏴‍☠️ Style overrides here
+* These adjustments to the border and background colors for
+* secondary button link styles are due to the elements appearing
+* in the container with the surface-faint background color.
 */
-.linkBorderColor {
+.linkOverrides {
+	&:hover:not(:disabled),
+	&:active:not(:disabled),
+	&:focus,
+	&:focus-visible {
+		text-decoration: none;
+	}
+}
+
+.secondaryLinkOverrides {
+	background-color: var(--token-color-surface-primary);
 	border-color: var(--token-color-border-primary);
+
+	&:hover:not(:disabled),
+	&:active:not(:disabled),
+	&:focus,
+	&:focus-visible {
+		border-color: var(--token-color-border-primary);
+	}
+
+	&:hover:not(:disabled) {
+		background-color: var(--token-color-surface-interactive-hover);
+	}
+
+	&:active:not(:disabled) {
+		background-color: var(--token-color-surface-interactive-active);
+	}
 }

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -12,6 +12,7 @@
 	composes: hds-font-weight-semibold from global;
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 8px;
+	display: block;
 }
 
 .list {

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -42,26 +42,37 @@
 	border: 1px solid;
 	padding: 6px 12px;
 	box-shadow: var(--token-elevation-low-box-shadow);
-}
 
-.activeLink {
-	background-color: var(--token-color-foreground-action);
-	border-color: var(--token-color-foreground-action-hover);
-	color: var(--token-color-foreground-high-contrast);
-	cursor: not-allowed;
-	box-shadow: none;
-}
+	/* Link styles for the 'current' or active link based on `aria-current` */
+	&[aria-current='page'] {
+		background-color: var(--token-color-foreground-action);
+		border-color: var(--token-color-foreground-action-hover);
+		color: var(--token-color-foreground-high-contrast);
+		cursor: not-allowed;
+		box-shadow: none;
 
-.inActiveLink {
-	background-color: var(--token-color-surface-primary);
-	border-color: var(--token-color-border-primary);
-	color: var(--token-color-foreground-primary);
-
-	&:hover {
-		background-color: var(--token-color-surface-interactive-hover);
+		/**
+		* We need a lighter color focus ring for this style so the blue
+		* focus styles are easily visible against the blue bg-color
+		*/
+		&:focus-visible {
+			box-shadow: inset 0 0 0 1px var(--token-color-palette-blue-300),
+				0 0 0 1px var(--token-color-surface-primary), 0 0 0 4px #5990ff;
+		}
 	}
 
-	&:active {
-		background-color: var(--token-color-surface-interactive-active);
+	/* Link styles for the inactive or not current links based on `aria-current` */
+	&:not([aria-current='page']) {
+		background-color: var(--token-color-surface-primary);
+		border-color: var(--token-color-border-primary);
+		color: var(--token-color-foreground-primary);
+
+		&:hover {
+			background-color: var(--token-color-surface-interactive-hover);
+		}
+
+		&:active {
+			background-color: var(--token-color-surface-interactive-active);
+		}
 	}
 }

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -9,7 +9,7 @@
 }
 
 .label {
-	composes: hds-typgraphy-body-200 from global;
+	composes: hds-typography-body-200 from global;
 	composes: hds-font-weight-semibold from global;
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 8px;

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -26,3 +26,11 @@
 	gap: 8px;
 	flex-wrap: wrap;
 }
+
+/** 
+* Subtle override here for the border color to adjust the button link
+* within the container background color
+*/
+.linkBorderColor {
+	border-color: var(--token-color-border-primary);
+}

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -42,11 +42,6 @@
 	border: 1px solid;
 	padding: 6px 12px;
 	box-shadow: var(--token-elevation-low-box-shadow);
-
-	&:focus,
-	&:focus-visible {
-		outline: transparent;
-	}
 }
 
 .activeLink {

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -1,3 +1,27 @@
 .root {
-	color: red;
+	margin-bottom: 24px;
+}
+
+.label {
+	composes: hds-typgraphy-body-200 from global;
+	composes: hds-font-weight-semibold from global;
+	color: var(--token-color-foreground-strong);
+	margin-bottom: 8px;
+	display: none;
+
+	@media (--dev-dot-tablet-up) {
+		display: block;
+	}
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	background: var(--token-color-surface-faint);
+	border: 1px solid var(--token-color-border-faint);
+	border-radius: 6px;
+	padding: 8px;
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
 }

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -54,10 +54,14 @@
 		/**
 		* We need a lighter color focus ring for this style so the blue
 		* focus styles are easily visible against the blue bg-color
+		*
+		* We could lift this up to a global focus ring helper in styles.css
+		* if we find this being used elsewhere
 		*/
 		&:focus-visible {
 			box-shadow: inset 0 0 0 1px var(--token-color-palette-blue-300),
-				0 0 0 1px var(--token-color-surface-primary), 0 0 0 4px #5990ff;
+				0 0 0 1px var(--token-color-surface-primary),
+				0 0 0 4px var(--token-color-focus-action-external);
 		}
 	}
 

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -28,37 +28,57 @@
 	flex-wrap: wrap;
 }
 
-/** 
-* 🏴‍☠️ Style overrides here
-* These adjustments to the border and background colors for
-* secondary button link styles are due to the elements appearing
-* in the container with the surface-faint background color.
+/**
+* Shares some similar styles with `button-link` but is unique enough
+* to warrant its own styles to avoid overrides
 */
-.linkOverrides {
-	&:hover:not(:disabled),
-	&:active:not(:disabled),
+
+.link {
+	--border-width: 1px;
+
+	composes: hds-typography-body-100 from global;
+	composes: hds-font-weight-medium from global;
+	composes: g-focus-ring-from-box-shadow from global;
+	border-radius: 5px;
+	border: var(--border-width) solid;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: calc(7px - var(--border-width)) calc(12px - var(--border-width));
+	box-shadow: var(--token-elevation-low-box-shadow);
+
 	&:focus,
 	&:focus-visible {
-		text-decoration: none;
+		outline: transparent;
 	}
 }
 
-.secondaryLinkOverrides {
-	background-color: var(--token-color-surface-primary);
-	border-color: var(--token-color-border-primary);
+.activeLink {
+	background-color: var(--token-color-foreground-action);
+	border-color: var(--token-color-foreground-action-hover);
+	color: var(--token-color-foreground-high-contrast);
 
-	&:hover:not(:disabled),
-	&:active:not(:disabled),
-	&:focus,
-	&:focus-visible {
-		border-color: var(--token-color-border-primary);
+	&:hover {
+		background-color: var(--token-color-foreground-action-hover);
+		border-color: var(--token-color-foreground-action-active);
 	}
 
-	&:hover:not(:disabled) {
+	&:active {
+		background-color: var(--token-color-foreground-action-active);
+		border-color: var(--token-color-foreground-action-active);
+	}
+}
+
+.inActiveLink {
+	background-color: var(--token-color-surface-primary);
+	border-color: var(--token-color-border-primary);
+	color: var(--token-color-foreground-primary);
+
+	&:hover {
 		background-color: var(--token-color-surface-interactive-hover);
 	}
 
-	&:active:not(:disabled) {
+	&:active {
 		background-color: var(--token-color-surface-interactive-active);
 	}
 }

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -1,4 +1,5 @@
 .root {
+	margin-top: 24px;
 	margin-bottom: 24px;
 	display: none;
 

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -34,17 +34,12 @@
 */
 
 .link {
-	--border-width: 1px;
-
 	composes: hds-typography-body-100 from global;
 	composes: hds-font-weight-medium from global;
 	composes: g-focus-ring-from-box-shadow from global;
 	border-radius: 5px;
-	border: var(--border-width) solid;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: calc(7px - var(--border-width)) calc(12px - var(--border-width));
+	border: 1px solid;
+	padding: 6px 12px;
 	box-shadow: var(--token-elevation-low-box-shadow);
 
 	&:focus,

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -48,16 +48,8 @@
 	background-color: var(--token-color-foreground-action);
 	border-color: var(--token-color-foreground-action-hover);
 	color: var(--token-color-foreground-high-contrast);
-
-	&:hover {
-		background-color: var(--token-color-foreground-action-hover);
-		border-color: var(--token-color-foreground-action-active);
-	}
-
-	&:active {
-		background-color: var(--token-color-foreground-action-active);
-		border-color: var(--token-color-foreground-action-active);
-	}
+	cursor: not-allowed;
+	box-shadow: none;
 }
 
 .inActiveLink {

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -37,6 +37,7 @@
 	composes: hds-typography-body-100 from global;
 	composes: hds-font-weight-medium from global;
 	composes: g-focus-ring-from-box-shadow from global;
+	display: flex;
 	border-radius: 5px;
 	border: 1px solid;
 	padding: 6px 12px;

--- a/src/components/tutorial-meta/components/variant-list/variant-list.module.css
+++ b/src/components/tutorial-meta/components/variant-list/variant-list.module.css
@@ -1,5 +1,10 @@
 .root {
 	margin-bottom: 24px;
+	display: none;
+
+	@media (--dev-dot-tablet-up) {
+		display: block;
+	}
 }
 
 .label {
@@ -7,11 +12,6 @@
 	composes: hds-font-weight-semibold from global;
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 8px;
-	display: none;
-
-	@media (--dev-dot-tablet-up) {
-		display: block;
-	}
 }
 
 .list {

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -81,6 +81,7 @@ export default function TutorialMeta({
 					to bookmark tutorials.
 				</Text>
 			) : null}
+			{variant ? <VariantList variant={variant} /> : null}
 		</header>
 	)
 }

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -12,6 +12,8 @@ import { Badges, getIsBeta } from './components'
 import InteractiveLabButton from './components/interactive-lab-button'
 import s from './tutorial-meta.module.css'
 import { TutorialMetaBookmarkButton } from 'components/bookmark-button'
+import { TutorialVariant } from 'views/tutorial-view/utils/variants'
+import VariantList from './components/variant-list'
 
 interface TutorialMetaProps {
 	heading: { slug: string; text: string }
@@ -20,12 +22,14 @@ interface TutorialMetaProps {
 		hasVideo: boolean
 	}
 	tutorialId: TutorialData['id']
+	variant?: TutorialVariant
 }
 
 export default function TutorialMeta({
 	heading,
 	meta,
 	tutorialId,
+	variant,
 }: TutorialMetaProps) {
 	const { isInteractive, hasVideo, edition, productsUsed, readTime } = meta
 

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -5,15 +5,14 @@
 
 import useAuthentication from 'hooks/use-authentication'
 import { TutorialData } from 'views/tutorial-view'
+import { TutorialVariant } from 'views/tutorial-view/utils/variants'
 import Heading from 'components/heading'
 import InlineLink from 'components/inline-link'
 import Text from 'components/text'
-import { Badges, getIsBeta } from './components'
+import { TutorialMetaBookmarkButton } from 'components/bookmark-button'
+import { Badges, getIsBeta, VariantList } from './components'
 import InteractiveLabButton from './components/interactive-lab-button'
 import s from './tutorial-meta.module.css'
-import { TutorialMetaBookmarkButton } from 'components/bookmark-button'
-import { TutorialVariant } from 'views/tutorial-view/utils/variants'
-import VariantList from './components/variant-list'
 
 interface TutorialMetaProps {
 	heading: { slug: string; text: string }

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -281,14 +281,12 @@ function TutorialView({
 								hasVideo,
 							}}
 							tutorialId={id}
-							variant={variantData[0] as TutorialVariant}
+							variant={
+								metadata.variant
+									? (variantData[0] as TutorialVariant)
+									: undefined
+							}
 						/>
-						{metadata.variant ? (
-							<div style={{ border: '1px solid magenta' }}>
-								<h2>Variant: {metadata.variant.slug}</h2>
-								<p>Option: {metadata.variant.optionSlug}</p>
-							</div>
-						) : null}
 						<span data-ref-id={progressRefsId} ref={progressRefs.startRef} />
 						{hasVideo && video.id && !video.videoInline && (
 							<VideoEmbed

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -281,6 +281,7 @@ function TutorialView({
 								hasVideo,
 							}}
 							tutorialId={id}
+							variant={variantData[0] as TutorialVariant}
 						/>
 						{metadata.variant ? (
 							<div style={{ border: '1px solid magenta' }}>

--- a/src/views/tutorial-view/utils/variants/_tmp-variants-data.json
+++ b/src/views/tutorial-view/utils/variants/_tmp-variants-data.json
@@ -8,12 +8,7 @@
 				"slug": "hcp",
 				"name": "Hashicorp Cloud Platform (HCP)"
 			},
-			{ "slug": "self-managed", "name": "Self Managed" },
-			{ "slug": "self-managed", "name": "Koba" },
-			{ "slug": "self-managed", "name": "Ubuntu" },
-			{ "slug": "self-managed", "name": "Frank Herbert" },
-			{ "slug": "self-managed", "name": "Calamansi" },
-			{ "slug": "self-managed", "name": "Lavender" }
+			{ "slug": "self-managed", "name": "Self Managed" }
 		]
 	}
 ]

--- a/src/views/tutorial-view/utils/variants/_tmp-variants-data.json
+++ b/src/views/tutorial-view/utils/variants/_tmp-variants-data.json
@@ -8,7 +8,12 @@
 				"slug": "hcp",
 				"name": "Hashicorp Cloud Platform (HCP)"
 			},
-			{ "slug": "self-managed", "name": "Self Managed" }
+			{ "slug": "self-managed", "name": "Self Managed" },
+			{ "slug": "self-managed", "name": "Koba" },
+			{ "slug": "self-managed", "name": "Ubuntu" },
+			{ "slug": "self-managed", "name": "Frank Herbert" },
+			{ "slug": "self-managed", "name": "Calamansi" },
+			{ "slug": "self-managed", "name": "Lavender" }
 		]
 	}
 ]


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksvariants-button-list-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-policies-ui?variants=deployment:hcp) 🔎
- [Asana task](https://app.asana.com/0/1204333057896641/1204615849802274) 🎟️
- [Figma File 🎨 ](https://www.figma.com/file/NAFjIPkbwjyY8jPl6T9nlP/Tutorial-Variants?type=design&node-id=165-30497&t=XEhCsJPFalEhRqQK-0)

🚧 Merging into an Assembly 🚧 

## 🗒️ What

This PR adds the variants button link list below the tutorial metadata.

<img width="523" alt="Screenshot 2023-05-17 at 10 31 58 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/f4b48e81-6212-4545-bb6d-7ed4c34471f2">

## 🛠️ How

Adds a new `VariantList` component within the tutorial metadata.

## 📸 Design Screenshots

<img width="385" alt="Screenshot 2023-05-17 at 9 00 06 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/5750e993-f129-42c8-9baf-6cd9bcee0536">

## 🧪 Testing

- [Visit the preview](https://dev-portal-git-ksvariants-button-list-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-policies-ui?variants=deployment:hcp), validate that the list matches the design spec
- Validate that it goes away <tablet sizes, we will add the mobile dropdown disclosure in a separate PR. 
- Testing at 200% text zoom
<img width="665" alt="Screenshot 2023-05-17 at 11 34 54 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/16261d19-d5c0-4b6c-9116-02ee0290b490">

- Test VO, ensure the label for the list is read when focusing on the first item along with noting the current list item.
<img width="725" alt="Screenshot 2023-05-17 at 12 46 27 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/051f4075-1822-49f5-8620-275a53f61791">


## 💭 Anything else?

- This isn't hooked up to real data yet so the interactivity is limited. The PR hard codes the active variant option as the first one, this won't change despite shifting URLs. 
