### PR TITLE
chore: `next-auth` 4.23.1

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -54,7 +54,7 @@ const ignorePatternForModuleType = isRunningInEsmMode
 const config: Config.InitialOptions = {
 	setupFilesAfterEnv: ['<rootDir>/.test/setup-jest.js'],
 	roots: ['config', 'src', 'build-libs', 'stylelint-rules'],
-	moduleDirectories: ['node_modules', 'src'],
+	moduleDirectories: ['node_modules', '<rootDir>/src'],
 	collectCoverageFrom: [
 		'**/*.{js,jsx,ts,tsx}',
 		'!**/*.d.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
 				"mdast-util-to-string": "^2.0.0",
 				"moize": "^6.1.0",
 				"next": "^13.0.5",
-				"next-auth": "^4.19.2",
+				"next-auth": "^4.23.1",
 				"next-mdx-remote": "^3.0.8",
 				"next-query-params": "^4.1.0",
 				"next-sitemap": "^3.1.21",
@@ -28665,16 +28665,16 @@
 			}
 		},
 		"node_modules/next-auth": {
-			"version": "4.19.2",
-			"resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.19.2.tgz",
-			"integrity": "sha512-6V2YG3IJQVhgCAH7mvT3yopTW92gMdUrcwGX7NQ0dCreT/+axGua/JmVdarjec0C/oJukKpIYRgjMlV+L5ZQOQ==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.23.1.tgz",
+			"integrity": "sha512-mL083z8KgRtlrIV6CDca2H1kduWJuK/3pTS0Fe2og15KOm4v2kkLGdSDfc2g+019aEBrJUT0pPW2Xx42ImN1WA==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.3",
-				"@panva/hkdf": "^1.0.1",
+				"@babel/runtime": "^7.20.13",
+				"@panva/hkdf": "^1.0.2",
 				"cookie": "^0.5.0",
-				"jose": "^4.9.3",
+				"jose": "^4.11.4",
 				"oauth": "^0.9.15",
-				"openid-client": "^5.1.0",
+				"openid-client": "^5.4.0",
 				"preact": "^10.6.3",
 				"preact-render-to-string": "^5.1.19",
 				"uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
 		"mdast-util-to-string": "^2.0.0",
 		"moize": "^6.1.0",
 		"next": "^13.0.5",
-		"next-auth": "^4.19.2",
+		"next-auth": "^4.23.1",
 		"next-mdx-remote": "^3.0.8",
 		"next-query-params": "^4.1.0",
 		"next-sitemap": "^3.1.21",


### PR DESCRIPTION
### What

This introduces https://next-auth.js.org/getting-started/client#updating-the-session

`next-auth` diff https://github.com/nextauthjs/next-auth/compare/next-auth%404.19.2...next-auth%404.23.1

This is in support of #2128 

### Preview

https://dev-portal-git-kwupgrade-next-auth-hashicorp.vercel.app/

If observing `https` being used in local dev, ensure `process.env.VERCEL` is not set.
- https://github.com/nextauthjs/next-auth/issues/7510

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205367031875887