### PR TITLE
[Tutorials Front Door] Add Tutorials link to primary navigation areas

### DIFF
--- a/src/components/navigation-header/components/home-page-content/index.tsx
+++ b/src/components/navigation-header/components/home-page-content/index.tsx
@@ -5,7 +5,11 @@
 
 import InlineSvg from '@hashicorp/react-inline-svg'
 import Link from 'components/link'
-import { NavBarListContainer, NavigationHeaderDropdownMenu } from '..'
+import {
+	NavBarListContainer,
+	NavigationHeaderDropdownMenu,
+	PrimaryNavLink,
+} from '..'
 import { getAllProductsNavItems } from 'components/navigation-header/helpers'
 import s from './home-page-content.module.css'
 
@@ -28,6 +32,12 @@ const HomePageHeaderContent = () => {
 					<NavigationHeaderDropdownMenu
 						itemGroups={[{ items: getAllProductsNavItems() }]}
 						label="Products"
+					/>
+				</li>
+				<li>
+					<PrimaryNavLink
+						ariaLabel="Tutorials"
+						navItem={{ label: 'Tutorials', url: '/tutorials' }}
 					/>
 				</li>
 			</NavBarListContainer>

--- a/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
@@ -13,6 +13,7 @@ import {
 import { IconHome16 } from '@hashicorp/flight-icons/svg-react/home-16'
 import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
+import { IconGuide16 } from '@hashicorp/flight-icons/svg-react/guide-16'
 import { ProductSlug } from 'types/products'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import Badge from 'components/badge'
@@ -42,6 +43,7 @@ const SUPPORTED_LEADING_ICONS: {
 	[key in SupportedIconName]: ReactElement
 } = {
 	home: <IconHome16 name="home" />,
+	guide: <IconGuide16 />,
 }
 
 /**

--- a/src/components/sidebar/components/sidebar-nav-menu-item/types.ts
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/types.ts
@@ -27,7 +27,7 @@ interface SidebarNavMenuItemProps {
 	item: MenuItem
 }
 
-type SupportedIconName = 'home' & ProductSlug
+type SupportedIconName = 'home' & 'guide' & ProductSlug
 interface SidebarNavLinkItem extends MenuItem {
 	leadingIconName?: SupportedIconName
 }

--- a/src/lib/generate-top-level-sub-nav-items.ts
+++ b/src/lib/generate-top-level-sub-nav-items.ts
@@ -33,6 +33,11 @@ export const generateTopLevelSubNavItems = () => {
 			title: 'HashiCorp Developer',
 			href: '/',
 		},
+		{
+			leadingIconName: 'guide',
+			title: 'Tutorials',
+			href: '/tutorials',
+		},
 		{ divider: true },
 		{ heading: 'Products' },
 		...productItems,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-tfd-ambnav-header-link-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204535818156240/1204763443280504) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

- Adds support for `'guide'` leading icon name in sidebar
- Adds a new link in `generateTopLevelSubNavItems`
- Adds a new `PrimaryNavLink` to `HomePageHeaderContent`

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to the preview URL
- [ ] In wider viewports, in the non product specific navigation header:
  - [ ] There should be a new "Tutorials" link
  - [ ] The new link should point to the correct page
- [ ] In smaller viewports, on any page, in the top level sidebar navigation:
  - [ ] There should be a new "Tutorials" link at the end of the "Main menu" section
  - [ ] The new link should point to the correct page
