### PR TITLE
Fix maximum callstack exceeded error on install page

### DIFF
--- a/src/views/product-downloads-view/index.tsx
+++ b/src/views/product-downloads-view/index.tsx
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import { ReactElement, useEffect, useMemo, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
 
 // HashiCorp imports
@@ -45,7 +45,6 @@ import Heading from 'components/heading'
 import viewStyles from 'views/product-downloads-view/product-downloads-view.module.css'
 import { SidebarProps } from 'components/sidebar/types'
 import { InstallPageAnchorHeading } from './components/downloads-section/types'
-import { Products } from '@hashicorp/platform-product-meta'
 
 /**
  * This component is used to make it possible to consume the `useCurrentVersion`
@@ -92,7 +91,7 @@ const ProductDownloadsViewContent = ({
 		),
 	]
 
-	useEffect(() => {
+	const updateInstallViewNavItems = useCallback(() => {
 		const updatedTableOfContents = setTableOfContents(
 			releases,
 			currentVersion,
@@ -100,18 +99,18 @@ const ProductDownloadsViewContent = ({
 			featuredTutorialCards,
 			currentProduct.slug
 		)
-		setInstallViewNavItems([
-			...updatedTableOfContents,
-			...sidebarMenuItems,
-		] as MenuItem[])
+		setInstallViewNavItems([...updatedTableOfContents, ...sidebarMenuItems])
 	}, [
 		releases,
 		currentVersion,
 		featuredCollectionCards,
 		featuredTutorialCards,
 		currentProduct.slug,
-		sidebarMenuItems,
 	])
+
+	useEffect(() => {
+		updateInstallViewNavItems()
+	}, [currentVersion, updateInstallViewNavItems])
 
 	return (
 		<SidebarSidecarLayout


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-bug-fixinstall-top-nav-hashicorp.vercel.app/terraform/install) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1206351772603030/f) 🎟️

## 🗒️ What

- Moved `setTableOfContents()` and `setState` outside of the `useEffect` hook.
- Wrapped `setTableOfContents()` in `useCallback`

## 🤷 Why

- Broken site navigation from `/install` pages due to maximum callstack error

## 🛠️ How

- Moved `setState` hook outside of the `useEffect()` hook.


## 🧪 Testing

- Visit [preview link](https://dev-portal-git-heat-bug-fixinstall-top-nav-hashicorp.vercel.app/terraform/install). Click on any link from the top nav, such as **Documentation > About the docs**
<img width="1092" alt="Screenshot 2024-01-16 at 12 13 13" src="https://github.com/hashicorp/dev-portal/assets/55773810/7552afc9-677d-46f4-9c44-cfbe7e5d0532">

- Visit the Packer i[nstall page](https://dev-portal-git-heat-bug-fixinstall-top-nav-hashicorp.vercel.app/packer/install). The items under **Operating Systems** should look like this:
<img width="329" alt="Screenshot 2024-01-16 at 12 22 00" src="https://github.com/hashicorp/dev-portal/assets/55773810/6a6988fb-d531-4c7d-9f8b-60040c57f337">

- Change the version to the earliest one (`v0.1.0`). The menu items under Operating system should update to this:
<img width="329" alt="Screenshot 2024-01-16 at 12 19 44" src="https://github.com/hashicorp/dev-portal/assets/55773810/e651dfb0-5981-4f26-8a52-5d4c4dd7e21f">

- You should be able to navigate to the new page

## 💭 Anything else?





nay
