### PR TITLE
Bug fix: resources section of nav in tutorials wasn't added

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -104,11 +104,25 @@ const Sidebar = ({
 
 	let sidebarContent
 	const filteredMenuItems = getFilteredNavItems(itemsWithMetadata, filterValue)
-	const navResourceItems = generateResourcesNavItems(currentProduct?.slug).map(
-		(item) => item
+	const navResourceItems = generateResourcesNavItems(currentProduct?.slug)
+	const resourcesComponent = (
+		<>
+			<SidebarHorizontalRule />
+			<SidebarNavList>
+				{navResourceItems.map((item, index) => (
+					// eslint-disable-next-line react/no-array-index-key
+					<SidebarNavMenuItem item={item} key={index} />
+				))}
+			</SidebarNavList>
+		</>
 	)
 	if (children) {
-		sidebarContent = children
+		sidebarContent = (
+			<>
+				{children}
+				{resourcesComponent}
+			</>
+		)
 	} else if (isInstallPage) {
 		sidebarContent = (
 			<OpenApiSidebarContents
@@ -126,17 +140,10 @@ const Sidebar = ({
 						return <SidebarNavMenuItem item={item} key={key} />
 					})}
 				</SidebarNavList>
-				<SidebarHorizontalRule />
-				<SidebarNavList>
-					{navResourceItems.map((item, index) => (
-						// eslint-disable-next-line react/no-array-index-key
-						<SidebarNavMenuItem item={item} key={index} />
-					))}
-				</SidebarNavList>
+				{resourcesComponent}
 			</>
 		)
 	}
-
 	return (
 		<div className={s.sidebar}>
 			{backToElement}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heatbugfix-tutorials-hashicorp.vercel.app/consul/tutorials) 🔎
- [Asana task](https://app.asana.com/0/1202801212949828/1206206356889965/f) 🎟️

## 🗒️ What

- Resources section of sidebar in product tutorials landing page wasn't present

## 🤷 Why

- Missed this case when code was changed in sidebar refactor

## 🛠️ How

- Added resources nav items to the case where the sidebar component is passed children

## 🧪 Testing

- Visit product tutorials preview [page](https://dev-portal-git-heatbugfix-tutorials-hashicorp.vercel.app/consul/tutorials). See that the resources section is now there
<img width="1728" alt="Screenshot 2023-12-19 at 15 57 24" src="https://github.com/hashicorp/dev-portal/assets/55773810/7cc609af-b821-42ca-b523-0ff8d59c5baa">

- Visit preview tutorial [page](https://dev-portal-git-heatbugfix-tutorials-hashicorp.vercel.app/consul/tutorials/get-started-hcp). See that the resources section is now there
<img width="1438" alt="Screenshot 2023-12-19 at 15 56 44" src="https://github.com/hashicorp/dev-portal/assets/55773810/0abe287a-624b-4949-ae4e-ccc36af2e7f0">

- Visit preview install page and prod install [page](https://developer.hashicorp.com/consul/install). They should match.
<img width="1728" alt="Screenshot 2023-12-19 at 15 57 49" src="https://github.com/hashicorp/dev-portal/assets/55773810/f42ea654-54df-415a-82fa-6b39ba9e9540">

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
