### PR TITLE
chore: revert open-api-docs dev & preview flags

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,6 @@
 		"max_static_paths": 1
 	},
 	"flags": {
-		"enable_hcp_vault_secrets_api_docs_revision": true
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -4,6 +4,6 @@
 		"max_static_paths": 10
 	},
 	"flags": {
-		"enable_hcp_vault_secrets_api_docs_revision": true
+		"enable_hcp_vault_secrets_api_docs_revision": false
 	}
 }


### PR DESCRIPTION
Reverts flags accidentally not set back to `false` in #2105.