### PR TITLE
chore: clean up basePaths

### DIFF
--- a/src/contexts/__tests__/current-product.test.tsx
+++ b/src/contexts/__tests__/current-product.test.tsx
@@ -25,7 +25,6 @@ const setup = (currentProduct: Product) => {
 				algoliaConfig: {
 					indexName: '',
 				},
-				basePaths: [],
 				rootDocsPaths: [],
 				integrationsConfig: {},
 			}}

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -30,15 +30,6 @@ See the `ProductSlug` type defined in [`types/products.ts`](/src/types/products.
 
 </details>
 
-<!-- basePaths -->
-
-<details>
-<summary><code>basePaths</code></summary>
-
-🚧 DEPRECATED - this property is being replaced by the `rootDocsPaths` property. The new property is detailed in the next section. 🚧
-
-</details>
-
 <!-- rootDocsPaths -->
 
 <details>

--- a/src/data/boundary.json
+++ b/src/data/boundary.json
@@ -56,7 +56,6 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "api-docs", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/consul.json
+++ b/src/data/consul.json
@@ -30,7 +30,6 @@
 	},
 	"version": "1.11.3",
 	"subnavItems": [],
-	"basePaths": ["docs", "api-docs", "commands", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/hcp.json
+++ b/src/data/hcp.json
@@ -5,7 +5,6 @@
 		"indexName": "product_HCP",
 		"searchOnlyApiKey": "1162c7d22059acafddb62badfdf68f35"
 	},
-	"basePaths": ["docs", "api-docs/packer"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/nomad.json
+++ b/src/data/nomad.json
@@ -72,7 +72,6 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "api-docs", "plugins", "tools", "intro", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/packer.json
+++ b/src/data/packer.json
@@ -29,7 +29,6 @@
 		"expirationDate": ""
 	},
 	"version": "1.7.10",
-	"basePaths": ["docs", "guides", "intro", "plugins", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/sentinel.json
+++ b/src/data/sentinel.json
@@ -53,7 +53,6 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "intro", "downloads"],
 	"rootDocsPaths": [
 		{
 			"basePathForLoader": "sentinel",

--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -4,25 +4,6 @@
 	"algoliaConfig": {
 		"indexName": "product_TERRAFORM"
 	},
-	"basePaths": [
-		"cdktf",
-		"cli",
-		"cloud-docs",
-		"cloud-docs/agents",
-		"docs",
-		"enterprise",
-		"internals",
-		"intro",
-		"language",
-		"plugin",
-		"plugin/framework",
-		"plugin/log",
-		"plugin/mux",
-		"plugin/sdkv2",
-		"plugin/testing",
-		"registry",
-		"downloads"
-	],
 	"docsNavItems": [
 		"docs",
 		"language",

--- a/src/data/vagrant.json
+++ b/src/data/vagrant.json
@@ -47,7 +47,6 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "intro", "vagrant-cloud", "vmware", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -145,7 +145,6 @@
 			"os": "linux"
 		}
 	],
-	"basePaths": ["docs", "api-docs", "intro", "tutorials", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/waypoint.json
+++ b/src/data/waypoint.json
@@ -59,7 +59,6 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["commands", "docs", "plugins", "tutorials", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/get-is-external-docs-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/get-is-external-docs-link.test.ts
@@ -21,7 +21,9 @@ describe('getIsRewriteableDocsLink', () => {
 
 	Object.keys(productSlugsToHostNames).forEach((slug: ProductSlug) => {
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const basePaths = require(`data/${slug}.json`).basePaths
+		const basePaths = require(`data/${slug}.json`).rootDocsPaths.map(
+			(e) => e.path
+		)
 		const hostname = productSlugsToHostNames[slug]
 		const origin = `https://${hostname}`
 

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-is-rewriteable-docs-link.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-is-rewriteable-docs-link.ts
@@ -47,7 +47,7 @@ const getIsRewriteableDocsLink = (link: string): boolean => {
 		 */
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const productData = require(`data/${productSlug}.json`) as ProductData
-		const acceptedBasePaths = productData.basePaths
+		const acceptedBasePaths = productData.rootDocsPaths.map((e) => e.path)
 		if (acceptedBasePaths.includes('api-docs')) {
 			acceptedBasePaths.push('api')
 		}

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -149,7 +149,6 @@ interface ProductData extends Product {
 	algoliaConfig: {
 		indexName: string
 	}
-	basePaths: string[]
 	rootDocsPaths: RootDocsPath[]
 	/**
 	 * When configuring docsNavItems, authors have the option to specify

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -132,9 +132,9 @@ export function rewriteDocsUrl(
 	}
 
 	// Prefix docs URLs. "/docs/some-path" becomes "/waypoint/docs/some-path"
-	const isCurrentProductDocsUrl = currentProduct.basePaths.some(
-		(basePath: string) => inputUrl.startsWith(`/${basePath}`)
-	)
+	const isCurrentProductDocsUrl = currentProduct.rootDocsPaths
+		.map((e) => e.path)
+		.some((basePath: string) => inputUrl.startsWith(`/${basePath}`))
 	const isProductPath = new RegExp(`^/(${productSlugs.join('|')})`)
 
 	if (isCurrentProductDocsUrl) {
@@ -205,7 +205,8 @@ function rewriteSentinelDocsUrls(
 	 * - Any other "/sentinel/:slug" URL is expected to be a "/docs" URL
 	 *   - We need to adjust these urls to be "/sentinel/docs/:slug"
 	 */
-	const isBasePathExceptDocs = sentinelData.basePaths
+	const isBasePathExceptDocs = sentinelData.rootDocsPaths
+		.map((e) => e.path)
 		.filter((p: string) => p !== 'docs')
 		.some(
 			(basePath: string) =>


### PR DESCRIPTION
# What

Remove deprecated `basePaths`; Update references to use `rootDocsPaths`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204865849100155