### PR TITLE
fix(warm-cache): avoid `.tsx` export side-effect

### DIFF
--- a/src/views/tutorial-view/utils/index.ts
+++ b/src/views/tutorial-view/utils/index.ts
@@ -5,7 +5,11 @@
 
 import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
 import { TutorialListItemProps } from 'components/tutorials-sidebar/types'
-import { getTutorialSlug } from 'views/collection-view/helpers'
+// A `.tsx` module exported in the barrel-export file (/helpers/index.ts) causes
+// hc-tools to error, which breaks our `./scripts/warm-cache.ts`.
+//
+// To avoid this, we import from the specific file here to avoid unintended side effects.
+import { getTutorialSlug } from 'views/collection-view/helpers/get-slug'
 
 export function splitProductFromFilename(slug: string): string {
 	return slug.split('/')[1]


### PR DESCRIPTION
# Description

This fixes our cache-warming workflow.

The cause:
A `.tsx` module added to a barrel-export causes our `npx hc-tools ./scripts/warm-cache.ts` script to error.
- see export: https://github.com/hashicorp/dev-portal/commit/5556b222346e70927eb9f3abf6a7e4f18fdb999a#diff-5fea0ff96b61e4194461e3cccee1ffa9e376ed1b5c9084e3dcc96aa788dfefebR9
- see error: https://github.com/hashicorp/dev-portal/actions/runs/5125219860/jobs/9218275252#step:6:8