### PR TITLE
fix: update DocsVersionAlertBanner to gracefully handle null versions

### DIFF
--- a/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
+++ b/src/layouts/docs-view-layout/components/docs-version-alert/index.tsx
@@ -29,7 +29,11 @@ function DocsVersionAlertBanner({
 		return null
 	}
 
-	// find curent version in list of versions, to give VersionAlertBanner access to VersionSelectItem's releaseStage and label
+	if (!versions || versions?.length === 0) {
+		return null
+	}
+
+	// find current version in list of versions, to give VersionAlertBanner access to VersionSelectItem's releaseStage and label
 	const { releaseStage, label } = versions.find(
 		(currentVersion: VersionSelectItem) =>
 			currentVersion.version === versionFromPath


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
There are some errors showing up in Datadog that look like this:
```
ERROR	TypeError: Cannot read properties of null (reading 'find')
	at DocsVersionAlertBanner (/var/task/.next/server/chunks/3864.js:1088:48)
	...
```

I've updated the component to gracefully handle the scenario where `versions` is `null`. This should hopefully mitigate the number of errors we see that look like this.