### PR TITLE
chore: add flag & placeholder for unified search

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -42,6 +42,7 @@
 	},
 	"flags": {
 		"enable_datadog": true,
-		"enable_io_beta_cta": true
+		"enable_io_beta_cta": true,
+		"enable_unified_search": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,6 @@
 		"max_static_paths": 1
 	},
 	"flags": {
-		"enable_unified_search": true
+		"enable_unified_search": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -11,5 +11,8 @@
 	},
 	"learn": {
 		"max_static_paths": 1
+	},
+	"flags": {
+		"enable_unified_search": true
 	}
 }

--- a/src/components/command-bar/commands/search/index.tsx
+++ b/src/components/command-bar/commands/search/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'components/command-bar/types'
 import { getCurrentProductTag } from './helpers'
 import SearchCommandBarDialogBody from './components/dialog-body'
+import { UnifiedSearchCommandBarDialogBody } from './unified-search/components'
 
 type Options = Parameters<CommandBarCommand['inputProps']['placeholder']>[0]
 
@@ -39,7 +40,9 @@ const searchCommand: CommandBarCommand = {
 	inputProps: {
 		placeholder: generatePlaceholder,
 	},
-	DialogBody: SearchCommandBarDialogBody,
+	DialogBody: __config.flags.enable_unified_search
+		? UnifiedSearchCommandBarDialogBody
+		: SearchCommandBarDialogBody,
 }
 
 export default searchCommand

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -1,0 +1,9 @@
+function UnifiedSearchCommandBarDialogBody() {
+	return (
+		<div style={{ border: '2px solid magenta' }}>
+			Unified search results pane will go here.
+		</div>
+	)
+}
+
+export { UnifiedSearchCommandBarDialogBody }

--- a/src/components/command-bar/commands/search/unified-search/components/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/index.tsx
@@ -1,0 +1,1 @@
+export * from './dialog-body'


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Stubs in unified search placeholder behind a feature flag, disabled in all environments for now.

## 🤷 Why

To set up a foundation off which to build a unified search "All" tab.

## 📸 Design Screenshots

| Flag off | Flag on |
| - | - |
| ![flag-off](https://github.com/hashicorp/dev-portal/assets/4624598/66936a6d-4c75-43f5-a2d1-10a661c9f85f) | ![flag-on](https://github.com/hashicorp/dev-portal/assets/4624598/32afbd68-6cfb-40aa-85cd-2d3b445c3685) | 

## 🧪 Testing

- [ ] Visit [the preview link][preview]
    - When you open the search modal, search should function exactly as it does [upstream]
- [ ] Pull down this branch, set `flags.enable_unified_search` to `true` in `config/development.json`, and run locally
    - When you open the search modal, there should be a useless search placeholder

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204333060736722/1204604641329009/f
[preview]: https://dev-portal-git-zsstart-unified-search-hashicorp.vercel.app
[upstream]: https://developer.hashicorp.com/