### PR TITLE
Updated vault-operations-professional.mdx

### DIFF
--- a/src/content/certifications/exam-faqs/vault-operations-professional.mdx
+++ b/src/content/certifications/exam-faqs/vault-operations-professional.mdx
@@ -25,7 +25,7 @@ We strongly recommend passing the associate-level Vault exam before taking the p
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Assessment Type** | Lab-based and multiple choice                                                                                                                          |
 | **Format**          | Online proctored                                                                                                                                       |
-| **Duration**        | 4 hours                                                                                                                                                |
+| **Duration**        | 4 hours; 15-minute break included                                                                                                                      |
 | **Price**           | $295 USD, plus locally applicable taxes and fees. [Includes free retake](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/360049773991). |
 | **Language**        | English                                                                                                                                                |
 | **Expiration**      | 2 years                                                                                                                                                |


### PR DESCRIPTION
Added information on the 15-min break that comes with the appointment

## 🔗 Relevant links

<!--
-->

- [Preview link](https://dev-portal-git-eganhashicorp-patch-1-hashicorp.vercel.app/certifications/security-automation) 🔎
- [Asana task](https://app.asana.com/0/1155877155450049/1204728308498735/f) 🎟️

## 🗒️ What

Added a few words explaining that a 15-min break can be taken during the exam

## 🤷 Why

Support tickets asking about breaks made us realize we did not advertise the break externally
