### PR TITLE
style: adjust docs sidebar chevron icon

### DIFF
--- a/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
@@ -11,7 +11,7 @@ import {
 	useState,
 } from 'react'
 import { IconHome16 } from '@hashicorp/flight-icons/svg-react/home-16'
-import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
+import { IconChevronDown16 } from '@hashicorp/flight-icons/svg-react/chevron-down-16'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import { IconGuide16 } from '@hashicorp/flight-icons/svg-react/guide-16'
 import { ProductSlug } from 'types/products'
@@ -266,7 +266,7 @@ const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
 							<SidebarNavMenuItemBadge {...(item as $TSFixMe).badge} />
 						) : undefined
 					}
-					icon={<IconChevronRight16 />}
+					icon={<IconChevronDown16 />}
 				/>
 			</button>
 			{isOpen && (

--- a/src/components/sidebar/components/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/sidebar-nav-menu-item.module.css
@@ -31,12 +31,19 @@
 		background-color: var(--token-color-palette-neutral-200);
 	}
 
+	& svg {
+		/* Only enable animation if query is supported and value is no-preference */
+		@media (prefers-reduced-motion: no-preference) {
+			transition: transform 0.2s;
+		}
+	}
+
 	/* AKA open */
 	&[aria-expanded='true'] {
 		margin-bottom: 0;
 
 		& svg {
-			transform: rotate(90deg);
+			transform: rotate(-180deg);
 		}
 	}
 

--- a/src/components/sidebar/components/sidebar-nav-menu-item/types.ts
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/types.ts
@@ -4,14 +4,14 @@
  */
 
 import { ReactElement } from 'react'
-import { IconChevronRight16 } from '@hashicorp/flight-icons/svg-react/chevron-right-16'
+import { IconChevronDown16 } from '@hashicorp/flight-icons/svg-react/chevron-down-16'
 import Badge, { BadgeProps } from 'components/badge'
 import { MenuItem } from 'components/sidebar'
 import { ProductSlug } from 'types/products'
 
 interface RightIconsContainerProps {
 	badge?: ReturnType<typeof Badge>
-	icon?: ReturnType<typeof IconChevronRight16>
+	icon?: ReturnType<typeof IconChevronDown16>
 }
 
 interface SidebarNavMenuItemBadgeProps {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadjust-chevron-direction-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204807665183200/1205002759200577/f) 🎟️
- [Figma file](https://www.figma.com/file/G6RNneOMHyRgcFx98VZUpp/IA-Improvements?type=design&node-id=406-54557&mode=design&t=rG3DKEUgroeRBpsY-0) 🎨 

## 🗒️ What

Updates the nested sidebar chevron icon to point down / up to align with the dropdown disclosure styles. 

## 📸 Design Screenshots
<img width="922" alt="Screenshot 2023-07-11 at 2 12 47 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/99719876-55bb-4b89-be64-98398398564c">

## 🧪 Testing

- [Visit a docs page ](https://dev-portal-git-ksadjust-chevron-direction-hashicorp.vercel.app/consul/docs)with nested sidebar items
- Validate that the chevron points down when closed and up when opened. 

## 💭 Anything else?


