### PR TITLE
[Tutorials Front Door] Fix "Explore more" general CTA text

### DIFF
--- a/src/views/tutorials-landing/components/product-section/index.tsx
+++ b/src/views/tutorials-landing/components/product-section/index.tsx
@@ -55,7 +55,7 @@ const ProductSection = ({
 							icon={<IconArrowRight24 />}
 							iconPosition="trailing"
 							size="large"
-							text={`Explore more ${name} tutorials`}
+							text={`Explore more ${name} learning paths`}
 						/>
 					</li>
 					<li>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-tfd-ambfix-explore-more-cta-hashicorp.vercel.app/tutorials) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Fixes the "Explore more" `StandaloneLink` CTA text in `ProductSection`

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

- It wasn't correct with what was designed & proposed in the RFC
