### PR TITLE
Chore: Implement ts path alias

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,33 @@
  */
 
 import { Config } from '@jest/types'
+
 import makeConfig from '@hashicorp/platform-configs/jest/config.js'
+import { compilerOptions } from './tsconfig.json'
+
+const tsPathsToModuleNameMapper = (mapping, baseUrl) => {
+	const jestMap = {}
+	for (const fromPath of Object.keys(mapping)) {
+		// we assume only one path, which I feel like is 99% the correct assumption
+		const toPath = mapping[fromPath][0]
+
+		// '@scripts/*' -> '^@scripts/(.*)$'
+		const jestFromPath = `^${fromPath.replace('*', '(.*)$')}`
+
+		let jestToPath
+		if (toPath.includes('../')) {
+			// ['../src/*'] -> "<rootDir>/src/$1"
+			jestToPath = `<rootDir>/${toPath.replace('../', '').replace('*', '$1')}`
+		} else {
+			// ['./src/*'] -> "<rootDir>/${baseUrl}/src/$1"
+			jestToPath = `<rootDir>/${baseUrl}/${toPath.replace('*', '$1')}`
+		}
+
+		jestMap[jestFromPath] = jestToPath
+	}
+
+	return jestMap
+}
 
 /**
  * We use a dynamic jest config in order to be able to run both
@@ -69,6 +95,10 @@ const config: Config.InitialOptions = {
 	],
 	testEnvironment: 'jsdom',
 	...(isRunningInEsmMode && esmConfig),
+	moduleNameMapper: tsPathsToModuleNameMapper(
+		compilerOptions.paths,
+		compilerOptions.baseUrl
+	),
 }
 
 export default makeConfig({ nextDir: './', ...config })

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,19 +8,22 @@ import { Config } from '@jest/types'
 import makeConfig from '@hashicorp/platform-configs/jest/config.js'
 import { compilerOptions } from './tsconfig.json'
 
-const tsPathsToModuleNameMapper = (mapping, baseUrl) => {
+const tsPathsToModuleNameMapper = (
+	mapping: { [key: string]: string[] },
+	baseUrl
+) => {
 	const jestMap = {}
-	for (const fromPath of Object.keys(mapping)) {
+	for (const [fromPath, paths] of Object.entries(mapping)) {
 		// we assume only one path, which I feel like is 99% the correct assumption
 		if (mapping[fromPath].length > 1) {
 			throw new Error(
-				`\n\n⚠️  Current typescript to jest path aliasing is limited to one path per alias.  ⚠️\n\nOffending ts path aliases:\n- [${fromPath}]: [${mapping[
-					fromPath
-				].join(',')}]\n`
+				`\n\n⚠️  Current typescript to jest path aliasing is limited to one path per alias.  ⚠️\n\nOffending ts path aliases:\n- [${fromPath}]: [${paths.join(
+					','
+				)}]\n`
 			)
 		}
 
-		const toPath = mapping[fromPath][0]
+		const toPath = paths[0]
 
 		// '@scripts/*' -> '^@scripts/(.*)$'
 		const jestFromPath = `^${fromPath.replace('*', '(.*)$')}`

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,14 @@ const tsPathsToModuleNameMapper = (mapping, baseUrl) => {
 	const jestMap = {}
 	for (const fromPath of Object.keys(mapping)) {
 		// we assume only one path, which I feel like is 99% the correct assumption
+		if (mapping[fromPath].length > 1) {
+			throw new Error(
+				`\n\n⚠️  Current typescript to jest path aliasing is limited to one path per alias.  ⚠️\n\nOffending ts path aliases:\n- [${fromPath}]: [${mapping[
+					fromPath
+				].join(',')}]\n`
+			)
+		}
+
 		const toPath = mapping[fromPath][0]
 
 		// '@scripts/*' -> '^@scripts/(.*)$'

--- a/scripts/docs-content-link-rewrites/helpers/fetch-nav-data-for-repo-and-base-path.ts
+++ b/scripts/docs-content-link-rewrites/helpers/fetch-nav-data-for-repo-and-base-path.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import fetchGithubFile from '../../../build-libs/fetch-github-file'
+import fetchGithubFile from '@build-libs/fetch-github-file'
 
 const fetchNavDataForBasePathAndRepo = async ({
 	filePath,

--- a/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
+++ b/src/__tests__/e2e/docs-content-link-rewrites.spec.ts
@@ -6,7 +6,7 @@
 import path from 'path'
 import { test, expect, Page, Locator } from '@playwright/test'
 import { SIDEBAR_NAV_ELEMENT_ID, MAIN_ELEMENT_ID } from 'constants/element-ids'
-import { ALL_PAGE_PATHS_OUTPUT_FILE_PATH } from '../../../scripts/docs-content-link-rewrites/constants'
+import { ALL_PAGE_PATHS_OUTPUT_FILE_PATH } from '@scripts/docs-content-link-rewrites/constants'
 
 const SIDEBAR_NAV_ANCHOR_SELECTOR = `${SIDEBAR_NAV_ELEMENT_ID} a`
 const CONTENT_AREA_ANCHOR_SELECTOR = `${MAIN_ELEMENT_ID} a`

--- a/src/__tests__/e2e/docs-landing-icon-card-links.spec.ts
+++ b/src/__tests__/e2e/docs-landing-icon-card-links.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { expect, test } from '@playwright/test'
-import waypointData from 'data/waypoint.json'
+import waypointData from '../../data/waypoint.json'
 
 // Run all the tests generated in this file in parallel
 test.describe.configure({ mode: 'parallel' })

--- a/src/__tests__/e2e/docs-landing-icon-card-links.spec.ts
+++ b/src/__tests__/e2e/docs-landing-icon-card-links.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { expect, test } from '@playwright/test'
-import waypointData from '../../data/waypoint.json'
+import waypointData from 'data/waypoint.json'
 
 // Run all the tests generated in this file in parallel
 test.describe.configure({ mode: 'parallel' })

--- a/src/__tests__/e2e/seo.spec.ts
+++ b/src/__tests__/e2e/seo.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { __config } from '../../../.test/app-config'
+import { __config } from '@test/app-config'
 
 test('should render the proper page title and description', async ({
 	page,

--- a/src/lib/remark-plugins/rewrite-static-hvd-assets/index.ts
+++ b/src/lib/remark-plugins/rewrite-static-hvd-assets/index.ts
@@ -7,7 +7,7 @@ import { Plugin } from 'unified'
 import { Image } from 'mdast'
 import { isAbsoluteUrl } from 'next/dist/shared/lib/utils'
 import { visit } from 'unist-util-visit'
-import { HVD_FINAL_IMAGE_ROOT_DIR } from '../../../../scripts/extract-hvd-content'
+import { HVD_FINAL_IMAGE_ROOT_DIR } from '@scripts/extract-hvd-content'
 
 function convertToHVDPathUrl(nodeUrl: string): string {
 	if (isAbsoluteUrl(nodeUrl)) {

--- a/src/views/tutorial-view/components/next-previous/index.tsx
+++ b/src/views/tutorial-view/components/next-previous/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import DirectionalLinkBox from '../../../../components/directional-link-box'
+import DirectionalLinkBox from '@components/directional-link-box'
 import s from './next-previous.module.css'
 
 export interface NextPreviousProps {

--- a/src/views/validated-designs/__tests__/server.ts
+++ b/src/views/validated-designs/__tests__/server.ts
@@ -2,7 +2,7 @@ import { getHvdCategoryGroupsPaths } from '../server'
 import { HvdCategoryGroup } from '../types'
 
 // mock the extract-hvd-content file because importing from it cause it's self-invoking function to perform a side effect
-jest.mock('../../../../scripts/extract-hvd-content', () => ({
+jest.mock('@scripts/extract-hvd-content', () => ({
 	__esModule: true, // this property makes it work
 	HVD_CONTENT_DIR: '',
 }))

--- a/src/views/validated-designs/server.ts
+++ b/src/views/validated-designs/server.ts
@@ -7,7 +7,7 @@ import fs from 'fs'
 import path from 'path'
 import yaml from 'js-yaml'
 import { isProductSlug } from 'lib/products'
-import { HVD_CONTENT_DIR } from '../../../scripts/extract-hvd-content'
+import { HVD_CONTENT_DIR } from '@scripts/extract-hvd-content'
 import { HvdCategoryGroup, HvdGuide, HvdPage } from './types'
 import { ValidatedDesignsGuideProps } from './guide'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
 		"noEmit": true,
 		"baseUrl": "src",
 		"paths": {
-			"@scripts/*": ["../scripts/*"]
+			"@scripts/*": ["../scripts/*"],
+			"@components/*": ["components/*"]
 		}
 	},
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
 		"baseUrl": "src",
 		"paths": {
 			"@scripts/*": ["../scripts/*"],
+			"@test/*": ["../.test/*"],
+			"@build-libs/*": ["../build-libs/*"],
 			"@components/*": ["components/*"]
 		}
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"baseUrl": "src",
 		"strict": false,
 		"target": "es5",
 		"incremental": true,
@@ -14,7 +13,11 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"noEmit": true
+		"noEmit": true,
+		"baseUrl": "src",
+		"paths": {
+			"@scripts/*": ["../scripts/*"]
+		}
 	},
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
 	"exclude": ["node_modules", "scripts/migrate-io/templates"]


### PR DESCRIPTION
## 🗒️ What

Implement TS path aliases, which cleans up a few verbose and difficult to understand paths. Mainly helps with importing from files outside of our base directory, `/src`. (`scripts`, `build-libs`, `.test`, etc.)

## 📸 Design Screenshots

Error message if multiple path aliasing are provided:
```
Error: Jest: Failed to parse the TypeScript config file /Users/ruben.nic/projects/dev-portal/jest.config.ts
  Error: 

⚠️  Current typescript to jest path aliasing is limited to one path per alias.  ⚠️

Offending ts path aliases:
- [@test/*]: [../.test/*,../.test2/*]
```

## 🧪 Testing

1. Should build without errors and Tests should pass