### PR TITLE
[HVD] Fix mobile UI bug where next/prev buttons do not have a width of 100%

### DIFF
--- a/src/views/validated-designs/guide/detail-view.module.css
+++ b/src/views/validated-designs/guide/detail-view.module.css
@@ -22,7 +22,10 @@
        each item takes up an equal amount of space. This comes at the
        cost of going to a single-column layout slightly earlier */
 		min-width: calc(50% - 12px);
-		max-width: 50%;
+
+		@media (--dev-dot-tablet-up) {
+			max-width: 50%;
+		}
 	}
 
 	@media (--dev-dot-tablet-up) {
@@ -36,5 +39,11 @@
 	/* same css var that SidebarSidecarLayout uses to hide the mobile menu, but we are using it here to hide the back button, that we add on mobile, on desktop */
 	@media (--dev-dot-hide-mobile-menu) {
 		display: none;
+	}
+}
+
+.hideOnMobile {
+	@media (--dev-dot-mobile) {
+		composes: g-hide-on-mobile from global;
 	}
 }

--- a/src/views/validated-designs/guide/index.tsx
+++ b/src/views/validated-designs/guide/index.tsx
@@ -70,7 +70,7 @@ export default function ValidatedDesignGuideView({
 			)
 		} else {
 			// We add this empty div here so that even when only one "paging buttons" is rendered, they always only take up 50%
-			return <div />
+			return <div className={s.hideOnMobile} />
 		}
 	}
 
@@ -90,7 +90,7 @@ export default function ValidatedDesignGuideView({
 			)
 		} else {
 			// We add this empty div here so that even when only one "paging buttons" is rendered, they always only take up 50%
-			return <div />
+			return <div className={s.hideOnMobile} />
 		}
 	}
 


### PR DESCRIPTION
## 🔗 Relevant links
- [Preview link](https://dev-portal-git-heat-bugfixhvd-next-prev-bttn-mobile-hashicorp.vercel.app/validated-designs/terraform-operating-guides-adoption/introduction) 🔎
- [Asana task](https://app.asana.com/0/1204908934882872/1206467043753971/f) 🎟️

## 🗒️ What
- Added media query for 50% width to apply only for tablet & up
- Added className to hide empty divs on mobile, which was adding space above single buttons (e.g. when there is only a Next button)

## 🤷 Why

- UI bug that needs to be fixed

## 🛠️ How

- Fixed width with media query by comparing with next/prev button in prod tutorials

## 📸 Screenshots

### Before
<img width="415" alt="Screenshot 2024-01-29 at 10 46 51" src="https://github.com/hashicorp/dev-portal/assets/55773810/f594b0d7-dfac-4da6-946e-184efa2786db">

### After
<img width="411" alt="Screenshot 2024-01-29 at 10 42 25" src="https://github.com/hashicorp/dev-portal/assets/55773810/e33d3d24-f116-4706-a735-531012a1e310">

## 🧪 Testing

1. Visit page with only a Next button [here](https://dev-portal-git-heat-bugfixhvd-next-prev-bttn-mobile-hashicorp.vercel.app/validated-designs/terraform-operating-guides-adoption/introduction)
1. The button **width** should match this screenshot:
<img width="1131" alt="Screenshot 2024-01-29 at 10 42 36" src="https://github.com/hashicorp/dev-portal/assets/55773810/032d4b32-1555-46a5-8b2f-f9a6a8309d38">

1. Visit a page with two Next/Prev buttons [here](https://dev-portal-git-heat-bugfixhvd-next-prev-bttn-mobile-hashicorp.vercel.app/validated-designs/terraform-operating-guides-adoption/people-and-process)
2. The buttons' **width** should match this screenshot:
<img width="1131" alt="Screenshot 2024-01-29 at 10 43 23" src="https://github.com/hashicorp/dev-portal/assets/55773810/f1fb7c0f-5c68-473e-9eda-dd26c406dd72">
3. Change the page to mobile view. The buttons should match this screenshot:
<img width="411" alt="Screenshot 2024-01-29 at 10 58 29" src="https://github.com/hashicorp/dev-portal/assets/55773810/8a8fa4b2-378b-4a58-ae7f-cdd15a21337a">


## 💭 Anything else?

nay
