### PR TITLE
fix: packer checklist position

### DIFF
--- a/src/components/author-primitives/packer/checklist/style.module.css
+++ b/src/components/author-primitives/packer/checklist/style.module.css
@@ -19,7 +19,7 @@
 				width: 18px;
 				margin-left: calc(-1 * 1.6rem);
 				height: 18px;
-				top: 7px;
+				top: 4px;
 				background: url('./check-circle-filled.svg');
 			}
 		}

--- a/src/components/author-primitives/packer/checklist/style.module.css
+++ b/src/components/author-primitives/packer/checklist/style.module.css
@@ -6,13 +6,15 @@
 .root {
 	& ul {
 		list-style: none;
-		margin-left: 2rem;
+		margin-left: 8px;
 
 		& li {
-			color: #525252;
+			color: var(--token-color-foreground-primary);
+			position: relative;
 
 			&::before {
 				content: '';
+				position: absolute;
 				display: block;
 				width: 18px;
 				margin-left: calc(-1 * 1.6rem);


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-check-item-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203368245666617/f) 🎟️

## 🗒️ What

Fixes a bug where packer checklist `::before` content wasn't rendering in the correct position. 

### Before
<img width="971" alt="Screenshot 2023-07-07 at 4 14 37 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/7a7b7a40-d5d1-43e6-9275-484fe0960fe1">

### After
<img width="769" alt="Screenshot 2023-07-07 at 4 14 27 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/211cf527-9abe-4384-a38a-b0b1983ca4ff">

## 🧪 Testing

- [Visit path](https://dev-portal-git-ksfix-check-item-hashicorp.vercel.app/packer/docs/partnerships#checklist) with checklist 
- Validate that it is positioned as expected.
- Lists outside of this packer checklist primitive should remain unaffected

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
