### PR TITLE
patch: fix up terraform version selector sort

### DIFF
--- a/src/components/version-context-switcher/index.tsx
+++ b/src/components/version-context-switcher/index.tsx
@@ -25,8 +25,25 @@ const VersionContextSwitcher = ({
 	options,
 }: VersionContextSwitcherProps): ReactElement => {
 	const currentProduct = useCurrentProduct()
-	const [selectedVersion, setSelectedVersion] =
-		useState<ContextSwitcherOption['value']>(initialValue)
+	let latestVersion = options[0].value
+	/** Update `latestVersion` to the latest version of the product
+	 * that has been released if it can be determined. This is needed
+	 * because not all products have `latest` listed as the first item
+	 * in the sorted array. E.g. `vault-enterprise` lists `+ent.hsm.fips1402`
+	 * variants first.
+	 */
+	for (let i = 0; i < options.length; i++) {
+		const versionLabel = options[i].label
+		const versionValue = options[i].value
+		if (versionLabel.indexOf('(latest)') >= 0) {
+			latestVersion = versionValue
+			break
+		}
+	}
+
+	const [selectedVersion, setSelectedVersion] = useState<
+		ContextSwitcherOption['value']
+	>(initialValue || latestVersion)
 
 	/**
 	 * Handle change event for switcher, invoking the `onChange` function last if


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-ksfix-tf-order-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202801212949828/1205921409065634/f) 🎟️

## 🗒️ What

This logic was removed in #2217 ([see comment](https://github.com/hashicorp/dev-portal/pull/2217#discussion_r1382281828)) but caused the [terraform version on the install page](https://developer.hashicorp.com/terraform/install) to not be sorted properly. This is just a patch to fix the issue and we can readjust. 

**Preview**
<img width="996" alt="Screenshot 2023-11-09 at 4 20 35 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/714fcdc2-9df2-43aa-8247-390c238e9eb2">

**Upstream**
<img width="981" alt="Screenshot 2023-11-09 at 4 20 50 PM" src="https://github.com/hashicorp/dev-portal/assets/36613477/502ce0d7-74d3-414e-8f10-5bfb73c68bee">

## 🧪 Testing

Validate that the version order on the [tf install page](https://dev-portal-git-ksfix-tf-order-hashicorp.vercel.app/terraform/install) is correct (latest first), [compared to production](https://developer.hashicorp.com/terraform/install). 
