### PR TITLE
chore: tweak tabs to allow vertical centering

### DIFF
--- a/src/components/command-bar/commands/search/components/custom-hits-container/custom-hits-container.module.css
+++ b/src/components/command-bar/commands/search/components/custom-hits-container/custom-hits-container.module.css
@@ -7,3 +7,9 @@
 	margin-bottom: 12px;
 	margin-top: 12px;
 }
+
+.noResultsSlot {
+	display: flex;
+	flex-direction: column;
+	flex: 1 0 0;
+}

--- a/src/components/command-bar/commands/search/components/custom-hits-container/custom-hits-container.module.css
+++ b/src/components/command-bar/commands/search/components/custom-hits-container/custom-hits-container.module.css
@@ -8,6 +8,10 @@
 	margin-top: 12px;
 }
 
+/**
+ * Flex attributes here allow specific pieces of content in the "No Results"
+ * to grow to fill the container.
+ */
 .noResultsSlot {
 	display: flex;
 	flex-direction: column;

--- a/src/components/command-bar/commands/search/components/custom-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/components/custom-hits-container/index.tsx
@@ -44,7 +44,7 @@ const CustomHitsContainer = ({
 			? integrationsHits && integrationsHits.length <= 0
 			: hits && hits.length <= 0
 	if (shouldShowNoResultsSlot) {
-		return <>{noResultsSlot}</>
+		return <div className={s.noResultsSlot}>{noResultsSlot}</div>
 	}
 
 	const labelElementId = `${type}-search-results-label`

--- a/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
+++ b/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+/**
+ * Flex attributes allow the `tabpanel` to grow to occupy any vertical space
+ * in the `.tabsWrapper` container not taken up by the tab controls.
+ */
 .tabsWrapper {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
 	padding-bottom: 16px;
 	padding-left: 16px;
 	padding-right: 16px;
 	padding-top: 8px;
-	min-height: 100%;
-	display: flex;
-	flex-direction: column;
 
 	& :global([role='tabpanel']) {
 		flex: 1 0 0;

--- a/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
+++ b/src/components/command-bar/commands/search/components/dialog-body/search-command-bar-dialog-body.module.css
@@ -8,6 +8,15 @@
 	padding-left: 16px;
 	padding-right: 16px;
 	padding-top: 8px;
+	min-height: 100%;
+	display: flex;
+	flex-direction: column;
+
+	& :global([role='tabpanel']) {
+		flex: 1 0 0;
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .suggestedPagesWrapper {

--- a/src/components/command-bar/commands/search/components/no-results-message/no-results-message.module.css
+++ b/src/components/command-bar/commands/search/components/no-results-message/no-results-message.module.css
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+/**
+ * Flex attributes here ensure the `no-results-message` eats up any
+ * remaining vertical space in the parent container, and also ensure
+ * the content of the `no-results-message` is vertically centered.
+ */
 .root {
 	color: var(--token-color-foreground-primary);
 	display: flex;

--- a/src/components/command-bar/commands/search/components/no-results-message/no-results-message.module.css
+++ b/src/components/command-bar/commands/search/components/no-results-message/no-results-message.module.css
@@ -4,9 +4,13 @@
  */
 
 .root {
+	color: var(--token-color-foreground-primary);
+	display: flex;
+	flex-direction: column;
+	flex: 1 0 0;
+	justify-content: center;
 	padding: 32px 0;
 	text-align: center;
-	color: var(--token-color-foreground-primary);
 }
 
 .checkOtherTabs {

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -74,7 +74,7 @@ const Tabs = ({
 
 	return (
 		<TabNestingProvider>
-			<div>
+			<>
 				<div
 					className={classNames(s.tabControls, s[`variant--${variant}`], {
 						[s.isCheckingOverflow]: hasOverflow === null,
@@ -114,7 +114,7 @@ const Tabs = ({
 						</div>
 					)
 				})}
-			</div>
+			</>
 		</TabNestingProvider>
 	)
 }


### PR DESCRIPTION
This PR targets #1936, building off of it to center the contents of the "no results" tab.

Due to how our `Tabs` component is constructed, this currently requires a few changes:
1. Removal of a wrapper `<div />` within `Tabs`
    - As far as I can tell this was in place so that `TabNestingProvider` could wrap all tabs content
    - Using a `<div />` here seems to limits layout possibilities
    - Have switched to `React.Fragment`
2. Styling of `.tabsWrapper > [role="tabpanel"]`
    - This feels a little bit like dangerously reaching in to the `Tabs` component...
    - Maybe this would be better as a layout prop on `Tabs`? Or maybe `Tabs` should accept a `tabPanelClass`? Open to ideas here, adding the `[role="tabpanel"]` for now to get styles in place for discussion.

## 🎨 Screenshots

| Before | After |
| - | - |
| ![docs-before](https://github.com/hashicorp/dev-portal/assets/4624598/35201cb5-ac50-4875-a245-54e4f9e4c9b5) | ![docs-after](https://github.com/hashicorp/dev-portal/assets/4624598/91af03f4-c1a1-4b25-ac28-2a80caf844b1) |
| ![tutorials-before](https://github.com/hashicorp/dev-portal/assets/4624598/a1497cc9-a0e9-43f6-9ff6-097639f10c1c) | ![tutorials-after](https://github.com/hashicorp/dev-portal/assets/4624598/8d57f739-4954-4546-b787-771c3da7741b) |
| ![integrations-beofre](https://github.com/hashicorp/dev-portal/assets/4624598/30688ddf-38e2-4646-a640-1607087e1c7d) | ![integrations-after](https://github.com/hashicorp/dev-portal/assets/4624598/6a023366-9d76-4745-b245-d93cb7fdace6) |

## 💭 Anything else?

While simple on the surface, this is unfortunately a relatively complex change to make as it will involve changing some small things about how our global `Tabs` component works. So, split this out from #1936 in order to be able to better test and VQA these changes, to help confirm they're not having unexpected effects on other `Tabs` uses.

