### PR TITLE
chore: update link to Sentinel playground

### DIFF
--- a/src/content/sentinel/product-landing.json
+++ b/src/content/sentinel/product-landing.json
@@ -69,7 +69,7 @@
 				{
 					"heading": "Sentinel playground",
 					"body": "Write and test policies in a free, hosted sandbox. Upload mock data to write policies against, or customize the provided example, which checks that an S3 bucket has a private ACL.",
-					"url": "https://docs.hashicorp.com/sentinel"
+					"url": "https://play.sentinelproject.io"
 				}
 			]
 		}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an incorrect link on the [/sentinel] landing page.

## 🧪 Testing

- [x] Visit the [/sentinel] landing page
    - The very last card, with the title `Sentinel Playground`, should link to https://play.sentinelproject.io/

[task]: https://app.asana.com/0/1204759533834554/1206321903608736/f
[preview]: https://dev-portal-git-zsfix-sentinel-playground-link-hashicorp.vercel.app/
[/sentinel]: https://dev-portal-git-zsfix-sentinel-playground-link-hashicorp.vercel.app/sentinel