### PR TITLE
refactor: variant dropdown disclosure layout

### DIFF
--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -114,7 +114,12 @@ const SidebarSidecarLayoutContent = ({
 								/>
 							) : null}
 						</main>
-						<div className={s.sidecarPosition}>
+						<div
+							className={classNames(
+								s.sidecarPosition,
+								sidecarTopSlot && s.topSlotDropdown
+							)}
+						>
 							{sidecarTopSlot}
 							<SidecarScrollContainer>{sidecarSlot}</SidecarScrollContainer>
 						</div>

--- a/src/layouts/sidebar-sidecar/index.tsx
+++ b/src/layouts/sidebar-sidecar/index.tsx
@@ -48,6 +48,7 @@ const SidebarSidecarLayoutContent = ({
 	AlternateSidebar,
 	showScrollProgress,
 	sidecarSlot,
+	sidecarTopSlot,
 	sidebarNavDataLevels,
 	mainWidth = 'wide',
 	alertBannerSlot,
@@ -114,6 +115,7 @@ const SidebarSidecarLayoutContent = ({
 							) : null}
 						</main>
 						<div className={s.sidecarPosition}>
+							{sidecarTopSlot}
 							<SidecarScrollContainer>{sidecarSlot}</SidecarScrollContainer>
 						</div>
 					</div>

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -144,11 +144,9 @@ for further details.
 	--sidecar-position-top: calc(
 		var(--sticky-bars-height) + var(--main-area-padding-top)
 	);
-	--sidecar-top-slot-variant-disclosure-height: 0;
 	--sidecar-viewport-bottom-spacing: 24px;
 	--max-sidecar-height: calc(
-		100vh - var(--sidecar-position-top) - var(--sidecar-viewport-bottom-spacing) -
-			var(--sidecar-top-slot-variant-disclosure-height)
+		100vh - var(--sidecar-position-top) - var(--sidecar-viewport-bottom-spacing)
 	);
 
 	display: none;
@@ -166,6 +164,12 @@ for further details.
 	*/
 	&.topSlotDropdown {
 		--sidecar-top-slot-variant-disclosure-height: 63px;
+		--max-sidecar-height: calc(
+			100vh - var(--sidecar-position-top) -
+				var(--sidecar-viewport-bottom-spacing) -
+				var(--sidecar-top-slot-variant-disclosure-height) -
+				var(--sidecar-top-slot-variant-disclosure-height)
+		);
 	}
 
 	@media (--dev-dot-sidecar-up) {

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -144,12 +144,29 @@ for further details.
 	--sidecar-position-top: calc(
 		var(--sticky-bars-height) + var(--main-area-padding-top)
 	);
+	--sidecar-top-slot-variant-disclosure-height: 0;
 	--sidecar-viewport-bottom-spacing: 24px;
 	--max-sidecar-height: calc(
-		100vh - var(--sidecar-position-top) - var(--sidecar-viewport-bottom-spacing)
+		100vh - var(--sidecar-position-top) - var(--sidecar-viewport-bottom-spacing) -
+			var(--sidecar-top-slot-variant-disclosure-height)
 	);
 
 	display: none;
+
+	/** 
+	* NOTE! 
+	* Hard-coded height value to account for the height of the variants
+	* dropdown disclosure. We should find a more permanent workaround
+	* for the topslot to work for every generic component. 
+	* 
+	* This solves an issue where the variant dropdown disclosure shouldn't
+	* be in the scrollable sidecarslot area, and need its dropdown content
+	* to render outside of that scrollable area. This workaround retains the 
+	* scroll / scrim style behavior of the current sidecar slot.
+	*/
+	&.topSlotDropdown {
+		--sidecar-top-slot-variant-disclosure-height: 63px;
+	}
 
 	@media (--dev-dot-sidecar-up) {
 		display: flex;

--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -161,6 +161,7 @@ for further details.
 	* be in the scrollable sidecarslot area, and need its dropdown content
 	* to render outside of that scrollable area. This workaround retains the 
 	* scroll / scrim style behavior of the current sidecar slot.
+	* https://app.asana.com/0/1204333057896641/1204669563792095
 	*/
 	&.topSlotDropdown {
 		--sidecar-top-slot-variant-disclosure-height: 63px;

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -24,6 +24,11 @@ export interface SidebarSidecarLayoutProps {
 	 */
 	sidecarSlot?: ReactNode
 	/**
+	 * Optionally render content above the scrollable sidecar area.
+	 * If omitted, blank space will be shown above the scrollable sidecar area.
+	 */
+	sidecarTopSlot?: ReactNode
+	/**
 	 * Optionally render an alert banner before the main content area.
 	 */
 	alertBannerSlot?: ReactNode

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -252,17 +252,15 @@ function TutorialView({
 						sidebarNavDataLevels={sidebarNavDataLevels as any}
 						showScrollProgress={true}
 						AlternateSidebar={TutorialsSidebar}
-						sidecarSlot={
-							<>
-								{metadata.variant ? (
-									<VariantDropdownDisclosure
-										variant={metadata.variant}
-										isFullWidth
-									/>
-								) : null}
-								<OutlineNavWithActive items={outlineItems} />
-							</>
+						sidecarTopSlot={
+							metadata.variant ? (
+								<VariantDropdownDisclosure
+									variant={metadata.variant}
+									isFullWidth
+								/>
+							) : null
 						}
+						sidecarSlot={<OutlineNavWithActive items={outlineItems} />}
 						mainWidth={layoutProps.mainWidth}
 					>
 						<LayoutContentWrapper


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksrefactor-variant-dropdown-disclosure-layout-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204333057896641/1204621999504614) 🎟️

## 🗒️ What

This PR introduces a workaround so that the variant dropdown disclosure in the sidecar is not contained in the scrollable sidecar area. However, the hard-coded height for the `max-sidecar-height` calculation [isn't a long term solution](https://app.asana.com/0/1204333057896641/1204669563792095), needs to be refactored after this launch so that this slot can accept any component, not just the dropdown disclosure. Since no other views use it currently, this isn't an issue. 
### Fix
<img width="651" alt="Screenshot 2023-05-25 at 4 51 36 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/e0615089-1dc5-430d-91e9-f957df6f0bdb">

### Upstream
<img width="593" alt="Screenshot 2023-05-25 at 4 51 58 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/d1007a4f-ba86-42da-9334-77698c4de61f">

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [Visit this Tutorial](https://dev-portal-git-ksrefactor-variant-dropdown-dis-97e464-hashicorp.vercel.app/vault/tutorials/getting-started-ui/getting-started-install), open the disclosure to verify that the variant dropdown disclosure content renders outside the scrollable sidecar area. [compare with upstream](https://dev-portal-git-ksvariants-assembly-hashicorp.vercel.app/vault/tutorials/getting-started/getting-started-install) and open the sidecar dropdown.
- [Visit a tutorial ](https://dev-portal-git-ksrefactor-variant-dropdown-dis-97e464-hashicorp.vercel.app/consul/tutorials/kubernetes/kubernetes-api-gateway)with longer sidecar content. Shrink your viewport to a small height, reload, so that the sidecar scrim renders, validate that no rendering issues occur. 
- Check tutorials without the variant dropdown, validate that nothing has changed for the sidecar scrollable area.
- [Check docs,](https://dev-portal-git-ksrefactor-variant-dropdown-dis-97e464-hashicorp.vercel.app/vault/api-docs/auth/aws) no changes should occur there. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
