### PR TITLE
feat: themed badges for openapi response headings

### DIFF
--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -27,14 +27,6 @@ const Badge = ({
 	const hasText = !!text
 	const hasLabel = !!ariaLabel
 	const isIconOnly = hasIcon && !hasText
-	const isStatusBadge =
-		color == 'success' || color == 'warning' || color == 'critical'
-
-	if (isStatusBadge && !hasIcon) {
-		throw new Error(
-			'`Badge`s used for communicating status must have an icon to avoid relying on color alone.'
-		)
-	}
 
 	if (!hasIcon && !hasText) {
 		throw new Error(

--- a/src/views/open-api-docs-view/components/operation-details/index.tsx
+++ b/src/views/open-api-docs-view/components/operation-details/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import Badge from 'components/badge'
 import { ContentWithPermalink } from '../content-with-permalink'
 import { PropertyDetails, PropertyDetailsProps } from '../property-details'
 import s from './operation-details.module.css'
@@ -11,6 +12,10 @@ export interface PropertyDetailsGroup {
 	heading: {
 		text: string
 		slug: string
+		/**
+		 * If `theme` is provided, we render a badge with that theme.
+		 */
+		theme?: 'success' | 'neutral' | 'critical'
 	}
 	propertyDetails: PropertyDetailsProps[]
 }
@@ -77,7 +82,15 @@ function PropertyDetailsSection({
 									ariaLabel={group.heading.text}
 								>
 									<h5 id={group.heading.slug} className={s.groupHeading}>
-										{group.heading.text}
+										{group.heading.theme ? (
+											<Badge
+												type="outlined"
+												text={group.heading.text}
+												color={group.heading.theme}
+											/>
+										) : (
+											group.heading.text
+										)}
 									</h5>
 								</ContentWithPermalink>
 								<div className={s.groupProperties}>

--- a/src/views/open-api-docs-view/utils/get-response-data.ts
+++ b/src/views/open-api-docs-view/utils/get-response-data.ts
@@ -62,11 +62,12 @@ export async function getResponseData(
 			// Determine the heading text to show
 			const headingText =
 				responseCode === 'default'
-					? `Default Response`
+					? `Default Error Response`
 					: `${responseCode} -  ${getReasonPhrase(responseCode)}`
+			const headingTheme = responseCode.startsWith('2') ? 'success' : 'critical'
 
 			responseData.push({
-				heading: { text: headingText, slug: responseSlug },
+				heading: { text: headingText, slug: responseSlug, theme: headingTheme },
 				propertyDetails,
 			})
 		}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates response data headings on `OpenApiDocsView` to use coloured badges, themed based on success and error response codes.

## 📸 Design Screenshots

<img width="1173" alt="CleanShot 2023-08-14 at 22 03 05@2x" src="https://github.com/hashicorp/dev-portal/assets/4624598/f31dc6d6-50ab-4520-ba98-9f7bd4f8f72e">

| Before | After |
| - | - |
| ![before-light](https://github.com/hashicorp/dev-portal/assets/4624598/6ed00274-f677-481d-9d12-05429c6a3942) | ![after-light](https://github.com/hashicorp/dev-portal/assets/4624598/64824cf2-32e4-443c-ab0d-a04e2feb418e) |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/d55dfbe0-8450-4166-a031-c74c2d88cdd2) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/b8e26731-1057-4810-98b3-b4906f810d65) |

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - Badges should have a theme, with successful response headings in `success`-coloured badges, and error response headings in `critical`-coloured badges.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205271542994757/f
[preview]: https://dev-portal-git-zsopenapi-response-badges-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-response-badges-hashicorp.vercel.app/hcp/api-docs/vault-secrets