### PR TITLE
chore: remove duplicate search index config

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -10,7 +10,6 @@
 		},
 		"algolia": {
 			"docsIndexName": "product_DEVDOT",
-			"tutorialsIndexName": "prod_DEVDOT_omni",
 			"unifiedIndexName": "prod_DEVDOT_omni"
 		},
 		"analytics": {

--- a/src/views/tutorial-library/constants.ts
+++ b/src/views/tutorial-library/constants.ts
@@ -8,7 +8,7 @@ import { productSlugsToNames } from 'lib/products'
 /**
  * The Algolia index we are searching against for tutorials
  */
-export const INDEX_NAME = __config.dev_dot.algolia.tutorialsIndexName
+export const INDEX_NAME = __config.dev_dot.algolia.unifiedIndexName
 
 /**
  * Duration used to throttle search requests to avoid excessive network calls


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Removes redundant configuration for search indices.

## 🤷 Why

Since we've shipped [dev-portal#2037 - chore: update tutorials library to use unified index](https://github.com/hashicorp/dev-portal/pull/2037), we're now using the unified `<env>_DEVDOT_omni` indices across Algolia search use cases on Dev Dot, including the Tutorials library.

Using a single configuration value for our search index feels like it can reduce the chance of misconfiguration and reduce complexity as we iterate on search-related features.

## 🧪 Testing

- [x] Visit the [preview]. Search should continue to work as expected.
- [x] Visit [/tutorials/library]. The tutorials library search & filter functions should continue to work as expected.

[task]: https://app.asana.com/0/1202097197789424/1204964938948006/f
[preview]: https://dev-portal-git-zsrm-duplicate-index-config-hashicorp.vercel.app/
[/tutorials/library]: https://dev-portal-git-zsrm-duplicate-index-config-hashicorp.vercel.app/tutorials/library
