### PR TITLE
feat: limit /well-architected-framework/* static path count

### DIFF
--- a/config/plugin.js
+++ b/config/plugin.js
@@ -37,20 +37,17 @@ const { getHashiConfig } = require('./index')
  * See the test file at `./config/__tests__/index.test.js` for a more thorough example.
  */
 module.exports = function HashiConfigPlugin() {
-	const env = process.env.HASHI_ENV
-		? (() => {
-				console.log(
-					'[HashiConfigPlugin] HASHI_ENV set to:',
-					process.env.HASHI_ENV
-				)
-				return process.env.HASHI_ENV
-		  })()
-		: (() => {
-				console.log(
-					"[HashiConfigPlugin] HASHI_ENV not set. Defaulting to 'development'"
-				)
-				return 'development'
-		  })()
+	let env = process.env.HASHI_ENV
+	if (env) {
+		console.log(
+			`[HashiConfigPlugin] HASHI_ENV set to: ${process.env.HASHI_ENV}`
+		)
+	} else {
+		console.log(
+			"[HashiConfigPlugin] HASHI_ENV not set. Defaulting to 'development'"
+		)
+		env = 'development'
+	}
 
 	const envConfigPath = path.join(process.cwd(), 'config', `${env}.json`)
 	const baseConfigPath = path.join(process.cwd(), 'config', `base.json`)

--- a/config/plugin.js
+++ b/config/plugin.js
@@ -37,7 +37,21 @@ const { getHashiConfig } = require('./index')
  * See the test file at `./config/__tests__/index.test.js` for a more thorough example.
  */
 module.exports = function HashiConfigPlugin() {
-	const env = process.env.HASHI_ENV || 'development'
+	const env = process.env.HASHI_ENV
+		? (() => {
+				console.log(
+					'[HashiConfigPlugin] HASHI_ENV set to:',
+					process.env.HASHI_ENV
+				)
+				return process.env.HASHI_ENV
+		  })()
+		: (() => {
+				console.log(
+					"[HashiConfigPlugin] HASHI_ENV not set. Defaulting to 'development'"
+				)
+				return 'development'
+		  })()
+
 	const envConfigPath = path.join(process.cwd(), 'config', `${env}.json`)
 	const baseConfigPath = path.join(process.cwd(), 'config', `base.json`)
 

--- a/config/plugin.js
+++ b/config/plugin.js
@@ -37,18 +37,7 @@ const { getHashiConfig } = require('./index')
  * See the test file at `./config/__tests__/index.test.js` for a more thorough example.
  */
 module.exports = function HashiConfigPlugin() {
-	let env = process.env.HASHI_ENV
-	if (env) {
-		console.log(
-			`[HashiConfigPlugin] HASHI_ENV set to: ${process.env.HASHI_ENV}`
-		)
-	} else {
-		console.log(
-			"[HashiConfigPlugin] HASHI_ENV not set. Defaulting to 'development'"
-		)
-		env = 'development'
-	}
-
+	const env = process.env.HASHI_ENV || 'development'
 	const envConfigPath = path.join(process.cwd(), 'config', `${env}.json`)
 	const baseConfigPath = path.join(process.cwd(), 'config', `base.json`)
 

--- a/src/pages/well-architected-framework/[...tutorialSlug]/index.tsx
+++ b/src/pages/well-architected-framework/[...tutorialSlug]/index.tsx
@@ -14,6 +14,7 @@ import { getWafTutorialViewProps } from 'views/well-architected-framework/tutori
 import wafData from 'data/well-architected-framework.json'
 import { WafTutorialViewProps } from 'views/well-architected-framework/types'
 import { GetStaticPropsContext } from 'next'
+import { getStaticPathsFromAnalytics } from 'lib/get-static-paths-from-analytics'
 
 export async function getStaticProps({
 	params,
@@ -31,7 +32,7 @@ export async function getStaticProps({
 
 export async function getStaticPaths() {
 	const allCollections = await getCollectionsBySection(wafData.slug)
-	const paths = []
+	let paths = []
 	allCollections.forEach((c: ApiCollection) => {
 		const collectionSlug = splitProductFromFilename(c.slug)
 		c.tutorials.forEach(({ slug }: { slug: ApiTutorialLite['slug'] }) =>
@@ -43,7 +44,28 @@ export async function getStaticPaths() {
 		)
 	})
 
-	return { paths, fallback: false }
+	// For hashicorp/tutorials PR previews, skip the call to determine paths
+	// from analytics, and statically build all paths.
+	if (process.env.HASHI_ENV === 'tutorials-preview') {
+		return {
+			paths: paths,
+			fallback: false,
+		}
+	}
+
+	try {
+		paths = await getStaticPathsFromAnalytics({
+			param: 'tutorialSlug',
+			limit: __config.learn.max_static_paths ?? 0,
+			pathPrefix: `/well-architected-framework`,
+			validPaths: paths,
+		})
+	} catch {
+		// In the case of an error, fallback to using the base list of generated paths to ensure we do _some_ form of static generation
+		paths = paths.slice(0, __config.learn.max_static_paths ?? 0)
+	}
+
+	return { paths, fallback: 'blocking' }
 }
 
 export default WellArchitectedFrameworkTutorialView

--- a/src/pages/well-architected-framework/[collectionSlug].tsx
+++ b/src/pages/well-architected-framework/[collectionSlug].tsx
@@ -57,7 +57,10 @@ export async function getStaticPaths() {
 		params: { collectionSlug: splitProductFromFilename(c.slug) },
 	}))
 
-	return { paths, fallback: false }
+	return {
+		paths: paths.slice(0, __config.learn.max_static_paths ?? 0),
+		fallback: 'blocking',
+	}
 }
 
 export default WellArchitectedFrameworkCollectionView


### PR DESCRIPTION
Same work as https://github.com/hashicorp/dev-portal/pull/1943

---

## 🗒️ What

This adds a static path limit (`__config.learn.max_static_paths`) to our `well-architected-framework/*` pages
- `src/pages/well-architected-framework/[collectionSlug].tsx`
- `src/pages/well-architected-framework/[...tutorialSlug]/index.tsx`

## 🤷 Why

Decrease build times and offload page building to ondemand generation.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204605831831148