### PR TITLE
fix: avoid TSX imports in hc-tools scripts

### DIFF
--- a/src/views/collection-view/helpers/index.ts
+++ b/src/views/collection-view/helpers/index.ts
@@ -6,4 +6,3 @@
 export * from './format-sidebar-sections'
 export * from './get-slug'
 export * from './generate-hcp-sidebar'
-export * from './generate-collection-sidebar-nav-data'

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -19,8 +19,8 @@ import {
 	CollectionCategorySidebarSection,
 	getCollectionSlug,
 	getTutorialSlug,
-	generateCollectionSidebarNavData,
 } from 'views/collection-view/helpers'
+import { generateCollectionSidebarNavData } from 'views/collection-view/helpers/generate-collection-sidebar-nav-data'
 import { getCollectionViewSidebarSections } from 'views/collection-view/server'
 
 import DevDotContent from 'components/dev-dot-content'


### PR DESCRIPTION
This removes `.tsx` import side effects in shared files between Node scripts & runtime app code.

A command this fixes is 

```jsonc
//package.json
"rewrite-docs-content-links": "hc-tools ./scripts/docs-content-link-rewrites/rewrite-links.ts"
```

Example observed error: https://github.com/hashicorp/ptfe-releases/actions/runs/5513172741/jobs/10051028728?pr=570#step:7:18
```
Error: Cannot find module './generate-collection-sidebar-nav-data'
```