### PR TITLE
Fixes a bug with Variants

### DIFF
--- a/src/views/tutorial-view/utils/variants/mdx-variant.tsx
+++ b/src/views/tutorial-view/utils/variants/mdx-variant.tsx
@@ -10,6 +10,9 @@ interface MdxVariantProps {
 
 export function MdxVariant({ slug, option, children }: MdxVariantProps) {
 	const { currentVariant } = useVariant()
+	if (!currentVariant) {
+		return null
+	}
 	const shouldRenderContent =
 		currentVariant.slug === slug && currentVariant.activeOption.slug === option
 	const isValidVariantOption = currentVariant.options.find(


### PR DESCRIPTION
It looks like the MdxVariant uses `useVariant`, which does not always yield a variant. We run into a null reference on lines right after this check / ejection I add without it, which prevents a build.

https://github.com/hashicorp/tutorials/actions/runs/5137008172/jobs/9244505941

