### PR TITLE
[Tutorials Front Door] Add link click event tracking

### DIFF
--- a/analytics/spec/events/tutorials_front_door_link_clicked.yaml
+++ b/analytics/spec/events/tutorials_front_door_link_clicked.yaml
@@ -1,0 +1,29 @@
+name: Tutorials Front Door Link Clicked
+description: User has clicked a link within the Tutorial Front Door page content
+rules:
+  ‘$schema’: http://json-schema.org/draft-04/schema#
+  type: object
+  properties:
+    context:
+      $ref: ../meta/context.yaml
+    properties:
+      type: object
+      properties:
+        link_category:
+          description: The category of the clicked link.
+          type: string
+          enum:
+            - certification-card
+            - collection-card
+            - featured-use-case
+            - product-tutorials-landing
+            - tutorial-library
+        link_path:
+          description: The page path of the clicked link.
+          type: string
+        product_slug:
+          $ref: ../global/types/hashicorp_product.yaml
+      required:
+        - link_category
+        - link_path
+        - product_slug

--- a/src/components/card-link/index.tsx
+++ b/src/components/card-link/index.tsx
@@ -16,6 +16,7 @@ const CardLink = ({
 	children,
 	className,
 	href,
+	onClick,
 	opensInNewTab,
 	'data-heap-track': dataHeapTrack,
 }: CardLinkProps): ReactElement => {
@@ -50,6 +51,7 @@ const CardLink = ({
 				data-heap-track={`card-link ${dataHeapTrack ?? ''}`}
 				href={href}
 				target={target}
+				onClick={onClick}
 			>
 				<span aria-hidden={true}>&nbsp;</span>
 			</Link>

--- a/src/components/card-link/types.ts
+++ b/src/components/card-link/types.ts
@@ -7,7 +7,7 @@ import { CardProps } from 'components/card'
 import { LinkProps } from 'components/link'
 
 type InheritedCardProps = Pick<CardProps, 'children' | 'className'>
-type InheritedLinkProps = Pick<LinkProps, 'href' | 'opensInNewTab'>
+type InheritedLinkProps = Pick<LinkProps, 'href' | 'onClick' | 'opensInNewTab'>
 
 export interface CardLinkProps extends InheritedCardProps, InheritedLinkProps {
 	/**

--- a/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
@@ -1,3 +1,4 @@
+import { trackCertificationCardLinkClicked } from 'views/tutorials-landing/analytics'
 import { type CertificationContentCardLinkProps } from '../types'
 import ContentCardLink from '../content-card-link'
 import networkingAutomationGraphic from './img/consul.svg'
@@ -21,12 +22,20 @@ const CERTIFICATION_PROGRAM_SLUGS_TO_BACKGROUND_IMAGES = {
 
 const CertificationContentCardLink = ({
 	certification,
+	product,
 }: CertificationContentCardLinkProps) => {
 	const { url, lightOrDark } =
 		CERTIFICATION_PROGRAM_SLUGS_TO_BACKGROUND_IMAGES[certification.slug]
 	const title = certification.title
 	const description = certification.description
 	const href = `/certifications/${certification.slug}`
+
+	const handleClick = () => {
+		trackCertificationCardLinkClicked({
+			linkPath: href,
+			productSlug: product.slug,
+		})
+	}
 
 	return (
 		<ContentCardLink
@@ -35,6 +44,7 @@ const CertificationContentCardLink = ({
 			description={description}
 			href={href}
 			title={title}
+			onClick={handleClick}
 		/>
 	)
 }

--- a/src/components/tutorials-landing-view/collection-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/collection-content-card-link/index.tsx
@@ -1,6 +1,7 @@
 import { ProductUsed, TutorialLite } from 'lib/learn-client/types'
 import { normalizeSlugForDevDot } from 'lib/tutorials/normalize-product-like-slug'
 import { getCollectionSlug } from 'views/collection-view/helpers'
+import { trackCollectionCardLinkClicked } from 'views/tutorials-landing/analytics'
 import { type CollectionContentCardLinkProps } from '../types'
 import ContentCardLink from '../content-card-link'
 import { BADGE_ICON_MAP, PRODUCT_SLUGS_TO_HEADER_IMAGES } from './constants'
@@ -54,6 +55,10 @@ const CollectionContentCardLink = ({
 		}
 	}
 
+	const handleClick = () => {
+		trackCollectionCardLinkClicked({ linkPath: href, productSlug })
+	}
+
 	return (
 		<ContentCardLink
 			badges={badges}
@@ -62,6 +67,7 @@ const CollectionContentCardLink = ({
 			href={href}
 			title={title}
 			eyebrowParts={eyebrowParts}
+			onClick={handleClick}
 		/>
 	)
 }

--- a/src/components/tutorials-landing-view/content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/content-card-link/index.tsx
@@ -19,6 +19,7 @@ const ContentCardLink = ({
 	eyebrowParts,
 	headerImageUrl,
 	href,
+	onClick,
 	title,
 }: ContentCardLinkProps) => {
 	const hasHeaderImage = headerImageUrl?.length > 0
@@ -38,7 +39,12 @@ const ContentCardLink = ({
 	}
 
 	return (
-		<CardLink ariaLabel={title} className={s.root} href={href}>
+		<CardLink
+			ariaLabel={title}
+			className={s.root}
+			href={href}
+			onClick={onClick}
+		>
 			{hasHeaderImage ? (
 				<div
 					className={s.headerImage}

--- a/src/components/tutorials-landing-view/types.ts
+++ b/src/components/tutorials-landing-view/types.ts
@@ -1,3 +1,4 @@
+import { ProductSlug } from 'types/products'
 import { Collection } from 'lib/learn-client/types'
 import { type BadgeProps } from 'components/badge'
 import { CardLinkProps } from 'components/card-link'
@@ -32,6 +33,9 @@ interface CertificationContentCardLinkProps {
 		slug: string
 		title: string
 		description: string
+	}
+	product: {
+		slug: ProductSlug
 	}
 }
 

--- a/src/components/tutorials-landing-view/types.ts
+++ b/src/components/tutorials-landing-view/types.ts
@@ -1,5 +1,6 @@
 import { Collection } from 'lib/learn-client/types'
 import { type BadgeProps } from 'components/badge'
+import { CardLinkProps } from 'components/card-link'
 
 interface ContentCardLinkBadge {
 	icon: BadgeProps['icon']
@@ -16,6 +17,7 @@ interface ContentCardLinkProps {
 	eyebrowParts?: ContentCardLinkEyebrowPart[]
 	headerImageUrl?: string
 	href: string
+	onClick?: CardLinkProps['onClick']
 	title: string
 }
 

--- a/src/views/tutorials-landing/analytics.ts
+++ b/src/views/tutorials-landing/analytics.ts
@@ -1,4 +1,4 @@
-import { ProductSlug } from 'types/products'
+// import { ProductSlug } from 'types/products'
 import { safeAnalyticsTrack } from 'lib/analytics'
 
 interface TutorialsFrontDoorLinkClickedEvent {
@@ -9,7 +9,8 @@ interface TutorialsFrontDoorLinkClickedEvent {
 		| 'product-tutorials-landing'
 		| 'tutorial-library'
 	linkPath: string
-	productSlug: ProductSlug
+	// @TODO clean up types across view's code
+	productSlug: $TSFixMe
 }
 
 type UtilWrapperArguments = Pick<

--- a/src/views/tutorials-landing/analytics.ts
+++ b/src/views/tutorials-landing/analytics.ts
@@ -1,0 +1,96 @@
+import { ProductSlug } from 'types/products'
+import { safeAnalyticsTrack } from 'lib/analytics'
+
+interface TutorialsFrontDoorLinkClickedEvent {
+	linkCategory:
+		| 'certification-card'
+		| 'collection-card'
+		| 'featured-use-case'
+		| 'product-tutorials-landing'
+		| 'tutorial-library'
+	linkPath: string
+	productSlug: ProductSlug
+}
+
+type UtilWrapperArguments = Pick<
+	TutorialsFrontDoorLinkClickedEvent,
+	'linkPath' | 'productSlug'
+>
+
+/**
+ * @see /analytics/spec/events/tutorials_front_door_link_clicked.yaml
+ */
+const trackTutorialsFrontDoorLinkClicked = ({
+	linkCategory: link_category,
+	linkPath: link_path,
+	productSlug: product_slug,
+}: TutorialsFrontDoorLinkClickedEvent) => {
+	safeAnalyticsTrack('Tutorials Front Door Link Clicked', {
+		link_category,
+		link_path,
+		product_slug,
+	})
+}
+
+const trackCertificationCardLinkClicked = ({
+	linkPath,
+	productSlug,
+}: UtilWrapperArguments) => {
+	trackTutorialsFrontDoorLinkClicked({
+		linkCategory: 'certification-card',
+		linkPath,
+		productSlug,
+	})
+}
+
+const trackCollectionCardLinkClicked = ({
+	linkPath,
+	productSlug,
+}: UtilWrapperArguments) => {
+	trackTutorialsFrontDoorLinkClicked({
+		linkCategory: 'collection-card',
+		linkPath,
+		productSlug,
+	})
+}
+
+const trackFeaturedUseCaseLinkClicked = ({
+	linkPath,
+	productSlug,
+}: UtilWrapperArguments) => {
+	trackTutorialsFrontDoorLinkClicked({
+		linkCategory: 'featured-use-case',
+		linkPath,
+		productSlug,
+	})
+}
+
+const trackProductTutorialsLandingLinkClicked = ({
+	linkPath,
+	productSlug,
+}: UtilWrapperArguments) => {
+	trackTutorialsFrontDoorLinkClicked({
+		linkCategory: 'product-tutorials-landing',
+		linkPath,
+		productSlug,
+	})
+}
+
+const trackTutorialLibraryLinkClicked = ({
+	linkPath,
+	productSlug,
+}: UtilWrapperArguments) => {
+	trackTutorialsFrontDoorLinkClicked({
+		linkCategory: 'tutorial-library',
+		linkPath,
+		productSlug,
+	})
+}
+
+export {
+	trackCertificationCardLinkClicked,
+	trackCollectionCardLinkClicked,
+	trackFeaturedUseCaseLinkClicked,
+	trackProductTutorialsLandingLinkClicked,
+	trackTutorialLibraryLinkClicked,
+}

--- a/src/views/tutorials-landing/components/product-section/index.tsx
+++ b/src/views/tutorials-landing/components/product-section/index.tsx
@@ -1,7 +1,10 @@
 import classNames from 'classnames'
 import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-24'
 import { ProductName, ProductSlug } from 'types/products'
-import { trackFeaturedUseCaseLinkClicked } from 'views/tutorials-landing/analytics'
+import {
+	trackFeaturedUseCaseLinkClicked,
+	trackProductTutorialsLandingLinkClicked,
+} from 'views/tutorials-landing/analytics'
 import ProductIcon from 'components/product-icon'
 import StandaloneLink from 'components/standalone-link'
 import CollectionContentCardLink from 'components/tutorials-landing-view/collection-content-card-link'
@@ -33,16 +36,23 @@ interface ProductSectionProps {
 
 const GeneralCtasList = ({ product }) => {
 	const { name, slug } = product
+	const href = `/${slug}/tutorials`
 	return (
 		<ul className={s.generalCtasList}>
 			<li>
 				<StandaloneLink
 					color="secondary"
-					href={`/${slug}/tutorials`}
+					href={href}
 					icon={<IconArrowRight24 />}
 					iconPosition="trailing"
 					size="large"
 					text={`Explore more ${name} learning paths`}
+					onClick={() => {
+						trackProductTutorialsLandingLinkClicked({
+							linkPath: href,
+							productSlug: product.slug,
+						})
+					}}
 				/>
 			</li>
 			<li>

--- a/src/views/tutorials-landing/components/product-section/index.tsx
+++ b/src/views/tutorials-landing/components/product-section/index.tsx
@@ -4,6 +4,7 @@ import { ProductName, ProductSlug } from 'types/products'
 import {
 	trackFeaturedUseCaseLinkClicked,
 	trackProductTutorialsLandingLinkClicked,
+	trackTutorialLibraryLinkClicked,
 } from 'views/tutorials-landing/analytics'
 import ProductIcon from 'components/product-icon'
 import StandaloneLink from 'components/standalone-link'
@@ -36,20 +37,22 @@ interface ProductSectionProps {
 
 const GeneralCtasList = ({ product }) => {
 	const { name, slug } = product
-	const href = `/${slug}/tutorials`
+	const productTutorialsLandingHref = `/${slug}/tutorials`
+	const tutorialLibraryHref = `/tutorials/library?product=${slug}`
+
 	return (
 		<ul className={s.generalCtasList}>
 			<li>
 				<StandaloneLink
 					color="secondary"
-					href={href}
+					href={productTutorialsLandingHref}
 					icon={<IconArrowRight24 />}
 					iconPosition="trailing"
 					size="large"
 					text={`Explore more ${name} learning paths`}
 					onClick={() => {
 						trackProductTutorialsLandingLinkClicked({
-							linkPath: href,
+							linkPath: productTutorialsLandingHref,
 							productSlug: product.slug,
 						})
 					}}
@@ -58,11 +61,17 @@ const GeneralCtasList = ({ product }) => {
 			<li>
 				<StandaloneLink
 					color="secondary"
-					href={`/tutorials/library?product=${slug}`}
+					href={tutorialLibraryHref}
 					icon={<IconArrowRight24 />}
 					iconPosition="trailing"
 					size="large"
 					text={`Browse all ${name} tutorials`}
+					onClick={() => {
+						trackTutorialLibraryLinkClicked({
+							linkPath: tutorialLibraryHref,
+							productSlug: product.slug,
+						})
+					}}
 				/>
 			</li>
 		</ul>

--- a/src/views/tutorials-landing/components/product-section/index.tsx
+++ b/src/views/tutorials-landing/components/product-section/index.tsx
@@ -1,5 +1,7 @@
+import classNames from 'classnames'
 import { IconArrowRight24 } from '@hashicorp/flight-icons/svg-react/arrow-right-24'
 import { ProductName, ProductSlug } from 'types/products'
+import { trackFeaturedUseCaseLinkClicked } from 'views/tutorials-landing/analytics'
 import ProductIcon from 'components/product-icon'
 import StandaloneLink from 'components/standalone-link'
 import CollectionContentCardLink from 'components/tutorials-landing-view/collection-content-card-link'
@@ -9,7 +11,6 @@ import {
 	CollectionContentCardLinkProps,
 } from 'components/tutorials-landing-view/types'
 import s from './product-section.module.css'
-import classNames from 'classnames'
 
 type Certification = CertificationContentCardLinkProps['certification']
 type Collection = CollectionContentCardLinkProps['collection']
@@ -58,7 +59,7 @@ const GeneralCtasList = ({ product }) => {
 	)
 }
 
-const FeaturedUseCasesList = ({ featuredUseCases }) => {
+const FeaturedUseCasesList = ({ featuredUseCases, product }) => {
 	return (
 		<>
 			<h3 className={s.featuredUseCasesTitle}>Featured use cases</h3>
@@ -73,6 +74,12 @@ const FeaturedUseCasesList = ({ featuredUseCases }) => {
 								iconPosition="trailing"
 								size="large"
 								text={text}
+								onClick={() => {
+									trackFeaturedUseCaseLinkClicked({
+										linkPath: href,
+										productSlug: product.slug,
+									})
+								}}
 							/>
 						</li>
 					)
@@ -87,7 +94,10 @@ const CtasAndFeaturedUseCases = ({ product, featuredUseCases }) => {
 		<>
 			<GeneralCtasList product={product} />
 			<hr className={s.separator} />
-			<FeaturedUseCasesList featuredUseCases={featuredUseCases} />
+			<FeaturedUseCasesList
+				featuredUseCases={featuredUseCases}
+				product={product}
+			/>
 		</>
 	)
 }

--- a/src/views/tutorials-landing/components/product-section/index.tsx
+++ b/src/views/tutorials-landing/components/product-section/index.tsx
@@ -126,7 +126,10 @@ const MobileProductSection = ({
 			<div className={s.mobileCertificationCardAndCtas}>
 				{certification ? (
 					<div>
-						<CertificationContentCardLink certification={certification} />
+						<CertificationContentCardLink
+							certification={certification}
+							product={product}
+						/>
 					</div>
 				) : null}
 				<div className={s.mobileCtasAndFeaturedUseCases}>
@@ -173,6 +176,7 @@ const NonMobileProductSection = ({
 						<CertificationContentCardLink
 							key={certification.slug}
 							certification={certification}
+							product={product}
 						/>
 					</li>
 				) : null}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-tfd-ambevent-tracking-hashicorp.vercel.app/tutorials) 🔎
- [Asana task](https://app.asana.com/0/1204535818156240/1204687872642324) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds analytics spec: `analytics/spec/events/tutorials_front_door_link_clicked.yaml`
- Adds analytics tracking helpers in: `src/views/tutorials-landing/analytics.ts`
  - Main helper, not exported: `trackTutorialsFrontDoorLinkClicked`
  - `trackCertificationCardLinkClicked`
  - `trackCollectionCardLinkClicked`
  - `trackFeaturedUseCaseLinkClicked`
  - `trackProductTutorialsLandingLinkClicked`
  - `trackTutorialLibraryLinkClicked`
- Adds `CardLink.onClick` prop
- Adds `ContentCardLink.onClick` prop
- Adds `CertificationContentCardLinkProps.product` prop
- Adds click event tracking to:
  - `CertificationContentCardLink`
  - `CollectionContentCardLink`
  - `GeneralCtasList`
  - `FeaturedUseCasesList`
