### PR TITLE
chore: add redirect for /sentinel/downloads

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -290,7 +290,7 @@ async function buildDevPortalRedirects() {
 		},
 		{
 			source:
-				'/:path(boundary|consul|nomad|packer|terraform|vagrant|vault|waypoint)/downloads',
+				'/:path(boundary|consul|nomad|packer|terraform|vagrant|vault|waypoint|sentinel)/downloads',
 			destination: '/:path/install',
 			permanent: true,
 		},

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -209,7 +209,7 @@ function rewriteSentinelDocsUrls(
 	 *   - This excludes the case where "basePath" is "docs"
 	 *   - This really just applies to "/sentinel/intro", but in theory could
 	 *     apply to other Sentinel "basePaths" if they get added
-	 * - The "/sentinel/downloads" URL does not need to be modified
+	 * - The "/sentinel/downloads" URL should be "/sentinel/install"
 	 * - Any other "/sentinel/:slug" URL is expected to be a "/docs" URL
 	 *   - We need to adjust these urls to be "/sentinel/docs/:slug"
 	 */
@@ -220,14 +220,17 @@ function rewriteSentinelDocsUrls(
 				inputUrl == `/sentinel/${basePath}` ||
 				inputUrl.startsWith(`/sentinel/${basePath}/`)
 		)
+	// Redirect /sentinel/downloads to /sentinel/install
 	const isDownloadsUrl = inputUrl == '/sentinel/downloads'
+	if (isDownloadsUrl) {
+		return '/sentinel/install'
+	}
 	/**
 	 * We assume all other "/sentinel/*" URLs are intended to be docs routes,
 	 * which on the previous site were rendered to "/sentinel/:slug".
 	 * We need to correct these URLs to be "/sentinel/docs/:slug".
 	 */
-	const isKnownUrl = isBasePathExceptDocs || isDownloadsUrl
-	const isDocsUrl = !isKnownUrl && inputUrl.startsWith('/sentinel')
+	const isDocsUrl = !isBasePathExceptDocs && inputUrl.startsWith('/sentinel')
 	if (isDocsUrl) {
 		return `/sentinel/docs${inputUrl.replace('/sentinel', '')}`
 	}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Adds a redirect from [/sentinel/downloads] to [/sentinel/install]. This is necessary as Sentinel's content has not yet been updated with `developer.hashicorp.com` URLs.

This PR also fixes URLs using our existing product URL adjuster setup. This makes content-level corrections at build time, swapping any `/sentinel/downloads` links authored in our Sentinel content to become `/sentinel/install`.

## 🧪 Testing

- [ ] This PR preview's [/sentinel/downloads] URL should redirect to [/sentinel/install]
    - Compare to the upstream [/sentinel/downloads][prod/sentinel/downloads], which `404`s 
- [ ] URLs written in content as `/sentinel/downloads` should render as `/sentinel/install`
    - For example, compare the URLs on [/sentinel/intro/getting-started/install] to [upstream][prod/sentinel/intro/getting-started/install]

[task]: https://app.asana.com/0/1204759533834554/1206321540168548/f
[preview]: https://dev-portal-git-zsredirect-sentinel-downloads-hashicorp.vercel.app/
[/sentinel/downloads]: https://dev-portal-git-zsredirect-sentinel-downloads-hashicorp.vercel.app/sentinel/downloads
[/sentinel/install]: https://dev-portal-git-zsredirect-sentinel-downloads-hashicorp.vercel.app/sentinel/install
[/sentinel/intro/getting-started/install]: https://dev-portal-git-zsredirect-sentinel-downloads-hashicorp.vercel.app/sentinel/intro/getting-started/install
[prod/sentinel/downloads]: https://developer.hashicorp.com/sentinel/downloads
[prod/sentinel/intro/getting-started/install]: https://developer.hashicorp.com/sentinel/intro/getting-started/install