### PR TITLE
fix: sidecar overflow for variant dropdown

### DIFF
--- a/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+++ b/src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
@@ -174,13 +174,15 @@ for further details.
 	flex-shrink: 0;
 
 	/* Note: we don't ever want the top slot to be very tall, and we don't
-	   really want this container to ever have to scroll.
-	   But we do want to gracefully handle unexpected edge cases where it 
-		 does exceed the available height. We set its max-height to
-		 half the available sidecar max-height, as otherwise it would clobber
-		 the sidecar scrollable content down to a 0px tall container. */
+	   really want this container to ever have to scroll. However, we also
+		 need overflow: visible here to allow things like the variant dropdown
+		 to visually overflow the .sidecarTopSlot rather than cause it to
+		 turn into a scrollable container or increase in height.
+		 There is still a potential edge case here where .sidecarTopSlot
+		 content is too tall even in its default state, but this is
+		 not expected to be an edge case we'll run into. */
 	max-height: calc(var(--max-sidecar-height) / 2);
-	overflow-y: auto;
+	overflow: visible;
 }
 
 /* .editOnGithubLink is an element within the `.main` area.


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
 
## 🗒️ What

Fixes a bug where the Variants dropdown in the sidecar did not overflow correctly. Overflow for the `.sidecarTopSlot` should be visible, rather than being cut off or scrolling.

## 📸 Design Screenshots

| Before | After | 
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/250bc76b-ef50-42d1-a523-c15aef156bd0) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/67867fd7-451c-43f4-a4f4-9352f6e7ad72) |

## 🧪 Testing

- [ ] Visit [this preview](https://tutorials-git-1396-hashicorp.vercel.app/terraform/tutorials/modules/module-use), and using browser inspect, replace the `overflow-y: auto` property with `overflow: visible`
    - The `.sidecarTopSlot` should no longer have scrolling overflow
    - Then the variants dropdown is open, the dropdown pane should be visible

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsfix-sidecar-overflow-hashicorp.vercel.app/