### PR TITLE
fix(open-api-docs): patch product repo deploy issues

### DIFF
--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -45,7 +45,7 @@ import type {
  * for each version of the OpenAPI documents that we detect.
  */
 export const getStaticPaths: GetStaticPaths<OpenApiDocsParams> = async () => {
-	// If we are in a deploy preview, don't pre-render any paths
+	// If we are in a product repo deploy preview, don't pre-render any paths
 	if (isDeployPreview()) {
 		return { paths: [], fallback: 'blocking' }
 	}

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -4,6 +4,7 @@
  */
 
 // Library
+import { isDeployPreview } from 'lib/env-checks'
 import fetchGithubFile from 'lib/fetch-github-file'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
 import { cachedGetProductData } from 'lib/get-product-data'
@@ -44,8 +45,11 @@ import type {
  * for each version of the OpenAPI documents that we detect.
  */
 export const getStaticPaths: GetStaticPaths<OpenApiDocsParams> = async () => {
-	// For the new template, regardless of whether we're in a deploy preview
-	// or production, statically render the single view.
+	// If we are in a deploy preview, don't pre-render any paths
+	if (isDeployPreview()) {
+		return { paths: [], fallback: 'blocking' }
+	}
+	// If we're in production, statically render the single view.
 	return {
 		paths: [{ params: { page: [] } }],
 		fallback: false,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
> Asana task 🎟️ - Not Applicable

## 🗒️ What

Fixes an issue where product repo deploy previews of the site would break.

- **Root cause**: a `GITHUB_TOKEN` is required to build `/hcp/api-docs/vault-secrets` (and also views like `/hcp/api-docs/packer` that source from closed repositories). This environment variable is not set in product repo contexts.
- **Context**: other pages, like `/hcp/api-docs/packer`, skip static rendering completely, which is why this issue has not surfaced for those pages.
- **Proposed solution**: avoid building `/hcp/api-docs/vault-secrets` in product repo deploy previews, this avoids the issue. The one caveat is that page will error and not function in product repo deploy previews, but this is currently not something we're worried about, I think (`/hcp/api-docs/packer` already has this behaviour).

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets] on this PR's preview
    - The page should look & function exactly as it does upstream

> **Note**: testing that this fixes the issue in product repo deploys is a little bit annoying, it requires checking out a product repo, updating the `build` script to checkout this branch after cloning down the repo, and then trying to run the build locally.

| Build script modification |
| - |
| <img width="702" alt="CleanShot 2023-09-06 at 13 04 28@2x" src="https://github.com/hashicorp/dev-portal/assets/4624598/c9bfeb02-7f84-4bde-95f2-c49a6b6fbaff"> |


## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zspatch-missing-github-token-hashicorp.vercel.app/