### PR TITLE
Adds a 'Type' Badge to Integration Cards

### DIFF
--- a/src/lib/get-integration-badges.tsx
+++ b/src/lib/get-integration-badges.tsx
@@ -56,8 +56,8 @@ export function getIntegrationBadges(
 	}
 
 	return [
-		...(typeBadge ? [typeBadge] : []),
 		...(tierFirst ? [tierBadge] : []),
+		...(typeBadge ? [typeBadge] : []),
 		...integration.flags.map((flag: Flag) => {
 			let icon = undefined
 			switch (flag.slug) {

--- a/src/lib/get-integration-badges.tsx
+++ b/src/lib/get-integration-badges.tsx
@@ -56,6 +56,7 @@ export function getIntegrationBadges(
 	}
 
 	return [
+		// Be sure to keep this tierFirst entry here as the first item
 		...(tierFirst ? [tierBadge] : []),
 		...(typeBadge ? [typeBadge] : []),
 		...integration.flags.map((flag: Flag) => {
@@ -84,6 +85,7 @@ export function getIntegrationBadges(
 				icon: icon,
 			}
 		}),
+		// Be sure to keep this tierFirst entry here as the last item
 		...(tierFirst ? [] : [tierBadge]),
 	]
 }

--- a/src/lib/get-integration-badges.tsx
+++ b/src/lib/get-integration-badges.tsx
@@ -47,7 +47,16 @@ export function getIntegrationBadges(
 			break
 	}
 
+	let typeBadge: Badge
+	if (integration.integration_type) {
+		typeBadge = {
+			text: integration.integration_type.name,
+			tooltip: integration.integration_type.description,
+		}
+	}
+
 	return [
+		...(typeBadge ? [typeBadge] : []),
 		...(tierFirst ? [tierBadge] : []),
 		...integration.flags.map((flag: Flag) => {
 			let icon = undefined


### PR DESCRIPTION
Incorporates a `type` badge to the integration cards if a type is set.

[🎟️ Asana Ticket](https://app.asana.com/0/1203792704477769/1204425861866904/f) 

## Screenshots

<img width="899" alt="CleanShot 2023-05-30 at 09 04 34@2x" src="https://github.com/hashicorp/dev-portal/assets/2105067/c2accc8c-5c5c-4fe7-9895-8ba8e5b6d9fb">

<img width="901" alt="CleanShot 2023-05-30 at 09 04 46@2x" src="https://github.com/hashicorp/dev-portal/assets/2105067/1bcc861f-f820-4a52-9c78-d68198ac8b9d">
