### PR TITLE
fix: render vertical line when badges exist

### DIFF
--- a/src/components/tutorial-meta/components/badges/index.tsx
+++ b/src/components/tutorial-meta/components/badges/index.tsx
@@ -35,7 +35,9 @@ export function Badges({ options }: BadgesProps): React.ReactElement {
 	return (
 		<ul className={s.list}>
 			<li className={s.listItem}>{getReadableTime(readTime)}</li>
-			<li className={classNames(s.listItem, s.seperator)}>|</li>
+			{badges.length > 0 ? (
+				<li className={classNames(s.listItem, s.seperator)}>|</li>
+			) : null}
 			{badges.map((badge: ReactElement, index: number) => (
 				// eslint-disable-next-line react/no-array-index-key
 				<li className={s.listItem} key={index}>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-vertical-line-metadata-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Only render the vertical separator in tutorial meta when badges beyond readtime exist.

🔧 Fix
<img width="765" alt="Screenshot 2023-05-17 at 11 26 08 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/d7778375-0b27-4bd7-80ee-0b5f0089778c">

🐛 Bug
<img width="779" alt="Screenshot 2023-05-17 at 11 28 11 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/7a574cb4-15b7-4411-bc78-9ecf67150fd1">

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [visit this tutorial](https://dev-portal-git-ksfix-vertical-line-metadata-hashicorp.vercel.app/well-architected-framework/security/security-introduction) that has no products or other metadata associated, verify [against upstream ](https://dev-portal-4a1q81voa-hashicorp.vercel.app/well-architected-framework/security/security-introduction)that the vertical line doesn't render.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
