### PR TITLE
chore: remove product modifier from zendesk crawlers 

### DIFF
--- a/src/components/head-metadata/index.tsx
+++ b/src/components/head-metadata/index.tsx
@@ -90,49 +90,58 @@ export default function HeadMetadata(props: HeadMetadataProps) {
 				 */}
 
 				<meta
-					name="zd-site-verification--hcp"
+					name="zd-site-verification"
 					key="9qmgy2yz6zbk00tcci2y"
 					content="9qmgy2yz6zbk00tcci2y"
+					data-product="hcp"
 				/>
 				<meta
-					name="zd-site-verification--terraform"
+					name="zd-site-verification"
 					key="xxmpuhow9r8iz9sq31d2bc"
 					content="xxmpuhow9r8iz9sq31d2bc"
+					data-product="terraform"
 				/>
 				<meta
-					name="zd-site-verification--packer"
+					name="zd-site-verification"
 					key="iuwt0p3j768fmso8hm98"
 					content="iuwt0p3j768fmso8hm98"
+					data-product="packer"
 				/>
 				<meta
-					name="zd-site-verification--consul"
+					name="zd-site-verification"
 					key="lhbjuf5innptc678ken0f8"
 					content="lhbjuf5innptc678ken0f8"
+					data-product="consul"
 				/>
 				<meta
-					name="zd-site-verification--boundary"
+					name="zd-site-verification"
 					key="d4udllp6txbot6z8cuzxs"
 					content="d4udllp6txbot6z8cuzxs"
+					data-product="boundary"
 				/>
 				<meta
-					name="zd-site-verification--vault"
+					name="zd-site-verification"
 					key="1i8so200ii4smuo4wm0j9"
 					content="1i8so200ii4smuo4wm0j9"
+					data-product="vault"
 				/>
 				<meta
-					name="zd-site-verification--nomad"
+					name="zd-site-verification"
 					key="ykjjnuk3ng93l06hwzj6ug"
 					content="ykjjnuk3ng93l06hwzj6ug"
+					data-product="nomad"
 				/>
 				<meta
-					name="zd-site-verification--waypoint"
+					name="zd-site-verification"
 					key="9kcw71js0xc1yjobla5mq"
 					content="9kcw71js0xc1yjobla5mq"
+					data-product="waypoint"
 				/>
 				<meta
-					name="zd-site-verification--vagrant"
+					name="zd-site-verification"
 					key="3aoyn57r4ver42w2u8cyy"
 					content="3aoyn57r4ver42w2u8cyy"
+					data-product="vagrant"
 				/>
 
 				{/* Some og tags do not get picked up for twitter's share cards, so we need these tags as well */}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why

This PR is a follow up to https://github.com/hashicorp/dev-portal/pull/1915 and removes `--[product]` from each Zendesk meta tag. Documentation showed nothing saying the `name` had to be `zd-site verification` but after deploying, the tags weren't working. I moved the product name to it's own data attribute instead. Hoping this approach works while also signaling which product the meta crawler is for for future us and for the requestor [here](https://app.asana.com/0/1202801212949828/1204197006767451/f).

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

These Zendesk crawler tags are for the sandbox instance. There is a ticket already created to handle the change to production crawlers once this implementation is verified. 
