### PR TITLE
chore: remove `App.getInitialProps`

### DIFF
--- a/src/components/head-metadata/index.tsx
+++ b/src/components/head-metadata/index.tsx
@@ -61,7 +61,7 @@ export default function HeadMetadata(props: HeadMetadataProps) {
 	)
 
 	const ogImagePath = props.localOgImage || `${productSlug ?? 'base'}.jpg`
-	const ogImageUrl = `${getDeployedUrl(props.host)}/og-image/${ogImagePath}`
+	const ogImageUrl = `${getDeployedUrl()}/og-image/${ogImagePath}`
 
 	return (
 		// TODO: OpenGraph image to be passed as the image prop here

--- a/src/components/head-metadata/types.ts
+++ b/src/components/head-metadata/types.ts
@@ -15,11 +15,6 @@ export interface HeadMetadataProps {
 	description?: string
 
 	/**
-	 * Optional host value, such as 'localhost:3000', used during development
-	 */
-	host?: string
-
-	/**
 	 * Optional custom image path to use as the og-image, relative to
 	 * the `/public/og-image` folder.
 	 */

--- a/src/lib/get-deployed-url.ts
+++ b/src/lib/get-deployed-url.ts
@@ -9,14 +9,14 @@
  *
  * Returns an empty string in development.
  */
-export default function getDeployedUrl(host?: string) {
+export default function getDeployedUrl() {
 	// preview deployments should derive the url from Vercel's env var
 	if (process.env.HASHI_ENV === 'preview') {
 		return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
 	}
 
 	if (process.env.HASHI_ENV === 'development') {
-		return host ? `http://${host}` : ''
+		return process.env.HOST_NAME || `http://localhost:3000`
 	}
 
 	// use our canonical URL for production

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -69,8 +69,7 @@ addGlobalLinkHandler((destinationUrl: string) => {
 export default function App({
 	Component,
 	pageProps: { session, ...pageProps },
-	host,
-}: CustomAppProps & Awaited<ReturnType<(typeof App)['getInitialProps']>>) {
+}: CustomAppProps) {
 	const flagBag = useFlags()
 	useAnchorLinkAnalytics()
 	useEffect(() => makeDevAnalyticsLogger(), [])

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -112,7 +112,7 @@ export default function App({
 									<DeviceSizeProvider>
 										<CurrentProductProvider currentProduct={currentProduct}>
 											<CodeTabsProvider>
-												<HeadMetadata {...pageProps.metadata} host={host} />
+												<HeadMetadata {...pageProps.metadata} />
 												<LazyMotion
 													features={() =>
 														import('lib/framer-motion-features').then(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import React, { useEffect, useState, ComponentType } from 'react'
+import React, { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { SSRProvider } from '@react-aria/ssr'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -28,7 +28,7 @@ import useAnchorLinkAnalytics from '@hashicorp/platform-util/anchor-link-analyti
 import CodeTabsProvider from '@hashicorp/react-code-block/provider'
 
 // Global imports
-import type { CustomAppProps, CustomAppContext } from 'types/_app'
+import type { CustomAppProps } from 'types/_app'
 import {
 	CurrentContentTypeProvider,
 	CurrentProductProvider,
@@ -142,27 +142,4 @@ export default function App({
 			</SSRProvider>
 		</QueryClientProvider>
 	)
-}
-
-App.getInitialProps = async ({
-	Component,
-	ctx,
-}: CustomAppContext<{ Component: ComponentType }>) => {
-	let pageProps = {}
-
-	if (Component.getInitialProps) {
-		pageProps = await Component.getInitialProps(ctx)
-	}
-
-	let host
-	if (ctx.req) {
-		host = ctx.req.headers.host
-	} else {
-		host = window.location.host
-	}
-
-	return {
-		pageProps,
-		host,
-	}
 }

--- a/src/types/_app.ts
+++ b/src/types/_app.ts
@@ -5,7 +5,7 @@
 
 import { FC } from 'react'
 import type { NextPage } from 'next'
-import type { AppProps, AppContext } from 'next/app'
+import type { AppProps } from 'next/app'
 import { CurrentContentType } from 'contexts'
 import { GlobalThemeOption } from 'styles/themes/types'
 
@@ -22,18 +22,9 @@ type ContextWithLayout = {
 	Component: CustomPageComponent
 }
 
-type AppContextNoComponent = Omit<AppContext, 'Component'>
-
-/**
- * This is our custom param type for `App.getInitialProps`
- */
-type CustomAppContext<T = Record<string, unknown>> = AppContextNoComponent &
-	ContextWithLayout &
-	T
-
 /**
  * This is our custom type for our Next.js `App` component
  */
 type CustomAppProps = AppProps<$TSFixMe> & ContextWithLayout
 
-export type { CustomPageComponent, CustomAppContext, CustomAppProps }
+export type { CustomPageComponent, CustomAppProps }


### PR DESCRIPTION
# What

This removes our usage of the legacy `getInitialProps` API
- The Next.js docs mark this as a legacy API. https://nextjs.org/docs/pages/api-reference/functions/get-initial-props

See PR diff comments for a more detailed explanation.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204865849100226