### PR TITLE
Remove boundary/oidc-auth product and install landing

### DIFF
--- a/src/content/boundary/install-landing.json
+++ b/src/content/boundary/install-landing.json
@@ -1,6 +1,5 @@
 {
 	"featuredTutorialsSlugs": [
-		"boundary/oidc-auth",
 		"boundary/oss-vault-cred-brokering-quickstart",
 		"boundary/hcp-manage-workers",
 		"boundary/hcp-ssh-cred-injection",

--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -42,11 +42,6 @@
 			"type": "linked_cards",
 			"cards": [
 				{
-					"heading": "Identity-based Access",
-					"body": "Enable privileged sessions for users and applications based on user identity and role.",
-					"url": "/boundary/tutorials/access-management/oidc-auth"
-				},
-				{
 					"heading": "Service Discovery",
 					"body": "Service discovery focuses on automating the process of onboarding new or changed infrastructure resources to Boundary as hosts.",
 					"url": "/boundary/docs/concepts/service-discovery"
@@ -72,7 +67,6 @@
 		{
 			"type": "tutorial_cards",
 			"tutorialSlugs": [
-				"boundary/oidc-auth",
 				"boundary/oss-vault-cred-brokering-quickstart",
 				"boundary/hcp-manage-workers",
 				"boundary/hcp-ssh-cred-injection",

--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -54,7 +54,7 @@
 				{
 					"heading": "Session Visibility and Audit Logs",
 					"body": "Visibility into session metrics, events, logs, and traces with the ability to export data to business intelligence and event monitoring tools",
-					"url": "/boundary/tutorials/oss-configuration/event-logging"
+					"url": "/boundary/tutorials/self-managed-deployment/event-logging"
 				}
 			]
 		},


### PR DESCRIPTION
## 🔗 Relevant links

This PR is related to the refactoring of the boundary/oidc-auth tutorial into three separate tutorials, documented in this [Jira task](https://hashicorp.atlassian.net/browse/SPE-207?atlOrigin=eyJpIjoiYjM1ZTg5MThjZDMzNGE3M2EzNmFjNDRkMTllMGEwZGMiLCJwIjoiaiJ9).

- [Boundary install page Preview](https://dev-portal-git-rabboundary-oidc-refs-hashicorp.vercel.app/boundary/install) 
- [Boundary product landing Preview](https://dev-portal-git-rabboundary-oidc-refs-hashicorp.vercel.app/boundary) 🔎
- [Jira task](https://hashicorp.atlassian.net/browse/SPE-207?atlOrigin=eyJpIjoiYjM1ZTg5MThjZDMzNGE3M2EzNmFjNDRkMTllMGEwZGMiLCJwIjoiaiJ9) 🎟️

## 🗒️ What

This PR removes references to the boundary/oidc-auth tutorial from the dev portal Boundary install and landing pages, which should allow the deploy preview for tutorials PR 1849 to build. This PR also updates an outdated link for the boundary/event-logging tutorial.

## 🤷 Why

[Tutorials PR 1849](https://github.com/hashicorp/tutorials/pull/1849) is failing because the oidc-auth tutorial has been deprecated, and it's currently referenced on the boundary install and landing pages.

References to the updated oidc tutorial slugs will be added back into the install and product landing pages after tutorials PR 1849 is approved.

## 🧪 Testing

Local deploy previews work when tested using a docker image using these changes.
