### PR TITLE
chore: link to release changelog from downloads

### DIFF
--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -162,7 +162,7 @@ const ChangelogSection = ({ selectedRelease }) => {
 				</div>
 				<MobileStandaloneLink
 					ariaLabel={`${name} version ${version} changelog`}
-					href={`https://github.com/hashicorp/${name}/blob/v${version}/CHANGELOG.md`}
+					href={`https://github.com/hashicorp/${name}/releases/tag/v${version}`}
 					size16Icon={<IconExternalLink16 />}
 					size24Icon={<IconExternalLink24 />}
 					iconPosition="trailing"


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates the downloads view template `Changelog` link to point to specific release URLs, at which we expect to see changelog notes for that release. Previously the `Changelog` link pointed to a markdown file in the commit associated with the release tag.

## 🧪 Testing

- [ ] Visit a downloads page, such as [/vault/downloads]
    - For any given version, there should be a `Changelog` link
    - The `Changelog` link should link out to the GitHub release page, for example 
    - Note: testing other products as well would be much appreciated!
 
> **Note**: We've validated that all products most often have some kind of changelog-equivalent content on every release. Part of the rational for this change is that release notes are relatively trivial to make changes to, at least compared to updating the contents of a markdown file associated with the `git` tree of a specific release tag.

[task]: https://app.asana.com/0/1202097197789424/1205233741731098/f
[preview]: https://dev-portal-git-zsupdate-downloads-changelog-link-hashicorp.vercel.app/
[/vault/downloads]: https://dev-portal-git-zsupdate-downloads-changelog-link-hashicorp.vercel.app/vault/downloads