### PR TITLE
fix(openapi): fix missing page title

### DIFF
--- a/src/views/api-docs-view/server/get-api-docs-static-props/index.ts
+++ b/src/views/api-docs-view/server/get-api-docs-static-props/index.ts
@@ -181,6 +181,9 @@ export async function getApiDocsStaticProps({
 	 */
 	return {
 		props: {
+			metadata: {
+				title: schema.info.title,
+			},
 			product: productData,
 			pageHeading,
 			layoutProps: {

--- a/src/views/api-docs-view/types.ts
+++ b/src/views/api-docs-view/types.ts
@@ -61,6 +61,15 @@ export interface ApiDocsVersionData {
  */
 export interface ApiDocsViewProps {
 	/**
+	 * Metadata is used to set the page title and description.
+	 * Note this is not used by the view itself, instead we have some magic
+	 * happening at the `_app.tsx` level, where we render `<HeadMetadata />`.
+	 */
+	metadata: {
+		title: string
+	}
+
+	/**
 	 * Layout props drive the breadcrumbs and sidebar in the
 	 * SidebarSidecarLayout we use to render API docs.
 	 */

--- a/src/views/open-api-docs-view/server.ts
+++ b/src/views/open-api-docs-view/server.ts
@@ -145,6 +145,9 @@ export async function getStaticProps({
 	 */
 	return {
 		props: {
+			metadata: {
+				title: schemaData.info.title,
+			},
 			productData,
 			topOfPageHeading: {
 				text: schemaData.info.title,
@@ -152,7 +155,6 @@ export async function getStaticProps({
 			},
 			releaseStage: targetVersion.releaseStage,
 			descriptionMdx,
-			IS_REVISED_TEMPLATE: true,
 			_placeholder: {
 				productSlug,
 				targetVersion,

--- a/src/views/open-api-docs-view/types.ts
+++ b/src/views/open-api-docs-view/types.ts
@@ -125,7 +125,15 @@ export interface StatusIndicatorConfig {
  * For now, we have a placeholder. We'll expand this as we build out the view.
  */
 export interface OpenApiDocsViewProps {
-	IS_REVISED_TEMPLATE: true
+	/**
+	 * Metadata is used to set the page title and description.
+	 * Note this is not used by the view itself, instead we have some magic
+	 * happening at the `_app.tsx` level, where we render `<HeadMetadata />`.
+	 */
+	metadata: {
+		title: string
+	}
+
 	productData: ProductData
 	topOfPageHeading: {
 		text: string


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where `OpenApiDocsView` pages did not have a custom `metadata.title`, resulting in the generic product name being used for the page title.

This PR also fixes an identical issue in the previous `ApiDocsView` template.

## 🛠️ How

- fix(openapi): add page title for OpenApiDocsView
- fix(api-docs-view): add page title for ApiDocsView

## 📸 Design Screenshots

| Note | Screenshot |
| - | - |
| vault-secrets-before | <img width="1734" alt="vault-secrets-before" src="https://github.com/hashicorp/dev-portal/assets/4624598/b36c24c4-a61a-4a96-a301-26152311f930"> |
| vault-secrets-after | <img width="1735" alt="vault-secrets-after" src="https://github.com/hashicorp/dev-portal/assets/4624598/0b805c53-e08d-439d-bda6-4914b3fa7c1b"> |
| boundary-before | <img width="1730" alt="boundary-before" src="https://github.com/hashicorp/dev-portal/assets/4624598/65cd501f-b586-4cee-99af-9b87282daff6"> |
| boundary-after | <img width="1736" alt="boundary-after" src="https://github.com/hashicorp/dev-portal/assets/4624598/1e89eeb6-afe5-464f-b135-3386c7d8703f"> |

## 🧪 Testing

- [ ] Visit a page using `OpenApiDocsView`, namely [/hcp/api-docs/vault-secrets]
    - The page should show a metadata title matching the `schema.info.title`
- [ ] Visit a page using the older `ApiDocsView`, such as [/boundary/api-docs]
    - The page should show a metadata title matching the `schema.info.title`

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204678746647847/1205399158730597/f
[preview]: https://dev-portal-git-zsopenapi-view-title-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopenapi-view-title-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[/boundary/api-docs]: https://dev-portal-git-zsopenapi-view-title-hashicorp.vercel.app/boundary/api-docs