### PR TITLE
fix(openapi): avoid extra line-break chars in copied code

### DIFF
--- a/src/views/open-api-docs-view/utils/get-operation-props.ts
+++ b/src/views/open-api-docs-view/utils/get-operation-props.ts
@@ -22,6 +22,18 @@ import type { OpenAPIV3 } from 'openapi-types'
 export async function getOperationProps(
 	schemaJson: OpenAPIV3.Document
 ): Promise<OperationProps[]> {
+	// Grab the server URL, we'll use this to build URL paths for each operation
+	let serverUrl = ''
+	if (schemaJson.servers?.length > 0) {
+		const rawServerUrl = schemaJson.servers[0].url
+		/**
+		 * If we up-converted from an older OpenAPI version, then the spec would
+		 * have defined a `host` rather than explicit server URL, and the resulting
+		 * server URL will start with `//` rather than a valid protocol.
+		 * In this case we assume HTTPs, and update the serverUrl accordingly.
+		 */
+		serverUrl = rawServerUrl.replace(/^\/\//, 'https://')
+	}
 	// Set up an accumulator array
 	const operationObjects: OperationProps[] = []
 	/**
@@ -90,7 +102,7 @@ export async function getOperationProps(
 				summary,
 				requestData,
 				responseData,
-				urlPathForCodeBlock: getUrlPathCodeHtml(path),
+				urlPathForCodeBlock: getUrlPathCodeHtml(serverUrl + path),
 				_placeholder: {
 					__type: type,
 					__path: path,

--- a/src/views/open-api-docs-view/utils/get-url-path-code-html.ts
+++ b/src/views/open-api-docs-view/utils/get-url-path-code-html.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { addWordBreaksToUrl } from './add-word-breaks-to-url'
-
 /**
  * Given a URL path,
  * Return HTML that represents the URL path, with `{parameters}` syntax
@@ -12,8 +10,13 @@ import { addWordBreaksToUrl } from './add-word-breaks-to-url'
  * to allow long URLs to wrap to multiple lines.
  */
 export default function getUrlPathCodeHtml(urlPath: string): string {
-	// Insert word breaks before forward slashes for more logical line breaks
-	const urlWithWordBreaks = addWordBreaksToUrl(urlPath)
+	/**
+	 * Insert <wbr/> before forward slashes for more logical line breaks
+	 *
+	 * Note: we can't use zero-width spaces here as in other use cases,
+	 * as they show up when the code block contents are copied.
+	 */
+	const urlWithWordBreaks = urlPath.replace(/\//g, '/<wbr/>')
 	// Add syntax highlighting around any {parameters} in the path
 	const parameterRegex = /{([^}]+)}/g
 	const urlPathForCodeBlock = urlWithWordBreaks.replace(


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR fixes an issue in OpenApiDocsView where copied URL paths would contain additional space characters.

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - When copied, URL paths should not contain any additional characters. Upstream, copied URL paths contained zero-width-space characters.
    - URL paths should now all start with the `host` value [defined in the HCP Vault Secrets spec](https://github.com/hashicorp/hcp-specs/blob/274566639360a420515acf61961479461ae51790/specs/cloud-vault-secrets/preview/2023-06-13/hcp.swagger.json#L13), which is `api.cloud.hashicorp.com`. Note that we assume HTTPS as the protocol for connecting to the host.

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsopenapi-url-path-tweaks-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1204678746647847/1205377232782704/f
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-url-path-tweaks-hashicorp.vercel.app/hcp/api-docs/vault-secrets