### PR TITLE
fix: tutorials image paths local dev

### DIFF
--- a/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
+++ b/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
@@ -59,6 +59,9 @@ export const rewriteStaticAssetsPlugin: Plugin = () => {
 				return [node]
 			}
 
+			const isVercelBuild =
+				process.env.VERCEL_ENV === 'production' ||
+				process.env.VERCEL_ENV === 'preview'
 			const newUrl = new URL(ASSET_API_ENDPOINT)
 			// The second arg, the dev-portal url, is arbitrary to satisfy the URL constructor
 			const { hash, pathname } = new URL(
@@ -78,7 +81,7 @@ export const rewriteStaticAssetsPlugin: Plugin = () => {
 			 * For the local tutorials repo workflow, a custom asset server hosts
 			 * the images, so we don't adjust the path.
 			 */
-			if (process.env.TUTORIALS_LOCAL === 'true') {
+			if (!isVercelBuild && process.env.TUTORIALS_LOCAL === 'true') {
 				newUrl.pathname = path.join(newUrl.pathname, pathname)
 			} else {
 				/**


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-rewrite-assets-local-dev-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1204908882543128/f) 🎟️

## 🗒️ What

Adjusts the `rewriteStaticAssets` plugin so that images load for local dev. The 'special' condition for the local tutorials workflow is set by a new env `TUTORIALS_LOCAL`, [see related PR](https://github.com/hashicorp/tutorials/pull/1482)

## 🧪 Testing

- Pull this down locally, run dev, visit a tutorial (example path: /consul/tutorials/resiliency/introduction-chaos-engineering) and validate that tutorials images load as expected.
- Validate that images work the same on preview as well.


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
