### PR TITLE
chore: Fixed mobile menu overlap with site alertbanner

### DIFF
--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -20,7 +20,6 @@
 	left: -150vw;
 	overflow-y: auto;
 	position: fixed;
-	top: var(--sticky-bars-height);
 	width: 100%;
 	z-index: 2;
 }

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -56,10 +56,7 @@ const BaseLayout = ({
 	return (
 		<CommandBarProvider>
 			{alertBannerData.enabled && (
-				<AlertBanner
-					{...(alertBannerData.data as AlertBannerProps)}
-					hideOnMobile
-				/>
+				<AlertBanner {...(alertBannerData.data as AlertBannerProps)} />
 			)}
 			<CoreDevDotLayoutWithTheme>
 				<div className={classNames(s.root, className)} data-layout="base-new">


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-heat-chorefix-mobile-banner-overlap-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1202097197789424/1203548570679724/f) 🎟️

## 🗒️ What

- Removed `top` css property from mobile menu to allow the default of `top: auto` to be applied

## 🤷 Why

- Fix UI bug where alert banner causes the header to overlap with the mobile menu, block sign in and sign up buttons

## 🛠️ How

- Tried `position: relative` as suggested in the Asana task screenshot comment. This didn't work because it messed up the opening/closing animation

## 📸 Screenshots

### Before
<img width="361" alt="Screenshot 2024-02-02 at 13 19 20" src="https://github.com/hashicorp/dev-portal/assets/55773810/aa58305e-4ebb-4641-9936-22f1fdf11505">

### After
<img width="362" alt="Screenshot 2024-02-02 at 13 19 36" src="https://github.com/hashicorp/dev-portal/assets/55773810/95422eca-ceeb-4649-811d-d9e8db583498">

## 🧪 Testing
1. Visit preview link [here](https://dev-portal-git-heat-chorefix-mobile-banner-overlap-hashicorp.vercel.app/) (alert banner should be visible)
1. Shrink viewport to mobile
1. Open mobile menu
1. It should match this screenshot:
<img width="361" alt="Screenshot 2024-02-02 at 13 19 20" src="https://github.com/hashicorp/dev-portal/assets/55773810/aa58305e-4ebb-4641-9936-22f1fdf11505">

1. Visit [production](https://developer.hashicorp.com/)
1. Shrink viewport to mobile (if on desktop)
1. Open/close mobile menu
1. Open another tab to visit the preview link [here](https://dev-portal-git-heat-chorefix-mobile-banner-overlap-hashicorp.vercel.app/)
1. Shrink viewport to mobile (if on desktop)
1. Open/close mobile menu
1. Animation to close/open mobile menu should match production

1. Visit [production](https://developer.hashicorp.com/)
1. Close alert banner, if visible
1. Shrink viewport to mobile (if on desktop)
1. Open mobile menu
1. Open another tab to visit the preview link [here](https://dev-portal-git-heat-chorefix-mobile-banner-overlap-hashicorp.vercel.app/)
1. Close alert banner
1. Shrink viewport to mobile (if on desktop)
1. Open/close mobile menu
1. Mobile menu should match production

