### PR TITLE
fix(open-api): hide code path on small viewports

### DIFF
--- a/src/views/open-api-docs-view/components/operation-sections/operation-sections.module.css
+++ b/src/views/open-api-docs-view/components/operation-sections/operation-sections.module.css
@@ -11,7 +11,7 @@
 .gridLayout {
 	display: grid;
 	gap: 24px;
-	grid-template-areas: 'header' 'examples' 'details';
+	grid-template-areas: 'header' 'details';
 	grid-template-columns: minmax(0, 1fr);
 
 	/* Note: 744px = 360px per column, plus 24px grid gap.
@@ -36,9 +36,15 @@
 }
 
 .examplesStickyContainer {
-	grid-area: examples;
-	height: 100%;
-	position: relative;
+	display: none;
+
+	/* stylelint-disable-next-line at-rule-no-unknown */
+	@container (min-width: 744px) {
+		display: block;
+		grid-area: examples;
+		height: 100%;
+		position: relative;
+	}
 }
 
 .examplesSlot {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Hides operation path code blocks in `OpenApiDocsView` when the layout of each operation changes to one column.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![768-before](https://github.com/hashicorp/dev-portal/assets/4624598/8fefaed7-b670-4f07-a8fc-af64f6e32aa6) | ![768-after](https://github.com/hashicorp/dev-portal/assets/4624598/e52075ec-b4e0-4c2c-95cc-40ea3c058123) |
| ![1024-before](https://github.com/hashicorp/dev-portal/assets/4624598/661342f7-ee6a-44d9-a31f-b442d3aa6ac4) | ![1024-after](https://github.com/hashicorp/dev-portal/assets/4624598/c9b23cbe-c6e1-45cf-a467-e6ceed8b7caf) |

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - When the layout of each operation changes to one-column, the code block should be hidden

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205316467934583/f
[preview]: https://dev-portal-git-zsopenapi-hide-code-onecol-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-hide-code-onecol-hashicorp.vercel.app/hcp/api-docs/vault-secrets