### PR TITLE
Adjust integration header card badge style

### DIFF
--- a/src/components/content-header-card/index.tsx
+++ b/src/components/content-header-card/index.tsx
@@ -81,7 +81,6 @@ export default function ContentHeaderCard({
 							{badges && (
 								<BadgeList
 									className={s.badgeList}
-									type="outlined"
 									size="small"
 									badges={badges}
 								/>


### PR DESCRIPTION
Adjust the badge style to be more consistent with the cards on the Integrations library page (per design)!

<img width="805" alt="CleanShot 2023-05-30 at 09 13 12@2x" src="https://github.com/hashicorp/dev-portal/assets/2105067/17ec1e05-7a95-463f-91f0-f02c5b916394">

[🎟️ Asana ticket](https://app.asana.com/0/1203792704477769/1204425861866904/f)

## Screenshot

<img width="880" alt="CleanShot 2023-05-30 at 09 13 47@2x" src="https://github.com/hashicorp/dev-portal/assets/2105067/41c47346-fedf-4855-93d5-5ec66d87a715">

