### PR TITLE
chore: update sentinel header

### DIFF
--- a/src/content/sentinel/product-landing.json
+++ b/src/content/sentinel/product-landing.json
@@ -1,7 +1,7 @@
 {
 	"hero": {
 		"heading": "Enforce policy as code for HashiCorp products",
-		"image": "https://www.datocms-assets.com/2885/1701706791-sentinel-landing-placeholder.png"
+		"image": "https://www.datocms-assets.com/2885/1702568388-sentinel-illi.png"
 	},
 	"overview": {
 		"heading": "What is Sentinel?",

--- a/src/views/product-landing/components/hero-heading-visual/index.tsx
+++ b/src/views/product-landing/components/hero-heading-visual/index.tsx
@@ -7,30 +7,63 @@ import { CSSProperties } from 'react'
 import { HeroHeadingVisualProps } from './types'
 import s from './hero-heading-visual.module.css'
 
+/**
+ * Only some of the values for `ProductSlug` have branded color tokens.
+ * Ref: https://helios.hashicorp.design/foundations/colors
+ */
+const PRODUCTS_WITH_COLOR_TOKENS = [
+	'boundary',
+	'consul',
+	'nomad',
+	'packer',
+	'terraform',
+	'vagrant',
+	'vault',
+	'waypoint',
+]
+
+/**
+ * Given a product slug,
+ * Return a `{ start, stop }` object representing color tokens for a gradient.
+ */
+function getProductGradient(
+	productSlug: HeroHeadingVisualProps['productSlug']
+): { start: string; stop: string } {
+	// If the given product slug has brand color tokens, use them
+	if (PRODUCTS_WITH_COLOR_TOKENS.includes(productSlug)) {
+		return {
+			start: `var(--token-color-${productSlug}-gradient-faint-start)`,
+			stop: `var(--token-color-${productSlug}-gradient-faint-stop)`,
+		}
+	}
+	// For Sentinel, use a blue gradient, as specified in designs
+	if (productSlug === 'sentinel') {
+		return {
+			start: `var(--token-color-palette-blue-50)`,
+			stop: `var(--token-color-palette-blue-100)`,
+		}
+	}
+	// As a base case, return a default gradient
+	return {
+		start: `var(--token-color-palette-neutral-100)`,
+		stop: `var(--token-color-palette-neutral-50)`,
+	}
+}
+
 function HeroHeadingVisual({
 	heading,
 	image,
 	productSlug,
 }: HeroHeadingVisualProps) {
-	const gradientDefault = {
-		start: `var(--token-color-palette-neutral-100)`,
-		stop: `var(--token-color-palette-neutral-50)`,
-	}
-	const gradient =
-		productSlug && productSlug !== 'hcp'
-			? {
-					start: `var(--token-color-${productSlug}-gradient-faint-start)`,
-					stop: `var(--token-color-${productSlug}-gradient-faint-stop)`,
-			  }
-			: gradientDefault
+	const productGradient = getProductGradient(productSlug)
 
 	return (
 		<div
 			className={s.root}
 			style={
 				{
-					'--gradient-start': gradient.start,
-					'--gradient-stop': gradient.stop,
+					'--gradient-start': productGradient.start,
+					'--gradient-stop': productGradient.stop,
 				} as CSSProperties
 			}
 		>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates the gradient and asset used in the hero heading for the [Sentinel landing page][/sentinel].

## 📸 Design Screenshots

| [Before][upstream/sentinel] | [After][/sentinel] |
| - | - |
| ![sentinel-header-before](https://github.com/hashicorp/dev-portal/assets/4624598/e56d4f14-8bb9-497d-9ac9-513c530d06ff) | ![sentinel-header-after](https://github.com/hashicorp/dev-portal/assets/4624598/1cd2d6cf-9377-475f-a891-2ac8b0693c21)  |

## 🧪 Testing

- [ ] Visit [/sentinel]
    - The asset shown in the header area should be updated as expected
    - The header bar should show a blue-ish gradient, rather than default neutral gradient shown [upstream][upstream/sentinel]

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204759533834554/1206143599875578/f
[preview]: https://dev-portal-git-zsupdate-sentinel-header-hashicorp.vercel.app/
[/sentinel]: https://dev-portal-git-zsupdate-sentinel-header-hashicorp.vercel.app/sentinel
[upstream]: https://developer.hashicorp.services
[upstream/sentinel]: https://developer.hashicorp.services/sentinel