### PR TITLE
fix: pin node & npm version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM docker.mirror.hashicorp.services/node:18-alpine AS deps
+FROM docker.mirror.hashicorp.services/node:18.18.2-alpine AS deps
 
 RUN apk add --update --no-cache \
 	autoconf \
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache \
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm install -g npm@latest
+RUN npm install -g npm@9.8.1
 
 # While imagemin/optipng-bin doesn't support arm64, set this env var as a workaround
 # - `npm ls imagemin`
@@ -27,7 +27,7 @@ RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install
 
 FROM docker.mirror.hashicorp.services/node:18-alpine AS builder
 
-RUN npm install -g npm@latest
+RUN npm install -g npm@9.8.1
 
 WORKDIR /app
 COPY . ./website-preview


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

The docker build image workflow [has been failing ](https://github.com/hashicorp/dev-portal/actions/runs/6658627905/job/18095903036)at `npm install`. I was able to repro the same `errno ECONNRESET` error locally during `npm install` without changing anything in the file.

I think the docker image build was failing because it was installing the latest version of npm (10) yet still using node 18. When I ran this locally after pinning, `docker build -t dev-portal:local .` the build succeeded. 

It's a weird error so definitely open to input if there's other things I should try! 😅 

<img width="1633" alt="Screenshot 2023-10-26 at 4 41 55 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/d81d3e39-5012-4002-980e-b2ccddc7c59a">
