### PR TITLE
chore: set up sentinel launch redirects

### DIFF
--- a/build-libs/__tests__/redirects.test.ts
+++ b/build-libs/__tests__/redirects.test.ts
@@ -22,7 +22,7 @@ function withHashiEnv(value, fn) {
 
 describe('splitRedirectsByType', () => {
 	test('splits simple and glob redirects', () => {
-		const { simpleRedirects, globRedirects } = splitRedirectsByType([
+		const { simpleRedirects, complexRedirects } = splitRedirectsByType([
 			{
 				source: '/:path',
 				destination: '/',
@@ -73,19 +73,8 @@ describe('splitRedirectsByType', () => {
 				destination: '',
 				permanent: true,
 			},
-			{
-				source: '/has-host',
-				destination: '/host',
-				permanent: true,
-				has: [
-					{
-						type: 'host',
-						value: 'www.host.com',
-					},
-				],
-			},
 		])
-		expect(globRedirects).toStrictEqual([
+		expect(complexRedirects).toStrictEqual([
 			{
 				source: '/:path',
 				destination: '/',
@@ -112,6 +101,17 @@ describe('splitRedirectsByType', () => {
 					{
 						type: 'cookie',
 						key: 'cookie',
+					},
+				],
+			},
+			{
+				source: '/has-host',
+				destination: '/host',
+				permanent: true,
+				has: [
+					{
+						type: 'host',
+						value: 'www.host.com',
 					},
 				],
 			},

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//@ts-check
+
+/** @typedef { import("next/dist/lib/load-custom-routes").Redirect } Redirect  */
+/** @typedef { import("next/dist/lib/load-custom-routes").RouteHas } RouteHas */
+
+/**
+ * Note: Proxy settings are how we determine whether the Sentinel migration
+ * has been launched. Once the Sentinel migration to Dev Dot is complete,
+ * there's a lot here we could clean up - we'd no longer need a conditional.
+ */
+const proxySettings = require('./proxy-settings')
+
+/**
+ * Builds redirects for the `docs.hashicorp.com` domain.
+ *
+ * Returns an empty array if the Sentinel product docs are still being served
+ * from `docs.hashicorp.com`, as in that case, we don't yet want to redirect.
+ *
+ * Otherwise, builds an array of redirects that forwards URLs for the Sentinel
+ * content that used to be present on `docs.hashicorp.com` to `developer`.
+ *
+ * @returns {Redirect[]}
+ */
+function getDocsDotHashiCorpRedirects() {
+	/**
+	 * If Sentinel is still being proxied, then don't add any redirects.
+	 * Redirects for `docs.hashicorp.com` will be handled by the `redirects.js`
+	 * file in the Sentinel repo until Sentinel is migrated.
+	 */
+	if (typeof proxySettings['sentinel'] !== 'undefined') {
+		return []
+	}
+
+	/**
+	 * Otherwise, we want to redirect content formerly hosted on
+	 * `docs.hashicorp.com` to `developer.hashicorp.com`.
+	 */
+	/** @type {Redirect[]} */
+	const redirects = [
+		/**
+		 * Redirect the root domain.
+		 *
+		 * Note we redirect to `/sentinel` for consistency with the previous
+		 * behaviour of `docs.hashicorp.com`. This could be changed later.
+		 */
+		{
+			source: '/',
+			destination: 'https://developer.hashicorp.com/sentinel',
+			permanent: true,
+		},
+		// Redirect `/intro` content
+		{
+			source: '/sentinel/intro',
+			destination: 'https://developer.hashicorp.com/sentinel/intro',
+			permanent: true,
+		},
+		{
+			source: '/sentinel/intro/:path*',
+			destination: 'https://developer.hashicorp.com/sentinel/intro/:path*',
+			permanent: true,
+		},
+		// Redirect the install page (formerly known as Downloads)
+		{
+			source: '/sentinel/downloads',
+			destination: 'https://developer.hashicorp.com/sentinel/install',
+			permanent: true,
+		},
+		/**
+		 * Redirect `/docs` content.
+		 *
+		 * Note this content was formerly kind of "merged" at `/sentinel`. For
+		 * example, `/sentinel/docs/foo-bar` would have been served at the URL
+		 * `/sentinel/foo-bar`. To avoid collisions with `intro` content,
+		 * and with the `downloads` page above, we use a negative look-ahead.
+		 */
+		{
+			source: '/sentinel/:path((?!intro|downloads).*)',
+			destination: 'https://developer.hashicorp.com/sentinel/docs/:path*',
+			permanent: true,
+		},
+	]
+
+	/**
+	 * We want each of these redirects to apply ONLY to specific target domains,,
+	 * so we need to add a `host` condition to each redirect. Note that for now,
+	 * we target both `docs.hashicorp.com` (the production domain) and
+	 * `sentinel-launch-redirects-test.hashicorp.vercel.app` (a test domain).
+	 *
+	 * TODO: actually target both, not just one, with regex.
+	 */
+	const targetHost = 'sentinel-launch-redirects-test.hashicorp.vercel.app'
+	return redirects.map((redirect) => ({
+		...redirect,
+		has: [{ type: 'host', value: targetHost }],
+	}))
+}
+
+module.exports = { getDocsDotHashiCorpRedirects }

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -90,13 +90,19 @@ function getDocsDotHashiCorpRedirects() {
 	 * so we need to add a `host` condition to each redirect. Note that for now,
 	 * we target both `docs.hashicorp.com` (the production domain) and
 	 * `sentinel-launch-redirects-test.hashicorp.vercel.app` (a test domain).
-	 *
-	 * TODO: actually target both, not just one, with regex.
 	 */
-	const targetHost = 'sentinel-launch-redirects-test.hashicorp.vercel.app'
+	const targetHosts = [
+		'docs.hashicorp.com',
+		'sentinel-launch-redirects-test.hashicorp.vercel.app',
+	]
+	/**
+	 * Build a regex-like string that matches any of the target hosts.
+	 * Ref: https://nextjs.org/docs/app/api-reference/next-config-js/redirects
+	 */
+	const hostsValue = targetHosts.map((h) => h.replace(/\./g, '\\.')).join('|')
 	return redirects.map((redirect) => ({
 		...redirect,
-		has: [{ type: 'host', value: targetHost }],
+		has: [{ type: 'host', value: hostsValue }],
 	}))
 }
 

--- a/build-libs/proxy-settings.js
+++ b/build-libs/proxy-settings.js
@@ -5,9 +5,6 @@
 
 //@ts-check
 
-/** TODO: remove the following line before merging dev-portal#2271 */
-/* eslint-disable no-unused-vars */
-
 const fs = require('fs')
 const path = require('path')
 const klawSync = require('klaw-sync')
@@ -25,18 +22,18 @@ const proxyConfig = require('./proxy-config')
  */
 const proxySettings = {
 	/** TODO: uncomment proxySettings.sentinel before merging dev-portal#2271 */
-	// sentinel: {
-	// 	domain: proxyConfig.sentinel.domain,
-	// 	host: proxyConfig.sentinel.host,
-	// 	routesToProxy: [
-	// 		...gatherRoutesToProxy('/_proxied-dot-io/sentinel'),
-	// 		...buildAssetRoutesToProxy(
-	// 			proxyConfig.sentinel.assets,
-	// 			'/sentinel-public'
-	// 		),
-	// 		...getDevPortalRoutesToProxy('sentinel'),
-	// 	],
-	// },
+	sentinel: {
+		domain: proxyConfig.sentinel.domain,
+		host: proxyConfig.sentinel.host,
+		routesToProxy: [
+			...gatherRoutesToProxy('/_proxied-dot-io/sentinel'),
+			...buildAssetRoutesToProxy(
+				proxyConfig.sentinel.assets,
+				'/sentinel-public'
+			),
+			...getDevPortalRoutesToProxy('sentinel'),
+		],
+	},
 }
 module.exports = proxySettings
 

--- a/build-libs/proxy-settings.js
+++ b/build-libs/proxy-settings.js
@@ -5,6 +5,9 @@
 
 //@ts-check
 
+/** TODO: remove the following line before merging dev-portal#2271 */
+/* eslint-disable no-unused-vars */
+
 const fs = require('fs')
 const path = require('path')
 const klawSync = require('klaw-sync')
@@ -21,18 +24,19 @@ const proxyConfig = require('./proxy-config')
  * @type {Record<string, SiteProxySettings>}
  */
 const proxySettings = {
-	sentinel: {
-		domain: proxyConfig.sentinel.domain,
-		host: proxyConfig.sentinel.host,
-		routesToProxy: [
-			...gatherRoutesToProxy('/_proxied-dot-io/sentinel'),
-			...buildAssetRoutesToProxy(
-				proxyConfig.sentinel.assets,
-				'/sentinel-public'
-			),
-			...getDevPortalRoutesToProxy('sentinel'),
-		],
-	},
+	/** TODO: uncomment proxySettings.sentinel before merging dev-portal#2271 */
+	// sentinel: {
+	// 	domain: proxyConfig.sentinel.domain,
+	// 	host: proxyConfig.sentinel.host,
+	// 	routesToProxy: [
+	// 		...gatherRoutesToProxy('/_proxied-dot-io/sentinel'),
+	// 		...buildAssetRoutesToProxy(
+	// 			proxyConfig.sentinel.assets,
+	// 			'/sentinel-public'
+	// 		),
+	// 		...getDevPortalRoutesToProxy('sentinel'),
+	// 	],
+	// },
 }
 module.exports = proxySettings
 

--- a/build-libs/proxy-settings.js
+++ b/build-libs/proxy-settings.js
@@ -21,7 +21,6 @@ const proxyConfig = require('./proxy-config')
  * @type {Record<string, SiteProxySettings>}
  */
 const proxySettings = {
-	/** TODO: uncomment proxySettings.sentinel before merging dev-portal#2271 */
 	sentinel: {
 		domain: proxyConfig.sentinel.domain,
 		host: proxyConfig.sentinel.host,

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -17,6 +17,9 @@ const fetchGithubFile = require('./fetch-github-file')
 const loadProxiedSiteRedirects = require('./load-proxied-site-redirects')
 const { getTutorialRedirects } = require('./tutorial-redirects')
 const {
+	getDocsDotHashiCorpRedirects,
+} = require('./docs-dot-hashicorp-redirects')
+const {
 	integrationMultipleComponentRedirects,
 } = require('./integration-multiple-component-redirects')
 const { packerPluginRedirects } = require('./integration-packer-redirects')
@@ -486,12 +489,14 @@ async function redirectsConfig() {
 	const devPortalRedirects = await buildDevPortalRedirects()
 	const proxiedSiteRedirects = await loadProxiedSiteRedirects()
 	const tutorialRedirects = await getTutorialRedirects()
+	const docsDotHashiCorpRedirects = getDocsDotHashiCorpRedirects()
 
 	const { simpleRedirects, complexRedirects } = splitRedirectsByType([
 		...proxiedSiteRedirects,
 		...productRedirects,
 		...devPortalRedirects,
 		...tutorialRedirects,
+		...docsDotHashiCorpRedirects,
 	])
 	const groupedSimpleRedirects = groupSimpleRedirects(simpleRedirects)
 	if (process.env.DEBUG_REDIRECTS) {

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -312,32 +312,37 @@ async function buildDevPortalRedirects() {
 
 /**
  * Splits an array of redirects into simple (one-to-one path matches without
- * regex matching) and glob-based (with regex matching). Enables processing
- * redirects via middleware instead of the built-in redirects handling.
+ * regex matching) and complex (with glob-based regex matching or conditions).
+ *
+ * This enables processing simple redirects via middleware, instead of the
+ * built-in redirects handling. Using middleware was previously a necessity
+ * as we handled a VERY large volume of redirects for the proxied `io` domains,
+ * which exceeded Vercel's limits for built-in redirects handling.
+ * For further details see: https://vercel.com/guides/how-can-i-increase-the-limit-of-redirects-or-use-dynamic-redirects-on-vercel
+ *
  * @param {Redirect[]} redirects
- * @returns {{ simpleRedirects: Redirect[], globRedirects: Redirect[] }}
+ * @returns {{ simpleRedirects: Redirect[], complexRedirects: Redirect[] }}
  */
 function splitRedirectsByType(redirects) {
 	/** @type {Redirect[]} */
 	const simpleRedirects = []
 
 	/** @type {Redirect[]} */
-	const globRedirects = []
+	const complexRedirects = []
 
 	redirects.forEach((redirect) => {
-		if (
-			['(', ')', '{', '}', ':', '*', '+', '?'].some((char) =>
-				redirect.source.includes(char)
-			) ||
-			(redirect.has && redirect.has.some((has) => has.type !== 'host'))
-		) {
-			globRedirects.push(redirect)
+		const isGlobRedirect = ['(', ')', '{', '}', ':', '*', '+', '?'].some(
+			(char) => redirect.source.includes(char)
+		)
+		const hasCondition = redirect.has?.length > 0
+		if (isGlobRedirect || hasCondition) {
+			complexRedirects.push(redirect)
 		} else {
 			simpleRedirects.push(redirect)
 		}
 	})
 
-	return { simpleRedirects, globRedirects }
+	return { simpleRedirects, complexRedirects }
 }
 
 /**
@@ -482,7 +487,7 @@ async function redirectsConfig() {
 	const proxiedSiteRedirects = await loadProxiedSiteRedirects()
 	const tutorialRedirects = await getTutorialRedirects()
 
-	const { simpleRedirects, globRedirects } = splitRedirectsByType([
+	const { simpleRedirects, complexRedirects } = splitRedirectsByType([
 		...proxiedSiteRedirects,
 		...productRedirects,
 		...devPortalRedirects,
@@ -492,12 +497,16 @@ async function redirectsConfig() {
 	if (process.env.DEBUG_REDIRECTS) {
 		console.log(
 			'[DEBUG_REDIRECTS]',
-			JSON.stringify({ simpleRedirects, groupedSimpleRedirects, globRedirects })
+			JSON.stringify({
+				simpleRedirects,
+				groupedSimpleRedirects,
+				complexRedirects,
+			})
 		)
 	}
 	return {
 		simpleRedirects: groupedSimpleRedirects,
-		globRedirects,
+		complexRedirects,
 	}
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -85,13 +85,13 @@ module.exports = withHashicorp({
 		return [temporary_hideDocsPaths, hideWaypointTipContent]
 	},
 	async redirects() {
-		const { simpleRedirects, globRedirects } = await redirectsConfig()
+		const { simpleRedirects, complexRedirects } = await redirectsConfig()
 		await fs.promises.writeFile(
 			path.join('src', 'data', '_redirects.generated.json'),
 			JSON.stringify(simpleRedirects, null, 2),
 			'utf-8'
 		)
-		return globRedirects
+		return complexRedirects
 	},
 	async rewrites() {
 		const rewrites = await rewritesConfig()


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds redirects that divert traffic from `docs.hashicorp.com` to `developer.hashicorp.com`, but only once `proxySettings.sentinel` have been removed.

## 🤷 Why

As soon as we launch Sentinel content on `developer.hashicorp.com`, we'll want to redirect traffic from the former `docs.hashicorp.com` domain. Since both domains are currently managed in the same Vercel project, it seems logical to put these redirects behind some sort of flag. We can then toggle the flag in order to complete the launch.

Our usual `config` flags don't seem suited to this use case, and we already have a kind of "flag" that captures proxied domain configuration in our `proxySettings`. So, this PR uses `proxySettings.sentinel` as the launch flag. To "toggle" it to launch, we'll remove `proxySettings.sentinel`.

## 🧪 Testing

For the purposes of testing this branch, we have some **temporary** measures in place:
- `proxySettings.sentinel` has been commented out, to simulate launch
- The `host` condition for the redirects we want to apply captures _both_ `docs.hashicorp.com` and an additional custom domain `sentinel-launch-redirects-test.hashicorp.vercel.app`. The former is what we actually need to care about for launch, but isn't feasible to mess around and test with. The latter has been set up for testing purposes.

To test that the work in this PR is functioning as expected, visit the [preview], where `proxySettings.sentinel` have been **temporarily** removed:

- [ ] The [default branch preview URL][preview] should behave as if it's `developer.hashicorp.com` in a post-launch scenario, with no redirects applied.
    - For example, the [root URL][preview] should _not_ redirect to [developer.hashicorp.com/sentinel]
    - Other `docs.hashicorp.com` URLs to redirect such as [/sentinel/downloads] should _not_ redirect to [developer.hashicorp.com/sentinel/install].
- [ ] The custom domain assigned to this branch, [sentinel-launch-redirects-test.hashicorp.vercel.app][custom], should behave as if it's the `docs.hashicorp.com` domain in a post-launch scenario.
    - For example, the [root URL][custom] should redirect to [developer.hashicorp.com/sentinel]
    - Other `docs.hashicorp.com` URLs to redirect such as [/sentinel/downloads][custom/sentinel/downloads] should redirect to [developer.hashicorp.com/sentinel/install].

Once this testing is done, we'll put the `proxySettings.sentinel` back in place before merging, as we're not yet ready to launch. Once the `proxySettings.sentinel` are back in place, the redirects added in this PR will no longer apply on either test domain, nor will they apply to `docs.hashicorp.com`, which we'll confirm with a quick visit to [sentinel-launch-redirects-test.hashicorp.vercel.app][custom].

## 💭 Anything else?

This change required a subtle change to how we split "simple" and "complex" redirects.

We now treat redirects with _any_ `has` condition as "complex". This means that now, redirects with `has` conditions will be handled by built-in redirects handling, rather than through our custom middleware.

Two notes on this change:
- This change seemed necessary to run the proof-of-concept for this PR using the one-off custom `sentinel-launch-redirects-test.hashicorp.vercel.app` domain
- This change has _minimal_ impact on the split of "simple" and "complex" redirects.
    - Upstream, we have `{ simpleRedirectsCount: 475, complexRedirectsCount: 47 }`
    - In this PR, we have `{ simpleRedirectsCount: 472, complexRedirectsCount: 50 }`, or `{ simpleRedirectsCount: 472, complexRedirectsCount: 49 }` when simulating a "launch" of the Sentinel migration by removing `proxySettings.sentinel`.

[task]: https://app.asana.com/0/1204759533834554/1206141921455040/f
[preview]: https://dev-portal-git-zsset-up-sentinel-launch-redirects-hashicorp.vercel.app/
[/sentinel/downloads]: https://dev-portal-git-zsset-up-sentinel-launch-redirects-hashicorp.vercel.app/sentinel/downloads
[/sentinel/install]: https://dev-portal-git-zsset-up-sentinel-launch-redirects-hashicorp.vercel.app/sentinel/install
[custom]: https://sentinel-launch-redirects-test.hashicorp.vercel.app
[custom/intro]: https://sentinel-launch-redirects-test.hashicorp.vercel.app/intro
[custom/sentinel/downloads]: https://sentinel-launch-redirects-test.hashicorp.vercel.app/sentinel/downloads
[developer.hashicorp.com/sentinel]: https://developer.hashicorp.com/sentinel
[developer.hashicorp.com/sentinel/install]: https://developer.hashicorp.com/sentinel/install