### PR TITLE
chore: Highlight HashiConf virtual session recordings in banner

### DIFF
--- a/src/data/alert-banner.json
+++ b/src/data/alert-banner.json
@@ -3,9 +3,9 @@
 	"data": {
 		"product": "hashicorp",
 		"tag": "HashiConf",
-		"url": "https://hashiconf.com/2023",
-		"text": "Last chance to register for our cloud conference October 10-12.",
-		"linkText": "Register today",
-		"expirationDate": "2023-10-10T00:00:00-08:00"
+		"url": "https://live.hashiconf.com",
+		"text": "All virtual session recordings now available.",
+		"linkText": "Watch now",
+		"expirationDate": "2023-10-20T00:00:00-08:00"
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-nq-update-alert-banner-2023-close-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/0/1205709435086907/f) 🎟️

## 🗒️ What

This PR updates the alert banner to signal the availability of virtual session recordings on the HashiConf event platform.

> [!Important]
> This PR should not merge until Oct 12 at 6pm PT (9pm ET) at the earliest.

## 🤷 Why

Events team request

## 🧪 Testing

- [ ] Visit the preview link
- [ ] Ensure the data within the alert banner matches the data in the config at `src/data/alert-banner.json`
