### PR TITLE
Update Dev AI sign-up banner expiry to March 1st 2024

### DIFF
--- a/src/data/alert-banner.json
+++ b/src/data/alert-banner.json
@@ -6,6 +6,6 @@
 		"url": "https://hashi.co/dev-ai-signup",
 		"text": "Private beta now available",
 		"linkText": "Sign up today",
-		"expirationDate": "2024-03-02T00:00:00-08:00"
+		"expirationDate": "2024-03-01T00:00:00-08:00"
 	}
 }

--- a/src/data/alert-banner.json
+++ b/src/data/alert-banner.json
@@ -6,6 +6,6 @@
 		"url": "https://hashi.co/dev-ai-signup",
 		"text": "Private beta now available",
 		"linkText": "Sign up today",
-		"expirationDate": "2024-02-01T00:00:00-08:00"
+		"expirationDate": "2024-03-02T00:00:00-08:00"
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links
- [Preview link](https://dev-portal-git-heat-choreupdate-dev-ai-banner-expiry-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1206176289707208/1206498827864755/f) 🎟️

## 🗒️ What

- Changed expiry date to March 1st, 2024

## 🤷 Why

- It expired on Feb 1st 2024

## 🧪 Testing

- Visit Dev Portal [homepage](https://dev-portal-git-heat-choreupdate-dev-ai-banner-expiry-hashicorp.vercel.app/). The sign-up banner should be visible as in the screenshot below
<img width="1285" alt="Screenshot 2024-02-01 at 15 07 22" src="https://github.com/hashicorp/dev-portal/assets/55773810/c7898725-422c-4811-8729-7f7412e74b9a">
