### PR TITLE
chore(openapi): mod slugs to match source

### DIFF
--- a/src/views/open-api-docs-view/utils/get-operation-props.ts
+++ b/src/views/open-api-docs-view/utils/get-operation-props.ts
@@ -4,7 +4,6 @@
  */
 
 // Third-party
-import { paramCase } from 'change-case'
 import slugify from 'slugify'
 // Local
 import { getRequestData, getResponseData, truncateHcpOperationPath } from './'
@@ -41,9 +40,7 @@ export async function getOperationProps(
 			}
 
 			// Create a slug for this operation
-			const operationSlug = slugify(paramCase(operation.operationId), {
-				lower: true,
-			})
+			const operationSlug = slugify(operation.operationId)
 
 			/**
 			 * Parse request and response details for this operation

--- a/src/views/open-api-docs-view/utils/get-property-detail-props.ts
+++ b/src/views/open-api-docs-view/utils/get-property-detail-props.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// Third party
+import slugify from 'slugify'
 // Utilities
 import markdownToHtml from '@hashicorp/platform-markdown-utils/markdown-to-html'
 // Types
@@ -17,7 +19,7 @@ export async function getPropertyDetailPropsFromParameter(
 	param: OpenAPIV3.ParameterObject,
 	parentSlug: string
 ): Promise<PropertyDetailsProps> {
-	const slug = `${parentSlug}_${param.name}`
+	const slug = `${parentSlug}_${slugify(param.name)}`
 	const paramSchemaDetails = await getPropertyDetailsFromSchema(
 		param.schema,
 		slug
@@ -44,7 +46,7 @@ export async function getPropertyDetailPropsFromSchemaObject(
 	isRequired: boolean,
 	parentSlug: string
 ): Promise<PropertyDetailsProps> {
-	const slug = `${parentSlug}_${key}`
+	const slug = `${parentSlug}_${slugify(key)}`
 	const schemaDetails = await getPropertyDetailsFromSchema(schema, slug, 0)
 	return {
 		name: key,
@@ -108,7 +110,7 @@ async function getPropertyDetailsFromSchema(
 		// and recursing into the schema for each property as necessary.
 		for (const propertyKey of Object.keys(schema.properties)) {
 			const property = schema.properties[propertyKey]
-			const propertySlug = `${parentSlug}.${propertyKey}`
+			const propertySlug = `${parentSlug}.${slugify(propertyKey)}`
 			const propertyDetails = await getPropertyDetailsFromSchema(
 				property,
 				propertySlug


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

In OpenAPI view, modifies all `#anchor-link` slug values so that they're truer to source, namely by retaining original casing.

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - All operation anchor links should now more closely match their operation IDs, like `#mySpecialOperation` rather than `#my-special-operation`
    - Similarly, all nested parameter slugs should more closely match their keys
    - With the above changes, all slugs should remain unique (not necessarily something easy to test in browser, probably better to assert this through code review, but clicking around a bunch would probably add some confidence)

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205367854380355/f
[preview]: https://dev-portal-git-zsopenapi-anchors-match-source-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-anchors-match-source-hashicorp.vercel.app/hcp/api-docs/vault-secrets