### PR TITLE
adds ctaSlot to inline alert, updates nomad downloads

### DIFF
--- a/src/components/inline-alert/docs.mdx
+++ b/src/components/inline-alert/docs.mdx
@@ -12,6 +12,7 @@ The `InlineAlert` component is currently used in long-form MDX content to highli
 | `description` | The alert body text to render.                             | Yes       | Undefined     | string                                   |
 | `color`       | The color theme with associated styles.                    | No        | Neutral       | neutral, highlight, warning, or critical |
 | `icon`        | An option to pass a 24x24 icon to render next to the title | No        | Info icon     | svg                                      |
+| `ctaSlot`     | An optional slot to render buttons or another CTA link     | No        | Undefined     | ReactNode                                |
 
 ## Playground
 

--- a/src/components/inline-alert/index.tsx
+++ b/src/components/inline-alert/index.tsx
@@ -14,6 +14,7 @@ export default function InlineAlert({
 	description,
 	icon = <IconInfo24 />,
 	title,
+	ctaSlot,
 }: InlineAlertProps) {
 	return (
 		<div className={classNames(s.default, s[color], className)}>
@@ -23,6 +24,7 @@ export default function InlineAlert({
 			<span className={s.content}>
 				<p className={s.title}>{title}</p>
 				<span className={s.description}>{description}</span>
+				{ctaSlot ? <span className={s.ctaSlot}>{ctaSlot}</span> : null}
 			</span>
 		</div>
 	)

--- a/src/components/inline-alert/inline-alert.module.css
+++ b/src/components/inline-alert/inline-alert.module.css
@@ -50,6 +50,11 @@
 	}
 }
 
+.ctaSlot {
+	width: fit-content;
+	margin-top: 16px;
+}
+
 .highlight {
 	--background-color: var(--token-color-palette-purple-50);
 	--accent-color: var(--token-color-foreground-highlight-on-surface);

--- a/src/components/inline-alert/types.ts
+++ b/src/components/inline-alert/types.ts
@@ -7,6 +7,7 @@ import { type ReactNode, type ReactElement } from 'react'
 
 export interface InlineAlertProps {
 	className?: string
+	ctaSlot?: ReactNode
 	color?: 'neutral' | 'highlight' | 'warning' | 'critical'
 	description: ReactNode
 	icon?: ReactElement<React.JSX.IntrinsicElements['svg']>

--- a/src/pages/nomad/downloads/index.tsx
+++ b/src/pages/nomad/downloads/index.tsx
@@ -3,29 +3,32 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { IconDownload16 } from '@hashicorp/flight-icons/svg-react/download-16'
 import nomadData from 'data/nomad.json'
 import { ProductData } from 'types/products'
 import ProductDownloadsView from 'views/product-downloads-view'
 import { generateGetStaticProps } from 'views/product-downloads-view/server'
-import Card from 'components/card'
-import InlineLink from 'components/inline-link'
-import Text from 'components/text'
-import s from './style.module.css'
+import InlineAlert from 'components/inline-alert'
+import ButtonLink from 'components/button-link'
 
 const NomadDownloadsPage = (props) => {
 	return (
 		<ProductDownloadsView
 			{...props}
 			merchandisingSlot={
-				<Card className={s.card} elevation="base">
-					<Text asElement="span">
-						A beta for Nomad v1.6.0 is available! The release can be{' '}
-						<InlineLink href="https://releases.hashicorp.com/nomad/1.6.0-beta.1/">
-							downloaded here
-						</InlineLink>
-						.
-					</Text>
-				</Card>
+				<InlineAlert
+					title="New beta release!"
+					description="A beta for Nomad v1.6.0 is available."
+					ctaSlot={
+						<ButtonLink
+							size="small"
+							color="secondary"
+							text="Download"
+							icon={<IconDownload16 />}
+							href="https://releases.hashicorp.com/nomad/1.6.0-beta.1/"
+						/>
+					}
+				/>
 			}
 		/>
 	)

--- a/src/pages/nomad/downloads/index.tsx
+++ b/src/pages/nomad/downloads/index.tsx
@@ -10,6 +10,7 @@ import ProductDownloadsView from 'views/product-downloads-view'
 import { generateGetStaticProps } from 'views/product-downloads-view/server'
 import InlineAlert from 'components/inline-alert'
 import ButtonLink from 'components/button-link'
+import s from './style.module.css'
 
 const NomadDownloadsPage = (props) => {
 	return (
@@ -21,8 +22,10 @@ const NomadDownloadsPage = (props) => {
 					description="A beta for Nomad v1.6.0 is available."
 					ctaSlot={
 						<ButtonLink
+							aria-label="Download beta for Nomad v.1.6.0"
+							className={s.downloadLink}
 							size="small"
-							color="secondary"
+							color="tertiary"
 							text="Download"
 							icon={<IconDownload16 />}
 							href="https://releases.hashicorp.com/nomad/1.6.0-beta.1/"

--- a/src/pages/nomad/downloads/style.module.css
+++ b/src/pages/nomad/downloads/style.module.css
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.card {
-	background-color: var(--token-color-surface-faint);
-	border-color: var(token-color-border-strong);
-	color: var(--token-color-foreground-primary);
+.downloadLink {
+	margin-left: -11px;
+	margin-top: -6px;
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksupdate-nomad-downloads-inline-alert-hashicorp.vercel.app/nomad/downloads) 🔎
- [Asana task](https://app.asana.com/0/1199634971449915/1204909025833155) 🎟️

## 🗒️ What

<img width="1060" alt="Screenshot 2023-06-28 at 2 28 56 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/568a3846-8f25-4aee-8f9f-a4bf21505944">

This PR adds a `ctaSlot` to the inline alert component and updates the nomad downloads alert to use inline alert. [Slack context. ](https://hashicorp.slack.com/archives/C01KCU4HDPY/p1687972000198179?thread_ts=1687969517.288049&cid=C01KCU4HDPY)

## 📸 Design Screenshots


![Group 1860](https://github.com/hashicorp/dev-portal/assets/36613477/b07d7220-f332-4957-bb89-d1028ba6212c)


## 🧪 Testing

- [Visit nomad downloads](https://dev-portal-git-ksupdate-nomad-downloads-inline-alert-hashicorp.vercel.app/nomad/downloads), validate that the alert renders as expected.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
