### PR TITLE
HVD: Add product logo, and make TOC h2+ only

### DIFF
--- a/src/views/validated-designs/guide/index.tsx
+++ b/src/views/validated-designs/guide/index.tsx
@@ -25,9 +25,11 @@ import s from './detail-view.module.css'
 import type { HvdPage, HvdPageMenuItem } from '../types'
 import type { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import type { OutlineLinkItem } from 'components/outline-nav/types'
+import { ProductSlug } from 'types/products'
 
 export interface ValidatedDesignsGuideProps {
 	title: string
+	productSlug: Exclude<ProductSlug, 'sentinel'>
 	markdown: {
 		mdxSource: MDXRemoteSerializeResult
 		title: string
@@ -41,6 +43,7 @@ export interface ValidatedDesignsGuideProps {
 
 export default function ValidatedDesignGuideView({
 	title,
+	productSlug,
 	markdown,
 	headers,
 	currentPageIndex,
@@ -103,7 +106,7 @@ export default function ValidatedDesignGuideView({
 					showResourcesList: false,
 					children: (
 						<>
-							<SidebarSectionBrandedHeading text={title} theme={'hcp'} />
+							<SidebarSectionBrandedHeading text={title} theme={productSlug} />
 							<SidebarHorizontalRule />
 							<SidebarNavList>
 								{pages.map((page: HvdPageMenuItem, index: number) => (

--- a/src/views/validated-designs/server.ts
+++ b/src/views/validated-designs/server.ts
@@ -18,6 +18,7 @@ import remarkPluginAnchorLinkData, {
 import { rewriteStaticHVDAssetsPlugin } from 'lib/remark-plugins/rewrite-static-hvd-assets'
 import grayMatter from 'gray-matter'
 import { ProductSlug } from 'types/products'
+import { OutlineLinkItem } from 'components/outline-nav/types'
 
 const basePath = '/validated-designs'
 
@@ -189,6 +190,7 @@ export async function getHvdGuidePropsFromSlug(
 
 	const validatedDesignsGuideProps: ValidatedDesignsGuideProps = {
 		title: '',
+		productSlug: 'hcp', // default to hcp
 		markdown: {
 			description: '',
 			title: '',
@@ -203,6 +205,8 @@ export async function getHvdGuidePropsFromSlug(
 	for (const categoryGroup of categoryGroups) {
 		for (const guide of categoryGroup.guides) {
 			if (guide.slug === guideSlug) {
+				validatedDesignsGuideProps.productSlug = categoryGroup.product
+
 				for (let index = 0; index < guide.pages.length; index++) {
 					const page = guide.pages[index]
 
@@ -212,7 +216,6 @@ export async function getHvdGuidePropsFromSlug(
 
 						let mdxFileString: string
 						try {
-							// TODO: this should be guarded with a try catch
 							mdxFileString = fs.readFileSync(page.filePath, 'utf8')
 						} catch (err) {
 							console.error(err)
@@ -231,10 +234,21 @@ export async function getHvdGuidePropsFromSlug(
 							},
 						})
 
-						const headers = anchorLinks.map((anchorLink: AnchorLinkItem) => ({
-							title: anchorLink.title,
-							url: `#${anchorLink.id}`,
-						}))
+						// only show heading level 1 & 2
+						const headers = anchorLinks.reduce(
+							(acc: OutlineLinkItem[], anchorLink: AnchorLinkItem) => {
+								if (anchorLink.level < 3) {
+									acc.push({
+										title: anchorLink.title,
+										url: `#${anchorLink.id}`,
+									})
+								}
+
+								return acc
+							},
+							[]
+						)
+
 						validatedDesignsGuideProps.headers = headers
 						validatedDesignsGuideProps.markdown = {
 							// this is temporary as we should always have these fields in the markdown


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-featfix-hvd-guide-styling-pass-1-hashicorp.vercel.app/validated-designs) 🔎
- [Asana task - HVD guide page QA & fixes](https://app.asana.com/0/1204908934882872/1205942535705313/f) 🎟️

## 🗒️ What

First style pass as part of design review for HVD.

## 📸 Design Screenshots

The product logo is now shown for the guide of the product, instead of the hashicorp logo

**Before:**
![Screenshot 2024-01-18 at 3 37 25 PM](https://github.com/hashicorp/dev-portal/assets/1957315/418d82d3-7a17-4e5e-b498-12b3271dc49f)

**After:**
![Screenshot 2024-01-18 at 3 36 03 PM](https://github.com/hashicorp/dev-portal/assets/1957315/c1e0b4d3-7541-4998-a57c-3d619e0ab87b)


## 🧪 Testing

- [Preview link](https://dev-portal-git-rn-featfix-hvd-guide-styling-pass-1-hashicorp.vercel.app/validated-designs) 🔎

- [ ] Ensure that the right hand side Table of Content, TOC, only contains the h2s or above in the markdown
- [ ] Ensure that the product logo is now shown for the guide of the product, instead of the hashicorp logo