### PR TITLE
chore: tweak tab padding for compact variant

### DIFF
--- a/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
+++ b/src/components/tabs/components/tab-button-controls/tab-button-controls.module.css
@@ -76,7 +76,7 @@ Styles for each tab button.
 	&.variant--compact {
 		background-color: transparent;
 		border: none;
-		padding-bottom: 6px;
+		padding-bottom: 12px;
 		padding-left: 12px;
 		padding-right: 12px;
 		padding-top: 8px;


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Increases the spacing between tab buttons and the border below them for `"compact"` variants of the `<Tabs />` component.

## 🤷 Why

To improve the Search results experience. Giving the tabs slightly more breathing room in the search results context should make them more visible and easier to use.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/378b6717-06de-4c6a-bd61-9f2c8c8c5992) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/a02d649b-363c-45db-ae29-056cf8645615) |

## 🧪 Testing

- [ ] Visit any page with search enabled, such as [the home page][preview]
    - The search experience should continue to function as expected
    - Tabs should have a little more breathing room in the spacing to the "tab line" below tab `<button />` controls
- [ ] Browse the preview for other uses of `<Tabs />`, and confirm the adjusted appearance works in other contexts
    - Note: I couldn't actually find a use of `"compact"` variant `<Tabs />` outside of the Search results use case. We do use the "compact" styles for nested tabs, visible on pages such as [/terraform/tutorials/aws-get-started/install-cli], but we have specialized styling for those cases which further reduces padding for "nested" contexts.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1202097197789424/1204604641329011/f
[preview]: https://dev-portal-git-zssearch-ui-padding-hashicorp.vercel.app
[/terraform/tutorials/aws-get-started/install-cli]: https://dev-portal-git-zssearch-ui-padding-hashicorp.vercel.app/terraform/tutorials/aws-get-started/install-cli