### PR TITLE
[integrations] only return h2s integration anchor link

### DIFF
--- a/src/lib/serialize-integration-markdown.ts
+++ b/src/lib/serialize-integration-markdown.ts
@@ -43,5 +43,6 @@ export default async function serializeIntegrationMarkdown(
 		},
 	}
 	const serializeResult = await serialize(markdown, SERIALIZE_OPTIONS)
-	return { serializeResult, anchorLinks }
+	const filteredAnchorLinks = anchorLinks.filter((item) => item.level <= 2)
+	return { serializeResult, anchorLinks: filteredAnchorLinks }
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksintegrations-h2-only-sidecar-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1203792704477775/1204583486667907/f) 🎟️

## 🗒️ What

Adjusts serialization to only return h2 anchor links for integrations sidecar. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
