### PR TITLE
chore: adjust product landing card link order

### DIFF
--- a/src/content/hcp/docs-landing.json
+++ b/src/content/hcp/docs-landing.json
@@ -2,6 +2,16 @@
 	"pageSubtitle": "Learn and develop your knowledge of HashiCorp Cloud Platform with these reference docs.",
 	"iconCardGridItems": [
 		{
+			"iconName": "boundary-color",
+			"name": "HCP Boundary",
+			"path": "docs/boundary"
+		},
+		{
+			"iconName": "consul-color",
+			"name": "HCP Consul",
+			"path": "docs/consul"
+		},
+		{
 			"iconName": "vault-color",
 			"name": "HCP Vault",
 			"path": "docs/vault"
@@ -12,19 +22,9 @@
 			"path": "docs/vault-secrets"
 		},
 		{
-			"iconName": "consul-color",
-			"name": "HCP Consul",
-			"path": "docs/consul"
-		},
-		{
 			"iconName": "packer-color",
 			"name": "HCP Packer",
 			"path": "docs/packer"
-		},
-		{
-			"iconName": "boundary-color",
-			"name": "HCP Boundary",
-			"path": "docs/boundary"
 		},
 		{
 			"iconName": "waypoint-color",

--- a/src/content/vagrant/docs-landing.json
+++ b/src/content/vagrant/docs-landing.json
@@ -6,14 +6,14 @@
 			"path": "docs/cli"
 		},
 		{
-			"iconName": "docs",
-			"name": "Vagrantfile",
-			"path": "docs/vagrantfile"
-		},
-		{
 			"iconName": "cloud",
 			"name": "Vagrant Cloud",
 			"path": "vagrant-cloud"
+		},
+		{
+			"iconName": "docs",
+			"name": "Vagrantfile",
+			"path": "docs/vagrantfile"
 		}
 	],
 	"pageSubtitle": "Vagrant is the command line utility for managing the lifecycle of virtual machines.",

--- a/src/views/product-landing/helpers/get-icon-cards.tsx
+++ b/src/views/product-landing/helpers/get-icon-cards.tsx
@@ -10,19 +10,13 @@ import { IconLearn16 } from '@hashicorp/flight-icons/svg-react/learn-16'
 import { ProductData } from 'types/products'
 import { getIsEnabledProductIntegrations } from 'lib/integrations/get-is-enabled-product-integrations'
 
+/**
+ * The order of these items is meaningful, should match the top navigation items
+ */
+
 export function getIconCards(product: ProductData) {
-	const iconCards = [
-		{
-			icon: <IconDocs16 />,
-			text: 'Documentation',
-			url: `/${product.slug}/docs`,
-		},
-		{
-			icon: <IconLearn16 />,
-			text: 'Tutorials',
-			url: `/${product.slug}/tutorials`,
-		},
-	]
+	const iconCards = []
+
 	if (product.slug !== 'hcp') {
 		iconCards.push({
 			icon: <IconDownload16 />,
@@ -30,6 +24,21 @@ export function getIconCards(product: ProductData) {
 			url: `/${product.slug}/downloads`,
 		})
 	}
+
+	iconCards.push(
+		...[
+			{
+				icon: <IconLearn16 />,
+				text: 'Tutorials',
+				url: `/${product.slug}/tutorials`,
+			},
+			{
+				icon: <IconDocs16 />,
+				text: 'Documentation',
+				url: `/${product.slug}/docs`,
+			},
+		]
+	)
 
 	// Add Integrations card if it's enabled for this product
 	if (getIsEnabledProductIntegrations(product.slug)) {


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadjust-top-nav-order-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204807665183200/1205002759200572/f) 🎟️
- [Figma file](https://www.figma.com/file/G6RNneOMHyRgcFx98VZUpp/IA-Improvements?type=design&node-id=338-41767&mode=design&t=rG3DKEUgroeRBpsY-0) 🎨 

## 🗒️ What

Adjusts the card link item order to align with the global nav. 

## 📸 Design Screenshots
<img width="584" alt="Screenshot 2023-07-11 at 3 01 40 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/88690012-2b28-4b2b-9be6-cf542b3faf2c">

## 🧪 Testing

- Visit all the [product landing pages](https://dev-portal-git-ksadjust-top-nav-order-hashicorp.vercel.app/vault), validate that the card link item order matches the top nav where the items match
- Validate that vagrantfile is after vagrant cloud on the [vagrant docs landing](https://dev-portal-git-ksadjust-top-nav-order-hashicorp.vercel.app/vagrant/docs)

## 💭 Anything else?

There's follow up work to align the sidebar on these views with the same order. 
