### PR TITLE
a11y: use inline link instead of plain anchor element

### DIFF
--- a/src/components/command-bar/commands/chat/index.tsx
+++ b/src/components/command-bar/commands/chat/index.tsx
@@ -17,7 +17,7 @@ const Icon = () => {
 		<IconArrowLeft24
 			tabIndex={0}
 			className={s.backArrow}
-			aria-label="Back to search"
+			aria-label="Return to search"
 			onKeyDown={(e) => {
 				if (e.key === 'Enter') {
 					setCurrentCommand('search')

--- a/src/views/profile/account-view/index.tsx
+++ b/src/views/profile/account-view/index.tsx
@@ -4,17 +4,18 @@
  */
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 
+import useAuthentication from 'hooks/use-authentication'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import AuthenticatedView from 'views/authenticated-view'
 import Text from 'components/text'
 import Heading from 'components/heading'
-
-import { ProfileSidebar } from '../sidebar'
-import s from './account-view.module.css'
-import useAuthentication from 'hooks/use-authentication'
 import CopySnippet from 'components/hds-copy-snippet'
 import Card from 'components/card'
 import StandaloneLink from 'components/standalone-link'
+import InlineLink from 'components/inline-link'
+
+import { ProfileSidebar } from '../sidebar'
+import s from './account-view.module.css'
 
 export default function ProfileAccountView() {
 	return (
@@ -47,9 +48,9 @@ const ProfileAccountViewContent = () => {
 			</Heading>
 			<Text className={s.subheading}>
 				A read-only view of your profile details from&nbsp;
-				<a href="https://portal.cloud.hashicorp.com/account-settings">
+				<InlineLink href="https://portal.cloud.hashicorp.com/account-settings">
 					HCP Account settings
-				</a>
+				</InlineLink>
 			</Text>
 
 			<Heading level={2} weight="bold" size={200} className={s.sectionTitle}>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-kssmall-a11y-fixes-hashicorp.vercel.app/profile/account) 🔎
- [Asana task](url) 🎟️

## 🗒️ What
Use `InlineLink` instead of plain `a` so that the link indication doesn't rely on color only. Also the aria label for the command bar header is aligned with the visible label. 

See issues outlined[ in this document.](https://docs.google.com/document/d/17VH69KP2TFNDkC7MEdP8-wUnec4UtcXfMUlCPX7eE6Y/edit#heading=h.38vj98htf15t)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- Sign in to the preview (with your HCP id added to accept list on edge config)
- Go to https://dev-portal-git-kssmall-a11y-fixes-hashicorp.vercel.app/profile/account
- You should see 'HCP Account Settings' link with an underline

- Use voice over or look in DOM to confirm that the aria-label for back icon in the command bar header says 'Return to search' instead of 'Back to search'
<img width="1376" alt="Screenshot 2023-10-05 at 11 07 39 AM" src="https://github.com/hashicorp/dev-portal/assets/36613477/127db50d-c3ef-486d-9102-9bc9acc77bce">

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
