### PR TITLE
[Tutorial Front Door] Add constant that specifies production section order

### DIFF
--- a/src/views/tutorials-landing/constants.tsx
+++ b/src/views/tutorials-landing/constants.tsx
@@ -1,3 +1,5 @@
+import { ProductSlug } from 'types/products'
+
 /**
  * General page-level constants
  */
@@ -10,6 +12,20 @@ const PAGE_SUBTITLE =
 /**
  * ProductSection constants
  */
+
+const PRODUCT_SECTIONS_ORDER_BY_SLUG: Exclude<
+	ProductSlug,
+	'hcp' | 'sentinel'
+>[] = [
+	'terraform',
+	'vault',
+	'consul',
+	'nomad',
+	'packer',
+	'boundary',
+	'vagrant',
+	'waypoint',
+]
 
 const PRODUCT_DESCRIPTIONS = {
 	terraform: 'Build, change, and destroy infrastructure',
@@ -66,6 +82,7 @@ const BETTER_TOGETHER_SECTION_COLLECTION_SLUGS = [
 export {
 	PAGE_TITLE,
 	PAGE_SUBTITLE,
+	PRODUCT_SECTIONS_ORDER_BY_SLUG,
 	PRODUCT_DESCRIPTIONS,
 	CONTENT_TYPES_SECTION_TITLE,
 	CONTENT_TYPES_SECTION_ITEMS,

--- a/src/views/tutorials-landing/index.tsx
+++ b/src/views/tutorials-landing/index.tsx
@@ -17,6 +17,7 @@ import { BADGE_ICON_MAP } from 'components/tutorials-landing-view/collection-con
 import {
 	PAGE_TITLE,
 	PAGE_SUBTITLE,
+	PRODUCT_SECTIONS_ORDER_BY_SLUG,
 	PRODUCT_DESCRIPTIONS,
 	CONTENT_TYPES_SECTION_TITLE,
 	CONTENT_TYPES_SECTION_ITEMS,
@@ -238,13 +239,12 @@ const BetterTogetherSection = () => {
 }
 
 const TutorialsLandingView = ({ pageContent }: $TSFixMe) => {
-	const productSlugKeys = Object.keys(pageContent)
 	const [
 		firstProductSlug,
 		secondProductSlug,
 		thirdProductSlug,
 		...remainingProductSlugs
-	] = productSlugKeys
+	] = PRODUCT_SECTIONS_ORDER_BY_SLUG
 
 	return (
 		<div className={s.root}>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-tfd-ambproduct-section-order-hashicorp.vercel.app/tutorials) 🔎
- [Asana task](https://app.asana.com/0/0/1204662262934320/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds `PRODUCT_SECTIONS_ORDER_BY_SLUG` constant scoped to `TutorialsLandingView` 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- Using a named constant makes the intended use clear. Other options for determining order are higher effort or not immediately clear:
  - Adding an `order` property to the `src/content/` file for each product requires more manual effort to reorder sections and runs the risk of accidentally setting the same number for multiple products
  - Inferring order from the product slug properties in the `src/content/` file would require moving a lot of lines of code around, and it's not explicit from the file that changing the order would change how the page looks

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the [/tutorials](https://dev-portal-git-tfd-ambproduct-section-order-hashicorp.vercel.app/tutorials) page on the preview
- [ ] Make sure the order of the product sections matches the order of the slugs in `PRODUCT_SECTIONS_ORDER_BY_SLUG`
