### PR TITLE
enable custom next collection slugs in dev portal

### DIFF
--- a/src/lib/learn-client/api/api-types.ts
+++ b/src/lib/learn-client/api/api-types.ts
@@ -68,6 +68,7 @@ export interface ApiCollectionLite extends ContentBaseModel {
 	ordered: boolean
 	level: CollectionLevelOption
 	category: CollectionCategoryOption
+	next_collection: ApiCollectionLite
 }
 
 // Collection interface that is enriched with tutorials

--- a/src/lib/learn-client/api/collection/formatting.ts
+++ b/src/lib/learn-client/api/collection/formatting.ts
@@ -45,9 +45,9 @@ export function formatCollection(collection: ApiCollection): Collection {
 		level,
 		category: category || undefined,
 		tutorials: tutorials.map(formatToTutorialLite),
-		...(next_collection
-			? { nextCollection: formatToCollectionLite(next_collection) }
-			: {}),
+		nextCollection: next_collection
+			? formatToCollectionLite(next_collection)
+			: undefined,
 	}
 }
 

--- a/src/lib/learn-client/api/collection/formatting.ts
+++ b/src/lib/learn-client/api/collection/formatting.ts
@@ -30,6 +30,7 @@ export function formatCollection(collection: ApiCollection): Collection {
 		level,
 		category,
 		tutorials,
+		next_collection,
 	} = collection
 
 	return {
@@ -44,6 +45,9 @@ export function formatCollection(collection: ApiCollection): Collection {
 		level,
 		category: category || undefined,
 		tutorials: tutorials.map(formatToTutorialLite),
+		...(next_collection
+			? { nextCollection: formatToCollectionLite(next_collection) }
+			: {}),
 	}
 }
 

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -104,6 +104,7 @@ export interface Collection {
 	ordered: boolean
 	tutorials: TutorialLite[]
 	category?: CollectionCategoryOption
+	nextCollection?: CollectionLite
 }
 
 export interface Product {

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -145,8 +145,7 @@ function TutorialView({
 	const nextPreviousData = getNextPrevious({
 		currentCollection: collectionCtx.current,
 		currentTutorialSlug: slug,
-		nextCollectionInSidebar:
-			collectionCtx.current.nextCollection ?? tutorial.nextCollectionInSidebar,
+		nextCollectionInSidebar: tutorial.nextCollectionInSidebar,
 		formatting: {
 			getTutorialSlug,
 			getCollectionSlug,

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -145,7 +145,8 @@ function TutorialView({
 	const nextPreviousData = getNextPrevious({
 		currentCollection: collectionCtx.current,
 		currentTutorialSlug: slug,
-		nextCollectionInSidebar: tutorial.nextCollectionInSidebar,
+		nextCollectionInSidebar:
+			collectionCtx.current.nextCollection ?? tutorial.nextCollectionInSidebar,
 		formatting: {
 			getTutorialSlug,
 			getCollectionSlug,

--- a/src/views/tutorial-view/server.ts
+++ b/src/views/tutorial-view/server.ts
@@ -139,7 +139,8 @@ export async function getTutorialPageProps(
 				...fullTutorialData,
 				content: serializedContent,
 				collectionCtx: collectionContext,
-				nextCollectionInSidebar: nextCollection,
+				nextCollectionInSidebar:
+					collectionContext.current.nextCollection ?? nextCollection,
 			},
 			pageHeading: {
 				slug: headings[0].slug,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1204810520737800/1205154011279146/f) 🎟️
- [`learn-api-content-sync`](https://github.com/hashicorp/learn-api-content-sync/pull/88)
- [`learn-api`](https://github.com/hashicorp/learn-api/pull/187)

## 🗒️ What

If `next_collection` is defined on a `collection`, the frontend will use this to override the default behaviour for the Next / Previous button. If a next_collection is not passed provided, the next logical collection in the sidebar will be used (current behavior).

## 🤷 Why

Add support for authors to supply a custom href for the 'Next collection' button. This will be optional and will be defined in the [collection files](https://github.com/hashicorp/tutorials/blob/main/content/collections/boundary/credential-management.yml) in the tutorials repo as a plain string.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.-->

- [ ] Step 1: add `next_collection: terraform/aws-get-started` to any file in `/content/collections` in your local `tutorials` repo. [`example collections file`](https://github.com/hashicorp/tutorials/blob/main/content/collections/boundary/credential-management.yml)
- [ ] Step 2: checkout `heat/feat/next_collection_slug` in `learn-api` and run `make`
- [ ] Step 3: checkout `heat/feat/next-collection` in `learn-api-content-sync`, and update the LEARN API value to your local port
- [ ] Step 4: checkout `heat/feat/custom-next-button` in this repo. Visit the page for the file you added `next_collection` to.


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
