### PR TITLE
[TF VPAT A11Y] - /terraform/cli Inconsistent identification

### DIFF
--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -198,7 +198,7 @@ describe('setProjectForAriaLabel', () => {
 		expect(result).toBe(`Terraform Enterprise`)
 	})
 
-	it('Terraform - Docs', () => {
+	it('Terraform - Intro', () => {
 		const result = setProjectForAriaLabel(
 			cases[3].projectName,
 			cases[3].currentRootDocsPath,

--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -8,6 +8,7 @@ import { VersionSelectItem } from 'views/docs-view/loaders/remote-content'
 import { render } from '@testing-library/react'
 import { CurrentProductProvider } from 'contexts'
 import DocsVersionSwitcher from '.'
+import { setProjectForAriaLabel } from '.'
 
 const mockUserRouter = jest.fn()
 jest.mock('next/router', () => ({
@@ -113,5 +114,97 @@ describe('DocsVersionSwitcher', () => {
 
 		// link to an older version
 		expect(links[2]).toHaveAttribute('rel', 'nofollow')
+	})
+})
+
+const cases = [
+	{
+		projectName: null,
+		currentRootDocsPath: {
+			iconName: 'file-source',
+			name: 'Configuration Language',
+			path: 'language',
+		},
+		currentProduct: {
+			slug: 'terraform',
+			name: 'Terraform',
+		},
+	},
+	{
+		projectName: null,
+		currentRootDocsPath: {
+			iconName: 'terminal-screen',
+			name: 'Terraform CLI',
+			path: 'cli',
+		},
+		currentProduct: {
+			slug: 'terraform',
+			name: 'Terraform',
+		},
+	},
+	{
+		projectName: 'Terraform Enterprise',
+		currentRootDocsPath: {
+			iconName: 'org',
+			name: 'Terraform Enterprise',
+			path: 'enterprise',
+			productSlugForLoader: 'ptfe-releases',
+		},
+		currentProduct: {
+			slug: 'terraform',
+			name: 'Terraform',
+		},
+	},
+	{
+		projectName: null,
+		currentRootDocsPath: {
+			iconName: 'docs',
+			name: 'Intro',
+			path: 'intro',
+		},
+		currentProduct: {
+			slug: 'terraform',
+			name: 'Terraform',
+		},
+	},
+]
+
+describe('setProjectForAriaLabel', () => {
+	it('Terraform - Configuration Language', () => {
+		const result = setProjectForAriaLabel(
+			cases[0].projectName,
+			cases[0].currentRootDocsPath,
+			cases[0].currentProduct
+		)
+
+		expect(result).toBe(`Terraform Configuration Language`)
+	})
+	it('Terraform - Terraform CLI', () => {
+		const result = setProjectForAriaLabel(
+			cases[1].projectName,
+			cases[1].currentRootDocsPath,
+			cases[1].currentProduct
+		)
+
+		expect(result).toBe(`Terraform CLI`)
+	})
+	it('Terraform - Terraform Enterprise', () => {
+		const result = setProjectForAriaLabel(
+			cases[2].projectName,
+			cases[2].currentRootDocsPath,
+			cases[2].currentProduct
+		)
+
+		expect(result).toBe(`Terraform Enterprise`)
+	})
+
+	it('Terraform - Docs', () => {
+		const result = setProjectForAriaLabel(
+			cases[3].projectName,
+			cases[3].currentRootDocsPath,
+			cases[3].currentProduct
+		)
+
+		expect(result).toBe(`Terraform Intro`)
 	})
 })

--- a/src/components/docs-version-switcher/index.tsx
+++ b/src/components/docs-version-switcher/index.tsx
@@ -18,6 +18,25 @@ import { DocsVersionSwitcherOption, DocsVersionSwitcherProps } from './types'
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
 /**
+ * Construct a project name to be used in ariaLabels for each option.
+ */
+export function setProjectForAriaLabel(
+	projectName,
+	currentRootDocsPath,
+	currentProduct
+) {
+	let projectNameForLabel: string
+	if (projectName) {
+		projectNameForLabel = projectName
+	} else {
+		const docsName = currentRootDocsPath.shortName ?? currentRootDocsPath.name
+		projectNameForLabel = docsName.includes(currentProduct.name)
+			? docsName
+			: `${currentProduct.name} ${docsName}`
+	}
+	return projectNameForLabel
+}
+/**
  * Render a docs version switcher directly from loaded `VersionSelectItem`s,
  * wrapping a generic `VersionSwitcher` in docs-related logic.
  */
@@ -56,18 +75,11 @@ const DocsVersionSwitcher = ({
 		)
 	}
 
-	/**
-	 * Construct a project name to be used in ariaLabels for each option.
-	 */
-	let projectNameForLabel: string
-	if (projectName) {
-		projectNameForLabel = projectName
-	} else {
-		const docsName = currentRootDocsPath.shortName || currentRootDocsPath.name
-		projectNameForLabel = docsName.includes(currentProduct.name)
-			? docsName
-			: `${currentProduct.name} ${docsName}`
-	}
+	const projectNameForLabel = setProjectForAriaLabel(
+		projectName,
+		currentRootDocsPath,
+		currentProduct
+	)
 
 	/**
 	 * Encode docs concerns into the `options` to pass to `VersionSwitcher`.

--- a/src/components/docs-version-switcher/index.tsx
+++ b/src/components/docs-version-switcher/index.tsx
@@ -64,7 +64,9 @@ const DocsVersionSwitcher = ({
 		projectNameForLabel = projectName
 	} else {
 		const docsName = currentRootDocsPath.shortName || currentRootDocsPath.name
-		projectNameForLabel = `${currentProduct.name} ${docsName}`
+		projectNameForLabel = docsName.includes(currentProduct.name)
+			? docsName
+			: `${currentProduct.name} ${docsName}`
 	}
 
 	/**


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-a11yterraform-cli-hashicorp.vercel.app/terraform/cli) 🔎
- [Asana task](https://app.asana.com/0/1205890709355230/1205890709355297/f) 🎟️

## 🗒️ What

- Aria-label contains "Terraform" twice, which is an inconsistent experience for AT users.
  `Choose a Terraform Terraform CLI version. Currently viewing v1.7.x (latest).`
- Added tests to ensure this doesn't happen again
  

## 📸  Screenshots
### Before
<img width="1410" alt="Screenshot 2024-02-02 at 18 15 36" src="https://github.com/hashicorp/dev-portal/assets/55773810/eb1a1b77-82b6-45d3-bcf2-7f60083f7816">

## 🧪 Testing

1. Visit [preview link](https://dev-portal-git-heat-a11yterraform-cli-hashicorp.vercel.app/terraform/cli)
2. Inspect version dropdown
3. Aria-label should read `Choose a Terraform CLI version. Currently viewing v1.7.x (latest).`
<img width="1407" alt="Screenshot 2024-02-02 at 18 20 02" src="https://github.com/hashicorp/dev-portal/assets/55773810/aea62264-5830-4654-9934-563838f2451d">


## 💭 Anything else?

nay
