### PR TITLE
Updated Vault Pro product version to match the live exam version

### DIFF
--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -25,7 +25,7 @@
 			"title": "Vault Operations Professional",
 			"examTier": "pro",
 			"productSlug": "vault",
-			"versionTested": "Vault 1.8.0 and higher",
+			"versionTested": "Vault 1.13.0 and higher",
 			"description": "The Vault Operations Professional exam is a lab-based exam for Cloud Engineers focused on deploying, configuring, managing, and monitoring HashiCorp Vault. You are well-qualified to take this exam if you hold the Vault Associate Certification (or equivalent knowledge), have experience operating Vault in production, and can evaluate Vault Enterprise functionality and use cases.",
 			"links": {
 				"prepare": "/vault/tutorials/ops-pro-cert",


### PR DESCRIPTION
## 🔗 Relevant links
GitHub Issue: https://github.com/hashicorp/certification-vault-ops-pro/issues/458

- [Preview link](https://dev-portal-git-VaultPro_VersionUpdate_Fix-hashicorp.vercel.app/certifications/security-automation) 🔎

## 🗒️ What

Updated text that states what version of Vault the exam tests

## 🤷 Why
We had updated the version with our last release in July

