### PR TITLE
_app/layouts: remove `.theme` usage

### DIFF
--- a/src/layouts/base-new/index.tsx
+++ b/src/layouts/base-new/index.tsx
@@ -59,7 +59,6 @@ const NonProductPageMobileMenu = () => {
 const BaseNewLayout = ({
 	children,
 	showFooterTopBorder = false,
-	theme,
 }: BaseNewLayoutProps) => {
 	const router = useRouter()
 
@@ -84,7 +83,7 @@ const BaseNewLayout = ({
 					hideOnMobile
 				/>
 			)}
-			<CoreDevDotLayoutWithTheme theme={theme}>
+			<CoreDevDotLayoutWithTheme>
 				<div className={s.root} data-layout="base-new">
 					<div className={s.header}>
 						<NavigationHeader />

--- a/src/layouts/base-new/types.ts
+++ b/src/layouts/base-new/types.ts
@@ -5,7 +5,6 @@
 
 import { ReactNode } from 'react'
 import { Products as HashiCorpProduct } from '@hashicorp/platform-product-meta'
-import { GlobalThemeOption } from 'styles/themes/types'
 
 interface BaseNewLayoutProps {
 	/**
@@ -18,7 +17,6 @@ interface BaseNewLayoutProps {
 	 * the footer from the page contents above.
 	 */
 	showFooterTopBorder?: boolean
-	theme?: GlobalThemeOption
 }
 
 interface AlertBannerProps {

--- a/src/layouts/core-dev-dot-layout/index.tsx
+++ b/src/layouts/core-dev-dot-layout/index.tsx
@@ -12,7 +12,6 @@ import { makeDarkModeToast } from 'lib/toast/make-dark-mode-notification'
 import isThemedPath from 'lib/isThemedPath'
 import { MobileMenuProvider } from 'contexts'
 import TabProvider from 'components/tabs/provider'
-import { GlobalThemeOption } from 'styles/themes/types'
 import { CoreDevDotLayoutProps } from './types'
 import s from './core-dev-dot-layout.module.css'
 
@@ -42,13 +41,10 @@ const CoreDevDotLayout = ({ children }: CoreDevDotLayoutProps) => {
 	)
 }
 
-export function CoreDevDotLayoutWithTheme(
-	props: CoreDevDotLayoutProps & { theme?: GlobalThemeOption }
-) {
-	const { theme, ...restProps } = props
+export function CoreDevDotLayoutWithTheme(props: CoreDevDotLayoutProps) {
 	return (
-		<ThemeProvider disableTransitionOnChange forcedTheme={theme || null}>
-			<CoreDevDotLayout {...restProps} />
+		<ThemeProvider disableTransitionOnChange>
+			<CoreDevDotLayout {...props} />
 		</ThemeProvider>
 	)
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -95,12 +95,6 @@ export default function App({
 	const currentContentType = Component.contentType ?? 'global'
 	const currentProduct = pageProps.product || null
 
-	/**
-	 * TODO: refactor this so that pageProps.layoutProps is the only place where
-	 * layoutProps come from.
-	 */
-	const allLayoutProps = { theme: Component.theme, ...pageProps.layoutProps }
-
 	return (
 		<QueryClientProvider client={queryClient}>
 			<SSRProvider>
@@ -121,7 +115,7 @@ export default function App({
 													}
 													strict={process.env.NODE_ENV === 'development'}
 												>
-													<Layout {...allLayoutProps}>
+													<Layout {...pageProps.layoutProps}>
 														<Component {...pageProps} />
 													</Layout>
 													<Toaster />

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -7,7 +7,6 @@
 import { ReactElement } from 'react'
 
 // Global imports
-import { GlobalThemeOption } from 'styles/themes/types'
 import BaseNewLayout from 'layouts/base-new'
 
 // Local imports


### PR DESCRIPTION
# Description

This continues off https://github.com/hashicorp/dev-portal/pull/2027 and cleans up no longer used `.theme` code after #2007 

> **Note**: See https://github.com/hashicorp/dev-portal/pull/2007/files#r1242886411 for the last identified case of `<PageComponent>.theme`