### PR TITLE
Install page enhancement: Release Information - command + code block (Consul only)

### DIFF
--- a/src/pages/consul/install/consul-downloads.module.css
+++ b/src/pages/consul/install/consul-downloads.module.css
@@ -3,33 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.notesList {
-	margin: 0;
-	padding: 0;
-	padding-left: 24px;
-}
-
-.notesListItem {
-	color: var(--token-color-foreground-primary);
-	margin-top: 8px;
-}
-
-.codeDescription {
-	color: var(--token-color-foreground-primary);
-	margin-bottom: 16px;
-	margin-top: 16px;
-}
-
-.inlineCode {
-	/* composition */
-	composes: hds-typography-code-100 from global;
-
-	/* properties */
-	color: var(--token-color-foreground-primary);
-	display: block;
-	margin-top: 16px;
-}
-
 .downloadToolsCardTitle {
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 4px;

--- a/src/pages/consul/install/index.tsx
+++ b/src/pages/consul/install/index.tsx
@@ -13,52 +13,9 @@ import { generateGetStaticProps } from 'views/product-downloads-view/server'
 import viewStyles from 'views/product-downloads-view/product-downloads-view.module.css'
 import s from './consul-downloads.module.css'
 
-const notesListItems = [
-	'Use Armelv5 for all 32-bit armel systems',
-	'Use Armhfv6 for all armhf systems with v6+ architecture',
-	'Use Arm64 for all v8 64-bit architectures',
-]
-
 const ConsulDownloadsMerchandisingSlot = () => {
 	return (
 		<div>
-			<Heading
-				className={viewStyles.heading2}
-				level={2}
-				size={300}
-				weight="bold"
-			>
-				Note for ARM users
-			</Heading>
-			<ul className={s.notesList}>
-				{notesListItems.map((item, index) => (
-					<Text
-						asElement="li"
-						className={s.notesListItem}
-						// eslint-disable-next-line react/no-array-index-key
-						key={index}
-						size={200}
-						weight="regular"
-					>
-						{item}
-					</Text>
-				))}
-			</ul>
-			<Text
-				asElement="p"
-				className={s.codeDescription}
-				size={200}
-				weight="regular"
-			>
-				The following commands can help determine the right version for your
-				system:
-			</Text>
-			<code className={s.inlineCode}>$ uname -m</code>
-			<code className={s.inlineCode}>
-				$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo
-				&quot;armhf&quot; || echo &quot;armel&quot;
-			</code>
-
 			<Heading
 				className={viewStyles.heading2}
 				level={2}

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -28,9 +28,8 @@ const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
 	const armNotes = [
-		'Use Armelv5 for all 32-bit armel systems',
-		'Use Armhfv6 for all armhf systems with v6+ architecture',
-		'Use Arm64 for all v8 64-bit architectures',
+		'Use Arm for all 32-bit armel systems',
+		'Use Arm64 for all 64-bit architectures',
 	]
 	return (
 		<>

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -102,6 +102,7 @@ const NoteCard = ({ selectedRelease }) => {
 						system:
 					</Text>
 					<CodeBlock
+						className={s.codeBlock}
 						code={`$ uname -m
 $ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
 						language="shell-session"

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -27,10 +27,6 @@ import s from './release-information.module.css'
 const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
-	const armNotes = [
-		'Use Arm for all 32-bit armel systems',
-		'Use Arm64 for all 64-bit architectures',
-	]
 	return (
 		<>
 			<InlineAlert
@@ -71,17 +67,12 @@ const NoteCard = ({ selectedRelease }) => {
 									ARM users
 								</Text>
 								<ul className={s.notesList}>
-									{armNotes.map((item, index) => (
-										<Text
-											asElement="li"
-											// eslint-disable-next-line react/no-array-index-key
-											key={index}
-											size={200}
-											weight="regular"
-										>
-											{item}
-										</Text>
-									))}
+									<Text asElement="li" size={200} weight="regular">
+										Use Arm for all 32-bit systems
+									</Text>
+									<Text asElement="li" size={200} weight="regular">
+										Use Arm64 for all 64-bit architectures
+									</Text>
 								</ul>
 							</>
 						)}

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -10,6 +10,7 @@ import { ReactElement } from 'react'
 import { IconExternalLink16 } from '@hashicorp/flight-icons/svg-react/external-link-16'
 import { IconExternalLink24 } from '@hashicorp/flight-icons/svg-react/external-link-24'
 import { IconInfo16 } from '@hashicorp/flight-icons/svg-react/info-16'
+import CodeBlock from '@hashicorp/react-code-block'
 
 // Global imports
 import Heading from 'components/heading'
@@ -17,7 +18,6 @@ import InlineLink from 'components/inline-link'
 import Text from 'components/text'
 import { useCurrentProduct } from 'contexts'
 import viewStyles from 'views/product-downloads-view/product-downloads-view.module.css'
-
 import InlineAlert from 'components/inline-alert'
 import MobileStandaloneLink from 'components/mobile-standalone-link'
 import { ReleaseVersion } from 'lib/fetch-release-data'
@@ -27,37 +27,89 @@ import s from './release-information.module.css'
 const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
-
+	const armNotes = [
+		'Use Armelv5 for all 32-bit armel systems',
+		'Use Armhfv6 for all armhf systems with v6+ architecture',
+		'Use Arm64 for all v8 64-bit architectures',
+	]
 	return (
-		<InlineAlert
-			className={s.alert}
-			color="neutral"
-			title="Note"
-			description={
+		<>
+			<InlineAlert
+				className={s.alert}
+				color="neutral"
+				title="Note"
+				description={
+					<>
+						You can find the{' '}
+						<InlineLink
+							href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
+							textSize={200}
+						>
+							SHA256 checksums for {currentProduct.name} {version}
+						</InlineLink>{' '}
+						online and you can{' '}
+						<InlineLink
+							href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
+							textSize={200}
+						>
+							verify the checksums signature file
+						</InlineLink>{' '}
+						which has been signed using{' '}
+						<InlineLink
+							href="https://www.hashicorp.com/security"
+							textSize={200}
+						>
+							{"HashiCorp's GPG key"}
+						</InlineLink>
+						.
+						{currentProduct.name === 'Consul' && (
+							<>
+								<Text
+									className={s.notesSubheading}
+									size={200}
+									weight="semibold"
+								>
+									ARM users
+								</Text>
+								<ul className={s.notesList}>
+									{armNotes.map((item, index) => (
+										<Text
+											asElement="li"
+											// eslint-disable-next-line react/no-array-index-key
+											key={index}
+											size={200}
+											weight="regular"
+										>
+											{item}
+										</Text>
+									))}
+								</ul>
+							</>
+						)}
+					</>
+				}
+				icon={<IconInfo16 className={s.cardIcon} />}
+			/>
+			{currentProduct.name === 'Consul' && (
 				<>
-					You can find the{' '}
-					<InlineLink
-						href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
-						textSize={200}
+					<Text
+						className={s.codePrompt}
+						asElement="p"
+						size={100}
+						weight="regular"
 					>
-						SHA256 checksums for {currentProduct.name} {version}
-					</InlineLink>{' '}
-					online and you can{' '}
-					<InlineLink
-						href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
-						textSize={200}
-					>
-						verify the checksums signature file
-					</InlineLink>{' '}
-					which has been signed using{' '}
-					<InlineLink href="https://www.hashicorp.com/security" textSize={200}>
-						{"HashiCorp's GPG key"}
-					</InlineLink>
-					.
+						The following commands can help determine the right version for your
+						system:
+					</Text>
+					<CodeBlock
+						code={`$ uname -m
+$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
+						language="shell-session"
+						options={{ showClipboard: true, wrapCode: true }}
+					/>
 				</>
-			}
-			icon={<IconInfo16 className={s.cardIcon} />}
-		/>
+			)}
+		</>
 	)
 }
 

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -28,60 +28,54 @@ const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
 	return (
-		<>
-			<InlineAlert
-				className={s.alert}
-				color="neutral"
-				title="Note"
-				description={
-					<>
-						You can find the{' '}
-						<InlineLink
-							href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
-							textSize={200}
-						>
-							SHA256 checksums for {currentProduct.name} {version}
-						</InlineLink>{' '}
-						online and you can{' '}
-						<InlineLink
-							href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
-							textSize={200}
-						>
-							verify the checksums signature file
-						</InlineLink>{' '}
-						which has been signed using{' '}
-						<InlineLink
-							href="https://www.hashicorp.com/security"
-							textSize={200}
-						>
-							{"HashiCorp's GPG key"}
-						</InlineLink>
-						.
-						{currentProduct.name === 'Consul' && (
-							<>
-								<Text
-									className={s.notesSubheading}
-									size={200}
-									weight="semibold"
-								>
-									ARM users
-								</Text>
-								<ul className={s.notesList}>
-									<Text asElement="li" size={200} weight="regular">
-										Use Arm for all 32-bit systems
-									</Text>
-									<Text asElement="li" size={200} weight="regular">
-										Use Arm64 for all 64-bit architectures
-									</Text>
-								</ul>
-							</>
-						)}
-					</>
-				}
-				icon={<IconInfo16 className={s.cardIcon} />}
-			/>
-			{currentProduct.name === 'Consul' && (
+		<InlineAlert
+			className={s.alert}
+			color="neutral"
+			title="Note"
+			description={
 				<>
+					You can find the{' '}
+					<InlineLink
+						href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
+						textSize={200}
+					>
+						SHA256 checksums for {currentProduct.name} {version}
+					</InlineLink>{' '}
+					online and you can{' '}
+					<InlineLink
+						href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
+						textSize={200}
+					>
+						verify the checksums signature file
+					</InlineLink>{' '}
+					which has been signed using{' '}
+					<InlineLink href="https://www.hashicorp.com/security" textSize={200}>
+						{"HashiCorp's GPG key"}
+					</InlineLink>
+					.
+				</>
+			}
+			icon={<IconInfo16 className={s.cardIcon} />}
+		/>
+	)
+}
+
+const ConsulNoteCard = (): ReactElement => {
+	return (
+		<InlineAlert
+			className={s.armUserNote}
+			color="neutral"
+			title="Note for ARM users"
+			description={
+				<>
+					<ul className={s.notesList}>
+						<Text asElement="li" size={200} weight="regular">
+							Use Arm for all 32-bit systems
+						</Text>
+						<Text asElement="li" size={200} weight="regular">
+							Use Arm64 for all 64-bit architectures
+						</Text>
+					</ul>
 					<Text
 						className={s.codePrompt}
 						asElement="p"
@@ -92,15 +86,26 @@ const NoteCard = ({ selectedRelease }) => {
 						system:
 					</Text>
 					<CodeBlock
-						className={s.codeBlock}
-						code={`$ uname -m
-$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
+						code="$ uname -m"
 						language="shell-session"
-						options={{ showClipboard: true, wrapCode: true }}
+						options={{
+							wrapCode: true,
+							showClipboard: true,
+						}}
+					/>
+					<CodeBlock
+						className={s.codeBlock}
+						code={`$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
+						language="shell-session"
+						options={{
+							wrapCode: true,
+							showClipboard: true,
+						}}
 					/>
 				</>
-			)}
-		</>
+			}
+			icon={<IconInfo16 className={s.cardIcon} />}
+		/>
 	)
 }
 
@@ -180,6 +185,7 @@ const ReleaseInformationSection = ({
 	selectedRelease,
 	isEnterpriseMode,
 }: ReleaseInformationSectionProps): ReactElement => {
+	const currentProduct = useCurrentProduct()
 	return (
 		<>
 			<Heading
@@ -194,6 +200,7 @@ const ReleaseInformationSection = ({
 			<ChangelogNote selectedRelease={selectedRelease} />
 			<OfficialReleasesCard />
 			<NoteCard selectedRelease={selectedRelease} />
+			{currentProduct.name === 'Consul' && <ConsulNoteCard />}
 			{isEnterpriseMode ? <EnterpriseLegalNote /> : null}
 		</>
 	)

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -14,7 +14,7 @@
 }
 
 .notesSubheading {
-	margin-top: 16px;
+	margin-top: 20px;
 }
 
 .codePrompt {
@@ -24,4 +24,8 @@
 .notesList {
 	padding-left: 5px;
 	list-style-position: inside;
+}
+
+.codeBlock {
+	margin-bottom: 40px;
 }

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -12,3 +12,16 @@
 	max-height: 16px;
 	max-width: 16px;
 }
+
+.notesSubheading {
+	margin-top: 16px;
+}
+
+.codePrompt {
+	margin-bottom: 8px;
+}
+
+.notesList {
+	padding-left: 5px;
+	list-style-position: inside;
+}

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -22,7 +22,7 @@
 }
 
 .notesList {
-	padding-left: 5px;
+	padding-left: 8px;
 	list-style-position: inside;
 }
 

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.alert {
+.alert,
+.armUserNote {
 	margin-bottom: 24px;
 }
 
@@ -13,12 +14,12 @@
 	max-width: 16px;
 }
 
-.notesSubheading {
-	margin-top: 20px;
+.armUserNote {
+	padding: 16px 30px 37px 16px;
 }
 
 .codePrompt {
-	margin-bottom: 8px;
+	margin: 25px 0 11px 0;
 }
 
 .notesList {
@@ -27,5 +28,5 @@
 }
 
 .codeBlock {
-	margin-bottom: 40px;
+	margin: 20px 0 37px 0;
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Link to [Slack thread](https://hashicorp.slack.com/archives/C011HP57U0Y/p1700247868763509) discussing changes to copy in ARM note
- [Consul install preview link](https://dev-portal-git-heat-featrelease-info-consul-hashicorp.vercel.app/consul/install) 🔎
- [Asana task](https://app.asana.com/0/1204817897905865/1205911880806870/f) 🎟️
- [Figma](https://figmashort.link/Sr42JA)

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
- Moved note for ARM users to Release information section
- Changed `<code>` blocks to `<CodeBlock>` so it can be copied

## 🤷 Why

- Necessary install page enhancement for Consul

## 🧪 Testing

- Navigate to [/consul/install](https://dev-portal-git-heat-featrelease-info-consul-hashicorp.vercel.app/consul/install) and see the note for ARM users has moved
- Navigate to [/consul/install/enterprise](https://dev-portal-git-heat-featrelease-info-consul-hashicorp.vercel.app/consul/install/enterprise) and see the note for ARM users has moved
- Navigated to [/vagrant/install](https://dev-portal-git-heat-featrelease-info-consul-hashicorp.vercel.app/vagrant/install) and see there is no note for ARM users

## 💭 Anything else?

- The Consul note for ARM users has been moved from Consul install page (`src/pages/consul/install/index.tsx`) to the Release Information section because the position of the merchandising slot is incompatible with the new designs. In the mocks, the "Consul Tools" element comes after the "Terms of Use" note on the enterprise install page. There's no low-effort way to implement this and keep the note for ARM users in the Consul install page's merchandising slot.