### PR TITLE
bug fix: Consul install has two next steps headings

### DIFF
--- a/src/views/product-downloads-view/components/featured-learn-cards-section/featured-learn-cards-section.module.css
+++ b/src/views/product-downloads-view/components/featured-learn-cards-section/featured-learn-cards-section.module.css
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-.heading {
-	margin: 66px 0 20px;
+.root {
+	margin-bottom: 28px;
 }

--- a/src/views/product-downloads-view/components/featured-learn-cards-section/index.tsx
+++ b/src/views/product-downloads-view/components/featured-learn-cards-section/index.tsx
@@ -11,7 +11,6 @@ import {
 import CardsGridList, {
 	TutorialCardsGridList,
 } from 'components/cards-grid-list'
-import Heading from 'components/heading'
 import { CollectionCardWithAuthElements } from 'components/collection-card'
 import s from './featured-learn-cards-section.module.css'
 
@@ -29,16 +28,7 @@ const FeaturedLearnCardsSection = ({
 	}
 
 	return (
-		<>
-			<Heading
-				id="featured-tutorials"
-				className={s.heading}
-				level={2}
-				size={500}
-				weight="bold"
-			>
-				Next steps
-			</Heading>
+		<div className={s.root}>
 			{cardType === 'tutorial' ? (
 				<TutorialCardsGridList tutorials={cards} />
 			) : (
@@ -55,7 +45,7 @@ const FeaturedLearnCardsSection = ({
 					)}
 				</CardsGridList>
 			)}
-		</>
+		</div>
 	)
 }
 

--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -38,6 +38,7 @@ import {
 	SidecarMarketingCard,
 } from './components'
 import s from './product-downloads-view.module.css'
+import Heading from 'components/heading'
 
 /**
  * This component is used to make it possible to consume the `useCurrentVersion`
@@ -134,6 +135,17 @@ const ProductDownloadsViewContent = ({
 				isEnterpriseMode={isEnterpriseMode}
 			/>
 			{merchandisingSlot?.position === 'below' ? merchandisingSlot.slot : null}
+			{featuredCollectionCards?.length || featuredTutorialCards?.length ? (
+				<Heading
+					className={s.nextStepsHeading}
+					id="next-steps"
+					level={2}
+					size={500}
+					weight="bold"
+				>
+					Next steps
+				</Heading>
+			) : null}
 			<FeaturedLearnCardsSection
 				cards={featuredCollectionCards}
 				cardType="collection"

--- a/src/views/product-downloads-view/product-downloads-view.module.css
+++ b/src/views/product-downloads-view/product-downloads-view.module.css
@@ -17,3 +17,7 @@
 .sidecarTryHcpCallout {
 	margin-top: 24px;
 }
+
+.nextStepsHeading {
+	margin: 66px 0 20px;
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->
- [Figma](https://www.figma.com/file/308QXXjFalJSFaCvmFU50L/Install%2FDownload-Template?type=design&node-id=705-20983)
- [Preview link](https://dev-portal-git-heat-bug-fixnext-steps-hashicorp.vercel.app/consul/install) 🔎

## 🗒️ What

- Moved "Next steps" heading to parent component for featured tutorial and collections.
- Added logic to show the "Next steps" heading if the install page has a featured tutorial or featured collections (this is to hide the section hiding on the Vagrant install page because it has neither featured content blocks)

## 🤷 Why

- Missed this case while completing the work in previous [PR](https://github.com/hashicorp/dev-portal/pull/2243)

## 📸 Screenshots
### Before
<img width="1213" alt="Screenshot 2023-11-28 at 3 04 54 PM" src="https://github.com/hashicorp/dev-portal/assets/55773810/f57a1722-ba43-4304-bae3-6d37e9c872a4">

### After
<img width="1728" alt="Screenshot 2023-11-28 at 3 04 36 PM" src="https://github.com/hashicorp/dev-portal/assets/55773810/0992af02-3173-41cb-b0e9-8794735ba379">

## 🧪 Testing

- Navigate to [Consul install page](https://dev-portal-git-heat-bug-fixnext-steps-hashicorp.vercel.app/consul/install). There should only be one "Next steps" heading
- Navigate to [Vagrant install page](https://dev-portal-git-heat-bug-fixnext-steps-hashicorp.vercel.app/vagrant/install). There should *not* be a "Next steps" heading