### PR TITLE
[integrations] feat: adds variable group list empty state 

### DIFF
--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -97,7 +97,7 @@ export default function SearchableVariableGroupList({
 				/>
 			) : (
 				<NoResultsMessage
-					description={'Try adjusting your keywords.'}
+					description="Try adjusting your keywords."
 					onClearFiltersClicked={() => {
 						setSearchQuery('')
 						if (requiredOnly) {

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -97,6 +97,7 @@ export default function SearchableVariableGroupList({
 				/>
 			) : (
 				<NoResultsMessage
+					description={'Try adjusting your keywords.'}
 					onClearFiltersClicked={() => {
 						setSearchQuery('')
 						if (requiredOnly) {

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -7,6 +7,7 @@ import { IconSearch16 } from '@hashicorp/flight-icons/svg-react/search-16'
 import FilterInput from 'components/filter-input'
 import { CheckboxField } from 'components/form/field-controls'
 import { useState } from 'react'
+import { NoResultsMessage } from 'views/product-integrations-landing/components/integrations-list'
 import { Variable, VariableGroupList } from '../variable-group-list'
 import {
 	applyQueryFilter,
@@ -86,18 +87,23 @@ export default function SearchableVariableGroupList({
 			 * Technique ARIA22: Using role=status to present status messages
 			 * https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22
 			 */}
+			<p className={s.results} role="status">
+				{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
+			</p>
 			{numMatches > 0 ? (
-				<>
-					<p className={s.results} role="status">
-						{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
-					</p>
-					<VariableGroupList
-						groupName={groupName}
-						variables={matchesWithAncestors}
-					/>
-				</>
+				<VariableGroupList
+					groupName={groupName}
+					variables={matchesWithAncestors}
+				/>
 			) : (
-				<p>Empty</p>
+				<NoResultsMessage
+					onClearFiltersClicked={() => {
+						setSearchQuery('')
+						if (requiredOnly) {
+							setRequiredOnly(false)
+						}
+					}}
+				/>
 			)}
 		</div>
 	)

--- a/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
+++ b/src/views/product-integration/component-view/components/searchable-variable-group-list/index.tsx
@@ -86,13 +86,19 @@ export default function SearchableVariableGroupList({
 			 * Technique ARIA22: Using role=status to present status messages
 			 * https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22
 			 */}
-			<p className={s.results} role="status">
-				{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
-			</p>
-			<VariableGroupList
-				groupName={groupName}
-				variables={matchesWithAncestors}
-			/>
+			{numMatches > 0 ? (
+				<>
+					<p className={s.results} role="status">
+						{numMatches} {numMatches === 1 ? 'Result' : 'Results'}
+					</p>
+					<VariableGroupList
+						groupName={groupName}
+						variables={matchesWithAncestors}
+					/>
+				</>
+			) : (
+				<p>Empty</p>
+			)}
 		</div>
 	)
 }

--- a/src/views/product-integrations-landing/components/integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/integrations-list/index.tsx
@@ -91,16 +91,19 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
 
 interface NoResultsMessageProps {
 	onClearFiltersClicked: () => void
+	description?: string
 }
 
 export function NoResultsMessage({
 	onClearFiltersClicked,
+	description,
 }: NoResultsMessageProps) {
 	return (
 		<div className={s.noResultsWrapper}>
 			<p className={s.noResultsTitle}>No Results</p>
 			<p className={s.noResultsDescription}>
-				Try adjusting your selected filters or using different keywords.
+				{description ||
+					'Try adjusting your selected filters or using different keywords.'}
 			</p>
 			<div className={s.noResultsButtonWrapper}>
 				<Button

--- a/src/views/product-integrations-landing/components/integrations-list/index.tsx
+++ b/src/views/product-integrations-landing/components/integrations-list/index.tsx
@@ -93,7 +93,9 @@ interface NoResultsMessageProps {
 	onClearFiltersClicked: () => void
 }
 
-function NoResultsMessage({ onClearFiltersClicked }: NoResultsMessageProps) {
+export function NoResultsMessage({
+	onClearFiltersClicked,
+}: NoResultsMessageProps) {
 	return (
 		<div className={s.noResultsWrapper}>
 			<p className={s.noResultsTitle}>No Results</p>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksadds-empty-state-integrations-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1204845103172089/1204068171740400/f) 🎟️

## 🗒️ What

Adds an empty state to variable group list integrations filtering. 

<img width="492" alt="Screenshot 2023-07-11 at 4 50 34 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/d20aa824-fa10-4e6a-b280-6e2a677ee33e">
<img width="1000" alt="Screenshot 2023-07-11 at 4 50 30 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/c1766720-0884-406c-bf34-37b00a01afa5">

## 🛠️ How

I used the same component from the integrations library empty results. 

## 🧪 Testing

- [Visit this page](https://dev-portal-git-ksadds-empty-state-integrations-hashicorp.vercel.app/waypoint/integrations/hashicorp/aws-ssm/latest/components/config-sourcer/aws-ssm-config-sourcer), enter in a weird filter term like 'pickles'
- View the no results component
- Click 'clear' 
- validate that the query is reset
- Test again with the required checkbox filter. 

## 💭 Anything else?

We may want to adjust the messaging in the 'no results' component body for this context? @braydenlove 
