### PR TITLE
Fix refocus on HVD next/prev buttons and title typo

### DIFF
--- a/src/components/directional-link-box/index.tsx
+++ b/src/components/directional-link-box/index.tsx
@@ -31,7 +31,7 @@ function DirectionalLinkBox({
 
 	return (
 		<Link
-			// Next.js's Link will attempt to refocus itself after a page transition, in order to keep the user focused on what it believes to be the same content. (https://github.com/vercel/next.js/issues/49386) This makes sense for a menu buttons/links, but not for content buttons/links.
+			// Next.js's Link will attempt to refocus itself after a page transition, in order to keep the user focused on what it believes to be the same content. (https://github.com/vercel/next.js/issues/49386) This makes sense for a menu buttons/links, but not for content buttons/links. Setting unique ids & keys convince's Next that this is now a new element
 			id={id || undefined}
 			key={id || undefined}
 			className={classNames(s.linkbox, s[`direction-${direction}`])}

--- a/src/components/directional-link-box/index.tsx
+++ b/src/components/directional-link-box/index.tsx
@@ -20,6 +20,7 @@ const IconDict: { [k in DirectionOption]: typeof IconArrowRight16 } = {
 }
 
 function DirectionalLinkBox({
+	id,
 	href,
 	label,
 	name,
@@ -30,6 +31,9 @@ function DirectionalLinkBox({
 
 	return (
 		<Link
+			// Next.js's Link will attempt to refocus itself after a page transition, in order to keep the user focused on what it believes to be the same content. (https://github.com/vercel/next.js/issues/49386) This makes sense for a menu buttons/links, but not for content buttons/links.
+			id={id || undefined}
+			key={id || undefined}
 			className={classNames(s.linkbox, s[`direction-${direction}`])}
 			href={href}
 			aria-label={ariaLabel}

--- a/src/components/directional-link-box/index.tsx
+++ b/src/components/directional-link-box/index.tsx
@@ -29,11 +29,11 @@ function DirectionalLinkBox({
 }: DirectionalLinkBoxProps) {
 	const Icon = IconDict[direction]
 
+  // Next.js's Link component will maintain a focus state even after a page transition (with static regeneration) (https://github.com/vercel/next.js/issues/49386). Adding a key attribute breaks that behaviour.
 	return (
 		<Link
-			// Next.js's Link will attempt to refocus itself after a page transition, in order to keep the user focused on what it believes to be the same content. (https://github.com/vercel/next.js/issues/49386) This makes sense for a menu buttons/links, but not for content buttons/links. Setting unique ids & keys convince's Next that this is now a new element
-			id={id || undefined}
-			key={id || undefined}
+			id={id}
+			key={id}
 			className={classNames(s.linkbox, s[`direction-${direction}`])}
 			href={href}
 			aria-label={ariaLabel}

--- a/src/components/directional-link-box/types.ts
+++ b/src/components/directional-link-box/types.ts
@@ -8,6 +8,7 @@ import { CardLinkProps } from 'components/card-link'
 export type DirectionOption = 'next' | 'previous' | 'final'
 
 export interface DirectionalLinkBoxProps {
+	id?: string
 	href: CardLinkProps['href']
 	label: string
 	name: string

--- a/src/views/validated-designs/guide/index.tsx
+++ b/src/views/validated-designs/guide/index.tsx
@@ -60,6 +60,7 @@ export default function ValidatedDesignGuideView({
 		if (currentPageIndex !== 0 && prevPage) {
 			return (
 				<DirectionalLinkBox
+					id={prevPage.href}
 					label="Previous"
 					name={prevPage.title}
 					href={prevPage.href}
@@ -79,6 +80,7 @@ export default function ValidatedDesignGuideView({
 		if (currentPageIndex !== pages.length - 1 && nextPage) {
 			return (
 				<DirectionalLinkBox
+					id={nextPage.href}
 					label="Next"
 					name={nextPage.title}
 					href={nextPage.href}

--- a/src/views/validated-designs/index.tsx
+++ b/src/views/validated-designs/index.tsx
@@ -34,11 +34,11 @@ export default function ValidatedDesignsLandingView({
 		<BaseLayout mobileMenuSlot={<MobileMenuLevelsGeneric />} className={s.root}>
 			<Head>
 				<meta name="robots" content="noindex, nofollow" />
-				<title>HashiCorp Validated Design</title>
-				<meta name="description" content="HashiCorp Validated Design" />
+				<title>HashiCorp Validated Designs</title>
+				<meta name="description" content="HashiCorp Validated Designs" />
 			</Head>
 			<LandingHero
-				heading="HashiCorp Validated Design"
+				heading="HashiCorp Validated Designs"
 				isHvd={true}
 				className={s.hvdHero}
 			/>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-feathvd-focus-fix-and-typo-hashicorp.vercel.app/validated-designs) 🔎
- [Asana task - odd behavior "pre/next" active state holding](https://app.asana.com/0/home/1205890531436275/1206376499174139) 🎟️

## 🗒️ What

* Fix type of Validated Designs not being plural
* Fix next and previous buttons refocusing after page transition

## 🛠️ How

Next.js's Link will attempt to refocus itself after a page transition, in order to keep the user focused on what it believes to be the same content. (https://github.com/vercel/next.js/issues/49386) This makes sense for a menu buttons/links, but not for content buttons/links. Setting unique ids & keys convince's Next that this is now a new element.

## 🧪 Testing

- [ ] [Tutorial next/prev buttons do not have an id param set](https://dev-portal-git-rn-feathvd-focus-fix-and-typo-hashicorp.vercel.app/terraform/tutorials/aws-get-started/aws-build)
- [ ] [HVD next/prev buttons do not have an id param set](https://dev-portal-git-rn-feathvd-focus-fix-and-typo-hashicorp.vercel.app/validated-designs/consul-operating-guides-adoption/sample-project-plan)
- [ ] [HVD next/prev buttons no longer hold focus on page transition ](https://dev-portal-git-rn-feathvd-focus-fix-and-typo-hashicorp.vercel.app/validated-designs/consul-operating-guides-adoption/sample-project-plan)
- [ ] [HVD landing page's title is now plural](https://dev-portal-git-rn-feathvd-focus-fix-and-typo-hashicorp.vercel.app/validated-designs)
