### PR TITLE
chore(feedback-form): customize placeholder

### DIFF
--- a/src/components/feedback-form/components/question/index.tsx
+++ b/src/components/feedback-form/components/question/index.tsx
@@ -66,7 +66,12 @@ const Question: React.FC<QuestionProps> = ({
 			break
 		}
 		case 'text': {
-			const { optional, buttonText, nextQuestion } = question
+			const {
+				optional,
+				buttonText,
+				nextQuestion,
+				placeholder = 'Your feedback...',
+			} = question
 			const isButtonDisabled =
 				!optional && (inputValue === '' || feedbackContext.isTransitioning)
 			const inputHasEntry = inputValue.length
@@ -82,7 +87,7 @@ const Question: React.FC<QuestionProps> = ({
 								s.textArea,
 								inputHasEntry ? s.visited : null
 							)}
-							placeholder="Your feedback..."
+							placeholder={placeholder}
 						/>
 						{optional && !inputHasEntry ? (
 							<span className={s.optionalText}>(optional)</span>

--- a/src/components/feedback-form/types.ts
+++ b/src/components/feedback-form/types.ts
@@ -29,6 +29,7 @@ interface FeedbackQuestionText extends FeedbackQuestionBase {
 	icon?: ReactElement<React.JSX.IntrinsicElements['svg']>
 	buttonText: string
 	nextQuestion?: string
+	placeholder?: string
 	optional?: boolean
 }
 


### PR DESCRIPTION
Allow `placeholder` to be customizable on feedback form

This is in service of #2128 