### PR TITLE
style: remove type-200 on filter input

### DIFF
--- a/src/components/filter-input/filter-input.module.css
+++ b/src/components/filter-input/filter-input.module.css
@@ -42,7 +42,6 @@
 
 .filterInput {
 	composes: g-focus-ring-from-box-shadow from global;
-	composes: hds-typography-body-200 from global;
 	appearance: none;
 	background-color: transparent;
 	border: var(--token-form-control-border-width) solid


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-filter-input-type-hashicorp.vercel.app/boundary/docs) 🔎
- [Asana task](https://app.asana.com/0/1204333057896641/1204623770940349) 🎟️

## 🗒️ What

Fixes an issue where the type-200 styles were overriding the filter input styles. Since all the type 200 styles were being overridden anyways, this removes that composition. 

<img width="1891" alt="image" src="https://github.com/hashicorp/dev-portal/assets/36613477/3e7caede-f147-4c70-9b03-bb3d95dc94bb">

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [Visit this URL](https://dev-portal-git-ksfix-filter-input-type-hashicorp.vercel.app/boundary/docs), verify the styles render as expected. [Compare against prod.](https://developer.hashicorp.com/boundary/docs) and [upstream 🐛 ](https://dev-portal-git-ksvariants-assembly-hashicorp.vercel.app/boundary/docs)
- Test on mobile

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
