### PR TITLE
Exclude h1 entries from TOC listing

### DIFF
--- a/src/components/outline-nav/components/outline-nav-with-active/index.tsx
+++ b/src/components/outline-nav/components/outline-nav-with-active/index.tsx
@@ -27,10 +27,10 @@ function OutlineNavWithActive({
 
 	/**
 	 * Determine the active section. Note we only enable this when the sidecar
-	 * is both visible and contains more than one item.
+	 * is both visible and contains at least one item.
 	 */
 	const itemSlugs = useMemo(() => getItemSlugs(items), [items])
-	const hasMultipleItems = itemSlugs.length > 1
+	const hasMultipleItems = itemSlugs.length >= 1
 	const enableActiveSection = isInView && hasMultipleItems
 	const activeSection = useActiveSection(itemSlugs, enableActiveSection)
 

--- a/src/components/outline-nav/utils/outline-items-from-headings.ts
+++ b/src/components/outline-nav/utils/outline-items-from-headings.ts
@@ -12,7 +12,7 @@ import { filterTableOfContentsHeadings } from 'components/table-of-contents/util
 export interface AnchorLinksPluginHeading {
 	title: string
 	slug: string
-	level: 1 | 2 | 3 | 4 | 5 | 6
+	level: 2 | 3 | 4 | 5 | 6
 }
 
 /**

--- a/src/components/outline-nav/utils/outline-items-from-headings.ts
+++ b/src/components/outline-nav/utils/outline-items-from-headings.ts
@@ -12,7 +12,7 @@ import { filterTableOfContentsHeadings } from 'components/table-of-contents/util
 export interface AnchorLinksPluginHeading {
 	title: string
 	slug: string
-	level: 2 | 3 | 4 | 5 | 6
+	level: 1 | 2 | 3 | 4 | 5 | 6
 }
 
 /**

--- a/src/components/outline-nav/utils/outline-items-from-headings.ts
+++ b/src/components/outline-nav/utils/outline-items-from-headings.ts
@@ -5,6 +5,7 @@
 
 import { OutlineLinkItem } from 'components/outline-nav/types'
 import { filterTableOfContentsHeadings } from 'components/table-of-contents/utils/filter-table-of-contents-headings'
+import { pruneHeadingsByLevel } from 'components/table-of-contents/utils/prune-headings-by-level'
 
 /**
  * Heading type coming from our remark anchor-links plugin.
@@ -22,7 +23,9 @@ export interface AnchorLinksPluginHeading {
 function outlineItemsFromHeadings(
 	headings: AnchorLinksPluginHeading[]
 ): OutlineLinkItem[] {
-	const filteredHeadings = filterTableOfContentsHeadings(headings)
+	const filteredHeadings = pruneHeadingsByLevel(
+		filterTableOfContentsHeadings(headings), 2
+	)
 	return filteredHeadings.map(
 		(heading: AnchorLinksPluginHeading, index: number) => {
 			const titleWithoutBackticks = heading.title.replace(/`/g, '')

--- a/src/components/table-of-contents/index.tsx
+++ b/src/components/table-of-contents/index.tsx
@@ -14,7 +14,7 @@ const TABLE_OF_CONTENTS_LABEL_ID = 'table-of-contents-label'
 
 const TableOfContents = ({ headings }: TableOfContentsProps): ReactElement => {
 	const { isDesktop } = useDeviceSize()
-	const hasManyHeadings = headings.length > 1
+	const hasManyHeadings = headings.length >= 1
 	const enableActiveSection = hasManyHeadings && isDesktop
 
 	/**

--- a/src/components/table-of-contents/utils/filter-table-of-contents-headings.ts
+++ b/src/components/table-of-contents/utils/filter-table-of-contents-headings.ts
@@ -40,12 +40,6 @@ export function filterTableOfContentsHeadings(
 			return false
 		}
 
-		// Level 1 headings are used for the page title and should not appear in
-		// the TOC
-		if (level == 1) {
-			return false
-		}
-
 		/**
 		 * Only include headings that are *outside* of <Tabs />.
 		 *
@@ -55,6 +49,13 @@ export function filterTableOfContentsHeadings(
 		if (typeof tabbedSectionDepth === 'number' && tabbedSectionDepth !== 0) {
 			return false
 		}
+
+		// Exclude level 1 headings, which are used for the page title and should
+		// not appear in the TOC
+		if (level == 1) {
+			return false
+		}
+
 
 		/**
 		 * Return true for headings that have not been filtered out

--- a/src/components/table-of-contents/utils/filter-table-of-contents-headings.ts
+++ b/src/components/table-of-contents/utils/filter-table-of-contents-headings.ts
@@ -40,6 +40,12 @@ export function filterTableOfContentsHeadings(
 			return false
 		}
 
+		// Level 1 headings are used for the page title and should not appear in
+		// the TOC
+		if (level == 1) {
+			return false
+		}
+
 		/**
 		 * Only include headings that are *outside* of <Tabs />.
 		 *

--- a/src/components/table-of-contents/utils/prune-headings-by-level.ts
+++ b/src/components/table-of-contents/utils/prune-headings-by-level.ts
@@ -8,37 +8,21 @@ import { TableOfContentsHeading } from '../types'
 /**
  * Filter headings for display in table of contents.
  *
- * - Retain headings that are <h1> or <h2>
- * 	- Headings <h3> through <h6> are filtered out.
- * - Retain headings that are not nested in <Tabs />
- * 	- Headings with `tabbedSectionDepth !== 0` are filtered out.
+ * - Retain headings with the requested heading level
+ * - Retain headings that are not nested in <Tabs /> (tabbedSectionDepth == 0)
  *
  * Note that to filter based on `tabbedSectionDepth`, we rely on functionality
  * in our `anchor-links` `remark-plugin` to add that property. For details, see
  * the `tabbedSectionDepth` logic here:
  * https://github.com/hashicorp/remark-plugins/blob/0f2d21516ab3c7120a24456838d83390e3ab179d/plugins/anchor-links/index.js#L29
  *
- * TODO: given the above dependency on anchor-links remark plugin,
- * this utility might make sense to move closer to the server-side code where
- * the anchor-links plugin is invoked - maybe move this into `getStaticProps`?
- *
  */
-export function filterTableOfContentsHeadings(
-	headings: TableOfContentsHeading[]
+export function pruneHeadingsByLevel(
+	headings: TableOfContentsHeading[],
+  targetLevel: 1 | 2 | 3 | 4 | 5 | 6
 ): TableOfContentsHeading[] {
 	return headings.filter((heading: TableOfContentsHeading) => {
 		const { level, tabbedSectionDepth } = heading
-
-		/**
-		 * Only include <h2> in the table of contents.
-		 *
-		 * Note that <h1> are also included, this is as a stopgap
-		 * while we implement content conformance that ensures there is
-		 * exactly one <h1> per page (which we would likely not include here).
-		 */
-		if (level > 2) {
-			return false
-		}
 
 		/**
 		 * Only include headings that are *outside* of <Tabs />.
@@ -51,9 +35,15 @@ export function filterTableOfContentsHeadings(
 		}
 
 		/**
-		 * Return true for headings that have not been filtered out
-		 * by previous criteria.
+		 * Return true if the heading level matches the requested header level
 		 */
-		return true
+		if (level == targetLevel) {
+			return true
+		}
+
+		/**
+		 * Return false for all other headings
+		 */
+		return false
 	})
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-scc-remove-h1-from-toc-hashicorp.vercel.app/vault/docs/concepts/client-count) 🔎
- [Asana task](https://app.asana.com/0/1202801212949828/1204886054682186/f) 🎟️

## 🗒️ What

Filter h1 from TOC

## 🤷 Why

The TOC on doc pages include the doc title in the list which is weird as it's not an actual content section and could confuse readers who are scanning the content quickly. It also goes against established standards in web content, which typically exclude the page title in the TOC (see example screenshots in Asana ticket)

## 🛠️ How

Added a prune function to perform a second filter on heading items based on level to avoid interfering with other uses of the current filter function for content validation (per the code comments).
Changed sidecar logic to consider 1 or more items "many" so the TOC renders when there is only one h2 entry.

## 📸 Design Screenshots

N/A

## 🧪 Testing

- [ ] Open a docs page and confirm the TOC renders identically to production minus the h1
- [ ] Open a tutorial page and confirm the TOC renders identically to production minus the h1
- [ ] Open a landing page and confirm the TOC renders identically to production minus the h1
