### PR TITLE
chore: bump next version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
 				"mdast": "^3.0.0",
 				"mdast-util-to-string": "^2.0.0",
 				"moize": "^6.1.0",
-				"next": "^13.0.5",
+				"next": "^13.4.8",
 				"next-auth": "^4.19.2",
 				"next-mdx-remote": "^3.0.8",
 				"next-query-params": "^4.1.0",
@@ -6090,40 +6090,10 @@
 				"glob": "7.1.7"
 			}
 		},
-		"node_modules/@next/swc-android-arm-eabi": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.5.tgz",
-			"integrity": "sha512-YO691dxHlviy6H0eghgwqn+5kU9J3iQnKERHTDSppqjjGDBl6ab4wz9XfI5AhljjkaTg3TknHoIEWFDoZ4Ve8g==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-android-arm64": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.5.tgz",
-			"integrity": "sha512-ugbwffkUmp8cd2afehDC8LtQeFUxElRUBBngfB5UYSWBx18HW4OgzkPFIY8jUBH16zifvGZWXbICXJWDHrOLtw==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.5.tgz",
-			"integrity": "sha512-mshlh8QOtOalfZbc17uNAftWgqHTKnrv6QUwBe+mpGz04eqsSUzVz1JGZEdIkmuDxOz00cK2NPoc+VHDXh99IQ==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.8.tgz",
+			"integrity": "sha512-MSFplVM4dTWOuKAUv0XR9gY7AWtMSBu9os9f+kp+s5rWhM1I2CdR3obFttd6366nS/W/VZxbPM5oEIdlIa46zA==",
 			"cpu": [
 				"arm64"
 			],
@@ -6136,9 +6106,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.5.tgz",
-			"integrity": "sha512-SfigOKW4Z2UB3ruUPyvrlDIkcJq1hiw1wvYApWugD+tQsAkYZKEoz+/8emCmeYZ6Gwgi1WHV+z52Oj8u7bEHPg==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.8.tgz",
+			"integrity": "sha512-Reox+UXgonon9P0WNDE6w85DGtyBqGitl/ryznOvn6TvfxEaZIpTgeu3ZrJLU9dHSMhiK7YAM793mE/Zii2/Qw==",
 			"cpu": [
 				"x64"
 			],
