### PR TITLE
fix: build variant URLs as paths to fix local dev

### DIFF
--- a/src/components/dropdown-disclosure/components/list-item/index.tsx
+++ b/src/components/dropdown-disclosure/components/list-item/index.tsx
@@ -112,6 +112,7 @@ const DropdownDisclosureButtonItem = ({
 const DropdownDisclosureLinkItem = ({
 	children,
 	href,
+	as,
 	icon,
 	rel,
 	target,
@@ -122,6 +123,7 @@ const DropdownDisclosureLinkItem = ({
 			<Link
 				className={s.link}
 				href={href}
+				as={as}
 				rel={rel}
 				target={target}
 				onClick={onClick}

--- a/src/components/dropdown-disclosure/components/list-item/types.ts
+++ b/src/components/dropdown-disclosure/components/list-item/types.ts
@@ -80,7 +80,9 @@ interface DropdownDisclosureLinkItemProps {
 	href: NativeAnchorProps['href']
 
 	/**
-	 * An alias to display when navigating to the href.
+	 * An optional URL to display instead of the provided `href`.
+	 * The `href` will still be navigated to, but the URL will appear to
+	 * be the value passed to `as`.
 	 */
 	as?: LinkProps['as']
 

--- a/src/components/dropdown-disclosure/components/list-item/types.ts
+++ b/src/components/dropdown-disclosure/components/list-item/types.ts
@@ -80,6 +80,11 @@ interface DropdownDisclosureLinkItemProps {
 	href: NativeAnchorProps['href']
 
 	/**
+	 * An alias to display when navigating to the href.
+	 */
+	as?: LinkProps['as']
+
+	/**
 	 * An optional icon to render to the left of the text content.
 	 */
 	icon?: ReactElement

--- a/src/components/tutorial-meta/components/variant-list/desktop/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/desktop/index.tsx
@@ -17,7 +17,13 @@ import {
 } from 'views/tutorial-view/utils/variants'
 import s from './desktop-variant-list.module.css'
 
-export function DesktopVariantList({ variant }: { variant: TutorialVariant }) {
+export function DesktopVariantList({
+	variant,
+	tutorialBasePath,
+}: {
+	variant: TutorialVariant
+	tutorialBasePath: string
+}) {
 	const VARIANT_LIST_ID = 'variant-list-label'
 	const { asPath } = useRouter()
 
@@ -37,7 +43,7 @@ export function DesktopVariantList({ variant }: { variant: TutorialVariant }) {
 								<li key={option.slug}>
 									<Link
 										className={classNames(s.link)}
-										href={getVariantPath(asPath, variantParam)}
+										href={getVariantPath(tutorialBasePath, variantParam)}
 										aria-current={isActiveOption ? 'page' : undefined}
 										onClick={() => {
 											handleVariantCookie(variant.slug, option.slug)

--- a/src/components/tutorial-meta/components/variant-list/desktop/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/desktop/index.tsx
@@ -10,6 +10,7 @@ import { safeAnalyticsTrack } from 'lib/analytics'
 import {
 	TutorialVariant,
 	TutorialVariantOption,
+	getVariantHref,
 	getVariantParam,
 	getVariantPath,
 	handleVariantCookie,
@@ -43,7 +44,8 @@ export function DesktopVariantList({
 								<li key={option.slug}>
 									<Link
 										className={classNames(s.link)}
-										href={getVariantPath(tutorialBasePath, variantParam)}
+										href={getVariantHref(tutorialBasePath, variantParam)}
+										as={getVariantPath(asPath, variantParam)}
 										aria-current={isActiveOption ? 'page' : undefined}
 										onClick={() => {
 											handleVariantCookie(variant.slug, option.slug)

--- a/src/components/tutorial-meta/components/variant-list/index.tsx
+++ b/src/components/tutorial-meta/components/variant-list/index.tsx
@@ -8,7 +8,11 @@ import { useVariant } from 'views/tutorial-view/utils/variants/context'
 import { DesktopVariantList } from './desktop'
 import s from './variant-list.module.css'
 
-export function VariantList() {
+export function VariantList({
+	tutorialBasePath,
+}: {
+	tutorialBasePath: string
+}) {
 	const { currentVariant } = useVariant()
 
 	if (!currentVariant) {
@@ -18,10 +22,17 @@ export function VariantList() {
 	return (
 		<>
 			<div className={s.desktopVariantList} data-heap-track="variant-list">
-				<DesktopVariantList variant={currentVariant} />
+				<DesktopVariantList
+					variant={currentVariant}
+					tutorialBasePath={tutorialBasePath}
+				/>
 			</div>
 			<div className={s.mobileVariantDropdownDisclosure}>
-				<VariantDropdownDisclosure isFullWidth variant={currentVariant} />
+				<VariantDropdownDisclosure
+					isFullWidth
+					variant={currentVariant}
+					tutorialBasePath={tutorialBasePath}
+				/>
 			</div>
 		</>
 	)

--- a/src/components/tutorial-meta/index.tsx
+++ b/src/components/tutorial-meta/index.tsx
@@ -20,12 +20,14 @@ interface TutorialMetaProps {
 		hasVideo: boolean
 	}
 	tutorialId: TutorialData['id']
+	tutorialBasePath: string
 }
 
 export default function TutorialMeta({
 	heading,
 	meta,
 	tutorialId,
+	tutorialBasePath,
 }: TutorialMetaProps) {
 	const { isInteractive, hasVideo, edition, productsUsed, readTime } = meta
 
@@ -77,7 +79,7 @@ export default function TutorialMeta({
 					to bookmark tutorials.
 				</Text>
 			) : null}
-			<VariantList />
+			<VariantList tutorialBasePath={tutorialBasePath} />
 		</header>
 	)
 }

--- a/src/views/onboarding/tutorial-view/index.tsx
+++ b/src/views/onboarding/tutorial-view/index.tsx
@@ -42,10 +42,7 @@ export default function OnboardingTutorialView({
 	const InteractiveLabWrapper = isInteractive ? InstruqtProvider : Fragment
 
 	/**
-	 * We use the tutorialsBasePath to construct variant URLs.
-	 *
-	 * TODO: write up more details on this, feels like this approach
-	 * could have other implications on tutorial variant context
+	 * We use the tutorialsBasePath to construct variant URLs as paths.
 	 */
 	const tutorialBasePath = getTutorialSlug(
 		tutorial.slug,

--- a/src/views/onboarding/tutorial-view/index.tsx
+++ b/src/views/onboarding/tutorial-view/index.tsx
@@ -17,6 +17,7 @@ import { NextPrevious } from 'views/tutorial-view/components'
 import VariantProvider from 'views/tutorial-view/utils/variants/context'
 import { VariantDropdownDisclosure } from 'views/tutorial-view/components'
 import { OnboardingTutorialViewProps } from '../types'
+import { getTutorialSlug } from 'views/collection-view/helpers'
 
 export default function OnboardingTutorialView({
 	tutorial,
@@ -40,6 +41,17 @@ export default function OnboardingTutorialView({
 	const isInteractive = Boolean(handsOnLab)
 	const InteractiveLabWrapper = isInteractive ? InstruqtProvider : Fragment
 
+	/**
+	 * We use the tutorialsBasePath to construct variant URLs.
+	 *
+	 * TODO: write up more details on this, feels like this approach
+	 * could have other implications on tutorial variant context
+	 */
+	const tutorialBasePath = getTutorialSlug(
+		tutorial.slug,
+		tutorial.collectionCtx.current.slug
+	)
+
 	return (
 		<>
 			<HashiHead>
@@ -56,11 +68,16 @@ export default function OnboardingTutorialView({
 						sidebarNavDataLevels={layoutProps.navLevels}
 						sidecarTopSlot={
 							variant ? (
-								<VariantDropdownDisclosure variant={variant} isFullWidth />
+								<VariantDropdownDisclosure
+									variant={variant}
+									isFullWidth
+									tutorialBasePath={tutorialBasePath}
+								/>
 							) : null
 						}
 					>
 						<TutorialMeta
+							tutorialBasePath={tutorialBasePath}
 							heading={pageHeading}
 							meta={{
 								readTime,

--- a/src/views/tutorial-view/components/variant-dropdown-disclosure/index.tsx
+++ b/src/views/tutorial-view/components/variant-dropdown-disclosure/index.tsx
@@ -23,6 +23,7 @@ import s from './variant-dropdown-disclosure.module.css'
 export function VariantDropdownDisclosure({
 	variant,
 	isFullWidth,
+	tutorialBasePath,
 }: VariantDropdownDisclosureProps) {
 	const labelId = useId()
 	const { asPath } = useRouter()
@@ -49,7 +50,7 @@ export function VariantDropdownDisclosure({
 							<DropdownDisclosureLinkItem
 								key={option.slug}
 								href={getVariantPath(
-									asPath,
+									tutorialBasePath,
 									getVariantParam(variant.slug, option.slug)
 								)}
 								onClick={() => {

--- a/src/views/tutorial-view/components/variant-dropdown-disclosure/index.tsx
+++ b/src/views/tutorial-view/components/variant-dropdown-disclosure/index.tsx
@@ -49,6 +49,10 @@ export function VariantDropdownDisclosure({
 						return (
 							<DropdownDisclosureLinkItem
 								key={option.slug}
+								as={getVariantPath(
+									asPath,
+									getVariantParam(variant.slug, option.slug)
+								)}
 								href={getVariantPath(
 									tutorialBasePath,
 									getVariantParam(variant.slug, option.slug)

--- a/src/views/tutorial-view/components/variant-dropdown-disclosure/types.ts
+++ b/src/views/tutorial-view/components/variant-dropdown-disclosure/types.ts
@@ -8,4 +8,5 @@ import { TutorialVariant } from 'views/tutorial-view/utils/variants/types'
 export interface VariantDropdownDisclosureProps {
 	variant: TutorialVariant
 	isFullWidth?: boolean
+	tutorialBasePath: string
 }

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -227,10 +227,7 @@ function TutorialView({
 	})
 
 	/**
-	 * We use the tutorialsBasePath to construct variant URLs.
-	 *
-	 * TODO: write up more details on this, feels like this approach
-	 * could have other implications on tutorial variant context
+	 * We use the tutorialsBasePath to construct variant URLs as paths.
 	 */
 	const tutorialBasePath = getTutorialSlug(
 		tutorial.slug,

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -226,6 +226,17 @@ function TutorialView({
 		collectionTutorialIds,
 	})
 
+	/**
+	 * We use the tutorialsBasePath to construct variant URLs.
+	 *
+	 * TODO: write up more details on this, feels like this approach
+	 * could have other implications on tutorial variant context
+	 */
+	const tutorialBasePath = getTutorialSlug(
+		tutorial.slug,
+		collectionCtx.current.slug
+	)
+
 	return (
 		<>
 			<Head>
@@ -255,6 +266,7 @@ function TutorialView({
 						sidecarTopSlot={
 							metadata.variant ? (
 								<VariantDropdownDisclosure
+									tutorialBasePath={tutorialBasePath}
 									variant={metadata.variant}
 									isFullWidth
 								/>
@@ -271,6 +283,7 @@ function TutorialView({
 							}
 						>
 							<TutorialMeta
+								tutorialBasePath={tutorialBasePath}
 								heading={pageHeading}
 								meta={{
 									readTime,

--- a/src/views/tutorial-view/utils/variants/index.ts
+++ b/src/views/tutorial-view/utils/variants/index.ts
@@ -10,8 +10,27 @@ import {
 } from 'lib/learn-client/types'
 import { TutorialVariant, TutorialVariantOption } from './types'
 
-export function getVariantPath(path: string, variantType: string) {
+/**
+ * Get the variant href for a given path and variant type.
+ * This is the link that we need for `getStaticProps` to return the
+ * correct variant data.
+ */
+export function getVariantHref(path: string, variantType: string) {
 	return `${path}/${variantType}`.replace(':', '%3A')
+}
+
+export function getVariantPath(path: string, variantType: string) {
+	const url = new URL(path, 'https://developer.hashicorp.com')
+
+	// if the variant is not defined, or if it is defined in the path already, use that
+	if (!variantType || url.searchParams.get('variants') === variantType) {
+		return path
+	}
+
+	// otherwise just add the variant to the path
+	url.searchParams.set('variants', variantType)
+
+	return url.pathname.toString() + url.search.toString()
 }
 
 export function getVariantParam(

--- a/src/views/tutorial-view/utils/variants/index.ts
+++ b/src/views/tutorial-view/utils/variants/index.ts
@@ -11,17 +11,7 @@ import {
 import { TutorialVariant, TutorialVariantOption } from './types'
 
 export function getVariantPath(path: string, variantType: string) {
-	const url = new URL(path, 'https://developer.hashicorp.com')
-
-	// if the variant is not defined, or if it is defined in the path already, use that
-	if (!variantType || url.searchParams.get('variants') === variantType) {
-		return path
-	}
-
-	// otherwise just add the variant to the path
-	url.searchParams.set('variants', variantType)
-
-	return url.pathname.toString() + url.search.toString()
+	return `${path}/${variantType}`.replace(':', '%3A')
 }
 
 export function getVariantParam(

--- a/src/views/tutorial-view/utils/variants/index.ts
+++ b/src/views/tutorial-view/utils/variants/index.ts
@@ -11,14 +11,21 @@ import {
 import { TutorialVariant, TutorialVariantOption } from './types'
 
 /**
- * Get the variant href for a given path and variant type.
- * This is the link that we need for `getStaticProps` to return the
- * correct variant data.
+ * Get the variant href for a given tutorial path and variant type.
+ *
+ * This is the URL with a path format, like `/variant:option`, that we need for
+ * `getStaticProps` to return the correct variant data.
  */
 export function getVariantHref(path: string, variantType: string) {
 	return `${path}/${variantType}`.replace(':', '%3A')
 }
 
+/**
+ * Get the variant path for a given current path and variant type.
+ *
+ * This is the URL with a search param format, like `?varaints=variant:option`.
+ * This is the URL that we want users to see.
+ */
 export function getVariantPath(path: string, variantType: string) {
 	const url = new URL(path, 'https://developer.hashicorp.com')
 

--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -51,10 +51,7 @@ export default function WellArchitectedFrameworkTutorialView({
 	const canonicalUrl = generateCanonicalUrl(canonicalCollectionSlug, slug)
 
 	/**
-	 * We use the tutorialsBasePath to construct variant URLs.
-	 *
-	 * TODO: write up more details on this, feels like this approach
-	 * could have other implications on tutorial variant context
+	 * We use the tutorialsBasePath to construct variant URLs as paths.
 	 */
 	const tutorialBasePath = getTutorialSlug(slug, canonicalCollectionSlug)
 

--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -20,6 +20,7 @@ import { NextPrevious } from 'views/tutorial-view/components'
 import { generateCanonicalUrl } from 'views/tutorial-view/utils'
 import s from 'views/tutorial-view/tutorial-view.module.css'
 import { WafTutorialViewProps } from '../types'
+import { getTutorialSlug } from 'views/collection-view/helpers'
 
 export default function WellArchitectedFrameworkTutorialView({
 	tutorial,
@@ -49,6 +50,14 @@ export default function WellArchitectedFrameworkTutorialView({
 	const canonicalCollectionSlug = tutorial.collectionCtx.default.slug
 	const canonicalUrl = generateCanonicalUrl(canonicalCollectionSlug, slug)
 
+	/**
+	 * We use the tutorialsBasePath to construct variant URLs.
+	 *
+	 * TODO: write up more details on this, feels like this approach
+	 * could have other implications on tutorial variant context
+	 */
+	const tutorialBasePath = getTutorialSlug(slug, canonicalCollectionSlug)
+
 	return (
 		<>
 			<HashiHead>
@@ -66,11 +75,16 @@ export default function WellArchitectedFrameworkTutorialView({
 						mainWidth="narrow"
 						sidecarTopSlot={
 							variant ? (
-								<VariantDropdownDisclosure variant={variant} isFullWidth />
+								<VariantDropdownDisclosure
+									variant={variant}
+									isFullWidth
+									tutorialBasePath={tutorialBasePath}
+								/>
 							) : null
 						}
 					>
 						<TutorialMeta
+							tutorialBasePath={tutorialBasePath}
 							heading={pageHeading}
 							meta={{
 								readTime,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes a tutorials-specific local development bug related of variants.

## 🤷 Why

For folks running the site locally from the `hashicorp/tutorials` repo, it seems the front-end has to be restarted for any new variants or variant options to function as expected. We want the front-end to work and display variants and their interactivity correctly, without requiring frequent restarts.

## 🛠️ How

The root cause of the local development bug seems to be related to middleware rewrites, which are generated only once when the dev server starts. In more detail:

- Rewrites allow links with search params like `?variants=variant:option` to be interpreted by `getStaticProps` as an additional `/variant:option` URL path segment built on the current tutorial URL
- Variants are switched on the front-end with `Link` elements, that link to variant URLs
    - When a variant URL is visited, new results are returned from `getStaticProps`, and this updates the variant data shown on the page
    - Note we do have a `VariantContext`, but this isn't exactly used as interactive client-side context, as it only updates when the variant data incoming from `getStaticProps` changes
- Upstream, variants URLs are built the format `?variants=variant:option`
- The upstream format of variant URLs _requires middleware rewrites_ to be up-to-date
- Middleware rewrites are only updated when the front-end process restarts, so in order for new variant URLs to function upstream, the front-end process must be restarted

This PR implements a short-term fix for the issue:

- Links are now constructed as path additions to the base tutorial URL
- In other words, we now use the `/<tutorialPath>/variant:option` URL format directly, rather than relying on middleware rewrites of `?variants=variant:option`
- This shift in URL structure means middleware rewrites do not need to be up to date (and in fact may not be needed at all? not sure), and the dev server does not need to be restarted for new variant and variants option URLs to function
- We use the `next/link` `as` prop to ensure the URL looks the same in the browser, appearing to be the search param style like `?variants=variant:option` 

## 🧪 Testing

- [ ] Work off a variants branch locally and test that new variant and option additions work as expected
    - Clone `hashicorp/tutorials`, and with Docker running, run `make`, this will start everything including a frontend we'll ignore at `http://localhost:3000`
    - Pull down this branch, modify `.env` to point this front-end to the Learn API running at `http://localhost:5001`
    - Start the front-end off this branch with `npm run start`, should start up at `http://localhost:3001`
    - Mess around with adding and removing variants, and interact with new variants on the front-end.
    - Variants and variant options added after starting the dev server should function as expected, even though they won't be accounted for in middleware rewrites.

## 💭 Anything else?

This PR does _not_ account for multiple combined variant options... not really if that's a thing, but the `?variants=key:value` format implies that `?variants=key1:value1,key2:value2` might be possible... It seems like our `getStaticProps` function supports only one additional path segment, so only one `key:value` variant pair... but figured worth mentioning in case I missed something!

[task]: https://app.asana.com/0/1202097197789424/1205317011687135/f
[preview]: https://dev-portal-git-zsdebug-variants-local-dev-hashicorp.vercel.app/