### PR TITLE
[integrations] chore: only show required filter only when required var(s) exist

### DIFF
--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -32,11 +32,10 @@ export default function SearchableVariableGroupList({
 	 * required property is relevant for the variables we're rendering.
 	 *
 	 * We consider the required property to be relevant if any of the variables
-	 * have their required property set to `true` or `false`, rather than
-	 * the default `null` setting.
+	 * have their required property set to `true`.
 	 */
 	const isRequiredRelevant = variables.find(
-		({ required }: Variable) => required === true || required === false
+		({ required }: Variable) => required === true
 	)
 
 	/**


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksshow-required-conditionally-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204845103172089/1204091239221872/f) 🎟️

## 🗒️ What

Updates the logic to render the 'Required Only' filter to only show when there is at least one required variable. 

## 🧪 Testing

- [Visit a page](https://dev-portal-git-ksshow-required-conditionally-hashicorp.vercel.app/waypoint/integrations/hashicorp/aws-ssm/latest/components/config-sourcer/aws-ssm-config-sourcer) where the required only filter should no longer show, compare [against upstream](https://developer.hashicorp.com/waypoint/integrations/hashicorp/aws-ssm/latest/components/config-sourcer/aws-ssm-config-sourcer)
- [Visit a page](https://dev-portal-git-ksshow-required-conditionally-hashicorp.vercel.app/waypoint/integrations/hashicorp/aws-ami/latest/components/builder/aws-ami-builder) where the required only filter should still show

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
