### PR TITLE
Remove version from breadcrumb on product install page

### DIFF
--- a/src/components/breadcrumb-bar/breadcrumb-bar.module.css
+++ b/src/components/breadcrumb-bar/breadcrumb-bar.module.css
@@ -46,7 +46,9 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-
+	&[aria-current='page'] {
+		color: var(--token-color-foreground-strong);
+	}
 	&[href] {
 		&:hover {
 			text-decoration: underline;
@@ -61,10 +63,6 @@
 			text-decoration: none;
 			margin: -5px;
 			padding: 5px;
-		}
-
-		&[aria-current='page'] {
-			color: var(--token-color-foreground-strong);
 		}
 	}
 }

--- a/src/components/breadcrumb-bar/breadcrumb-bar.module.css
+++ b/src/components/breadcrumb-bar/breadcrumb-bar.module.css
@@ -46,7 +46,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	&.current {
+	&[aria-current='page'] {
 		color: var(--token-color-foreground-strong);
 	}
 	&[href] {

--- a/src/components/breadcrumb-bar/breadcrumb-bar.module.css
+++ b/src/components/breadcrumb-bar/breadcrumb-bar.module.css
@@ -46,7 +46,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	&[aria-current='page'] {
+	&.current {
 		color: var(--token-color-foreground-strong);
 	}
 	&[href] {

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -71,7 +71,8 @@ function BreadcrumbBar({
 			<ol className={s.listRoot}>
 				{links.map(({ title, url, isCurrentPage }) => {
 					const cleanTitle = title.replace(/<[^>]+>/g, '')
-					const Elem = url ? InternalLink : 'span'
+					const Elem = url && !isCurrentPage ? InternalLink : 'span'
+
 					return (
 						<Text
 							asElement="li"
@@ -82,7 +83,7 @@ function BreadcrumbBar({
 						>
 							<Elem
 								className={s.breadcrumbText}
-								href={url}
+								href={!isCurrentPage ? url : undefined}
 								aria-current={isCurrentPage ? 'page' : undefined}
 								data-heap-track="breadcrumb-bar-item"
 							>

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -9,6 +9,7 @@ import Link, { LinkProps } from 'components/link'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import Text from 'components/text'
 import s from './breadcrumb-bar.module.css'
+import classNames from 'classnames'
 
 interface BreadcrumbLink {
 	/** Text to be shown for the link */
@@ -82,9 +83,11 @@ function BreadcrumbBar({
 							weight="medium"
 						>
 							<Elem
-								className={s.breadcrumbText}
+								className={classNames(
+									s.breadcrumbText,
+									isCurrentPage ? s.current : undefined
+								)}
 								href={!isCurrentPage ? url : undefined}
-								aria-current={isCurrentPage ? 'page' : undefined}
 								data-heap-track="breadcrumb-bar-item"
 							>
 								{cleanTitle}

--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -9,7 +9,6 @@ import Link, { LinkProps } from 'components/link'
 import isAbsoluteUrl from 'lib/is-absolute-url'
 import Text from 'components/text'
 import s from './breadcrumb-bar.module.css'
-import classNames from 'classnames'
 
 interface BreadcrumbLink {
 	/** Text to be shown for the link */
@@ -83,11 +82,9 @@ function BreadcrumbBar({
 							weight="medium"
 						>
 							<Elem
-								className={classNames(
-									s.breadcrumbText,
-									isCurrentPage ? s.current : undefined
-								)}
+								className={s.breadcrumbText}
 								href={!isCurrentPage ? url : undefined}
+								aria-current={isCurrentPage ? 'page' : undefined}
 								data-heap-track="breadcrumb-bar-item"
 							>
 								{cleanTitle}

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -163,8 +163,13 @@ export const getPageSubtitle = ({
 
 export const initializeBreadcrumbLinks = (
 	currentProduct: Pick<ProductData, 'name' | 'slug'>,
-	isEnterpriseMode: boolean
+	isEnterpriseMode: boolean,
+	pathname: string
 ): BreadcrumbLink[] => {
+	const nonEnterpriseTitle =
+		pathname === '/vagrant/downloads/vmware'
+			? `Install VMware Utility`
+			: `Install`
 	return [
 		{
 			title: 'Developer',
@@ -176,12 +181,8 @@ export const initializeBreadcrumbLinks = (
 		},
 		{
 			isCurrentPage: true,
-			title: isEnterpriseMode
-				? `Install ${currentProduct.name} Enterprise`
-				: `Install`,
-			url: isEnterpriseMode
-				? `/${currentProduct.slug}/downloads/enterprise`
-				: `/${currentProduct.slug}/downloads`,
+			title: isEnterpriseMode ? `Install Enterprise` : `${nonEnterpriseTitle}`,
+			url: `${pathname}`,
 		},
 	]
 }

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -182,7 +182,6 @@ export const initializeBreadcrumbLinks = (
 		{
 			isCurrentPage: true,
 			title: isEnterpriseMode ? `Install Enterprise` : `${nonEnterpriseTitle}`,
-			url: `${pathname}`,
 		},
 	]
 }

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -163,7 +163,6 @@ export const getPageSubtitle = ({
 
 export const initializeBreadcrumbLinks = (
 	currentProduct: Pick<ProductData, 'name' | 'slug'>,
-	selectedVersion: string,
 	isEnterpriseMode: boolean
 ): BreadcrumbLink[] => {
 	return [
@@ -179,7 +178,7 @@ export const initializeBreadcrumbLinks = (
 			isCurrentPage: true,
 			title: isEnterpriseMode
 				? `Install ${currentProduct.name} Enterprise`
-				: `Install v${selectedVersion}`,
+				: `Install`,
 			url: isEnterpriseMode
 				? `/${currentProduct.slug}/downloads/enterprise`
 				: `/${currentProduct.slug}/downloads`,

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -62,13 +62,8 @@ const ProductDownloadsViewContent = ({
 	const currentProduct = useCurrentProduct()
 	const { currentVersion } = useCurrentVersion()
 	const breadcrumbLinks = useMemo(
-		() =>
-			initializeBreadcrumbLinks(
-				currentProduct,
-				currentVersion,
-				isEnterpriseMode
-			),
-		[currentProduct, currentVersion, isEnterpriseMode]
+		() => initializeBreadcrumbLinks(currentProduct, isEnterpriseMode),
+		[currentProduct, isEnterpriseMode]
 	)
 	const sidebarNavDataLevels = [
 		generateTopLevelSidebarNavData(currentProduct.name),

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -37,7 +37,7 @@ import {
 	SidecarMarketingCard,
 } from './components'
 import s from './product-downloads-view.module.css'
-
+import { useRouter } from 'next/router'
 /**
  * This component is used to make it possible to consume the `useCurrentVersion`
  * hook in this view. `ProductDownloadsView` renders `CurrentVersionProvider`
@@ -61,9 +61,11 @@ const ProductDownloadsViewContent = ({
 	} = pageContent
 	const currentProduct = useCurrentProduct()
 	const { currentVersion } = useCurrentVersion()
+	const { pathname } = useRouter()
+
 	const breadcrumbLinks = useMemo(
-		() => initializeBreadcrumbLinks(currentProduct, isEnterpriseMode),
-		[currentProduct, isEnterpriseMode]
+		() => initializeBreadcrumbLinks(currentProduct, isEnterpriseMode, pathname),
+		[currentProduct, isEnterpriseMode, pathname]
 	)
 	const sidebarNavDataLevels = [
 		generateTopLevelSidebarNavData(currentProduct.name),

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -5,6 +5,7 @@
 
 // Third-party imports
 import { ReactElement, useMemo } from 'react'
+import { useRouter } from 'next/router'
 
 // HashiCorp imports
 import HashiHead from '@hashicorp/react-head'
@@ -37,7 +38,7 @@ import {
 	SidecarMarketingCard,
 } from './components'
 import s from './product-downloads-view.module.css'
-import { useRouter } from 'next/router'
+
 /**
  * This component is used to make it possible to consume the `useCurrentVersion`
  * hook in this view. `ProductDownloadsView` renders `CurrentVersionProvider`


### PR DESCRIPTION
## 🔗 Relevant links

- Project brief [here](https://docs.google.com/document/d/12YmA6vo3eO6RpK0xfY8ARk-WR1jGxzq1aDDS5Viq2-c/edit#heading=h.p2a9c84bi0uv)
- [Asana project](https://app.asana.com/0/1204817897905865/1205117623326498)
- [Asana task](https://app.asana.com/0/1204817897905865/1205712837415356/f) 


## 🗒️ What

- Removed `selectedVersion` from `initializeBreadcrumbLinks()` as it is no longer needed
- Added `useRouter()` in `product-downloads-view` to access the `pathname` to handle the VMware Utility breadcrumb edge case detailed below.
- A couple edge cases discovered during this task:
  - Breadcrumb links on Enterprise install:
    - current: `Developer / [product] / Install [product] Enterprise`
    - new: `Developer / [product] / Install Enterprise`
  - Vagrant VMware Utility:
    - current: `Developer / Vagrant / Install [version]`
    - new: `Developer / Vagrant / Install VMware Utility`
    
 - Added a change to how breadcrumbs work. The existing functionality is that the last breadcrumb/current page is a link, which is unnecesary as the user has the url for the current page. The change made in this PR is to make a span. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
- One task in overall install page enhancements project. The install page is the only place we include the version in the breadcrumb, so we want this to be consistent with docs.

## 🛠️ How
<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
- worked off the task in Asana and mocks in figma

## 📸 Design Screenshots
[Figma](https://www.figma.com/file/308QXXjFalJSFaCvmFU50L/Install%2FDownload-Template?type=design&node-id=705-19725&mode=dev)

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.
-->
- [ ] Go to [`Consul install page`](https://developer.hashicorp.com/consul/downloads)
- [ ] See that the breadcrumb reads `Developer / Consul / Install v1.16.3`
- [ ] Navigate to preview link for [`the Consul install`](https://dev-portal-git-heat-featbreadcrumb-versioning-hashicorp.vercel.app/consul/downloads)
- [ ] See that the breadcrumb reads `Developer / Consul / Install`
