### PR TITLE
Statically build all variant pages for Tutorials Preview

### DIFF
--- a/src/lib/learn-client/api/collection/formatting.ts
+++ b/src/lib/learn-client/api/collection/formatting.ts
@@ -13,6 +13,7 @@ import {
 import {
 	formatHandsOnLab,
 	formatToCollectionLite,
+	formatVariant,
 	formatVideo,
 } from '../tutorial/formatting'
 
@@ -62,6 +63,10 @@ export function formatToTutorialLite(
 	const productsUsed = products_used.map(formatProductUsed)
 	const video = formatVideo(item.tutorial)
 	const handsOnLab = formatHandsOnLab(item.tutorial)
+	const formattedVariant =
+		item.tutorial.variants?.length > 0
+			? formatVariant(item.tutorial.variants[0])
+			: undefined
 
 	return {
 		id,
@@ -74,6 +79,7 @@ export function formatToTutorialLite(
 		video,
 		handsOnLab,
 		defaultContext: formatToCollectionLite(default_collection),
+		variant: formattedVariant,
 	}
 }
 

--- a/src/lib/learn-client/api/tutorial/formatting.ts
+++ b/src/lib/learn-client/api/tutorial/formatting.ts
@@ -143,7 +143,7 @@ export function formatHandsOnLab({
 	return handsOnLab
 }
 
-function formatVariant(variant: ApiTutorialVariant): TutorialVariant {
+export function formatVariant(variant: ApiTutorialVariant): TutorialVariant {
 	const { options, ...rest } = variant
 	return {
 		...rest,

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -80,6 +80,7 @@ export interface TutorialLite
 		| 'productsUsed'
 		| 'video'
 		| 'handsOnLab'
+		| 'variant'
 	> {
 	defaultContext: CollectionLite
 }

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -33,6 +33,7 @@ import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items
 import {
 	TutorialVariantOption,
 	getTutorialViewVariantData,
+	getVariantParam,
 } from './utils/variants'
 
 /**
@@ -215,15 +216,17 @@ export async function getTutorialPagePaths(): Promise<TutorialPagePaths[]> {
 				if (tutorial.variant) {
 					tutorial.variant.options.forEach(
 						(variantOption: TutorialVariantOption) => {
-							const variantPathValue =
-								tutorial.variant.slug + ':' + variantOption.slug
+							const variantParam = getVariantParam(
+								tutorial.variant.slug,
+								variantOption.slug
+							)
 							paths.push({
 								params: {
 									productSlug: normalizedProductSlug,
 									tutorialSlug: [
 										collectionSlug,
 										tutorialSlug,
-										variantPathValue,
+										variantParam,
 									] as [string, string, string],
 								},
 							})

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -30,7 +30,10 @@ import { getCollectionViewSidebarSections } from 'views/collection-view/server'
 import { normalizeSlugForTutorials } from 'lib/tutorials/normalize-product-like-slug'
 import { normalizeSlugForDevDot } from 'lib/tutorials/normalize-product-like-slug'
 import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items-from-headings'
-import { getTutorialViewVariantData } from './utils/variants'
+import {
+	TutorialVariantOption,
+	getTutorialViewVariantData,
+} from './utils/variants'
 
 /**
  * Given a ProductData object (imported from src/data JSON files) and a tutorial
@@ -208,9 +211,27 @@ export async function getTutorialPagePaths(): Promise<TutorialPagePaths[]> {
 						tutorialSlug: [collectionSlug, tutorialSlug] as [string, string],
 					},
 				})
+				// If the Tutorial has variants, push a path for each one
+				if (tutorial.variant) {
+					tutorial.variant.options.forEach(
+						(variantOption: TutorialVariantOption) => {
+							const variantPathValue =
+								tutorial.variant.slug + ':' + variantOption.slug
+							paths.push({
+								params: {
+									productSlug: normalizedProductSlug,
+									tutorialSlug: [
+										collectionSlug,
+										tutorialSlug,
+										variantPathValue,
+									] as [string, string, string],
+								},
+							})
+						}
+					)
+				}
 			})
 		}
 	})
-
 	return paths
 }


### PR DESCRIPTION
Updates the `getTutorialPagePaths` function to also return all variant paths.  This is needed for our tutorials preview to statically build all variant paths.