### PR TITLE
feat(unified-search): revise suggested pages design

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,6 @@
 		"max_static_paths": 1
 	},
 	"flags": {
-		"enable_unified_search": false
+		"enable_unified_search": true
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,6 +4,6 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_unified_search": false
+		"enable_unified_search": true
 	}
 }

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -16,8 +16,9 @@ import {
 import { useCommandBar } from 'components/command-bar'
 // Shared search
 import { generateSuggestedPages } from '../../../helpers'
-import { RecentSearches, SuggestedPages } from '../../../components'
+import { RecentSearches } from '../../../components'
 // Unified search
+import SuggestedPages from '../suggested-pages'
 import { UnifiedHitsContainer } from '../unified-hits-container'
 import { gatherSearchTabsData } from '../unified-hits-container/helpers'
 import {

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
@@ -3,27 +3,51 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {
-	CommandBarLinkListItem,
-	CommandBarList,
-} from 'components/command-bar/components'
-import { SuggestedPage, SuggestedPagesProps } from './types'
+import Text from 'components/text'
+import LinkRegion from 'components/link-region'
+import IconTile from 'components/icon-tile'
+import { CommandBarList } from 'components/command-bar/components'
+import { SuggestedPageProps } from './types'
+// Styles
+import s from './suggested-page.module.css'
 
-const SuggestedPages = ({ pages }: SuggestedPagesProps) => {
+/**
+ * Renders a single suggested page list item.
+ */
+function SuggestedPage({ icon, url, text }: SuggestedPageProps) {
 	return (
-		<CommandBarList label="Suggested Pages">
-			{pages.map((page: SuggestedPage) => (
-				<div key={page.url} style={{ border: '1px solid magenta' }}>
-					<CommandBarLinkListItem
-						icon={page.icon}
-						title={page.text}
-						url={page.url}
+		<LinkRegion className={s.root} href={url} ariaLabel={text}>
+			<div className={s.content}>
+				<IconTile className={s.icon} size="small">
+					{icon}
+				</IconTile>
+				<div className={s.content}>
+					<Text
+						dangerouslySetInnerHTML={{ __html: text }}
+						asElement="span"
+						className={s.text}
+						size={300}
+						weight="medium"
 					/>
 				</div>
+			</div>
+		</LinkRegion>
+	)
+}
+
+/**
+ * Renders a list of suggested search result pages.
+ */
+function SuggestedPages({ pages }: { pages: SuggestedPageProps[] }) {
+	return (
+		<CommandBarList label="Suggested Pages">
+			{pages.map(({ url, icon, text }: SuggestedPageProps) => (
+				<li key={url}>
+					<SuggestedPage icon={icon} text={text} url={url} />
+				</li>
 			))}
 		</CommandBarList>
 	)
 }
 
-export type { SuggestedPage, SuggestedPagesProps }
 export default SuggestedPages

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import {
+	CommandBarLinkListItem,
+	CommandBarList,
+} from 'components/command-bar/components'
+import { SuggestedPage, SuggestedPagesProps } from './types'
+
+const SuggestedPages = ({ pages }: SuggestedPagesProps) => {
+	return (
+		<CommandBarList label="Suggested Pages">
+			{pages.map((page: SuggestedPage) => (
+				<div key={page.url} style={{ border: '1px solid magenta' }}>
+					<CommandBarLinkListItem
+						icon={page.icon}
+						title={page.text}
+						url={page.url}
+					/>
+				</div>
+			))}
+		</CommandBarList>
+	)
+}
+
+export type { SuggestedPage, SuggestedPagesProps }
+export default SuggestedPages

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/index.tsx
@@ -21,15 +21,13 @@ function SuggestedPage({ icon, url, text }: SuggestedPageProps) {
 				<IconTile className={s.icon} size="small">
 					{icon}
 				</IconTile>
-				<div className={s.content}>
-					<Text
-						dangerouslySetInnerHTML={{ __html: text }}
-						asElement="span"
-						className={s.text}
-						size={300}
-						weight="medium"
-					/>
-				</div>
+				<Text
+					dangerouslySetInnerHTML={{ __html: text }}
+					asElement="span"
+					className={s.text}
+					size={300}
+					weight="medium"
+				/>
 			</div>
 		</LinkRegion>
 	)

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
@@ -1,0 +1,34 @@
+.root {
+	--border-radius: 5px;
+
+	border-radius: var(--border-radius);
+	padding: 8px;
+
+	&:hover {
+		background: var(--token-color-surface-strong);
+		box-shadow: var(--token-surface-base-box-shadow);
+		cursor: pointer;
+	}
+}
+
+.content {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.icon {
+	flex-shrink: 0;
+
+	@media (--dev-dot-mobile) {
+		display: none;
+	}
+}
+
+.text {
+	color: var(--token-color-foreground-strong);
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
@@ -14,7 +14,7 @@
 .content {
 	display: flex;
 	align-items: center;
-	gap: 12px;
+	gap: 8px;
 }
 
 .icon {

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/suggested-page.module.css
@@ -18,6 +18,7 @@
 }
 
 .icon {
+	color: var(--token-color-foreground-primary);
 	flex-shrink: 0;
 
 	@media (--dev-dot-mobile) {

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/types.ts
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { ReactElement } from 'react'
+
+interface SuggestedPage {
+	icon: ReactElement
+	text: string
+	url: string
+}
+
+interface SuggestedPagesProps {
+	pages: SuggestedPage[]
+}
+
+export type { SuggestedPage, SuggestedPagesProps }

--- a/src/components/command-bar/commands/search/unified-search/components/suggested-pages/types.ts
+++ b/src/components/command-bar/commands/search/unified-search/components/suggested-pages/types.ts
@@ -5,14 +5,10 @@
 
 import { ReactElement } from 'react'
 
-interface SuggestedPage {
+interface SuggestedPageProps {
 	icon: ReactElement
 	text: string
 	url: string
 }
 
-interface SuggestedPagesProps {
-	pages: SuggestedPage[]
-}
-
-export type { SuggestedPage, SuggestedPagesProps }
+export type { SuggestedPageProps }

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
@@ -3,13 +3,9 @@ import Tabs, { Tab } from 'components/tabs'
 import { CommandBarDivider } from 'components/command-bar/components'
 import { CommandBarList } from 'components/command-bar/components'
 // Shared search
-import {
-	NoResultsMessage,
-	SuggestedPage,
-	SuggestedPages,
-	TabHeadingWithCount,
-} from '../../../components'
+import { NoResultsMessage, TabHeadingWithCount } from '../../../components'
 // Unified search
+import SuggestedPages, { SuggestedPage } from '../suggested-pages'
 import { UnifiedHit } from '../unified-hit'
 import { getUnifiedHitProps } from '../unified-hit/helpers'
 // Types

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
@@ -5,12 +5,13 @@ import { CommandBarList } from 'components/command-bar/components'
 // Shared search
 import { NoResultsMessage, TabHeadingWithCount } from '../../../components'
 // Unified search
-import SuggestedPages, { SuggestedPage } from '../suggested-pages'
+import SuggestedPages from '../suggested-pages'
 import { UnifiedHit } from '../unified-hit'
 import { getUnifiedHitProps } from '../unified-hit/helpers'
 // Types
 import type { Hit } from 'instantsearch.js'
 import type { UnifiedSearchTabContent } from './helpers'
+import type { SuggestedPageProps } from '../suggested-pages/types'
 // Styles
 import s from './unified-hits-container.module.css'
 
@@ -22,7 +23,7 @@ export function UnifiedHitsContainer({
 	suggestedPages,
 }: {
 	tabsData: UnifiedSearchTabContent[]
-	suggestedPages: SuggestedPage[]
+	suggestedPages: SuggestedPageProps[]
 }) {
 	return (
 		<div className={s.tabsWrapper}>
@@ -50,10 +51,9 @@ export function UnifiedHitsContainer({
 									<div className={s.commandBarListWrapper}>
 										<CommandBarList ariaLabelledBy={resultsLabelId}>
 											{hits.map((hit: Hit) => (
-												<UnifiedHit
-													key={hit.objectID}
-													{...getUnifiedHitProps(hit)}
-												/>
+												<li key={hit.objectID}>
+													<UnifiedHit {...getUnifiedHitProps(hit)} />
+												</li>
 											))}
 										</CommandBarList>
 										{/* TODO: add suggested pages */}

--- a/src/components/link-region/link-region.module.css
+++ b/src/components/link-region/link-region.module.css
@@ -20,6 +20,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
+	user-select: none;
 
 	/* makes the whole region clickable */
 	&::before {


### PR DESCRIPTION
> **Note**: 🚧 should disable `development` and `preview` flags for unified search before merging.

---

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Revises the "suggested page" list items in the unified search modal, to match designs.

## 🛠️ How

- Ejects from the existing `SuggestedPages` component, builds a new one for unified search

## 📸 Design Screenshots

Empty query

| Before | After |
| - | - |
| ![empty-before](https://github.com/hashicorp/dev-portal/assets/4624598/55a96672-f23d-4d10-92b5-6e3615283a41) | ![empty-after](https://github.com/hashicorp/dev-portal/assets/4624598/28fc88d1-3923-4041-95c2-88f4a42be35a) |

Query with zero results

| Before | After |
| - | - |
| ![noresults-before](https://github.com/hashicorp/dev-portal/assets/4624598/5847b2aa-08bb-49bf-8272-a7dbbfdfd1a8) | ![noresults-after](https://github.com/hashicorp/dev-portal/assets/4624598/cbf285a7-4cee-4145-bd4e-46969f5c7386) |

## 🧪 Testing

- [ ] Visit the [preview]
    - When opening the search modal, suggested pages should appear, and should match [designs]
    - When a query returns zero results in a given tab, suggested pages should appear, and should match [designs]

## 💭 Anything else?

Not at the moment.

[task]: https://app.asana.com/0/1204333060736722/1204910642466493/f
[preview]: https://dev-portal-git-zsunified-search-suggested-page-b3f2e9-hashicorp.vercel.app/
[designs]: https://www.figma.com/file/O3gJUgXVTuPQn6GpjcZO9T/Search?type=design&node-id=218-15512&mode=design&t=0cmkZyeAWnem2E9P-4