### PR TITLE
feat: use staging Algolia index for previews

### DIFF
--- a/config/preview.json
+++ b/config/preview.json
@@ -3,6 +3,11 @@
 	"io_sites": {
 		"max_static_paths": 10
 	},
+	"dev_dot": {
+		"algolia": {
+			"unifiedIndexName": "staging_DEVDOT_omni"
+		}
+	},
 	"flags": {
 		"enable_hvd": true
 	}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates the `preview.json` configuration so that all preview deployments use the `staging_DEVDOT_omni` Algolia index.

## 🤷 Why

To better test changes to our search index, specifically for migrating Sentinel content to `developer.hashicorp.com`.

For context, we want to use our staging preview deployment at https://developer.hashicorp.services to stage the Sentinel migration. Using the `staging_DEVDOT_omni` search index for preview deployments will enable more realistic staging.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![staging-search-before](https://github.com/hashicorp/dev-portal/assets/4624598/e05a6efc-5deb-445e-bdc3-0abe052d5e90) | ![staging-search-after](https://github.com/hashicorp/dev-portal/assets/4624598/138ba42b-68df-4fca-ae37-93b76436dbee) |

## 🧪 Testing

- [ ] Visit the [preview]
    - Search should work as expected
    - Search should show results from our [staging_DEVDOT_omni Algolia index][algolia/staging_DEVDOT_omni], namely Sentinel search results, which are not present in our [production index][algolia/prod_DEVDOT_omni]

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204759533834554/1206124952920862/f
[preview]: https://dev-portal-git-zspreviews-use-staging-search-hashicorp.vercel.app/
[algolia/staging_DEVDOT_omni]: https://dashboard.algolia.com/apps/YY0FFNI7MF/explorer/browse/staging_DEVDOT_omni
[algolia/prod_DEVDOT_omni]: https://dashboard.algolia.com/apps/YY0FFNI7MF/explorer/browse/prod_DEVDOT_omni