### PR TITLE
Harden SSG for when HVD docs do not exist

### DIFF
--- a/src/pages/validated-designs/[...slug]/index.tsx
+++ b/src/pages/validated-designs/[...slug]/index.tsx
@@ -15,6 +15,13 @@ import {
 export async function getStaticPaths() {
 	const pagePaths = getHvdCategoryGroupsPaths()
 
+	if (!pagePaths) {
+		return {
+			paths: [],
+			fallback: false,
+		}
+	}
+
 	return {
 		paths: [
 			...pagePaths.map((path: string[]) => ({
@@ -37,6 +44,12 @@ export async function getStaticProps(context) {
 
 	const slugs = context.params.slug
 	const props = await getHvdGuidePropsFromSlugs(slugs)
+
+	if (!props) {
+		return {
+			notFound: true,
+		}
+	}
 
 	return {
 		props,

--- a/src/views/validated-designs/server.ts
+++ b/src/views/validated-designs/server.ts
@@ -33,7 +33,7 @@ function loadMetadata(path: string): { title: string; description: string } {
 	}
 }
 
-export function getHvdCategoryGroups(): HvdCategoryGroup[] {
+export function getHvdCategoryGroups(): HvdCategoryGroup[] | null {
 	let hvdRepoContents
 
 	try {
@@ -61,7 +61,10 @@ export function getHvdCategoryGroups(): HvdCategoryGroup[] {
 			// throw e
 			console.error(e)
 		}
+
+		return null
 	}
+
 	if (!hvdRepoContents) {
 		return null
 	}
@@ -157,8 +160,12 @@ export function getHvdCategoryGroups(): HvdCategoryGroup[] {
 	return hvdCategoryGroups
 }
 
-export function getHvdCategoryGroupsPaths(): string[][] {
+export function getHvdCategoryGroupsPaths(): string[][] | null {
 	const categoryGroups = getHvdCategoryGroups()
+
+	if (!categoryGroups) {
+		return null
+	}
 	// [[guide-slug], [guide-slug, page-slug]]
 	// e.g. [[terraform-operation-guide-adoption], [terraform-operation-guide-adoption, page-slug]]
 	const paths = []
@@ -191,9 +198,14 @@ function getMarkdownHeaders(markdown: string) {
 }
 
 export async function getHvdGuidePropsFromSlugs(
-	slugs: string[]
+	slugs: string[] | null
 ): Promise<ValidatedDesignsGuideProps> {
 	const categoryGroups = getHvdCategoryGroups()
+
+	if (!categoryGroups) {
+		return null
+	}
+
 	const [guideSlug, pageSlug] = slugs
 
 	const validatedDesignsGuideProps = {
@@ -246,6 +258,12 @@ export async function getHvdGuidePropsFromSlugs(
 
 export function getHvdLandingProps(): ValidatedDesignsLandingProps | null {
 	// @TODO — the title and description should be sourced from the content repo
+	const categoryGroups = getHvdCategoryGroups()
+
+	if (!categoryGroups) {
+		return null
+	}
+
 	return {
 		title: 'HashiCorp Validated Designs',
 		description:


### PR DESCRIPTION
Bug Fix for the issue of [breaking content preview/vercel builds for other teams.](https://hashicorp.slack.com/archives/C058H0MULTE/p1701812997016709)

## 🗒️ What

Due to HVD docs being built during Static Site Generation, i.e. build time, we expected the HVD docs directory to exist. If the provided env variable GITHUB_TOKEN does not have access to the repo then the directory cannot be built. This code makes it so that any HVD pages will return 404 if the HVD docs directory cannot be found.

## 🧪 Testing

Locally edit [HVD_CONTENT_DIR](https://github.com/hashicorp/dev-portal/blob/b59f2dbe6b0da9dc1fb98b1bf126cb9182ac2155/src/views/validated-designs/server.ts#L41) to be something nonsensical, like '/test' and then build. HVD pages shouldn't cause a build to fail, but rather return a 404. e.g.
* /validated-designs
* /validated-designs/terraform-operation-guides-adoption
