### PR TITLE
feat: adds waf variant support

### DIFF
--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -13,6 +13,8 @@ import DevDotContent from 'components/dev-dot-content'
 import { OutlineNavWithActive } from 'components/outline-nav/components'
 import MDX_COMPONENTS from 'views/tutorial-view/utils/mdx-components'
 import { FeaturedInCollections } from 'views/tutorial-view/components'
+import VariantProvider from 'views/tutorial-view/utils/variants/context'
+import { VariantDropdownDisclosure } from 'views/tutorial-view/components'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import { NextPrevious } from 'views/tutorial-view/components'
 import { generateCanonicalUrl } from 'views/tutorial-view/utils'
@@ -36,6 +38,7 @@ export default function WellArchitectedFrameworkTutorialView({
 		content,
 		collectionCtx,
 		nextPreviousData,
+		variant,
 	} = tutorial
 	const hasVideo = Boolean(video)
 	const isInteractive = Boolean(handsOnLab)
@@ -55,40 +58,47 @@ export default function WellArchitectedFrameworkTutorialView({
 				key={slug}
 				{...(isInteractive && { labId: handsOnLab.id })}
 			>
-				<SidebarSidecarLayout
-					sidecarSlot={<OutlineNavWithActive items={outlineItems.slice()} />}
-					breadcrumbLinks={layoutProps.breadcrumbLinks}
-					sidebarNavDataLevels={layoutProps.navLevels}
-					mainWidth="narrow"
-				>
-					<TutorialMeta
-						heading={pageHeading}
-						meta={{
-							readTime,
-							edition,
-							productsUsed,
-							isInteractive,
-							hasVideo,
-						}}
-						tutorialId={id}
-					/>
-					{video?.id && !video.videoInline && (
-						<VideoEmbed
-							url={getVideoUrl({
-								videoId: video.id,
-								videoHost: video.videoHost,
-							})}
+				<VariantProvider variant={variant}>
+					<SidebarSidecarLayout
+						sidecarSlot={<OutlineNavWithActive items={outlineItems.slice()} />}
+						breadcrumbLinks={layoutProps.breadcrumbLinks}
+						sidebarNavDataLevels={layoutProps.navLevels}
+						mainWidth="narrow"
+						sidecarTopSlot={
+							variant ? (
+								<VariantDropdownDisclosure variant={variant} isFullWidth />
+							) : null
+						}
+					>
+						<TutorialMeta
+							heading={pageHeading}
+							meta={{
+								readTime,
+								edition,
+								productsUsed,
+								isInteractive,
+								hasVideo,
+							}}
+							tutorialId={id}
 						/>
-					)}
-					<DevDotContent
-						mdxRemoteProps={{ ...content, components: MDX_COMPONENTS }}
-					/>
-					<NextPrevious {...nextPreviousData} />
-					<FeaturedInCollections
-						className={s.featuredInCollections}
-						collections={featuredInWithoutCurrent}
-					/>
-				</SidebarSidecarLayout>
+						{video?.id && !video.videoInline && (
+							<VideoEmbed
+								url={getVideoUrl({
+									videoId: video.id,
+									videoHost: video.videoHost,
+								})}
+							/>
+						)}
+						<DevDotContent
+							mdxRemoteProps={{ ...content, components: MDX_COMPONENTS }}
+						/>
+						<NextPrevious {...nextPreviousData} />
+						<FeaturedInCollections
+							className={s.featuredInCollections}
+							collections={featuredInWithoutCurrent}
+						/>
+					</SidebarSidecarLayout>
+				</VariantProvider>
 			</InteractiveLabWrapper>
 		</>
 	)

--- a/src/views/well-architected-framework/tutorial-view/server.ts
+++ b/src/views/well-architected-framework/tutorial-view/server.ts
@@ -22,11 +22,14 @@ import { EnrichedNavItem } from 'components/sidebar/types'
 import { generateWafCollectionSidebar } from 'views/well-architected-framework/utils/generate-collection-sidebar'
 import { getNextPrevious } from 'views/tutorial-view/components'
 import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items-from-headings'
+import { getTutorialViewVariantData } from 'views/tutorial-view/utils/variants'
 import { WafTutorialViewProps } from '../types'
 
 export async function getWafTutorialViewProps(
-	tutorialSlug: [string, string]
+	fullSlug: [string, string] | [string, string, string] // Third option is a variant
 ): Promise<{ props: WafTutorialViewProps }> {
+	// Remove the variant from the slug
+	const tutorialSlug = fullSlug.slice(0, 2) as [string, string]
 	const [collectionFilename, tutorialFilename] = tutorialSlug
 	const currentPath = `/${wafData.slug}/${tutorialSlug.join('/')}`
 
@@ -52,6 +55,12 @@ export async function getWafTutorialViewProps(
 	if (fullTutorialData === null) {
 		return null
 	}
+
+	const variantSlug = fullSlug[2]
+	const variant = getTutorialViewVariantData(
+		variantSlug,
+		fullTutorialData.variant
+	)
 
 	const { content: serializedContent, headings } = await serializeContent(
 		fullTutorialData
@@ -121,6 +130,7 @@ export async function getWafTutorialViewProps(
 							`/${collectionSlug}/${splitProductFromFilename(tutorialSlug)}`,
 					},
 				}),
+				variant,
 			},
 			pageHeading,
 			outlineItems,

--- a/src/views/well-architected-framework/types.ts
+++ b/src/views/well-architected-framework/types.ts
@@ -13,6 +13,7 @@ import { OverviewCtaProps } from 'views/product-landing/components/overview-cta/
 import { ProductViewBlock } from 'views/product-tutorials-view/components/product-view-content'
 import { TutorialData } from 'views/tutorial-view'
 import { OutlineLinkItem } from 'components/outline-nav/types'
+import { TutorialViewProps } from 'views/tutorial-view'
 
 export interface WellArchitectedFrameworkLandingProps {
 	metadata: {
@@ -51,6 +52,7 @@ export interface WellArchitectedFrameworkCollectionViewProps {
 export interface WafTutorialViewProps {
 	tutorial: TutorialData & {
 		nextPreviousData: NextPreviousProps
+		variant?: TutorialViewProps['metadata']['variant']
 	}
 	pageHeading: {
 		slug: string


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-waf-variants-support-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204650842219622) 🎟️

## 🗒️ What

Adds variants support to waf tutorials.

## 🧪 Testing

There isn't any waf tutorials in the staging api with variants data. I tested this locally with manually seeded api data and validated that it works as expected. 

<img width="1465" alt="Screenshot 2023-06-15 at 3 01 28 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/754d6dee-c21f-4efd-88f0-add9288adcaa">


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
