### PR TITLE
fix: adds accordion margin

### DIFF
--- a/src/components/accordion-disclosure/index.tsx
+++ b/src/components/accordion-disclosure/index.tsx
@@ -20,6 +20,7 @@ import useHover from 'hooks/use-hover'
 
 const AccordionDisclosure = ({
 	children,
+	className,
 	description,
 	initialOpen,
 	title,
@@ -67,7 +68,7 @@ const AccordionDisclosure = ({
 				initialOpen={initialOpen}
 			>
 				<DisclosureActivator
-					className={s.button}
+					className={classNames(s.button, className)}
 					data-heap-track="accordion-disclosure-activator"
 					ref={hoverRef}
 				>

--- a/src/components/accordion-disclosure/types.ts
+++ b/src/components/accordion-disclosure/types.ts
@@ -13,6 +13,8 @@ export interface AccordionDisclosureProps {
 	 */
 	children: ReactNode
 
+	className?: string
+
 	/**
 	 * Secondary label text that renders below the main `title` with less
 	 * emphasis. Always shows regardless of the `AccordionDisclosure`'s

--- a/src/components/dev-dot-content/mdx-components/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+export * from './mdx-accordion'
 export * from './mdx-blockquote'
 export * from './mdx-code-blocks'
 export * from './mdx-headings'

--- a/src/components/dev-dot-content/mdx-components/mdx-accordion/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/mdx-accordion/index.tsx
@@ -1,0 +1,15 @@
+import AccordionDisclosure from 'components/accordion-disclosure'
+import s from './mdx-accordion.module.css'
+
+/**
+ * @TODO
+ *   - deprecate string option for collapse
+ *   - warn that collapse is `true` by default now?
+ */
+export const MdxAccordion = ({ children, collapse, heading }) => {
+	return (
+		<AccordionDisclosure title={heading} className={s.accordionWrapper}>
+			{children}
+		</AccordionDisclosure>
+	)
+}

--- a/src/components/dev-dot-content/mdx-components/mdx-accordion/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/mdx-accordion/index.tsx
@@ -1,14 +1,24 @@
+import { ReactNode } from 'react'
 import AccordionDisclosure from 'components/accordion-disclosure'
 import s from './mdx-accordion.module.css'
 
-/**
- * @TODO
- *   - deprecate string option for collapse
- *   - warn that collapse is `true` by default now?
- */
-export const MdxAccordion = ({ children, collapse, heading }) => {
+interface MdxAccordionProps {
+	children: ReactNode
+	collapse?: 'true' | boolean
+	heading: string
+}
+
+export const MdxAccordion = ({
+	children,
+	collapse,
+	heading,
+}: MdxAccordionProps) => {
 	return (
-		<AccordionDisclosure title={heading} className={s.accordionWrapper}>
+		<AccordionDisclosure
+			title={heading}
+			className={s.accordionWrapper}
+			initialOpen={!collapse}
+		>
 			{children}
 		</AccordionDisclosure>
 	)

--- a/src/components/dev-dot-content/mdx-components/mdx-accordion/mdx-accordion.module.css
+++ b/src/components/dev-dot-content/mdx-components/mdx-accordion/mdx-accordion.module.css
@@ -1,0 +1,3 @@
+.accordionWrapper {
+	margin-top: 16px;
+}

--- a/src/views/tutorial-view/utils/mdx-components.tsx
+++ b/src/views/tutorial-view/utils/mdx-components.tsx
@@ -4,25 +4,15 @@
  */
 
 // Global imports
-import AccordionDisclosure from 'components/accordion-disclosure'
+import { MdxAccordion } from 'components/dev-dot-content/mdx-components'
 import Image from 'components/image'
 import InteractiveLabCallout from 'components/interactive-lab-callout'
 import VideoEmbed from 'components/video-embed'
 import { MdxVariant } from './variants/mdx-variant'
 
-/**
- * @TODO
- *   - deprecate string option for collapse
- *   - warn that collapse is `true` by default now?
- *   - pass classname with a margin-top setting for when there are multiple?
- */
-const AccordionWrapper = ({ children, collapse, heading }) => {
-	return <AccordionDisclosure title={heading}>{children}</AccordionDisclosure>
-}
-
 //  these components are automatically imported into scope within MDX content
 const MDX_COMPONENTS = {
-	Accordion: AccordionWrapper,
+	Accordion: MdxAccordion,
 	InteractiveLabCallout,
 	img: Image,
 	Variant: MdxVariant,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ks-fix-accordion-space-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1204131002305975/f) 🎟️

## 🗒️ What

Fixes an issue where multiple accordions stacked next to each other don't have margin. 

![image](https://github.com/hashicorp/dev-portal/assets/36613477/f59773a3-aaa1-4613-adce-0495bc4fde8b)

## 🧪 Testing

- [Visit a path](https://dev-portal-git-ks-fix-accordion-space-hashicorp.vercel.app/terraform/tutorials/aws/blue-green-canary-tests-deployments) with multiple accordions
- Ensure that they have space between 
- Also ensure that they remain collapsed as expected

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
