### PR TITLE
[Tutorials Front Door] Adding ContentTypesSection subcomponent

### DIFF
--- a/src/views/tutorials-landing/components/content-types-section/content-types-section.module.css
+++ b/src/views/tutorials-landing/components/content-types-section/content-types-section.module.css
@@ -1,0 +1,44 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: 40px;
+}
+
+.title {
+	composes: hds-typography-display-500 from global;
+	composes: hds-font-weight-bold from global;
+	color: var(--token-color-foreground-primary);
+}
+
+.list {
+	align-items: flex-start;
+	display: flex;
+	gap: 64px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.listItem {
+	align-items: flex-start;
+	display: flex;
+	gap: 40px;
+}
+
+.listItemTextContainer {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.listItemTitle {
+	composes: hds-typography-display-400 from global;
+	composes: hds-font-weight-semibold from global;
+	color: var(--token-color-foreground-primary);
+}
+
+.listItemDescription {
+	composes: hds-typography-display-200 from global;
+	composes: hds-font-weight-semibold from global;
+	color: var(--token-color-foreground-primary);
+}

--- a/src/views/tutorials-landing/components/content-types-section/index.tsx
+++ b/src/views/tutorials-landing/components/content-types-section/index.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames'
+import s from './content-types-section.module.css'
+
+// TODO update imageSource to `icon`
+interface ContentTypesSectionItem {
+	imageSource: string
+	title: string
+	description: string
+}
+
+interface ContentTypesSectionProps {
+	className?: string
+	items: ContentTypesSectionItem[]
+	title: string
+}
+
+const ContentTypesSection = ({
+	className,
+	items,
+	title,
+}: ContentTypesSectionProps) => {
+	return (
+		<section className={classNames(s.root, className)}>
+			<h2 className={s.title}>{title}</h2>
+			<ul className={s.list}>
+				{items.map(
+					({ imageSource, title, description }: ContentTypesSectionItem) => {
+						return (
+							<li key={title} className={s.listItem}>
+								{/* TODO <img /> will be replaced with icon */}
+								{/* eslint-disable-next-line @next/next/no-img-element */}
+								<img alt="" src={imageSource} />
+								<div className={s.listItemTextContainer}>
+									<h3 className={s.listItemTitle}>{title}</h3>
+									<p className={s.listItemDescription}>{description}</p>
+								</div>
+							</li>
+						)
+					}
+				)}
+			</ul>
+		</section>
+	)
+}
+
+export { ContentTypesSection }

--- a/src/views/tutorials-landing/components/index.ts
+++ b/src/views/tutorials-landing/components/index.ts
@@ -1,1 +1,2 @@
+export * from './content-types-section'
 export * from './page-hero'

--- a/src/views/tutorials-landing/index.tsx
+++ b/src/views/tutorials-landing/index.tsx
@@ -11,7 +11,6 @@ import ProductIcon from 'components/product-icon'
 import StandaloneLink, {
 	StandaloneLinkContents,
 } from 'components/standalone-link'
-import { GlobalThemeOption } from 'styles/themes/types'
 
 // Local imports
 import {
@@ -24,7 +23,7 @@ import {
 	BETTER_TOGETHER_SECTION_TITLE,
 	BETTER_TOGETHER_SECTION_COLLECTION_SLUGS,
 } from './constants'
-import { PageHero } from './components/page-hero'
+import { ContentTypesSection, PageHero } from './components'
 import s from './tutorials-landing.module.css'
 
 const ProductSection = ({
@@ -192,78 +191,6 @@ const renderProductSections = (productSlugs, pageContent) => {
 	})
 }
 
-const ContentTypesSection = () => {
-	return (
-		<section
-			className={s.contentTypesSection}
-			style={{ paddingTop: 80, paddingBottom: 80 }}
-		>
-			<div className={s.contentTypesSectionTextWrapper}>
-				<h2
-					className={s.contentTypesTitle}
-					style={{
-						marginTop: 0,
-						marginBottom: 42,
-						fontSize: '1.875rem',
-						fontWeight: 700,
-						lineHeight: '1.27',
-						maxWidth: '60%',
-					}}
-				>
-					{CONTENT_TYPES_SECTION_TITLE}
-				</h2>
-				<ul
-					style={{
-						display: 'flex',
-						alignItems: 'flex-start',
-						gap: 48,
-						listStyle: 'none',
-						padding: 0,
-						margin: 0,
-					}}
-				>
-					{CONTENT_TYPES_SECTION_ITEMS.map(
-						({ imageSource, title, description }) => {
-							return (
-								<li
-									key={title}
-									style={{ display: 'flex', alignItems: 'flex-start', gap: 32 }}
-								>
-									<img alt="" src={imageSource} />
-									<div>
-										<h3
-											style={{
-												marginTop: 0,
-												marginBottom: 8,
-												fontSize: '1.5rem',
-												fontWeight: 600,
-												lineHeight: '1.3',
-											}}
-										>
-											{title}
-										</h3>
-										<p
-											style={{
-												fontSize: '1rem',
-												fontWeight: 600,
-												lineHeight: '1.5',
-												color: '#656A76',
-												margin: 0,
-											}}
-										>
-											{description}
-										</p>
-									</div>
-								</li>
-							)
-						}
-					)}
-				</ul>
-			</div>
-		</section>
-	)
-}
-
 const BetterTogetherSection = () => {
 	return (
 		<section className={s.betterTogetherSection}>
@@ -330,7 +257,10 @@ const TutorialsLandingView = ({ pageContent }: $TSFixMe) => {
 				[firstProductSlug, secondProductSlug, thirdProductSlug],
 				pageContent
 			)}
-			<ContentTypesSection />
+			<ContentTypesSection
+				items={CONTENT_TYPES_SECTION_ITEMS}
+				title={CONTENT_TYPES_SECTION_TITLE}
+			/>
 			{renderProductSections(remainingProductSlugs, pageContent)}
 			<BetterTogetherSection />
 		</div>

--- a/src/views/tutorials-landing/tutorials-landing.module.css
+++ b/src/views/tutorials-landing/tutorials-landing.module.css
@@ -11,21 +11,6 @@
 
 /*
 
-ContentTypesSection
-
-*/
-
-.contentTypesSection {
-	background-color: #d9d9d940;
-}
-
-.contentTypesSectionTextWrapper {
-	margin: 0 auto;
-	max-width: var(--content-max-width);
-}
-
-/*
-
 BetterTogetherSection
 
 */


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-tfd-ambcontent-types-section-hashicorp.vercel.app/tutorials) 🔎
- [Asana task](https://app.asana.com/0/0/1204660968035224/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `ContentTypesSection` component under `src/views/tutorials-landing/components/`

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

[Figma link](https://www.figma.com/file/mmbCubXM9sOQqvGG0b8o0D/Tutorial_LP?type=design&node-id=303-23730&t=zidhDWZL6umha1KR-11)

![CleanShot 2023-05-26 at 16 27 26](https://github.com/hashicorp/dev-portal/assets/43934258/30bc301b-4a26-4dae-8d7a-ccc3d5fe428c)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] Verify that the elements are the correct size, weight, etc.
- [ ] Verify that the elements are placed correctly in relation to one another
- [ ] Verify that the text colors are correct in dark & light themes

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

- The kitten placeholder images will be replaced next week in a follow-up PR; one of them is still being discussed.
- The way this component sits in the view will be worked on when all components are arranged.
