### PR TITLE
Removing apt-key as this method of importing the key is deprecated.

### DIFF
--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -103,8 +103,8 @@
 		{
 			"label": "Ubuntu/Debian",
 			"commands": [
-				"curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -",
-				"sudo apt-add-repository \"deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main\"",
+				"wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg",
+				"echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main\" | sudo tee /etc/apt/sources.list.d/hashicorp.list",
 				"sudo apt-get update && sudo apt-get install vault"
 			],
 			"os": "linux"


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Changing the way repository gpg sign keys are imported in Ubuntu.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The currently used apt-key command is deprecated and it's not considered best practices to import all keys in the trusted.db gpg keystore.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

I used the same approach as here: https://github.com/hashicorp/dev-portal/blob/main/src/views/product-downloads-view/helpers.ts#L120

