### PR TITLE
feat: responsive styling for OpenAPI docs view header

### DIFF
--- a/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
+++ b/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
@@ -13,10 +13,11 @@
 	display: flex;
 	align-items: flex-start;
 	flex-direction: column-reverse;
-	gap: 16px;
+	gap: 8px;
 
 	@media (--dev-dot-tablet-up) {
 		flex-direction: row;
+		gap: 16px;
 	}
 }
 

--- a/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
+++ b/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
@@ -12,7 +12,12 @@
 .header {
 	display: flex;
 	align-items: flex-start;
+	flex-direction: column-reverse;
 	gap: 16px;
+
+	@media (--dev-dot-tablet-up) {
+		flex-direction: row;
+	}
 }
 
 .heading {
@@ -23,10 +28,18 @@
 }
 
 .icon {
-	margin-top: 3px;
+	display: none;
+
+	@media (--dev-dot-tablet-up) {
+		display: block;
+		margin-top: 3px;
+	}
 }
 
 .releaseStageBadge {
-	margin-top: 13px;
 	text-transform: capitalize;
+
+	@media (--dev-dot-tablet-up) {
+		margin-top: 13px;
+	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Refines responsive styling for the overview section of `OpenApiDocsView`

## 📸 Design Screenshots

🎨 [Figma][figma]

<img width="1847" alt="CleanShot 2023-08-18 at 13 01 12@2x" src="https://github.com/hashicorp/dev-portal/assets/4624598/fb56ee93-0a06-420e-bb81-2d9f5df2672e">

### Before

https://github.com/hashicorp/dev-portal/assets/4624598/77b7c98f-bdb0-45c6-9292-dfb84c357ce9

### After

https://github.com/hashicorp/dev-portal/assets/4624598/9a2b5cc5-1122-41c8-98dc-8c8ee5aec70e

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - The mobile appearance should match [designs][figma], hiding the icon on small viewports, and stacking the "release stage" badge (eg `Preview`) above the page heading

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205278197175200/f
[preview]: https://dev-portal-git-zsopenapi-overview-responsive-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-overview-responsive-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[figma]: https://www.figma.com/file/wjoC3ZVsA1kDuPsFLjEFuY/API-Template?type=design&node-id=386-16963&mode=design&t=q9t1fnV1B0mY3mjd-4