### PR TITLE
chore: rm Sentinel landing placeholder img

### DIFF
--- a/src/content/sentinel/product-landing.json
+++ b/src/content/sentinel/product-landing.json
@@ -9,10 +9,6 @@
 		"cta": {
 			"text": "Learn more",
 			"url": "/sentinel/intro/what"
-		},
-		"image": {
-			"light": "https://www.datocms-assets.com/2885/1701706795-what-is-sentinel-placeholder.png",
-			"dark": "https://www.datocms-assets.com/2885/1701706795-what-is-sentinel-placeholder.png"
 		}
 	},
 	"get_started": {

--- a/src/views/product-landing/components/overview-cta/index.tsx
+++ b/src/views/product-landing/components/overview-cta/index.tsx
@@ -11,6 +11,7 @@ import StandaloneLink from 'components/standalone-link'
 import { OverviewCtaProps } from './types'
 import s from './overview-cta.module.css'
 import ThemedImage from 'views/product-landing/components/themed-image'
+import classNames from 'classnames'
 
 function OverviewCta({
 	heading,
@@ -19,9 +20,10 @@ function OverviewCta({
 	cta,
 	image,
 }: OverviewCtaProps) {
+	const hasImage = Boolean(image)
 	return (
 		<div className={s.root}>
-			<div className={s.textPart}>
+			<div className={classNames(s.textPart, { [s.hasImage]: hasImage })}>
 				<h2 id={headingSlug} className={s.heading}>
 					{heading}
 				</h2>
@@ -43,9 +45,11 @@ function OverviewCta({
 					/>
 				) : null}
 			</div>
-			<div className={s.imagePart}>
-				<ThemedImage src={image} alt="" />
-			</div>
+			{hasImage ? (
+				<div className={s.imagePart}>
+					<ThemedImage src={image} alt="" />
+				</div>
+			) : null}
 		</div>
 	)
 }

--- a/src/views/product-landing/components/overview-cta/overview-cta.module.css
+++ b/src/views/product-landing/components/overview-cta/overview-cta.module.css
@@ -16,8 +16,10 @@
 	flex: 1 1 0;
 	min-width: min(100%, 260px);
 
-	@media (--dev-dot-tablet-up) {
-		max-width: 400px;
+	&.hasImage {
+		@media (--dev-dot-tablet-up) {
+			max-width: 400px;
+		}
 	}
 }
 

--- a/src/views/product-landing/components/overview-cta/types.ts
+++ b/src/views/product-landing/components/overview-cta/types.ts
@@ -9,7 +9,7 @@ export interface OverviewCtaProps {
 	heading: string
 	headingSlug: string
 	body: string
-	image: ThemedImageProps['src']
+	image?: ThemedImageProps['src']
 	cta?: {
 		text: string
 		url: string

--- a/src/views/product-landing/schema.ts
+++ b/src/views/product-landing/schema.ts
@@ -137,7 +137,6 @@ export interface ProductLandingContent {
 			text: string
 			url: string
 		}
-		image: ThemedImageProps['src']
 	}
 	overviewParagraph?: string
 	get_started: {
@@ -147,6 +146,7 @@ export interface ProductLandingContent {
 			text: string
 			url: string
 		}[]
+		image?: ThemedImageProps['src']
 	}
 	blocks: ProductLandingContentBlock[]
 }
@@ -166,7 +166,7 @@ const ProductLandingOverviewSchema = Joi.object({
 	image: Joi.object({
 		light: Joi.string().required(),
 		dark: Joi.string().required(),
-	}).required(),
+	}),
 })
 
 // Require either `ctas` or `iconCardLinks`


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Removes a placeholder diagram image from the [Sentinel landing page][/sentinel].

## 🤷 Why

We intend to add this diagram separately from the Sentinel migration. See 🎟 `🚧 TODO` for details.

## 🛠️ How

- Adds support for omitting `overview.image` in `product-landing.json` content
- Updates the associated `OverviewCta` component to not require an `image`
- Removes the `overview.image` from Sentinel's `product-landing.json`

## 📸 Design Screenshots

| [Before][upstream/sentinel] | [After][/sentinel] |
| - | - | 
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/807665ff-9057-46ed-8314-814e9efbf9bd) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/c8dd5e9b-61c6-441a-9c7e-9b4f74a50e2b) |

## 🧪 Testing

- [x] Visit [/sentinel]
    - The landing page image next to the `What is Sentinel?` section should no longer appear
- [x] Visit another product landing page, such as [/consul]
    - The landing page image next to the `What is <product>?` section should appear as expected

## 💭 Anything else?

Not at the moment! Note that a separate PR updates the header at the top of the [/sentinel] landing page:
- https://github.com/hashicorp/dev-portal/pull/2277

[task]: https://app.asana.com/0/1204759533834554/1206175869632389/f
[preview]: https://dev-portal-git-zsrm-sentinel-gs-image-hashicorp.vercel.app/
[/sentinel]: https://dev-portal-git-zsrm-sentinel-gs-image-hashicorp.vercel.app/sentinel
[/consul]: https://dev-portal-git-zsrm-sentinel-gs-image-hashicorp.vercel.app/consul
[upstream/sentinel]: https://developer.hashicorp.services/sentinel