### PR TITLE
fix: current tutorial data path match

### DIFF
--- a/src/views/onboarding/tutorial-view/server.ts
+++ b/src/views/onboarding/tutorial-view/server.ts
@@ -48,10 +48,8 @@ export async function getOnboardingTutorialProps(
 			collection.slug === `${onboardingData.slug}/${collectionFilename}`
 	)
 	const currentTutorialReference = currentCollection?.tutorials.find(
-		(t: ApiTutorialLite) => {
-			const [, currentTFilename] = t.slug.split('/')
-			return tutorialFilename === currentTFilename
-		}
+		(t: ApiTutorialLite) =>
+			tutorialFilename === splitProductFromFilename(t.slug)
 	)
 
 	// The tutorial doesn't exist in collection - return 404

--- a/src/views/onboarding/tutorial-view/server.ts
+++ b/src/views/onboarding/tutorial-view/server.ts
@@ -36,7 +36,6 @@ export async function getOnboardingTutorialProps(
 ): Promise<{ props: OnboardingTutorialViewProps }> {
 	// Remove the variant from the slug
 	const tutorialSlug = fullSlug.slice(0, 2) as [string, string]
-	console.log({ tutorialSlug })
 	const [collectionFilename, tutorialFilename] = tutorialSlug
 	const currentPath = `/${onboardingData.slug}/${tutorialSlug.join('/')}`
 
@@ -48,17 +47,17 @@ export async function getOnboardingTutorialProps(
 		(collection: ApiCollection) =>
 			collection.slug === `${onboardingData.slug}/${collectionFilename}`
 	)
-	const currentTutorialReference = currentCollection?.tutorials.find((t) => {
-		const [, currentTFilename] = t.slug.split('/')
-		return tutorialFilename === currentTFilename
-	})
+	const currentTutorialReference = currentCollection?.tutorials.find(
+		(t: ApiTutorialLite) => {
+			const [, currentTFilename] = t.slug.split('/')
+			return tutorialFilename === currentTFilename
+		}
+	)
 
 	// The tutorial doesn't exist in collection - return 404
 	if (!currentCollection || !currentTutorialReference) {
 		return null
 	}
-
-	console.log({ currentTutorialReference })
 
 	// Need to get tutorial data with full mdx content
 	const fullTutorialData = await getTutorial(currentTutorialReference.slug)

--- a/src/views/onboarding/tutorial-view/server.ts
+++ b/src/views/onboarding/tutorial-view/server.ts
@@ -36,6 +36,7 @@ export async function getOnboardingTutorialProps(
 ): Promise<{ props: OnboardingTutorialViewProps }> {
 	// Remove the variant from the slug
 	const tutorialSlug = fullSlug.slice(0, 2) as [string, string]
+	console.log({ tutorialSlug })
 	const [collectionFilename, tutorialFilename] = tutorialSlug
 	const currentPath = `/${onboardingData.slug}/${tutorialSlug.join('/')}`
 
@@ -47,14 +48,17 @@ export async function getOnboardingTutorialProps(
 		(collection: ApiCollection) =>
 			collection.slug === `${onboardingData.slug}/${collectionFilename}`
 	)
-	const currentTutorialReference = currentCollection?.tutorials.find((t) =>
-		t.slug.endsWith(tutorialFilename)
-	)
+	const currentTutorialReference = currentCollection?.tutorials.find((t) => {
+		const [, currentTFilename] = t.slug.split('/')
+		return tutorialFilename === currentTFilename
+	})
 
 	// The tutorial doesn't exist in collection - return 404
 	if (!currentCollection || !currentTutorialReference) {
 		return null
 	}
+
+	console.log({ currentTutorialReference })
 
 	// Need to get tutorial data with full mdx content
 	const fullTutorialData = await getTutorial(currentTutorialReference.slug)

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -14,6 +14,7 @@ import {
 import { getCollection } from 'lib/learn-client/api/collection'
 import { CollectionContext } from '..'
 import { formatCollectionCard } from 'components/collection-card/helpers'
+import { splitProductFromFilename } from '.'
 
 /**
  * We need to get the database slug for this tutorial, which may belong in a different
@@ -57,10 +58,8 @@ export async function getCurrentCollectionTutorial(
 	 * so we only need the slug to make another request to get the full tutorial data in server.ts
 	 */
 	const currentTutorial = collection?.tutorials.find(
-		(t: ClientTutorialLite) => {
-			const [, currentTFilename] = t.slug.split('/')
-			return tutorialFilename === currentTFilename
-		}
+		(t: ClientTutorialLite) =>
+			tutorialFilename === splitProductFromFilename(t.slug)
 	)
 
 	if (!currentTutorial) {

--- a/src/views/tutorial-view/utils/get-collection-context.ts
+++ b/src/views/tutorial-view/utils/get-collection-context.ts
@@ -9,6 +9,7 @@ import {
 	ProductOption,
 	SectionOption,
 	TutorialFullCollectionCtx as ClientTutorialFullCollectionCtx,
+	TutorialLite as ClientTutorialLite,
 } from 'lib/learn-client/types'
 import { getCollection } from 'lib/learn-client/api/collection'
 import { CollectionContext } from '..'
@@ -55,8 +56,11 @@ export async function getCurrentCollectionTutorial(
 	 * This type is only `TutorialLite` which doesn't have the tutorial content
 	 * so we only need the slug to make another request to get the full tutorial data in server.ts
 	 */
-	const currentTutorial = collection?.tutorials.find((t) =>
-		t.slug.endsWith(tutorialFilename)
+	const currentTutorial = collection?.tutorials.find(
+		(t: ClientTutorialLite) => {
+			const [, currentTFilename] = t.slug.split('/')
+			return tutorialFilename === currentTFilename
+		}
 	)
 
 	if (!currentTutorial) {

--- a/src/views/well-architected-framework/tutorial-view/server.ts
+++ b/src/views/well-architected-framework/tutorial-view/server.ts
@@ -40,10 +40,8 @@ export async function getWafTutorialViewProps(
 			collection.slug === `${wafData.slug}/${collectionFilename}`
 	)
 	const currentTutorialReference = currentCollection?.tutorials.find(
-		(t: ClientTutorialLite) => {
-			const [, currentTFilename] = t.slug.split('/')
-			return tutorialFilename === currentTFilename
-		}
+		(t: ClientTutorialLite) =>
+			tutorialFilename === splitProductFromFilename(t.slug)
 	)
 
 	// The tutorial doesn't exist in collection - return 404

--- a/src/views/well-architected-framework/tutorial-view/server.ts
+++ b/src/views/well-architected-framework/tutorial-view/server.ts
@@ -39,8 +39,11 @@ export async function getWafTutorialViewProps(
 		(collection: ApiCollection) =>
 			collection.slug === `${wafData.slug}/${collectionFilename}`
 	)
-	const currentTutorialReference = currentCollection?.tutorials.find((t) =>
-		t.slug.endsWith(tutorialFilename)
+	const currentTutorialReference = currentCollection?.tutorials.find(
+		(t: ApiTutorialLite) => {
+			const [, currentTFilename] = t.slug.split('/')
+			return tutorialFilename === currentTFilename
+		}
 	)
 
 	// The tutorial doesn't exist in collection - return 404

--- a/src/views/well-architected-framework/tutorial-view/server.ts
+++ b/src/views/well-architected-framework/tutorial-view/server.ts
@@ -13,8 +13,8 @@ import wafData from 'data/well-architected-framework.json'
 import wafContent from 'content/well-architected-framework/index.json'
 import { buildCategorizedWafSidebar } from 'views/well-architected-framework/utils/generate-sidebar-items'
 import {
-	Collection as ApiCollection,
-	TutorialLite as ApiTutorialLite,
+	Collection as ClientCollection,
+	TutorialLite as ClientTutorialLite,
 } from 'lib/learn-client/types'
 import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
 import { MenuItem, SidebarProps } from 'components/sidebar'
@@ -36,11 +36,11 @@ export async function getWafTutorialViewProps(
 	// get all the waf collections to generate the collection level sidebar
 	const allWafCollections = await getCollectionsBySection(wafData.slug)
 	const currentCollection = allWafCollections.find(
-		(collection: ApiCollection) =>
+		(collection: ClientCollection) =>
 			collection.slug === `${wafData.slug}/${collectionFilename}`
 	)
 	const currentTutorialReference = currentCollection?.tutorials.find(
-		(t: ApiTutorialLite) => {
+		(t: ClientTutorialLite) => {
 			const [, currentTFilename] = t.slug.split('/')
 			return tutorialFilename === currentTFilename
 		}
@@ -73,7 +73,7 @@ export async function getWafTutorialViewProps(
 		fullTutorialData.collectionCtx
 	)
 	const tutorialNavLevelMenuItems = collectionContext.current.tutorials.map(
-		(t: ApiTutorialLite) => {
+		(t: ClientTutorialLite) => {
 			const fullTutorialPath = `/${
 				collectionContext.current.slug
 			}/${splitProductFromFilename(t.slug)}`


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-onboarding-path-match-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

Fixes a loose match on tutorial slugs for determining the correct tutorial data. 

## 🧪 Testing

- Visit some tutorial paths, validate that the correct data shows
- Visit a path that is [broken in prod](https://developer.hashicorp.com/onboarding/hcp-vault-week-3/database-secrets), validate that the [correct data](https://dev-portal-git-ksfix-onboarding-path-match-hashicorp.vercel.app/onboarding/hcp-vault-week-3/database-secrets) now shows. 

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
