### PR TITLE
Tiny Wins: SEO: fix duplicated description tag

### DIFF
--- a/src/views/well-architected-framework/tutorial-view/index.tsx
+++ b/src/views/well-architected-framework/tutorial-view/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import HashiHead from '@hashicorp/react-head'
+import Head from 'next/head'
 import { Fragment } from 'react'
 import InstruqtProvider from 'contexts/instruqt-lab'
 import TutorialMeta from 'components/tutorial-meta'
@@ -51,9 +51,9 @@ export default function WellArchitectedFrameworkTutorialView({
 
 	return (
 		<>
-			<HashiHead>
+			<Head>
 				<link rel="canonical" href={canonicalUrl.toString()} key="canonical" />
-			</HashiHead>
+			</Head>
 			<InteractiveLabWrapper
 				key={slug}
 				{...(isInteractive && { labId: handsOnLab.id })}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-mwseo-fix-dupe-description-hashicorp.vercel.app/well-architected-framework/security/security-zero-trust-video) 🔎
- [Asana task](https://app.asana.com/0/0/1206199745721339/f) 🎟️

## 🗒️ What

Prevent duplicate meta description tags.

One WAF page ([this one](https://developer.hashicorp.com/well-architected-framework/security/security-zero-trust-video)) was flagging in ahrefs.com as having duplicate `description` meta tags.

<img width="1090" alt="image" src="https://github.com/hashicorp/dev-portal/assets/845983/eea140c2-1b9f-4165-b627-a11f2c798928">

So digging in, I saw that all the existing WAF pages have duplicated `description` meta tags.

![CleanShot 2023-12-06 at 19 14 15@2x](https://github.com/hashicorp/dev-portal/assets/845983/5fe1052f-e411-4574-8186-3d30f7ea16b7)

## 🛠️ How

Replaced `HashiHead` with `next/head`

## 🤷 Why

Weak answer, but I actually don't know. I do know that our `<HashiHead>` component needs some love and improvement at some point. 

## 🧪 Testing

- [ ] Navigate to [production page here](https://developer.hashicorp.com/well-architected-framework/security/security-zero-trust-video) and see two `description` meta tags
- [ ] Navigate to the [deploy preview](https://dev-portal-git-mwseo-fix-dupe-description-hashicorp.vercel.app/well-architected-framework/security/security-zero-trust-video) and observe that there are no longer duplicated head tags.

## 💭 Anything else

I think there are some more systemic problems with `<HashiHead>`, but that's outside the scope of what I could get to here. I'll create a backlog ticket to track this additional follow-up work. 
