### PR TITLE
feat: reduce dev-dot paths from 50 to 15

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -4,7 +4,7 @@
 		"max_static_paths": 9999
 	},
 	"dev_dot": {
-		"max_static_paths": 50,
+		"max_static_paths": 15,
 		"datadog_config": {
 			"applicationId": "4486817b-44b8-4e6c-b6a4-cef83e48cf46",
 			"clientToken": "pub750ceadc5a9c79a6d3da59b534eb5108",


### PR DESCRIPTION
## 🔗 Relevant links

## 🗒️ What

This reduces `__config.dev_dot.max_static_paths` from `50` to `15`.

This offloads some amount of static generation to post-build ondemand generation

## 🤷 Why

This aims to reduce production build times

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204565843516262