### PR TITLE
[chore]: Fix HVD guide sidebar styling

### DIFF
--- a/src/views/validated-designs/guide/index.tsx
+++ b/src/views/validated-designs/guide/index.tsx
@@ -14,15 +14,15 @@ import DirectionalLinkBox from 'components/directional-link-box'
 import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
 import {
 	SidebarHorizontalRule,
-	SidebarNavHighlightItem,
 	SidebarSectionBrandedHeading,
+	SidebarNavMenuItem,
 } from 'components/sidebar/components'
 import SidebarNavList from 'components/sidebar/components/sidebar-nav-list'
 import SidebarBackToLink from 'components/sidebar/components/sidebar-back-to-link'
 
 import s from './detail-view.module.css'
 
-import type { HvdPage } from '../types'
+import type { HvdPage, HvdPageMenuItem } from '../types'
 import type { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import type { OutlineLinkItem } from 'components/outline-nav/types'
 
@@ -106,17 +106,15 @@ export default function ValidatedDesignGuideView({
 							<SidebarSectionBrandedHeading text={title} theme={'hcp'} />
 							<SidebarHorizontalRule />
 							<SidebarNavList>
-								{pages.map((page: HvdPage, index: number) => {
-									return (
-										<SidebarNavHighlightItem
-											key={page.slug}
-											text={page.title}
-											theme={'generic'}
-											href={page.href}
-											isActive={index === currentPageIndex}
-										/>
-									)
-								})}
+								{pages.map((page: HvdPageMenuItem, index: number) => (
+									<SidebarNavMenuItem
+										key={page.slug}
+										item={{
+											...page,
+											isActive: index === currentPageIndex,
+										}}
+									/>
+								))}
 							</SidebarNavList>
 						</>
 					),

--- a/src/views/validated-designs/types.ts
+++ b/src/views/validated-designs/types.ts
@@ -22,3 +22,7 @@ export interface HvdPage {
 	href: string // e.g. /validated-designs/terraform-operation-guides-adoption/people-and-process
 	filePath: string // full path to the file e.g. /content/terraform/operation-guides/adoption/0000-people-and-process.mdx
 }
+
+export interface HvdPageMenuItem extends HvdPage {
+	isActive: boolean
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->
- [Figma](https://www.figma.com/file/jS4ztJs2X6jspnHn7RjC7J/Developer-Components?type=design&node-id=24-7912&mode=design&t=Npo0KA1xG4ScQTmP-0)
- [Preview link](https://dev-portal-git-heat-chorehvd-sidebar-hashicorp.vercel.app/validated-designs/terraform-solution-design-guides-terraform-enterprise-fdo/introduction) 🔎
- [Asana task](https://app.asana.com/0/1202801212949828/1206186326415820/f) 🎟️

## 🗒️ What

- Changed HVD Guide sidebar to use `<SidebarNavMenuItem>` instead of `<SidebarNavHighlightItem>`
- Added type `HvdPageMenuItem` to add the `isActive` property required for the current page/active styling to work.

## 🤷 Why

Styling for HVD sidebar did not match the [current designs](https://www.figma.com/file/jS4ztJs2X6jspnHn7RjC7J/Developer-Components?type=design&node-id=24-7912&mode=design&t=Npo0KA1xG4ScQTmP-0) for sidebar menu items

## 🛠️ How

Compared the implementation of the sidebar for the install page and the implementation of the HVD guide page to narrow down the issue.

## 📸 Design Screenshots
<img width="351" alt="Screenshot 2024-01-10 at 16 15 39" src="https://github.com/hashicorp/dev-portal/assets/55773810/ae19d149-c1d7-4f3c-93b2-63ac364a69df">

## 🧪 Testing



- Visit staging HVD guide [page](https://developer.hashicorp.services/validated-designs/terraform-solution-design-guides-terraform-enterprise-fdo)
- Visit preview HVD guide [page](https://dev-portal-git-heat-chorehvd-sidebar-hashicorp.vercel.app/validated-designs/terraform-solution-design-guides-terraform-enterprise-fdo/introduction)
- See that the styling is different and the preview HVD guide page sidebar matches the [design](https://www.figma.com/file/jS4ztJs2X6jspnHn7RjC7J/Developer-Components?type=design&node-id=71-8133&mode=design&t=Npo0KA1xG4ScQTmP-0)

## 💭 Anything else?
nay