### PR TITLE
chore: add flag for revised Vault Secrets API docs

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -45,6 +45,7 @@
 	"flags": {
 		"enable_datadog": true,
 		"enable_io_beta_cta": true,
-		"enable_unified_search": true
+		"enable_unified_search": true,
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,6 @@
 		"max_static_paths": 1
 	},
 	"flags": {
-		"enable_hcp_vault_secrets_api_docs_revision": true
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -11,5 +11,8 @@
 	},
 	"learn": {
 		"max_static_paths": 1
+	},
+	"flags": {
+		"enable_hcp_vault_secrets_api_docs_revision": true
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,6 +4,6 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_hcp_vault_secrets_api_docs_revision": true
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -2,5 +2,8 @@
 	"extends": "base",
 	"io_sites": {
 		"max_static_paths": 10
+	},
+	"flags": {
+		"enable_hcp_vault_secrets_api_docs_revision": true
 	}
 }

--- a/config/production.json
+++ b/config/production.json
@@ -14,5 +14,8 @@
 			"idp_url": "https://auth.idp.hashicorp.com"
 		},
 		"product_slugs_with_integrations": ["vault", "waypoint", "nomad"]
+	},
+	"flags": {
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }

--- a/src/views/open-api-docs-view/index.tsx
+++ b/src/views/open-api-docs-view/index.tsx
@@ -1,0 +1,17 @@
+import type { OpenApiDocsViewProps } from './types'
+
+/**
+ * Placeholder for a revised OpenAPI docs view.
+ */
+function OpenApiDocsView(props: OpenApiDocsViewProps) {
+	return (
+		<div style={{ border: '1px solid magenta' }}>
+			<h1>OpenApiDocsView Placeholder</h1>
+			<pre>
+				<code>{JSON.stringify(props, null, 2)}</code>
+			</pre>
+		</div>
+	)
+}
+
+export default OpenApiDocsView

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -1,0 +1,40 @@
+import { GetStaticPaths, GetStaticProps } from 'next'
+import { OpenApiDocsParams, OpenApiDocsViewProps } from './types'
+
+/**
+ * Get static paths for the view.
+ *
+ * Initially, without versioning, we expect a single page. We use
+ * `getStaticPaths` for flag-based compatibility with the previous template.
+ *
+ * Later, when we implement versioned API docs for the new template,
+ * we'll likely need to retain `getStaticPaths`, using separate paths
+ * for each version of the OpenAPI documents that we detect.
+ */
+export const getStaticPaths: GetStaticPaths<OpenApiDocsParams> = async () => {
+	// For the new template, regardless of whether we're in a deploy preview
+	// or production, statically render the single view.
+	return {
+		paths: [{ params: { page: [] } }],
+		fallback: false,
+	}
+}
+
+/**
+ * Get static props for the view.
+ *
+ * This is where we expect to fetch the OpenAPI document, and transform
+ * the schema `.json` data into props for the view component.
+ *
+ * For now, we have a placeholder. We'll expand this as we build out the view.
+ */
+export const getStaticProps: GetStaticProps<
+	OpenApiDocsViewProps
+> = async () => {
+	return {
+		props: {
+			placeholder: 'placeholder data for the revised API docs template',
+			IS_REVISED_TEMPLATE: true,
+		},
+	}
+}

--- a/src/views/open-api-docs-view/types.ts
+++ b/src/views/open-api-docs-view/types.ts
@@ -1,0 +1,26 @@
+import type { ParsedUrlQuery } from 'querystring'
+
+/**
+ * Params type for `getStaticPaths` and `getStaticProps`.
+ * Encodes our assumption that a `[[page]].tsx` file is being used.
+ *
+ * Note: this is only needed for compatibility with the previous API docs,
+ * which could potentially render multiple pages, one for each service.
+ * In this revised template, we only render a single page.
+ *
+ * We will still need a dynamic route for versioning, but will need a refactor.
+ * TODO: revise this type once we've fully activated and then removed the
+ * `enable_hcp_vault_secrets_api_docs_revision` flag.
+ */
+export interface OpenApiDocsParams extends ParsedUrlQuery {
+	page: string[]
+}
+
+/**
+ * We'll use this type to document the shape of props for the view component.
+ * For now, we have a placeholder. We'll expand this as we build out the view.
+ */
+export interface OpenApiDocsViewProps {
+	placeholder: string
+	IS_REVISED_TEMPLATE: true
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds a `enable_hcp_vault_secrets_api_docs_revision` feature flag, and a related placeholder `open-api-docs-view`.

## 🤷 Why

To allow development of the revised API docs template to happen behind a feature flag.

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets] to ensure the flag is not active in previews
    - The preview should be identical to the [upstream /hcp/api-docs/vault-secrets][upstream/hcp/api-docs/vault-secrets]
- [ ] Test the flag locally
    - Pull this branch down locally, and set the `enable_hcp_vault_secrets_api_docs_revision` flag to `false` in `src/config/development.json`
    - Running the site locally, you should see a placeholder view at `/hcp/api-docs/vault-secrets`

[task]: https://app.asana.com/0/1204678746647847/1205011719572370/f
[preview]: https://dev-portal-git-zsadd-revised-api-docs-flag-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsadd-revised-api-docs-flag-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[upstream/hcp/api-docs/vault-secrets]: https://developer.hashicorp.com/hcp/api-docs/vault-secrets