### PR TITLE
chore: add missing Sentinel redirects

### DIFF
--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -37,6 +37,12 @@ function getDocsDotHashiCorpRedirects() {
 			destination: 'https://developer.hashicorp.com/sentinel',
 			permanent: true,
 		},
+		// Redirect the `/sentinel` landing page
+		{
+			source: '/sentinel',
+			destination: 'https://developer.hashicorp.com/sentinel',
+			permanent: true,
+		},
 		// Redirect `/intro` content
 		{
 			source: '/sentinel/intro',

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -60,6 +60,12 @@ function getDocsDotHashiCorpRedirects() {
 			destination: 'https://developer.hashicorp.com/sentinel/install',
 			permanent: true,
 		},
+		// Redirect the docs landing page
+		{
+			source: '/sentinel/docs',
+			destination: 'https://developer.hashicorp.com/sentinel/docs',
+			permanent: true,
+		},
 		/**
 		 * Redirect `/docs` content.
 		 *

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -60,7 +60,8 @@ function getDocsDotHashiCorpRedirects() {
 			destination: 'https://developer.hashicorp.com/sentinel/install',
 			permanent: true,
 		},
-		// Redirect the docs landing page
+		// Redirect the docs landing page (previously 404'd, but this redirect
+		// avoids redirecting `/sentinel/docs` to `/sentinel/docs/docs`)
 		{
 			source: '/sentinel/docs',
 			destination: 'https://developer.hashicorp.com/sentinel/docs',


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where not all `docs.hashicorp.com` redirects behaved as expected.

## 🧪 Testing

> **Note**: Using the staging domain `sentinel-launch-redirects-test.hashicorp.vercel.app`, as [configured in Vercel](https://vercel.com/hashicorp/dev-portal/settings/domains) to point to this PR's branch deployment.

- [ ] https://sentinel-launch-redirects-test.hashicorp.vercel.app/sentinel should redirect to https://developer.hashicorp.com/sentinel
    - Note the "upstream" https://docs.hashicorp.com/sentinel does _not_ redirect at all. It renders a page, but this is not the correct behaviour, as we need the URL to be correct.
- [ ] https://sentinel-launch-redirects-test.hashicorp.vercel.app/sentinel/docs should redirect to https://developer.hashicorp.com/sentinel/docs
    - Note the "upstream" https://docs.hashicorp.com/sentinel/docs redirects to https://developer.hashicorp.com/sentinel/docs/docs, which 404s

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1204759533834554/1206313101427625/f
[preview]: https://dev-portal-git-zsadd-missing-sentinel-redirect-hashicorp.vercel.app/