### PR TITLE
fix: don't rewrite waf / onboarding links

### DIFF
--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -31,6 +31,33 @@ describe('rewriteDocsUrl', () => {
 		)
 	})
 
+	describe('does not rewrite tutorial links', () => {
+		const testData = [
+			{
+				input:
+					'/well-architected-framework/operational-excellence/operational-excellence-workspaces-projects',
+				expected:
+					'/well-architected-framework/operational-excellence/operational-excellence-workspaces-projects',
+			},
+			{
+				input: '/onboarding/tfcb-week-5/module-use',
+				expected: '/onboarding/tfcb-week-5/module-use',
+			},
+			{
+				input:
+					'/boundary/tutorials/hcp-getting-started/hcp-getting-started-intro',
+				expected:
+					'/boundary/tutorials/hcp-getting-started/hcp-getting-started-intro',
+			},
+		]
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const hcpProductData = require(`data/hcp.json`)
+
+		test.each(testData)('Testing subpath', (item) => {
+			expect(rewriteDocsUrl(item.input, hcpProductData)).toBe(item.expected)
+		})
+	})
+
 	describe('Rewrite non-docs base paths to external links', () => {
 		const testData = [
 			{ input: '/pricing', expected: 'https://cloud.hashicorp.com/pricing' },

--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -39,6 +39,11 @@ describe('rewriteDocsUrl', () => {
 				expected:
 					'/well-architected-framework/operational-excellence/operational-excellence-workspaces-projects',
 			},
+			// special case for non devdot 'waf' link
+			{
+				input: 'https://aws.amazon.com/architecture/well-architected/',
+				expected: 'https://aws.amazon.com/architecture/well-architected/',
+			},
 			{
 				input: '/onboarding/tfcb-week-5/module-use',
 				expected: '/onboarding/tfcb-week-5/module-use',

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -7,6 +7,7 @@ import isAbsoluteUrl from 'lib/is-absolute-url'
 import { rewriteWaypointPluginsToIntegrations } from 'lib/content-adjustments'
 import { productSlugs, productSlugsToHostNames } from 'lib/products'
 import { ProductData } from 'types/products'
+import { SectionOption } from 'lib/learn-client/types'
 
 /**
  * Given some product data,
@@ -136,6 +137,13 @@ export function rewriteDocsUrl(
 		(basePath: string) => inputUrl.startsWith(`/${basePath}`)
 	)
 	const isProductPath = new RegExp(`^/(${productSlugs.join('|')})`)
+	const isTutorialsPath = new RegExp(
+		`^/(${[
+			...productSlugs,
+			SectionOption['well-architected-framework'],
+			SectionOption.onboarding,
+		].join('|')}(/tutorials)?)`
+	)
 
 	if (isCurrentProductDocsUrl) {
 		// The vagrant vmware utility downloads page is a unique case, where we did
@@ -147,7 +155,7 @@ export function rewriteDocsUrl(
 			return `/${currentProduct.slug}/downloads/vmware`
 		}
 		return `/${currentProduct.slug}${inputUrl}`
-	} else if (!isProductPath.test(inputUrl)) {
+	} else if (!isProductPath.test(inputUrl) && !isTutorialsPath.test(inputUrl)) {
 		// if the path doesnt already start with a product slug i.e. /consul/tutorials
 		// and its not an absolute url we assume it is an internal .io link
 		// for this product context that is not a docs link, and should link to the external .io site


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-waf-link-docs-rewrite-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1204937553758581) 🎟️

## 🗒️ What

Fixes a bug where waf / onboarding links were getting rewritten to .io urls. 

## 🧪 Testing

There are no active waf urls in use in docs content. However, this [aws waf link](https://dev-portal-git-ksfix-waf-link-docs-rewrite-hashicorp.vercel.app/terraform/enterprise/reference-architecture/aws#high-availability-failure-scenarios) shouldn't be rewritten. Other tutorial urls should still work as expected in docs content.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204937553758581