### PR TITLE
feat(openapi): support dynamic API service icon

### DIFF
--- a/src/pages/hcp/api-docs/vault-secrets/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/vault-secrets/[[...page]].tsx
@@ -25,6 +25,7 @@ import type {
  */
 const PAGE_CONFIG: OpenApiDocsPageConfig = {
 	productSlug: 'hcp',
+	serviceProductSlug: 'vault',
 	basePath: '/hcp/api-docs/vault-secrets',
 	githubSourceDirectory: {
 		owner: 'hashicorp',
@@ -98,6 +99,7 @@ export const getStaticProps: GetStaticProps<
 	return await getOpenApiDocsStaticProps({
 		basePath: PAGE_CONFIG.basePath,
 		productSlug: PAGE_CONFIG.productSlug,
+		serviceProductSlug: PAGE_CONFIG.serviceProductSlug,
 		statusIndicatorConfig: PAGE_CONFIG.statusIndicatorConfig,
 		navResourceItems: PAGE_CONFIG.navResourceItems,
 		massageSchemaForClient: PAGE_CONFIG.massageSchemaForClient,

--- a/src/views/open-api-docs-view/components/open-api-overview/index.tsx
+++ b/src/views/open-api-docs-view/components/open-api-overview/index.tsx
@@ -3,17 +3,16 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Third-party
-import { IconVaultColor16 } from '@hashicorp/flight-icons/svg-react/vault-color-16'
 // Components
 import Badge from 'components/badge'
 import IconTile from 'components/icon-tile'
+import ProductIcon from 'components/product-icon'
 // Local
 import { Status } from './components/status'
 // Types
 import type { StatusIndicatorConfig } from 'views/open-api-docs-view/types'
-// Types
 import type { ReactNode } from 'react'
+import type { ProductSlug } from 'types/products'
 // Styles
 import s from './open-api-overview.module.css'
 
@@ -31,6 +30,7 @@ export interface OpenApiOverviewProps {
 		id: string
 	}
 	badgeText: string
+	serviceProductSlug: ProductSlug
 	statusIndicatorConfig?: StatusIndicatorConfig
 	contentSlot?: ReactNode
 	className?: string
@@ -39,6 +39,7 @@ export interface OpenApiOverviewProps {
 export function OpenApiOverview({
 	heading,
 	badgeText,
+	serviceProductSlug,
 	statusIndicatorConfig,
 	contentSlot,
 }: OpenApiOverviewProps) {
@@ -46,7 +47,7 @@ export function OpenApiOverview({
 		<div className={s.overviewWrapper}>
 			<header className={s.header}>
 				<IconTile size="medium" className={s.icon}>
-					<IconVaultColor16 />
+					<ProductIcon productSlug={serviceProductSlug} />
 				</IconTile>
 				<span>
 					<h1 id={heading.id} className={s.heading}>

--- a/src/views/open-api-docs-view/index.tsx
+++ b/src/views/open-api-docs-view/index.tsx
@@ -33,6 +33,7 @@ function OpenApiDocsView({
 	navResourceItems,
 	breadcrumbLinks,
 	statusIndicatorConfig,
+	serviceProductSlug,
 }: OpenApiDocsViewProps) {
 	return (
 		<SidebarLayout
@@ -59,6 +60,7 @@ function OpenApiDocsView({
 					<OpenApiOverview
 						heading={topOfPageHeading}
 						badgeText={releaseStage}
+						serviceProductSlug={serviceProductSlug}
 						statusIndicatorConfig={statusIndicatorConfig}
 						contentSlot={
 							descriptionMdx ? (

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -67,6 +67,7 @@ export const getStaticPaths: GetStaticPaths<OpenApiDocsParams> = async () => {
 export async function getStaticProps({
 	context,
 	productSlug,
+	serviceProductSlug = productSlug,
 	versionData,
 	basePath,
 	statusIndicatorConfig,
@@ -76,6 +77,7 @@ export async function getStaticProps({
 }: {
 	context: GetStaticPropsContext<OpenApiDocsParams>
 	productSlug: ProductSlug
+	serviceProductSlug?: ProductSlug
 	versionData: OpenApiDocsVersionData[]
 	basePath: string
 	statusIndicatorConfig?: StatusIndicatorConfig
@@ -146,6 +148,7 @@ export async function getStaticProps({
 	return {
 		props: {
 			productData,
+			serviceProductSlug,
 			topOfPageHeading: {
 				text: schemaData.info.title,
 				id: topOfPageId,

--- a/src/views/open-api-docs-view/types.ts
+++ b/src/views/open-api-docs-view/types.ts
@@ -163,6 +163,14 @@ export interface OpenApiDocsViewProps {
 	 * Some temporary data we'll remove for the production implementation.
 	 */
 	_placeholder: $TSFixMe
+
+	/**
+	 * Product slug to use for the theming of the service itself.
+	 * For example, many product-themed services exist within the broader
+	 * HCP product context. In those cases, the API docs pages would have
+	 * `productData` for `hcp`, and a different `serviceProductSlug` here.
+	 */
+	serviceProductSlug: ProductSlug
 }
 
 /**
@@ -173,6 +181,15 @@ export interface OpenApiDocsPageConfig {
 	 * The product slug is used to fetch product data for the layout.
 	 */
 	productSlug: ProductSlug
+
+	/**
+	 * Optional slug used to theme smaller elements within the service API docs.
+	 * For example, HCP consul will have a `productSlug` of `hcp`,
+	 * but a `serviceProductSlug` of `consul`. If omitted, the `productSlug`
+	 * will be used.
+	 */
+	serviceProductSlug?: ProductSlug
+
 	/**
 	 * The baseUrl is used to generate
 	 * breadcrumb links, sidebar nav levels, and version switcher links.


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

In `OpenApiDocsView`, this PR makes the icon shown next to the OpenAPI spec title name configurable, rather than being fixed to the `VaultIcon`.

## 🤷 Why

As we onboard new products to the revised `OpenApiDocsView`, we need to be able to show icons other than the Vault icon.

## 🛠️ How

- Adds an optional `serviceProductSlug` option to `OpenApiDocsView` `PageConfig`
    - Falls back to the existing required `productSlug` configuration option
- Uses `ProductIcon` rather than `IconVaultColor16` in `OpenApiOverview`, passing the provided `serviceProductSlug` to drive which icon is shown.

## 📸 Design Screenshots

No design changes, appearance should be identical to upstream.

## 🧪 Testing

- [ ] Visit [/hcp/api-docs/vault-secrets]
    - The icon next to the page title should appear as it does upstream, showing the `Vault` icon
- [ ] Visit the preview tool at [/open-api-docs-preview]
    - When previewing any OpenAPI spec, a generic HashiCorp icon should always be shown
    - Note: we could consider adding a "service product slug" input to the preview tool, but this doesn't feel at all necessary at this point. The preview tool is intended to focus on other aspects of content.

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205543368360332/f
[preview]: https://dev-portal-git-zsopenapi-service-product-icon-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-service-product-icon-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[/open-api-docs-preview]: https://dev-portal-git-zsopenapi-service-product-icon-hashicorp.vercel.app/open-api-docs-preview