### PR TITLE
update vault secrets icon

### DIFF
--- a/src/content/hcp/docs-landing.json
+++ b/src/content/hcp/docs-landing.json
@@ -17,7 +17,7 @@
 			"path": "docs/vault"
 		},
 		{
-			"iconName": "vault-color",
+			"iconName": "vault-secrets-color",
 			"name": "HCP Vault Secrets",
 			"path": "docs/vault-secrets"
 		},

--- a/src/content/hcp/product-landing.json
+++ b/src/content/hcp/product-landing.json
@@ -25,7 +25,7 @@
 				"url": "/vault/tutorials/cloud"
 			},
 			{
-				"icon": "vault-color",
+				"icon": "vault-secrets-color",
 				"text": "HCP Vault Secrets",
 				"url": "/vault/tutorials/hcp-vault-secrets-get-started"
 			},

--- a/src/content/supported-icons.tsx
+++ b/src/content/supported-icons.tsx
@@ -38,6 +38,7 @@ import { IconVault16 } from '@hashicorp/flight-icons/svg-react/vault-16'
 import { IconVmware16 } from '@hashicorp/flight-icons/svg-react/vmware-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
+import { IconVaultSecrets24 } from '@hashicorp/flight-icons/svg-react/vault-secrets-24'
 import ThemedAwsIcon from './themed-icons/aws-color'
 
 /**
@@ -81,7 +82,11 @@ export const SUPPORTED_ICONS = {
 	terminal: <IconTerminal16 />,
 	'terraform-color': <IconTerraformColor16 />,
 	tools: <IconTools16 />,
-	'vault-color': <IconVault16 color={`var(--token-color-vault-brand)`} />, // vault's brand color changes between light and dark mode
+	// vault's brand color changes between light and dark mode
+	'vault-color': <IconVault16 color={`var(--token-color-vault-brand)`} />,
+	'vault-secrets-color': (
+		<IconVaultSecrets24 color={`var(--token-color-vault-brand)`} />
+	),
 	vmware: <IconVmware16 />,
 	'waypoint-color': <IconWaypointColor16 />,
 	wrench: <IconWrench16 />,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-featupdate-vault-secrets-icon-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1205837019136532/1205837019136544/f) 🎟️

## 🗒️ What

Update the Vault Secrets icon to our latest icon, given our icon refresh.

## 📸 Design Screenshots

New Icon:
![Screenshot 2024-01-10 at 2 07 16 PM](https://github.com/hashicorp/dev-portal/assets/1957315/ca9a2551-a2a2-414b-a1b2-2a675346e5e3)

## 🧪 Testing

- [ ] New Vault Secrets Icon show up on the [HCP Docs landing page](https://dev-portal-git-rn-featupdate-vault-secrets-icon-hashicorp.vercel.app/hcp)
