### PR TITLE
chore: remove tutorials from sentinel spike

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -139,6 +139,7 @@ module.exports = withSwingset({
 				'www.datocms-assets.com',
 				'mktg-content-api-hashicorp.vercel.app',
 				'content.hashicorp.com',
+				'place-hold.it',
 			],
 			dangerouslyAllowSVG: true,
 			contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",

--- a/next.config.js
+++ b/next.config.js
@@ -139,7 +139,6 @@ module.exports = withSwingset({
 				'www.datocms-assets.com',
 				'mktg-content-api-hashicorp.vercel.app',
 				'content.hashicorp.com',
-				'place-hold.it',
 			],
 			dangerouslyAllowSVG: true,
 			contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",

--- a/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
@@ -121,11 +121,15 @@ export function getNavItems(currentProduct: ProductData): NavItem[] {
 
 	/**
 	 * Tutorials
+	 *
+	 * Note: we exclude Sentinel, as it does not have tutorials yet.
 	 */
-	items.push({
-		label: 'Tutorials',
-		url: `/${currentProduct.slug}/tutorials`,
-	})
+	if (currentProduct.slug !== 'sentinel') {
+		items.push({
+			label: 'Tutorials',
+			url: `/${currentProduct.slug}/tutorials`,
+		})
+	}
 
 	/**
 	 * Documentation categories

--- a/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
@@ -70,7 +70,7 @@ export const generateProductLandingSidebarMenuItems = (
 		menuItems.push(introNavItem)
 	}
 
-	// Add a `Tutorials` link for all products except sentinel
+	// Add a "Tutorials" link for all products except sentinel
 	if (product.slug !== 'sentinel') {
 		menuItems.push({
 			title: 'Tutorials',
@@ -78,7 +78,7 @@ export const generateProductLandingSidebarMenuItems = (
 		})
 	}
 
-	// Add docs items for all products
+	// Add "Documentation" item links for all products
 	menuItems.push(...docsItems)
 
 	if (getIsEnabledProductIntegrations(product.slug)) {

--- a/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-product-landing-nav-items.ts
@@ -70,15 +70,16 @@ export const generateProductLandingSidebarMenuItems = (
 		menuItems.push(introNavItem)
 	}
 
-	menuItems.push(
-		...[
-			{
-				title: 'Tutorials',
-				fullPath: `/${product.slug}/tutorials`,
-			},
-			...docsItems,
-		]
-	)
+	// Add a `Tutorials` link for all products except sentinel
+	if (product.slug !== 'sentinel') {
+		menuItems.push({
+			title: 'Tutorials',
+			fullPath: `/${product.slug}/tutorials`,
+		})
+	}
+
+	// Add docs items for all products
+	menuItems.push(...docsItems)
 
 	if (getIsEnabledProductIntegrations(product.slug)) {
 		menuItems.push({

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -128,40 +128,36 @@ function generateResourcesNavItems(
 ): ResourceNavItem[] {
 	const additionalResources = generateAdditionalResources(productSlug)
 
-	const resourceNavItems: ResourceNavItem[] = [{ heading: 'Resources' }]
-
-	// Add a "Tutorials" link for all products except Sentinel
-	if (productSlug !== 'sentinel') {
-		resourceNavItems.push({
-			title: 'Tutorial Library',
-			href: getTutorialLibraryUrl(productSlug),
-		})
-	}
-
-	resourceNavItems.push(
-		...[
-			...getCertificationsLink(productSlug),
-			{
-				title: 'Community Forum',
-				href: productSlug
-					? COMMUNITY_LINKS_BY_PRODUCT[productSlug]
-					: DEFAULT_COMMUNITY_FORUM_LINK,
-			},
-			{
-				title: 'Support',
-				href: DEFAULT_SUPPORT_LINK,
-			},
-			{
-				title: 'GitHub',
-				href: productSlug
-					? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
-					: DEFAULT_GITHUB_LINK,
-			},
-			...additionalResources,
-		]
-	)
-
-	return resourceNavItems
+	return [
+		{ heading: 'Resources' },
+		...(productSlug !== 'sentinel'
+			? [
+					{
+						// Add a "Tutorials" link for all products except Sentinel
+						title: 'Tutorial Library',
+						href: getTutorialLibraryUrl(productSlug),
+					},
+			  ]
+			: []),
+		...getCertificationsLink(productSlug),
+		{
+			title: 'Community Forum',
+			href: productSlug
+				? COMMUNITY_LINKS_BY_PRODUCT[productSlug]
+				: DEFAULT_COMMUNITY_FORUM_LINK,
+		},
+		{
+			title: 'Support',
+			href: DEFAULT_SUPPORT_LINK,
+		},
+		{
+			title: 'GitHub',
+			href: productSlug
+				? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
+				: DEFAULT_GITHUB_LINK,
+		},
+		...additionalResources,
+	]
 }
 
 export { generateResourcesNavItems }

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -10,6 +10,21 @@ import {
 	VALID_PRODUCT_SLUGS_FOR_FILTERING,
 } from 'views/tutorial-library/constants'
 
+/**
+ * Note: these types could probably be abstracted up or lifted out,
+ * but for now, since the functions here had very little type information,
+ * felt pragmatic to declare them just for this file.
+ */
+
+type ResourceNavLink = {
+	title: string
+	href: string
+}
+type ResourceNavHeading = {
+	heading: string
+}
+type ResourceNavItem = ResourceNavLink | ResourceNavHeading
+
 const DEFAULT_COMMUNITY_FORUM_LINK = 'https://discuss.hashicorp.com/'
 const DEFAULT_GITHUB_LINK = 'https://github.com/hashicorp'
 const DEFAULT_SUPPORT_LINK = 'https://www.hashicorp.com/customer-success'
@@ -46,7 +61,9 @@ const GITHUB_LINKS_BY_PRODUCT_SLUG: { [key in ProductSlug]: string } = {
  * `src/content` directory, and it has the correct data structure, the specified
  * nav items will be appended to the Resources section.
  */
-const generateAdditionalResources = (productSlug?: ProductSlug) => {
+function generateAdditionalResources(
+	productSlug?: ProductSlug
+): ResourceNavItem[] {
 	if (productSlug) {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -64,7 +81,7 @@ const generateAdditionalResources = (productSlug?: ProductSlug) => {
  * Return a link to the Tutorials Library with filters applied
  * that correspond to that product.
  */
-function getTutorialLibraryUrl(productSlug?: ProductSlug) {
+function getTutorialLibraryUrl(productSlug?: ProductSlug): string {
 	const baseUrl = '/tutorials/library'
 	if (!productSlug) {
 		return baseUrl
@@ -88,10 +105,7 @@ function getTutorialLibraryUrl(productSlug?: ProductSlug) {
  * If the given product does not have a certifications page,
  * we return an empty array.
  */
-function getCertificationsLink(productSlug?: ProductSlug): {
-	title: string
-	href: string
-}[] {
+function getCertificationsLink(productSlug?: ProductSlug): ResourceNavLink[] {
 	// If this product does not have a certifications link, return an empty array
 	const programSlug = certificationProgramSlugMap[productSlug]
 	if (!programSlug) {
@@ -109,34 +123,45 @@ function getCertificationsLink(productSlug?: ProductSlug): {
  * Generates the sidebar nav items for the Resources section of the sidebar.
  * Optionally accepts a Product slug for customization of links.
  */
-const generateResourcesNavItems = (productSlug?: ProductSlug) => {
+function generateResourcesNavItems(
+	productSlug?: ProductSlug
+): ResourceNavItem[] {
 	const additionalResources = generateAdditionalResources(productSlug)
 
-	return [
-		{ heading: 'Resources' },
-		{
+	const resourceNavItems: ResourceNavItem[] = [{ heading: 'Resources' }]
+
+	// Add a "Tutorials" link for all products except Sentinel
+	if (productSlug !== 'sentinel') {
+		resourceNavItems.push({
 			title: 'Tutorial Library',
 			href: getTutorialLibraryUrl(productSlug),
-		},
-		...getCertificationsLink(productSlug),
-		{
-			title: 'Community Forum',
-			href: productSlug
-				? COMMUNITY_LINKS_BY_PRODUCT[productSlug]
-				: DEFAULT_COMMUNITY_FORUM_LINK,
-		},
-		{
-			title: 'Support',
-			href: DEFAULT_SUPPORT_LINK,
-		},
-		{
-			title: 'GitHub',
-			href: productSlug
-				? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
-				: DEFAULT_GITHUB_LINK,
-		},
-		...additionalResources,
-	]
+		})
+	}
+
+	resourceNavItems.push(
+		...[
+			...getCertificationsLink(productSlug),
+			{
+				title: 'Community Forum',
+				href: productSlug
+					? COMMUNITY_LINKS_BY_PRODUCT[productSlug]
+					: DEFAULT_COMMUNITY_FORUM_LINK,
+			},
+			{
+				title: 'Support',
+				href: DEFAULT_SUPPORT_LINK,
+			},
+			{
+				title: 'GitHub',
+				href: productSlug
+					? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
+					: DEFAULT_GITHUB_LINK,
+			},
+			...additionalResources,
+		]
+	)
+
+	return resourceNavItems
 }
 
 export { generateResourcesNavItems }

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -11,7 +11,7 @@ import {
 } from 'views/tutorial-library/constants'
 
 /**
- * Note: these types could probably be abstracted up or lifted out,
+ * Note: these ResourceNav types could probably be abstracted up or lifted out,
  * but for now, since the functions here had very little type information,
  * felt pragmatic to declare them just for this file.
  */

--- a/src/content/sentinel/product-landing.json
+++ b/src/content/sentinel/product-landing.json
@@ -1,7 +1,7 @@
 {
 	"hero": {
 		"heading": "Enforce policy as code for HashiCorp products",
-		"image": "https://place-hold.it/600x320"
+		"image": "https://www.datocms-assets.com/2885/1701706791-sentinel-landing-placeholder.png"
 	},
 	"overview": {
 		"heading": "What is Sentinel?",
@@ -11,8 +11,8 @@
 			"url": "/sentinel/intro/what"
 		},
 		"image": {
-			"light": "https://place-hold.it/680x250",
-			"dark": "https://place-hold.it/680x250"
+			"light": "https://www.datocms-assets.com/2885/1701706795-what-is-sentinel-placeholder.png",
+			"dark": "https://www.datocms-assets.com/2885/1701706795-what-is-sentinel-placeholder.png"
 		}
 	},
 	"get_started": {

--- a/src/views/product-landing/helpers/get-icon-cards.tsx
+++ b/src/views/product-landing/helpers/get-icon-cards.tsx
@@ -26,20 +26,21 @@ export function getIconCards(product: ProductData) {
 		})
 	}
 
-	iconCards.push(
-		...[
-			{
-				icon: <IconLearn16 />,
-				text: 'Tutorials',
-				url: `/${product.slug}/tutorials`,
-			},
-			{
-				icon: <IconDocs16 />,
-				text: 'Documentation',
-				url: `/${product.slug}/docs`,
-			},
-		]
-	)
+	// Add a "Tutorials" link for all products except sentinel
+	if (product.slug !== 'sentinel') {
+		iconCards.push({
+			icon: <IconLearn16 />,
+			text: 'Tutorials',
+			url: `/${product.slug}/tutorials`,
+		})
+	}
+
+	// Add a "Documentation" link for all products
+	iconCards.push({
+		icon: <IconDocs16 />,
+		text: 'Documentation',
+		url: `/${product.slug}/docs`,
+	})
 
 	// Add Integrations card if it's enabled for this product
 	if (getIsEnabledProductIntegrations(product.slug)) {


### PR DESCRIPTION
> **Note**: this PR affects the `/sentinel` page, which is not yet published to production, as for now, we're continuing to serve the Sentinel docs content from https://docs.hashicorp.com. We remove the page with the `remove-inactive-product-pages` script, and this PR does not touch that script.

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Removes `Tutorials` links from the spiked `/sentinel` landing page.

## 🤷 Why

Sentinel does not currently have tutorials content. `Tutorials` links and pages need to be omitted from the Sentinel product landing pages during migration.

## 🛠️ How

- Avoids automatic addition of "Tutorials" links in various "generate items" type code
    - Note this doesn't necessarily feel ideal, we might prefer to author content rather than "generate" it to avoid such conditionals. However, the lack of Sentinel tutorials is _likely_ a temporary thing (see [this Slack thread][slack-thread-on-sentinel-tutorials]), so the additional conditional felt acceptable for now, and a pragmatic alternative to diving into a deeper refactor to achieve the same ends.
    - Also updated some type information in `generate-resources-nav-items`, since a few functions there were missing clear return types
- Replaces `place-hold.it` images with placeholder images loaded from Dato
    - This was a pretty unrelated change, done because `place-hold.it` images were causing local issues since we've upgraded `next/image` since starting this spike.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![sentinel-rm-tutorials-before](https://github.com/hashicorp/dev-portal/assets/4624598/7c8b6646-c899-474c-9bf7-d49bafe7ffb8) | ![sentinel-rm-tutorials-after](https://github.com/hashicorp/dev-portal/assets/4624598/b9f2f2ac-266e-4966-84dc-746c1d5f8697) |

## 🧪 Testing

> **Note**: you can compare to the upstream page on our staging deploy at https://developer.hashicorp.services/sentinel.

- [ ] Visit [/sentinel] in the preview
    - There should not be any references or links to "Tutorials"

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204759533834554/1206094789306922/f
[slack-thread-on-sentinel-tutorials]: https://hashicorp.slack.com/archives/C05Q345GY5N/p1701358785224379?thread_ts=1701294710.863459&cid=C05Q345GY5N
[preview]: https://dev-portal-git-zsrm-sentinel-tutorials-hashicorp.vercel.app
[/sentinel]: https://dev-portal-git-zsrm-sentinel-tutorials-hashicorp.vercel.app/sentinel