### PR TITLE
Enable AI alert banner

### DIFF
--- a/src/data/alert-banner.json
+++ b/src/data/alert-banner.json
@@ -6,6 +6,6 @@
 		"url": "https://hashi.co/dev-ai-signup",
 		"text": "Private beta now available",
 		"linkText": "Sign up today",
-		"expirationDate": "2023-11-17T00:00:00-08:00"
+		"expirationDate": "2023-12-22T00:00:00-08:00"
 	}
 }


### PR DESCRIPTION
Re-enables the previously live alert banner promoting signups for the private beta. I set the expiry date of Dec 22 since most of us will be out for the holiday break. 