### PR TITLE
fix: overflow-y auto on modal content

### DIFF
--- a/src/components/dialog/dialog.module.css
+++ b/src/components/dialog/dialog.module.css
@@ -47,7 +47,7 @@
 
 	&.bottom {
 		height: 100%;
-		overflow-y: scroll;
+		overflow-y: auto;
 		max-width: none;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎

## 🗒️ What

Fixes an issue where on certain viewports, a scrollbar is shown on modal contents when it's not strictly needed.

## 📸 Design Screenshots

| Before | After |
| - | - |
| <img width="654" alt="before" src="https://github.com/hashicorp/dev-portal/assets/4624598/258930f6-8b99-4505-881c-9cf3b3b6e2a3"> | <img width="659" alt="after" src="https://github.com/hashicorp/dev-portal/assets/4624598/0d254a8f-b9d9-4ed7-94ab-c07e3c2579b6"> |

### Before

https://github.com/hashicorp/dev-portal/assets/4624598/16e3eef8-5368-456b-b96d-e30fd1a2a8f9 

### After

https://github.com/hashicorp/dev-portal/assets/4624598/9aaf89a9-ca26-4a8f-a73c-4abfa4bb4151








[preview]: https://dev-portal-git-zsfix-dialog-bottom-overflow-hashicorp.vercel.app/