### PR TITLE
Disallow gptbot on HVD pages

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -15,6 +15,10 @@ module.exports = {
 			// sitemap generated from ./pages/server-sitemap.xml/index.tsx
 			`${siteUrl}/server-sitemap.xml`,
 		],
+		policies: [
+			{ userAgent: 'GPTBot', disallow: '/validated-designs' },
+			{ userAgent: '*', allow: '/' }, // default policy
+		],
 	},
 	/*
 	 * Exhaustive exclude list to remove duplicate sitemap paths.


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-disallow-gptbot-on-hvd-hashicorp.vercel.app/) 🔎
- [Asana task - Ensure that HVD content is not being ingested by Developer AI](https://app.asana.com/0/1204908934882872/1206365592254052/f) 🎟️

## 🗒️ What

We don't want HVD content to be crawled. Even though we have `noindex` on those pages [OpenAI is unclear if it even respects `noindex`](https://community.openai.com/t/does-openai-honor-noindex-and-robots-txt-when-scraping-for-training-data-how-does-it-deal-with-scraped-personal-data/133803), and [instead recommends disallowing it through robots.txt policies](https://platform.openai.com/docs/gptbot).

## 🧪 Testing

- [ ] [Visit robots.txt](https://dev-portal-git-disallow-gptbot-on-hvd-hashicorp.vercel.app/robots.txt), and make sure this line exists:

> User-agent: GPTBot
> Disallow: /validated-designs

