### PR TITLE
fix: allow empty sidebarItems on install pages

### DIFF
--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -63,7 +63,7 @@ const ProductDownloadsViewContent = ({
 		featuredTutorialCards,
 		sidecarMarketingCard,
 		sidecarHcpCallout,
-		sidebarMenuItems,
+		sidebarMenuItems = [],
 		installName,
 	} = pageContent
 	const currentProduct = useCurrentProduct()


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where install pages that did not define the optional `sidebarMenuItems` would break.

In particular, the install page for Sentinel has undefined `sidebarMenuItems`, so is currently not working as expected in our staging environment - see https://developer.hashicorp.services/sentinel/install.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![sentinel-install-before](https://github.com/hashicorp/dev-portal/assets/4624598/f892bd66-abb4-4936-828d-69e36239e71c) | ![sentinel-install-after](https://github.com/hashicorp/dev-portal/assets/4624598/ba54bfa6-cb6c-4731-ba8f-83da9e5f6307) |

## 🧪 Testing

- [ ] Visit [/sentinel/install]
    - The page should load as expected, without errors
    - Compare to [upstream][upstream/sentinel/install], where the page errors immediately after load

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204759533834554/1206121485692996/f
[preview]: https://dev-portal-git-zsfix-sentinel-install-hashicorp.vercel.app
[/sentinel/install]: https://dev-portal-git-zsfix-sentinel-install-hashicorp.vercel.app/sentinel/install
[upstream/sentinel/install]: https://developer.hashicorp.services/sentinel/install