### PR TITLE
move global css to _app; remove undefined session

### DIFF
--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -58,7 +58,6 @@ export default function Dialog({
 						className={classNames(s.contentWrapper, s[variant])}
 					>
 						<DialogContent
-							style={{ background: 'red' }}
 							aria-describedby={ariaDescribedBy}
 							aria-label={label}
 							className={classNames(s.content, s[variant], contentClassName)}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// See _app.tsx for global reach style
 import { DialogOverlay, DialogContent } from '@reach/dialog'
-import '@reach/dialog/styles.css'
+
 import {
 	AnimatePresence,
 	m as slimMotion,
@@ -57,6 +58,7 @@ export default function Dialog({
 						className={classNames(s.contentWrapper, s[variant])}
 					>
 						<DialogContent
+							style={{ background: 'red' }}
 							aria-describedby={ariaDescribedBy}
 							aria-label={label}
 							className={classNames(s.content, s[variant], contentClassName)}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -36,6 +36,7 @@ import { makeDevAnalyticsLogger } from 'lib/analytics'
 import { DevDotClient } from 'views/error-views'
 import HeadMetadata from 'components/head-metadata'
 import { Toaster } from 'components/toast'
+import '@reach/dialog/styles.css' // Global CSS for components/dialog; Potentially redudant given our applied styles
 
 // Local imports
 import './style.css'
@@ -64,7 +65,7 @@ addGlobalLinkHandler((destinationUrl: string) => {
 
 export default function App({
 	Component,
-	pageProps: { session, ...pageProps },
+	pageProps,
 }: AppProps<{ session?: Session } & Record<string, any>>) {
 	const flagBag = useFlags()
 	useAnchorLinkAnalytics()
@@ -95,7 +96,7 @@ export default function App({
 				<QueryParamProvider adapter={NextAdapter}>
 					<ErrorBoundary FallbackComponent={DevDotClient}>
 						<FlagBagProvider value={flagBag}>
-							<SessionProvider session={session}>
+							<SessionProvider>
 								<DeviceSizeProvider>
 									<CurrentProductProvider currentProduct={currentProduct}>
 										<CodeTabsProvider>


### PR DESCRIPTION
# Description

Cleaning up paper cuts seen during app router spike work (https://github.com/hashicorp/dev-portal/pull/2095)

1. move global Reach CSS to `_app` (see [tutorial](https://nextjs.org/learn/basics/assets-metadata-css/global-styles))
2. remove never-defined `session` prop