### PR TITLE
chore(openapi): update sidebar overview link to be anchor

### DIFF
--- a/src/views/open-api-docs-view/components/open-api-overview/index.tsx
+++ b/src/views/open-api-docs-view/components/open-api-overview/index.tsx
@@ -26,7 +26,10 @@ import s from './open-api-overview.module.css'
  */
 
 export interface OpenApiOverviewProps {
-	title: string
+	heading: {
+		text: string
+		slug: string
+	}
 	badgeText: string
 	statusIndicatorConfig?: StatusIndicatorConfig
 	contentSlot?: ReactNode
@@ -34,7 +37,7 @@ export interface OpenApiOverviewProps {
 }
 
 export function OpenApiOverview({
-	title,
+	heading,
 	badgeText,
 	statusIndicatorConfig,
 	contentSlot,
@@ -46,7 +49,9 @@ export function OpenApiOverview({
 					<IconVaultColor16 />
 				</IconTile>
 				<span>
-					<h1 className={s.heading}>{title}</h1>
+					<h1 id={heading.slug} className={s.heading}>
+						{heading.text}
+					</h1>
 					{statusIndicatorConfig ? (
 						<Status
 							endpointUrl={statusIndicatorConfig.endpointUrl}

--- a/src/views/open-api-docs-view/components/open-api-overview/index.tsx
+++ b/src/views/open-api-docs-view/components/open-api-overview/index.tsx
@@ -28,7 +28,7 @@ import s from './open-api-overview.module.css'
 export interface OpenApiOverviewProps {
 	heading: {
 		text: string
-		slug: string
+		id: string
 	}
 	badgeText: string
 	statusIndicatorConfig?: StatusIndicatorConfig
@@ -49,7 +49,7 @@ export function OpenApiOverview({
 					<IconVaultColor16 />
 				</IconTile>
 				<span>
-					<h1 id={heading.slug} className={s.heading}>
+					<h1 id={heading.id} className={s.heading}>
 						{heading.text}
 					</h1>
 					{statusIndicatorConfig ? (

--- a/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
+++ b/src/views/open-api-docs-view/components/open-api-overview/open-api-overview.module.css
@@ -23,6 +23,9 @@
 
 .heading {
 	composes: hds-typography-display-600 from global;
+
+	/* Ensure we jump to the very top of the page when linking to this item */
+	scroll-margin-top: calc(var(--total-scroll-offset) + 999vh);
 	font-weight: var(--token-typography-font-weight-bold);
 	color: var(--token-color-foreground-strong);
 	margin: 0 0 9px 0;

--- a/src/views/open-api-docs-view/index.tsx
+++ b/src/views/open-api-docs-view/index.tsx
@@ -25,7 +25,7 @@ import { DescriptionMdx } from './components/open-api-overview/components/descri
  */
 function OpenApiDocsView({
 	productData,
-	title,
+	topOfPageHeading,
 	releaseStage,
 	descriptionMdx,
 	operationGroups,
@@ -57,7 +57,7 @@ function OpenApiDocsView({
 				<div className={s.spaceBreadcrumbsOverview}>
 					<BreadcrumbBar links={breadcrumbLinks} />
 					<OpenApiOverview
-						title={title}
+						heading={topOfPageHeading}
 						badgeText={releaseStage}
 						statusIndicatorConfig={statusIndicatorConfig}
 						contentSlot={

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -66,6 +66,7 @@ export async function getStaticProps({
 	versionData,
 	basePath,
 	statusIndicatorConfig,
+	topOfPageSlug = 'overview',
 	massageSchemaForClient = (s: OpenAPIV3.Document) => s,
 	navResourceItems = [],
 }: {
@@ -74,6 +75,7 @@ export async function getStaticProps({
 	versionData: OpenApiDocsVersionData[]
 	basePath: string
 	statusIndicatorConfig: StatusIndicatorConfig
+	topOfPageSlug?: string
 	massageSchemaForClient?: (
 		schemaData: OpenAPIV3.Document
 	) => OpenAPIV3.Document
@@ -115,7 +117,7 @@ export async function getStaticProps({
 	const operationGroups = groupOperations(operationProps)
 	const navItems = getNavItems({
 		operationGroups,
-		basePath,
+		topOfPageSlug,
 		title: schemaData.info.title,
 		productSlug: productData.slug,
 	})
@@ -140,7 +142,10 @@ export async function getStaticProps({
 	return {
 		props: {
 			productData,
-			title: schemaData.info.title,
+			topOfPageHeading: {
+				text: schemaData.info.title,
+				slug: topOfPageSlug,
+			},
 			releaseStage: targetVersion.releaseStage,
 			descriptionMdx,
 			IS_REVISED_TEMPLATE: true,

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -66,7 +66,7 @@ export async function getStaticProps({
 	versionData,
 	basePath,
 	statusIndicatorConfig,
-	topOfPageSlug = 'overview',
+	topOfPageId = 'overview',
 	massageSchemaForClient = (s: OpenAPIV3.Document) => s,
 	navResourceItems = [],
 }: {
@@ -75,7 +75,7 @@ export async function getStaticProps({
 	versionData: OpenApiDocsVersionData[]
 	basePath: string
 	statusIndicatorConfig: StatusIndicatorConfig
-	topOfPageSlug?: string
+	topOfPageId?: string
 	massageSchemaForClient?: (
 		schemaData: OpenAPIV3.Document
 	) => OpenAPIV3.Document
@@ -117,7 +117,7 @@ export async function getStaticProps({
 	const operationGroups = groupOperations(operationProps)
 	const navItems = getNavItems({
 		operationGroups,
-		topOfPageSlug,
+		topOfPageId,
 		title: schemaData.info.title,
 		productSlug: productData.slug,
 	})
@@ -144,7 +144,7 @@ export async function getStaticProps({
 			productData,
 			topOfPageHeading: {
 				text: schemaData.info.title,
-				slug: topOfPageSlug,
+				id: topOfPageId,
 			},
 			releaseStage: targetVersion.releaseStage,
 			descriptionMdx,

--- a/src/views/open-api-docs-view/types.ts
+++ b/src/views/open-api-docs-view/types.ts
@@ -126,7 +126,10 @@ export interface StatusIndicatorConfig {
 export interface OpenApiDocsViewProps {
 	IS_REVISED_TEMPLATE: true
 	productData: ProductData
-	title: string
+	topOfPageHeading: {
+		text: string
+		slug: string
+	}
 	descriptionMdx: MDXRemoteSerializeResult
 	releaseStage: string
 

--- a/src/views/open-api-docs-view/types.ts
+++ b/src/views/open-api-docs-view/types.ts
@@ -128,7 +128,7 @@ export interface OpenApiDocsViewProps {
 	productData: ProductData
 	topOfPageHeading: {
 		text: string
-		slug: string
+		id: string
 	}
 	descriptionMdx: MDXRemoteSerializeResult
 	releaseStage: string

--- a/src/views/open-api-docs-view/utils/get-nav-items.ts
+++ b/src/views/open-api-docs-view/utils/get-nav-items.ts
@@ -10,12 +10,12 @@ import { OperationGroup, OpenApiNavItem } from '../types'
  * Build nav items for each operation, group-by-group.
  */
 export function getNavItems({
-	topOfPageSlug,
+	topOfPageId,
 	operationGroups,
 	productSlug,
 	title,
 }: {
-	topOfPageSlug: string
+	topOfPageId: string
 	operationGroups: OperationGroup[]
 	productSlug: ProductSlug
 	title: string
@@ -23,7 +23,7 @@ export function getNavItems({
 	// Build the top-level page nav item
 	const pageNavItem = {
 		title,
-		fullPath: `#${topOfPageSlug}`,
+		fullPath: `#${topOfPageId}`,
 		theme: productSlug,
 	}
 	// Include grouped operation items

--- a/src/views/open-api-docs-view/utils/get-nav-items.ts
+++ b/src/views/open-api-docs-view/utils/get-nav-items.ts
@@ -10,12 +10,12 @@ import { OperationGroup, OpenApiNavItem } from '../types'
  * Build nav items for each operation, group-by-group.
  */
 export function getNavItems({
-	basePath,
+	topOfPageSlug,
 	operationGroups,
 	productSlug,
 	title,
 }: {
-	basePath: string
+	topOfPageSlug: string
 	operationGroups: OperationGroup[]
 	productSlug: ProductSlug
 	title: string
@@ -23,7 +23,7 @@ export function getNavItems({
 	// Build the top-level page nav item
 	const pageNavItem = {
 		title,
-		fullPath: basePath,
+		fullPath: `#${topOfPageSlug}`,
 		theme: productSlug,
 	}
 	// Include grouped operation items


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds an `#overview` anchor link to the OpenAPI docs view sidebar, to make it easier for visitors to jump to the top of the page.

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - The first link in the sidebar should now lead to and `#overview` anchor link
    - The `#overview` anchor link should jump to the top of the page
    - The "active state" on this link should now change when `activeSection` changes, such that only one sidebar link is ever highlighted at one time.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205211659139665/f
[preview]: https://dev-portal-git-zsopenapi-overview-link-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-overview-link-hashicorp.vercel.app/hcp/api-docs/vault-secrets