### PR TITLE
Revert "chore: Fixed mobile menu overlap with site alert banner (#2318)"

### DIFF
--- a/src/components/mobile-menu-container/mobile-menu-container.module.css
+++ b/src/components/mobile-menu-container/mobile-menu-container.module.css
@@ -20,6 +20,7 @@
 	left: -150vw;
 	overflow-y: auto;
 	position: fixed;
+	top: var(--sticky-bars-height);
 	width: 100%;
 	z-index: 2;
 }

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -56,7 +56,10 @@ const BaseLayout = ({
 	return (
 		<CommandBarProvider>
 			{alertBannerData.enabled && (
-				<AlertBanner {...(alertBannerData.data as AlertBannerProps)} />
+				<AlertBanner
+					{...(alertBannerData.data as AlertBannerProps)}
+					hideOnMobile
+				/>
 			)}
 			<CoreDevDotLayoutWithTheme>
 				<div className={classNames(s.root, className)} data-layout="base-new">


### PR DESCRIPTION
This reverts commit 7c35e7ae006123dde16f5ad5a95abb6c1d213539.

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

- navigation styling is broken, this PR reverts the commit that broke it while a better solution is figured out

## 📸 Screenshots

<img width="1120" alt="Screenshot 2024-02-06 at 15 39 15" src="https://github.com/hashicorp/dev-portal/assets/55773810/4a063400-29c9-4cc1-bea5-f9ff3f051385">

## 🧪 Testing
1. Visit [this preview link](https://dev-portal-git-heat-fixnav-hashicorp.vercel.app/nomad)
1. Scroll down the page
1. The sidebar navigation on the left-hand side should stay fixed 

## 💭 Anything else?

nay