### PR TITLE
chore: don't publish consul api docs from 2-15

### DIFF
--- a/src/pages/hcp/api-docs/consul/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/consul/[[...page]].tsx
@@ -99,7 +99,7 @@ export const getStaticProps: GetStaticProps<
 	 * https://hashicorp.slack.com/archives/C5FSPUGDS/p1698178472462449
 	 */
 	const filteredVersionData = versionData.filter(
-		(version: ApiDocsVersionData) => version.versionId === '2022-02-15'
+		(version: ApiDocsVersionData) => version.versionId !== '2022-02-15'
 	)
 
 	// Generate static props based on page configuration, params, and versionData

--- a/src/pages/hcp/api-docs/consul/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/consul/[[...page]].tsx
@@ -5,6 +5,7 @@
 
 // Lib
 import { fetchCloudApiVersionData } from 'lib/api-docs/fetch-cloud-api-version-data'
+import { ApiDocsVersionData } from 'lib/api-docs/types'
 // View
 import OpenApiDocsView from 'views/open-api-docs-view'
 import {
@@ -92,11 +93,20 @@ export const getStaticProps: GetStaticProps<
 	const versionData = await fetchCloudApiVersionData(
 		PAGE_CONFIG.githubSourceDirectory
 	)
+	/**
+	 * TODO: add in support for conditionally publishing specs in hcp-specs repo
+	 * For now just manually filtering out this spec as per request in slack.
+	 * https://hashicorp.slack.com/archives/C5FSPUGDS/p1698178472462449
+	 */
+	const filteredVersionData = versionData.filter(
+		(version: ApiDocsVersionData) => version.versionId === '2022-02-15'
+	)
+
 	// Generate static props based on page configuration, params, and versionData
 	return await getOpenApiDocsStaticProps({
 		...PAGE_CONFIG,
 		context: { params },
-		versionData,
+		versionData: filteredVersionData,
 	})
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksmanually-filter-consul-api-version-hashicorp.vercel.app/) 🔎
- [Asana ticket](https://app.asana.com/0/1202097197789424/1205798063280001) 🎟️ 

## 🗒️ What

Manually filters out this version until we support configuration in the spec to filter out a spec file from publishing as per request in slack.

## 🧪 Testing

- [Visit the preview ](https://dev-portal-git-ksmanually-filter-consul-api-version-hashicorp.vercel.app/hcp/api-docs/consul)
- Validate that 2-15-2022 isn't an available version. There should be no version selector visible as we only have the single version [spec from 10-10-23](https://github.com/hashicorp/hcp-specs/tree/main/specs/cloud-global-network-manager-service/preview/2023-10-10)

## 💭 Anything else?

We should support config based option for authors to not publish a spec version.
