### PR TITLE
Fix OutlineNavWithActive when items is 1 or less

### DIFF
--- a/src/components/outline-nav/components/outline-nav-with-active/index.tsx
+++ b/src/components/outline-nav/components/outline-nav-with-active/index.tsx
@@ -48,7 +48,10 @@ function OutlineNavWithActive({
 	 * if we don't have multiple items, then we render null
 	 */
 	if (!hasMultipleItems) {
-		return null
+		// Next is caching refs so we need to hold on to this ref. Otherwise Next will lose this reference and break this component if we:
+		// 1. visit a page with 0 or 1 items
+		// 2. then visit a page with items
+		return <div ref={rootRef}></div>
 	}
 
 	return (


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://developer.hashicorp.services/validated-designs/vault-operating-guides-adoption/disaster-recovery-setup) 🔎
- [Asana task - sidecar not highlighting sections on scroll](https://app.asana.com/0/1205890531436279/1206376499174145/f) 🎟️

## 🗒️ What

When visiting a page without any sections in the sidecar, and then moving back to a page with sections in the sidecar the sidecar sections fail to update. 

## 🤷 Why

I believe this is due to Next caching elements, one of which has a ref on it.

## 🛠️ How

Keep the ref around on by rendering the empty container div.

## 🧪 Testing

1. visit [Disaster Recovery Setup](https://developer.hashicorp.services/validated-designs/vault-operating-guides-adoption/disaster-recovery-setup) and scroll around and see the sidebar active item change
2. (in the same tab) click on **Vault organizational concepts** in the side menu and scroll around
3. (in the same tab) go back to **Disaster Recovery Setup** and scroll around
4. Sidebar active item now updates scroll.
