### PR TITLE
Install page enhancement: Move OS downloads from tabs to individual cards

### DIFF
--- a/src/pages/consul/install/enterprise.tsx
+++ b/src/pages/consul/install/enterprise.tsx
@@ -14,7 +14,7 @@ const ConsulEnterpriseDownloadsPage = (props) => {
 		<ProductDownloadsView
 			{...props}
 			merchandisingSlot={{
-				position: 'middle',
+				position: 'below',
 				slot: <ConsulDownloadsMerchandisingSlot />,
 			}}
 		/>

--- a/src/pages/consul/install/enterprise.tsx
+++ b/src/pages/consul/install/enterprise.tsx
@@ -14,7 +14,7 @@ const ConsulEnterpriseDownloadsPage = (props) => {
 		<ProductDownloadsView
 			{...props}
 			merchandisingSlot={{
-				position: 'below',
+				position: 'middle',
 				slot: <ConsulDownloadsMerchandisingSlot />,
 			}}
 		/>

--- a/src/views/product-downloads-view/boundary/components/desktop-client-callout/desktop-client-callout.module.css
+++ b/src/views/product-downloads-view/boundary/components/desktop-client-callout/desktop-client-callout.module.css
@@ -7,3 +7,25 @@
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 16px;
 }
+
+.downloadContainer {
+	display: grid;
+	gap: 24px;
+	@media (--dev-dot-tablet-up) {
+		grid-template-columns: 1fr 1fr;
+		gap: 28px 24px;
+	}
+}
+
+.downloadCard {
+	display: grid;
+	grid-template-columns: 16px 1fr 24px;
+	align-items: center;
+	column-gap: 8px;
+	&:last-child {
+		margin-bottom: 0;
+	}
+	@media (--dev-dot-tablet-up) {
+		grid-template-columns: 16px 1fr 90px;
+	}
+}

--- a/src/views/product-downloads-view/boundary/components/desktop-client-callout/index.tsx
+++ b/src/views/product-downloads-view/boundary/components/desktop-client-callout/index.tsx
@@ -5,8 +5,9 @@
 
 // Components
 import Card from 'components/card'
+import CardWithLink from 'views/product-downloads-view/components/card-with-link'
+import MobileDownloadStandaloneLink from 'components/mobile-download-standalone-link'
 import Heading from 'components/heading'
-import IconCardLinkGridList from 'components/icon-card-link-grid-list'
 import { IconDownload16 } from '@hashicorp/flight-icons/svg-react/download-16'
 // Types
 import { DesktopClientProps, ReleaseBuild } from './types'
@@ -25,21 +26,35 @@ function DesktopClientCallout({
 	desktopClientProps: DesktopClientProps
 }) {
 	const { latestVersion, builds } = desktopClientProps
-
 	return (
 		<Card elevation="low">
-			<Heading className={s.heading} level={2} size={200} weight="semibold">
+			<Heading
+				className={s.heading}
+				level={2}
+				size={400}
+				id="operating-system-desktop"
+				weight="bold"
+			>
 				{`Desktop Client v${latestVersion}`}
 			</Heading>
-			<IconCardLinkGridList
-				fixedColumns={3}
-				gridGap="16px"
-				cards={builds.map(({ os, url, filename, arch }: ReleaseBuild) => {
-					const icon = operatingSystemIcons[os] || <IconDownload16 />
-					const text = `.${getFileExtension(filename)} (${humanArch(arch)})`
-					return { icon, url, text }
-				})}
-			/>
+			<div className={s.downloadContainer}>
+				{builds.map(({ os, url, filename, arch }: ReleaseBuild) => (
+					<CardWithLink
+						className={s.downloadCard}
+						key={filename}
+						icon={operatingSystemIcons[os] || <IconDownload16 />}
+						heading={`.${getFileExtension(filename)} (${humanArch(arch)})`}
+						link={
+							<MobileDownloadStandaloneLink
+								ariaLabel={`download .${getFileExtension(
+									filename
+								)}, architecture ${arch}`}
+								href={url}
+							/>
+						}
+					/>
+				))}
+			</div>
 		</Card>
 	)
 }

--- a/src/views/product-downloads-view/boundary/index.tsx
+++ b/src/views/product-downloads-view/boundary/index.tsx
@@ -24,7 +24,7 @@ function BoundaryDownloadsView({
 		<ProductDownloadsView
 			{...baseProps}
 			merchandisingSlot={{
-				position: 'below',
+				position: 'middle',
 				slot: <DesktopClientCallout desktopClientProps={desktopClientProps} />,
 			}}
 		/>

--- a/src/views/product-downloads-view/components/card-with-link/card-with-link.module.css
+++ b/src/views/product-downloads-view/components/card-with-link/card-with-link.module.css
@@ -6,10 +6,14 @@
 .root {
 	display: flex;
 	padding: 16px;
-	margin-bottom: 24px;
 	justify-content: space-between;
 }
 
 .contentHeading {
-	margin-bottom: 4px;
+	color: var(--token-color-foreground-strong);
+}
+
+.contentSubheading {
+	color: var(--token-color-foreground-faint);
+	margin-top: 4px;
 }

--- a/src/views/product-downloads-view/components/card-with-link/index.tsx
+++ b/src/views/product-downloads-view/components/card-with-link/index.tsx
@@ -12,8 +12,10 @@ import Text from 'components/text'
 
 // Local imports
 import s from './card-with-link.module.css'
+import classNames from 'classnames'
 
 interface CardWithLinkProps {
+	className?: string
 	heading: string
 	subheading: string | ReactNode
 	icon?: ReactNode
@@ -21,13 +23,14 @@ interface CardWithLinkProps {
 }
 
 const CardWithLink = ({
+	className,
 	heading,
 	subheading,
 	icon,
 	link,
 }: CardWithLinkProps) => {
 	return (
-		<Card className={s.root} elevation="base">
+		<Card className={classNames(s.root, className)} elevation="base">
 			{typeof icon !== undefined ? icon : null}
 			<div className={s.contentContainer}>
 				<Text className={s.contentHeading} size={200} weight="semibold">

--- a/src/views/product-downloads-view/components/card-with-link/index.tsx
+++ b/src/views/product-downloads-view/components/card-with-link/index.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames'
 interface CardWithLinkProps {
 	className?: string
 	heading: string
-	subheading: string | ReactNode
+	subheading?: string | ReactNode
 	icon?: ReactNode
 	link?: ReactNode
 }
@@ -31,16 +31,18 @@ const CardWithLink = ({
 }: CardWithLinkProps) => {
 	return (
 		<Card className={classNames(s.root, className)} elevation="base">
-			{typeof icon !== undefined ? icon : null}
+			{typeof icon !== 'undefined' ? icon : null}
 			<div className={s.contentContainer}>
 				<Text className={s.contentHeading} size={200} weight="semibold">
 					{heading}
 				</Text>
-				<Text className={s.contentSubheading} size={200} weight="regular">
-					{subheading}
-				</Text>
+				{typeof subheading !== 'undefined' ? (
+					<Text className={s.contentSubheading} size={200} weight="regular">
+						{subheading}
+					</Text>
+				) : null}
 			</div>
-			{typeof link !== undefined ? link : null}
+			{typeof link !== 'undefined' ? link : null}
 		</Card>
 	)
 }

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -7,25 +7,14 @@
 	margin-bottom: 48px;
 }
 
-.cardHeader {
-	align-items: center;
-	display: flex;
-
-	/* Note: logical order is Vault version, then OS.
-     But in flex layout, we want Vault version after OS heading,
-     so that it appears in the top left of the downloads section box */
-	flex-direction: row-reverse;
-	flex-wrap: wrap;
-	gap: 12px;
-	justify-content: space-between;
-	padding-bottom: 12px;
+.card {
+	margin-bottom: 32px;
+	padding: 16px;
 }
 
 .operatingSystemTitle {
 	color: var(--token-color-foreground-strong);
-
-	/* Flex-grow as much as possible to keep .versionSwitcherWrapper small */
-	flex-grow: 100;
+	margin-bottom: 16px;
 }
 
 .tabContent {
@@ -35,28 +24,31 @@
 .subHeading {
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 16px;
-	margin-top: 24px;
 }
 
-.textAndLinkCard {
-	align-items: center;
-	display: flex;
-	justify-content: space-between;
-
-	&:not(:last-child) {
-		margin-bottom: 16px;
+.binaryDownloadContainer {
+	@media (--medium-up) {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 24px;
 	}
 }
 
-.textAndLinkCardTextContainer {
-	margin-right: 16px;
+.binaryCard {
+	&:last-child {
+		margin: 0;
+	}
+	@media (--medium-up) {
+		flex: 1 1 auto;
+		width: calc(50% - 12px);
+		margin: 0;
+	}
 }
 
-.textAndLinkCardLabel {
-	color: var(--token-color-foreground-strong);
-	margin-bottom: 4px;
+.codeBlock {
+	margin-bottom: 32px;
 }
 
-.textAndLinkCardVersionLabel {
-	color: var(--token-color-foreground-faint);
+.codeBlocks {
+	margin-bottom: 24px;
 }

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -14,7 +14,6 @@
 
 .operatingSystemTitle {
 	color: var(--token-color-foreground-strong);
-	margin-bottom: 16px;
 }
 
 .tabContent {
@@ -23,7 +22,7 @@
 
 .subHeading {
 	color: var(--token-color-foreground-strong);
-	margin-bottom: 16px;
+	margin: 16px 0;
 }
 
 .binaryDownloadContainer {

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -2,17 +2,12 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-.root {
-	margin-bottom: 48px;
-}
-
 .card {
 	margin-bottom: 32px;
 	padding: 16px;
 }
 
-.operatingSystemTitle {
+.heading {
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 16px;
 }
@@ -21,27 +16,26 @@
 	margin-top: 16px;
 }
 
-.subHeading {
-	color: var(--token-color-foreground-strong);
-	margin-bottom: 16px;
-}
-
-.binaryDownloadContainer {
-	@media (--medium-up) {
-		display: flex;
+.downloadContainer {
+	display: flex;
+	gap: 24px;
+	flex-direction: column;
+	@media (--dev-dot-tablet-up) {
 		flex-wrap: wrap;
-		gap: 24px;
+		flex-direction: row;
 	}
 }
 
-.binaryCard {
+.downloadCard {
 	&:last-child {
-		margin: 0;
+		margin-bottom: 0;
 	}
-	@media (--medium-up) {
+	@media (--dev-dot-tablet-up) {
 		flex: 1 1 auto;
 		width: calc(50% - 12px);
-		margin: 0;
+		&:last-child {
+			margin-bottom: auto;
+		}
 	}
 }
 

--- a/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
+++ b/src/views/product-downloads-view/components/downloads-section/downloads-section.module.css
@@ -14,6 +14,7 @@
 
 .operatingSystemTitle {
 	color: var(--token-color-foreground-strong);
+	margin-bottom: 16px;
 }
 
 .tabContent {
@@ -22,7 +23,7 @@
 
 .subHeading {
 	color: var(--token-color-foreground-strong);
-	margin: 16px 0;
+	margin-bottom: 16px;
 }
 
 .binaryDownloadContainer {

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -25,6 +25,7 @@ import s from './downloads-section.module.css'
 import { groupDownloadsByOS, groupPackageManagersByOS } from './helpers'
 import { DownloadsSectionProps } from './types'
 import CardWithLink from '../card-with-link'
+import { ContentWithPermalink } from 'views/open-api-docs-view/components/content-with-permalink'
 
 const SHARED_HEADING_LEVEL_3_PROPS = {
 	className: s.subHeading,
@@ -156,15 +157,17 @@ const DownloadsSection = ({
 					 */
 					return (
 						<Card className={s.card} elevation="base" key={os}>
-							<Heading
-								className={s.operatingSystemTitle}
-								level={2}
-								size={400}
-								id="operating-system"
-								weight="bold"
-							>
-								{prettyOSName}
-							</Heading>
+							<ContentWithPermalink id={prettyOSName} ariaLabel={prettyOSName}>
+								<Heading
+									id={prettyOSName}
+									className={s.operatingSystemTitle}
+									level={2}
+									size={400}
+									weight="bold"
+								>
+									{prettyOSName}
+								</Heading>
+							</ContentWithPermalink>
 							<div className={s.tabContent}>
 								{isLatestVersion && (
 									<PackageManagerSection

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -34,7 +34,6 @@ const SHARED_HEADING_LEVEL_3_PROPS = {
 
 const PackageManagerSection = ({
 	packageManagers,
-	prettyOSName,
 }: {
 	packageManagers: PackageManager[]
 	prettyOSName: string

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -25,7 +25,6 @@ import s from './downloads-section.module.css'
 import { groupDownloadsByOS, groupPackageManagersByOS } from './helpers'
 import { DownloadsSectionProps } from './types'
 import CardWithLink from '../card-with-link'
-import { ContentWithPermalink } from 'views/open-api-docs-view/components/content-with-permalink'
 
 const SHARED_HEADING_LEVEL_3_PROPS = {
 	className: s.subHeading,
@@ -157,17 +156,15 @@ const DownloadsSection = ({
 					 */
 					return (
 						<Card className={s.card} elevation="base" key={os}>
-							<ContentWithPermalink id={prettyOSName} ariaLabel={prettyOSName}>
-								<Heading
-									id={prettyOSName}
-									className={s.operatingSystemTitle}
-									level={2}
-									size={400}
-									weight="bold"
-								>
-									{prettyOSName}
-								</Heading>
-							</ContentWithPermalink>
+							<Heading
+								className={s.operatingSystemTitle}
+								level={2}
+								size={400}
+								id="operating-system"
+								weight="bold"
+							>
+								{prettyOSName}
+							</Heading>
 							<div className={s.tabContent}>
 								{isLatestVersion && (
 									<PackageManagerSection

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -131,46 +131,38 @@ const DownloadsSection = ({
 
 	return (
 		<>
-			<>
-				{Object.keys(downloadsByOS).map((os) => {
-					const packageManagers = packageManagersByOS[os]
-					const prettyOSName = prettyOs(os)
+			{Object.keys(downloadsByOS).map((os) => {
+				const packageManagers = packageManagersByOS[os]
+				const prettyOSName = prettyOs(os)
 
-					/**
-					 * TODO: it might be nice to introduce a local Context here with all
-					 * the information needed so that these helper components don't have
-					 * APIs that could potentially require changes with every visual
-					 * change.
-					 */
-					return (
-						<Card className={s.card} elevation="base" key={os}>
-							<Heading
-								className={s.heading}
-								level={2}
-								size={400}
-								id={`operating-system-${prettyOSName}`}
-								weight="bold"
-							>
-								{prettyOSName}
-							</Heading>
-							<div className={s.tabContent}>
-								{isLatestVersion && (
-									<PackageManagerSection
-										packageManagers={packageManagers}
-										prettyOSName={prettyOSName}
-									/>
-								)}
-								<BinaryDownloadsSection
-									downloadsByOS={downloadsByOS}
-									os={os}
+				return (
+					<Card className={s.card} elevation="base" key={os}>
+						<Heading
+							className={s.heading}
+							level={2}
+							size={400}
+							id={`operating-system-${prettyOSName}`}
+							weight="bold"
+						>
+							{prettyOSName}
+						</Heading>
+						<div className={s.tabContent}>
+							{isLatestVersion && (
+								<PackageManagerSection
+									packageManagers={packageManagers}
 									prettyOSName={prettyOSName}
-									selectedRelease={selectedRelease}
 								/>
-							</div>
-						</Card>
-					)
-				})}
-			</>
+							)}
+							<BinaryDownloadsSection
+								downloadsByOS={downloadsByOS}
+								os={os}
+								prettyOSName={prettyOSName}
+								selectedRelease={selectedRelease}
+							/>
+						</div>
+					</Card>
+				)
+			})}
 		</>
 	)
 }

--- a/src/views/product-downloads-view/components/downloads-section/index.tsx
+++ b/src/views/product-downloads-view/components/downloads-section/index.tsx
@@ -20,14 +20,13 @@ import { prettyOs } from 'views/product-downloads-view/helpers'
 
 // Local imports
 import { PackageManager } from 'views/product-downloads-view/types'
-import ReleaseInformationSection from '../release-information'
 import s from './downloads-section.module.css'
 import { groupDownloadsByOS, groupPackageManagersByOS } from './helpers'
 import { DownloadsSectionProps } from './types'
 import CardWithLink from '../card-with-link'
 
 const SHARED_HEADING_LEVEL_3_PROPS = {
-	className: s.subHeading,
+	className: s.heading,
 	level: 3 as HeadingProps['level'],
 	size: 200 as HeadingProps['size'],
 	weight: 'semibold' as HeadingProps['weight'],
@@ -50,12 +49,7 @@ const PackageManagerSection = ({
 
 	return (
 		<>
-			<Heading
-				{...SHARED_HEADING_LEVEL_3_PROPS}
-				id={`package-manager-for-${prettyOSName}`}
-			>
-				Package manager
-			</Heading>
+			<Heading {...SHARED_HEADING_LEVEL_3_PROPS}>Package manager</Heading>
 			{hasOnePackageManager && (
 				<CodeBlock
 					className={s.codeBlock}
@@ -73,7 +67,7 @@ const PackageManagerSection = ({
 								key={label}
 								code={installCodeHtml}
 								language="shell-session"
-								options={{ showClipboard: true, wrapCode: true }}
+								options={{ showClipboard: true }}
 							/>
 						)
 					})}
@@ -92,16 +86,11 @@ const BinaryDownloadsSection = ({
 	const { name, version } = selectedRelease
 	return (
 		<>
-			<Heading
-				{...SHARED_HEADING_LEVEL_3_PROPS}
-				id={`binary-download-for-${prettyOSName}`}
-			>
-				Binary download
-			</Heading>
-			<div className={s.binaryDownloadContainer}>
+			<Heading {...SHARED_HEADING_LEVEL_3_PROPS}>Binary download</Heading>
+			<div className={s.downloadContainer}>
 				{Object.keys(downloadsByOS[os]).map((arch) => (
 					<CardWithLink
-						className={s.binaryCard}
+						className={s.downloadCard}
 						key={arch}
 						heading={arch.toUpperCase()}
 						subheading={`Version: ${version}`}
@@ -127,7 +116,6 @@ const BinaryDownloadsSection = ({
 }
 
 const DownloadsSection = ({
-	isEnterpriseMode = false,
 	packageManagers,
 	selectedRelease,
 }: DownloadsSectionProps): ReactElement => {
@@ -143,7 +131,7 @@ const DownloadsSection = ({
 
 	return (
 		<>
-			<div className={s.root}>
+			<>
 				{Object.keys(downloadsByOS).map((os) => {
 					const packageManagers = packageManagersByOS[os]
 					const prettyOSName = prettyOs(os)
@@ -157,10 +145,10 @@ const DownloadsSection = ({
 					return (
 						<Card className={s.card} elevation="base" key={os}>
 							<Heading
-								className={s.operatingSystemTitle}
+								className={s.heading}
 								level={2}
 								size={400}
-								id="operating-system"
+								id={`operating-system-${prettyOSName}`}
 								weight="bold"
 							>
 								{prettyOSName}
@@ -182,11 +170,7 @@ const DownloadsSection = ({
 						</Card>
 					)
 				})}
-			</div>
-			<ReleaseInformationSection
-				selectedRelease={selectedRelease}
-				isEnterpriseMode={isEnterpriseMode}
-			/>
+			</>
 		</>
 	)
 }

--- a/src/views/product-downloads-view/components/downloads-section/types.ts
+++ b/src/views/product-downloads-view/components/downloads-section/types.ts
@@ -7,7 +7,6 @@ import { ReleaseVersion } from 'lib/fetch-release-data'
 import { PackageManager } from 'views/product-downloads-view/types'
 
 export interface DownloadsSectionProps {
-	isEnterpriseMode: boolean
 	packageManagers: PackageManager[]
 	selectedRelease: ReleaseVersion
 }

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -28,7 +28,6 @@ const NoteCard = ({ selectedRelease }) => {
 	const { name, shasums, shasums_signature, version } = selectedRelease
 	return (
 		<InlineAlert
-			className={s.alert}
 			color="neutral"
 			title="Note"
 			description={

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -67,17 +67,12 @@ const NoteCard = ({ selectedRelease }) => {
 									ARM users
 								</Text>
 								<ul className={s.notesList}>
-									{armNotes.map((item, index) => (
-										<Text
-											asElement="li"
-											// eslint-disable-next-line react/no-array-index-key
-											key={index}
-											size={200}
-											weight="regular"
-										>
-											{item}
-										</Text>
-									))}
+									<Text asElement="li" size={200} weight="regular">
+										Use Arm for all 32-bit systems
+									</Text>
+									<Text asElement="li" size={200} weight="regular">
+										Use Arm64 for all 64-bit architectures
+									</Text>
 								</ul>
 							</>
 						)}

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -96,7 +96,7 @@ const NoteCard = ({ selectedRelease }) => {
 						code={`$ uname -m
 $ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
 						language="shell-session"
-						options={{ showClipboard: true, wrapCode: true }}
+						options={{ showClipboard: true }}
 					/>
 				</>
 			)}

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -231,11 +231,11 @@ const ReleaseInformationSection = ({
 }: ReleaseInformationSectionProps): ReactElement => {
 	const currentProduct = useCurrentProduct()
 	return (
-		<>
+		<div className={s.root}>
 			<Heading
-				className={viewStyles.heading2}
+				className={s.heading}
 				level={2}
-				size={300}
+				size={400}
 				id="looking-for-more"
 				weight="bold"
 			>
@@ -246,7 +246,7 @@ const ReleaseInformationSection = ({
 			<NoteCard selectedRelease={selectedRelease} />
 			{currentProduct.name === 'Consul' && <ConsulNoteCard />}
 			{isEnterpriseMode ? <EnterpriseLegalNote /> : null}
-		</>
+		</div>
 	)
 }
 

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -17,7 +17,6 @@ import Heading from 'components/heading'
 import InlineLink from 'components/inline-link'
 import Text from 'components/text'
 import { useCurrentProduct } from 'contexts'
-import viewStyles from 'views/product-downloads-view/product-downloads-view.module.css'
 import InlineAlert from 'components/inline-alert'
 import MobileStandaloneLink from 'components/mobile-standalone-link'
 import { ReleaseVersion } from 'lib/fetch-release-data'
@@ -28,40 +27,35 @@ const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
 	return (
-		<>
-			<InlineAlert
-				className={s.alert}
-				color="neutral"
-				title="Note"
-				description={
-					<>
-						You can find the{' '}
-						<InlineLink
-							href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
-							textSize={200}
-						>
-							SHA256 checksums for {currentProduct.name} {version}
-						</InlineLink>{' '}
-						online and you can{' '}
-						<InlineLink
-							href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
-							textSize={200}
-						>
-							verify the checksums signature file
-						</InlineLink>{' '}
-						which has been signed using{' '}
-						<InlineLink
-							href="https://www.hashicorp.com/security"
-							textSize={200}
-						>
-							{"HashiCorp's GPG key"}
-						</InlineLink>
-						.
-					</>
-				}
-				icon={<IconInfo16 className={s.cardIcon} />}
-			/>
-		</>
+		<InlineAlert
+			className={s.alert}
+			color="neutral"
+			title="Note"
+			description={
+				<>
+					You can find the{' '}
+					<InlineLink
+						href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
+						textSize={200}
+					>
+						SHA256 checksums for {currentProduct.name} {version}
+					</InlineLink>{' '}
+					online and you can{' '}
+					<InlineLink
+						href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
+						textSize={200}
+					>
+						verify the checksums signature file
+					</InlineLink>{' '}
+					which has been signed using{' '}
+					<InlineLink href="https://www.hashicorp.com/security" textSize={200}>
+						{"HashiCorp's GPG key"}
+					</InlineLink>
+					.
+				</>
+			}
+			icon={<IconInfo16 className={s.cardIcon} />}
+		/>
 	)
 }
 
@@ -192,7 +186,7 @@ const ReleaseInformationSection = ({
 }: ReleaseInformationSectionProps): ReactElement => {
 	const currentProduct = useCurrentProduct()
 	return (
-		<div className={s.root}>
+		<>
 			<Heading
 				className={s.heading}
 				level={2}
@@ -200,14 +194,16 @@ const ReleaseInformationSection = ({
 				id="looking-for-more"
 				weight="bold"
 			>
-				Release Information
+				Release information
 			</Heading>
-			<ChangelogNote selectedRelease={selectedRelease} />
-			<OfficialReleasesCard />
-			<NoteCard selectedRelease={selectedRelease} />
-			{currentProduct.name === 'Consul' && <ConsulNoteCard />}
-			{isEnterpriseMode ? <EnterpriseLegalNote /> : null}
-		</div>
+			<div className={s.notesContainer}>
+				<ChangelogNote selectedRelease={selectedRelease} />
+				<OfficialReleasesCard />
+				<NoteCard selectedRelease={selectedRelease} />
+				{currentProduct.name === 'Consul' && <ConsulNoteCard />}
+				{isEnterpriseMode ? <EnterpriseLegalNote /> : null}
+			</div>
+		</>
 	)
 }
 

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -135,7 +135,6 @@ const ChangelogNote = ({ selectedRelease }) => {
 const EnterpriseLegalNote = () => {
 	return (
 		<InlineAlert
-			className={s.alert}
 			title="Terms of use"
 			description={
 				<Text className={s.contentSubheading} size={200} weight="regular">

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -184,7 +184,7 @@ const ReleaseInformationSection = ({
 }: ReleaseInformationSectionProps): ReactElement => {
 	const currentProduct = useCurrentProduct()
 	return (
-		<>
+		<div className={s.root}>
 			<Heading
 				className={s.heading}
 				level={2}
@@ -201,7 +201,7 @@ const ReleaseInformationSection = ({
 				{currentProduct.name === 'Consul' && <ConsulNoteCard />}
 				{isEnterpriseMode ? <EnterpriseLegalNote /> : null}
 			</div>
-		</>
+		</div>
 	)
 }
 

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -97,6 +97,7 @@ const NoteCard = ({ selectedRelease }) => {
 						system:
 					</Text>
 					<CodeBlock
+						className={s.codeBlock}
 						code={`$ uname -m
 $ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
 						language="shell-session"

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -28,35 +28,83 @@ const NoteCard = ({ selectedRelease }) => {
 	const currentProduct = useCurrentProduct()
 	const { name, shasums, shasums_signature, version } = selectedRelease
 	return (
-		<InlineAlert
-			className={s.alert}
-			color="neutral"
-			title="Note"
-			description={
+		<>
+			<InlineAlert
+				className={s.alert}
+				color="neutral"
+				title="Note"
+				description={
+					<>
+						You can find the{' '}
+						<InlineLink
+							href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
+							textSize={200}
+						>
+							SHA256 checksums for {currentProduct.name} {version}
+						</InlineLink>{' '}
+						online and you can{' '}
+						<InlineLink
+							href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
+							textSize={200}
+						>
+							verify the checksums signature file
+						</InlineLink>{' '}
+						which has been signed using{' '}
+						<InlineLink
+							href="https://www.hashicorp.com/security"
+							textSize={200}
+						>
+							{"HashiCorp's GPG key"}
+						</InlineLink>
+						.
+						{currentProduct.name === 'Consul' && (
+							<>
+								<Text
+									className={s.notesSubheading}
+									size={200}
+									weight="semibold"
+								>
+									ARM users
+								</Text>
+								<ul className={s.notesList}>
+									{armNotes.map((item, index) => (
+										<Text
+											asElement="li"
+											// eslint-disable-next-line react/no-array-index-key
+											key={index}
+											size={200}
+											weight="regular"
+										>
+											{item}
+										</Text>
+									))}
+								</ul>
+							</>
+						)}
+					</>
+				}
+				icon={<IconInfo16 className={s.cardIcon} />}
+			/>
+			{currentProduct.name === 'Consul' && (
 				<>
-					You can find the{' '}
-					<InlineLink
-						href={`https://releases.hashicorp.com/${name}/${version}/${shasums}`}
-						textSize={200}
+					<Text
+						className={s.codePrompt}
+						asElement="p"
+						size={100}
+						weight="regular"
 					>
-						SHA256 checksums for {currentProduct.name} {version}
-					</InlineLink>{' '}
-					online and you can{' '}
-					<InlineLink
-						href={`https://releases.hashicorp.com/${name}/${version}/${shasums_signature}`}
-						textSize={200}
-					>
-						verify the checksums signature file
-					</InlineLink>{' '}
-					which has been signed using{' '}
-					<InlineLink href="https://www.hashicorp.com/security" textSize={200}>
-						{"HashiCorp's GPG key"}
-					</InlineLink>
-					.
+						The following commands can help determine the right version for your
+						system:
+					</Text>
+					<CodeBlock
+						code={`$ uname -m
+$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
+						language="shell-session"
+						options={{ showClipboard: true, wrapCode: true }}
+					/>
 				</>
-			}
-			icon={<IconInfo16 className={s.cardIcon} />}
-		/>
+			)}
+		</>
 	)
 }
 

--- a/src/views/product-downloads-view/components/release-information/index.tsx
+++ b/src/views/product-downloads-view/components/release-information/index.tsx
@@ -57,49 +57,10 @@ const NoteCard = ({ selectedRelease }) => {
 							{"HashiCorp's GPG key"}
 						</InlineLink>
 						.
-						{currentProduct.name === 'Consul' && (
-							<>
-								<Text
-									className={s.notesSubheading}
-									size={200}
-									weight="semibold"
-								>
-									ARM users
-								</Text>
-								<ul className={s.notesList}>
-									<Text asElement="li" size={200} weight="regular">
-										Use Arm for all 32-bit systems
-									</Text>
-									<Text asElement="li" size={200} weight="regular">
-										Use Arm64 for all 64-bit architectures
-									</Text>
-								</ul>
-							</>
-						)}
 					</>
 				}
 				icon={<IconInfo16 className={s.cardIcon} />}
 			/>
-			{currentProduct.name === 'Consul' && (
-				<>
-					<Text
-						className={s.codePrompt}
-						asElement="p"
-						size={100}
-						weight="regular"
-					>
-						The following commands can help determine the right version for your
-						system:
-					</Text>
-					<CodeBlock
-						className={s.codeBlock}
-						code={`$ uname -m
-$ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"`}
-						language="shell-session"
-						options={{ showClipboard: true }}
-					/>
-				</>
-			)}
 		</>
 	)
 }

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -3,16 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.root {
-	& > * {
-		margin-bottom: 24px;
-	}
-}
-
 .heading {
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 16px;
 	margin-top: 56px;
+}
+
+.notesContainer {
+	display: grid;
+	gap: 24px 0;
 }
 
 .alert,

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+.root {
+	margin-bottom: 24px;
+}
+
 .heading {
 	color: var(--token-color-foreground-strong);
 	margin-bottom: 16px;

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -14,11 +14,6 @@
 	gap: 24px 0;
 }
 
-.alert,
-.armUserNote {
-	margin-bottom: 24px;
-}
-
 .cardIcon {
 	margin-top: 3px;
 	max-height: 16px;

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -3,6 +3,18 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+.root {
+	& > * {
+		margin-bottom: 24px;
+	}
+}
+
+.heading {
+	color: var(--token-color-foreground-strong);
+	margin-bottom: 16px;
+	margin-top: 56px;
+}
+
 .alert,
 .armUserNote {
 	margin-bottom: 24px;

--- a/src/views/product-downloads-view/components/release-information/release-information.module.css
+++ b/src/views/product-downloads-view/components/release-information/release-information.module.css
@@ -27,7 +27,7 @@
 }
 
 .armUserNote {
-	padding: 16px 30px 37px 16px;
+	padding: 16px;
 }
 
 .codePrompt {

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -34,6 +34,7 @@ import {
 	DownloadsSection,
 	FeaturedLearnCardsSection,
 	PageHeader,
+	ReleaseInformationSection,
 	SidecarMarketingCard,
 } from './components'
 import s from './product-downloads-view.module.css'
@@ -124,12 +125,14 @@ const ProductDownloadsViewContent = ({
 			/>
 			{merchandisingSlot?.position === 'above' ? merchandisingSlot.slot : null}
 			<DownloadsSection
-				isEnterpriseMode={isEnterpriseMode}
 				packageManagers={packageManagers}
 				selectedRelease={releases.versions[currentVersion]}
 			/>
 			{merchandisingSlot?.position === 'below' ? merchandisingSlot.slot : null}
-
+			<ReleaseInformationSection
+				selectedRelease={releases.versions[currentVersion]}
+				isEnterpriseMode={isEnterpriseMode}
+			/>
 			<FeaturedLearnCardsSection
 				cards={featuredCollectionCards}
 				cardType="collection"

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -128,11 +128,12 @@ const ProductDownloadsViewContent = ({
 				packageManagers={packageManagers}
 				selectedRelease={releases.versions[currentVersion]}
 			/>
-			{merchandisingSlot?.position === 'below' ? merchandisingSlot.slot : null}
+			{merchandisingSlot?.position === 'middle' ? merchandisingSlot.slot : null}
 			<ReleaseInformationSection
 				selectedRelease={releases.versions[currentVersion]}
 				isEnterpriseMode={isEnterpriseMode}
 			/>
+			{merchandisingSlot?.position === 'below' ? merchandisingSlot.slot : null}
 			<FeaturedLearnCardsSection
 				cards={featuredCollectionCards}
 				cardType="collection"

--- a/src/views/product-downloads-view/types.ts
+++ b/src/views/product-downloads-view/types.ts
@@ -53,7 +53,10 @@ export type FeaturedTutorialCard = TutorialCardPropsWithId
 export interface ProductDownloadsViewProps {
 	isEnterpriseMode: boolean
 	latestVersion: string
-	merchandisingSlot?: { position: 'above' | 'below'; slot: ReactElement }
+	merchandisingSlot?: {
+		position: 'above' | 'middle' | 'below'
+		slot: ReactElement
+	}
 	pageContent: {
 		featuredCollectionCards?: FeaturedCollectionCard[]
 		featuredTutorialCards?: FeaturedTutorialCard[]


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-featinstallos-cards-hashicorp.vercel.app/vault/install) 🔎
- [Asana task](https://app.asana.com/0/1204817897905865/1205911880806862/f) 🎟️
- [Figma](https://www.figma.com/file/308QXXjFalJSFaCvmFU50L/Install%2FDownload-Template?type=design&node-id=926-11525&mode=design&t=dxobrdCfnqNtkqsw-0)

## 🗒️ What

- Move OS download content from tabs to individual cards per Figma mocks
- Added a `'middle'` option for the merchandising slot.
  - This allows for Boundary Desktop Client to be passed as the `merchandisingSlot` in `/pages/boundary/install`

## 📸 Design Screenshots

<img width="500" alt="Screenshot 2023-11-20 at 2 34 37 PM" src="https://github.com/hashicorp/dev-portal/assets/55773810/28e47c78-dc0c-49fa-ba92-fe1dcb369052">

### Boundary Desktop client
<img width="568" alt="Screenshot 2023-11-21 at 4 50 10 PM" src="https://github.com/hashicorp/dev-portal/assets/55773810/7339e4f9-716b-437f-a7c5-c5a2e2d4ec3e">

## 🧪 Testing

- Navigate to current [Vault install page](https://developer.hashicorp.com/vault/install) and see the changes
- Navigate to the [Vault install preview page](https://dev-portal-git-heat-featinstallos-cards-hashicorp.vercel.app/vault/install) to see the changes
- Navigate to [Boundary install page](https://dev-portal-git-heat-featinstallos-cards-hashicorp.vercel.app/boundary/install) to see the Desktop client

## 💭 Anything else?

- Making each OS download card heading an anchor link ([example here](https://developer.hashicorp.com/well-architected-framework/security/security-sensitive-data)) will be addressed in a future PR once the page restructuring is complete.