@@ -6150,40 +6120,10 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/@next/swc-freebsd-x64": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.5.tgz",
-			"integrity": "sha512-0NJg8HZr4yG8ynmMGFXQf+Mahvq4ZgBmUwSlLXXymgxEQgH17erH/LoR69uITtW+KTsALgk9axEt5AAabM4ucg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@next/swc-linux-arm-gnueabihf": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.5.tgz",
-			"integrity": "sha512-Cye+h3oDT3NDWjACMlRaolL8fokpKie34FlPj9nfoW7bYKmoMBY1d4IO/GgBF+5xEl7HkH0Ny/qex63vQ0pN+A==",
-			"cpu": [
-				"arm"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.5.tgz",
-			"integrity": "sha512-5BfDS/VoRDR5QUGG9oedOCEZGmV2zxUVFYLUJVPMSMeIgqkjxWQBiG2BUHZI6/LGk9yvHmjx7BTvtBCLtRg6IQ==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.8.tgz",
+			"integrity": "sha512-kdyzYvAYtqQVgzIKNN7e1rLU8aZv86FDSRqPlOkKZlvqudvTO0iohuTPmnEEDlECeBM6qRPShNffotDcU/R2KA==",
 			"cpu": [
 				"arm64"
 			],
@@ -6196,9 +6136,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.5.tgz",
-			"integrity": "sha512-xenvqlXz+KxVKAB1YR723gnVNszpsCvKZkiFFaAYqDGJ502YuqU2fwLsaSm/ASRizNcBYeo9HPLTyc3r/9cdMQ==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.8.tgz",
+			"integrity": "sha512-oWxx4yRkUGcR81XwbI+T0zhZ3bDF6V1aVLpG+C7hSG50ULpV8gC39UxVO22/bv93ZlcfMY4zl8xkz9Klct6dpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -6211,9 +6151,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.5.tgz",
-			"integrity": "sha512-9Ahi1bbdXwhrWQmOyoTod23/hhK05da/FzodiNqd6drrMl1y7+RujoEcU8Dtw3H1mGWB+yuTlWo8B4Iba8hqiQ==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.8.tgz",
+			"integrity": "sha512-anhtvuO6eE9YRhYnaEGTfbpH3L5gT/9qPFcNoi6xS432r/4DAtpJY8kNktqkTVevVIC/pVumqO8tV59PR3zbNg==",
 			"cpu": [
 				"x64"
 			],
@@ -6226,9 +6166,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.5.tgz",
-			"integrity": "sha512-V+1mnh49qmS9fOZxVRbzjhBEz9IUGJ7AQ80JPWAYQM5LI4TxfdiF4APLPvJ52rOmNeTqnVz1bbKtVOso+7EZ4w==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.8.tgz",
+			"integrity": "sha512-aR+J4wWfNgH1DwCCBNjan7Iumx0lLtn+2/rEYuhIrYLY4vnxqSVGz9u3fXcgUwo6Q9LT8NFkaqK1vPprdq+BXg==",
 			"cpu": [
 				"x64"
 			],
@@ -6241,9 +6181,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.5.tgz",
-			"integrity": "sha512-wRE9rkp7I+/3Jf2T9PFIJOKq3adMWYEFkPOA7XAkUfYbQHlDJm/U5cVCWUsKByyQq5RThwufI91sgd19MfxRxg==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.8.tgz",
+			"integrity": "sha512-OWBKIrJwQBTqrat0xhxEB/jcsjJR3+diD9nc/Y8F1mRdQzsn4bPsomgJyuqPVZs6Lz3K18qdIkvywmfSq75SsQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -6256,9 +6196,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.5.tgz",
-			"integrity": "sha512-Q1XQSLEhFuFhkKFdJIGt7cYQ4T3u6P5wrtUNreg5M+7P+fjSiC8+X+Vjcw+oebaacsdl0pWZlK+oACGafush1w==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.8.tgz",
+			"integrity": "sha512-agiPWGjUndXGTOn4ChbKipQXRA6/UPkywAWIkx7BhgGv48TiJfHTK6MGfBoL9tS6B4mtW39++uy0wFPnfD0JWg==",
 			"cpu": [
 				"ia32"
 			],
@@ -6271,9 +6211,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.5.tgz",
-			"integrity": "sha512-t5gRblrwwiNZP6cT7NkxlgxrFgHWtv9ei5vUraCLgBqzvIsa7X+PnarZUeQCXqz6Jg9JSGGT9j8lvzD97UqeJQ==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.8.tgz",
+			"integrity": "sha512-UIRKoByVKbuR6SnFG4JM8EMFlJrfEGuUQ1ihxzEleWcNwRMMiVaCj1KyqfTOW8VTQhJ0u8P1Ngg6q1RwnIBTtw==",
 			"cpu": [
 				"x64"
 			],
@@ -10276,17 +10216,17 @@
 			}
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.4.14",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-			"integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+			"integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@swc/helpers/node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+			"integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
 		},
 		"node_modules/@tanstack/match-sorter-utils": {
 			"version": "8.1.1",
@@ -13730,6 +13670,17 @@
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
 		},
 		"node_modules/bytes": {
 			"version": "3.1.0",
@@ -27381,49 +27332,48 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/next/-/next-13.0.5.tgz",
-			"integrity": "sha512-awpc3DkphyKydwCotcBnuKwh6hMqkT5xdiBK4OatJtOZurDPBYLP62jtM2be/4OunpmwIbsS0Eyv+ZGU97ciEg==",
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/next/-/next-13.4.8.tgz",
+			"integrity": "sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==",
 			"dependencies": {
-				"@next/env": "13.0.5",
-				"@swc/helpers": "0.4.14",
+				"@next/env": "13.4.8",
+				"@swc/helpers": "0.5.1",
+				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001406",
 				"postcss": "8.4.14",
-				"styled-jsx": "5.1.0"
+				"styled-jsx": "5.1.1",
+				"watchpack": "2.4.0",
+				"zod": "3.21.4"
 			},
 			"bin": {
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": ">=14.6.0"
+				"node": ">=16.8.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-android-arm-eabi": "13.0.5",
-				"@next/swc-android-arm64": "13.0.5",
-				"@next/swc-darwin-arm64": "13.0.5",
-				"@next/swc-darwin-x64": "13.0.5",
-				"@next/swc-freebsd-x64": "13.0.5",
-				"@next/swc-linux-arm-gnueabihf": "13.0.5",
-				"@next/swc-linux-arm64-gnu": "13.0.5",
-				"@next/swc-linux-arm64-musl": "13.0.5",
-				"@next/swc-linux-x64-gnu": "13.0.5",
-				"@next/swc-linux-x64-musl": "13.0.5",
-				"@next/swc-win32-arm64-msvc": "13.0.5",
-				"@next/swc-win32-ia32-msvc": "13.0.5",
-				"@next/swc-win32-x64-msvc": "13.0.5"
+				"@next/swc-darwin-arm64": "13.4.8",
+				"@next/swc-darwin-x64": "13.4.8",
+				"@next/swc-linux-arm64-gnu": "13.4.8",
+				"@next/swc-linux-arm64-musl": "13.4.8",
+				"@next/swc-linux-x64-gnu": "13.4.8",
+				"@next/swc-linux-x64-musl": "13.4.8",
+				"@next/swc-win32-arm64-msvc": "13.4.8",
+				"@next/swc-win32-ia32-msvc": "13.4.8",
+				"@next/swc-win32-x64-msvc": "13.4.8"
 			},
 			"peerDependencies": {
+				"@opentelemetry/api": "^1.1.0",
 				"fibers": ">= 3.1.0",
-				"node-sass": "^6.0.0 || ^7.0.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
-				"fibers": {
+				"@opentelemetry/api": {
 					"optional": true
 				},
-				"node-sass": {
+				"fibers": {
 					"optional": true
 				},
 				"sass": {
@@ -27646,9 +27596,9 @@
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"node_modules/next/node_modules/@next/env": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.5.tgz",
-			"integrity": "sha512-F3KLtiDrUslAZhTYTh8Zk5ZaavbYwLUn3NYPBnOjAXU8hWm0QVGVzKIOuURQ098ofRU4e9oglf3Sj9pFx5nI5w=="
+			"version": "13.4.8",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.8.tgz",
+			"integrity": "sha512-twuSf1klb3k9wXI7IZhbZGtFCWvGD4wXTY2rmvzIgVhXhs7ISThrbNyutBx3jWIL8Y/Hk9+woytFz5QsgtcRKQ=="
 		},
 		"node_modules/nextjs-bundle-analysis": {
 			"version": "0.5.0-canary.1",
@@ -37615,6 +37565,14 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -37892,9 +37850,9 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/styled-jsx": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
-			"integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+			"integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
 			"dependencies": {
 				"client-only": "0.0.1"
 			},
@@ -41218,6 +41176,18 @@
 				"makeerror": "1.0.x"
 			}
 		},
+		"node_modules/watchpack": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dependencies": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/watchpack-chokidar2": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
@@ -41550,6 +41520,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/watchpack/node_modules/glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
 		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
@@ -42381,9 +42356,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.20.2",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
-			"integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
+			"version": "3.21.4",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 		"mdast": "^3.0.0",
 		"mdast-util-to-string": "^2.0.0",
 		"moize": "^6.1.0",
-		"next": "^13.0.5",
+		"next": "^13.4.8",
 		"next-auth": "^4.19.2",
 		"next-mdx-remote": "^3.0.8",
 		"next-query-params": "^4.1.0",

--- a/src/components/dev-dot-content/mdx-components/mdx-headings/utils/is-injected-permalink.ts
+++ b/src/components/dev-dot-content/mdx-components/mdx-headings/utils/is-injected-permalink.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { ReactChild, ReactFragment, ReactPortal } from 'react'
+import { ReactNode } from 'react'
 
 /**
  * Given a React child, determine if it a permalink element injected by our
@@ -15,14 +15,13 @@ import { ReactChild, ReactFragment, ReactPortal } from 'react'
  * We expect injected permalink elements to have a `__permalink-h` className.
  * Ref: https://github.com/hashicorp/remark-plugins/blob/d7869b253b3ae07116f280f95fe2b414145594f1/plugins/anchor-links/index.js#L155
  */
-export function isInjectedPermalink(
-	child: ReactChild | ReactFragment | ReactPortal
-): boolean {
+export function isInjectedPermalink(child: ReactNode): boolean {
 	const isLiteral = typeof child === 'string' || typeof child === 'number'
 	if (isLiteral) {
 		return false
 	}
-	const hasClassName = 'props' in child && 'className' in child.props
+	const hasClassName =
+		typeof child === 'object' && 'props' in child && 'className' in child.props
 	if (!hasClassName) {
 		return false
 	}


### PR DESCRIPTION
# Description

Bumps `next` from `13.0.5` to `13.4.8`

**Preview**: https://dev-portal-git-kwupdate-next-hashicorp.vercel.app/

Related: https://github.com/hashicorp/dev-portal/pull/2036
Related: https://vercel.com/teams/hashicorp/support/cases/00143787

### Tested URLs

(ensure these URLs are rendering the correct content)

- [x] https://dev-portal-git-kwupdate-next-hashicorp.vercel.app/vault/tutorials/cloud/get-started-vault
- [x] https://dev-portal-git-kwupdate-next-hashicorp.vercel.app/terraform/tutorials/azure-get-started/infrastructure-as-code
- [x] https://dev-portal-git-kwupdate-next-hashicorp.vercel.app/vault/tutorials/kubernetes/kubernetes-minikube-raft