### PR TITLE
Fix mdx /sentinel/install links

### DIFF
--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -213,6 +213,12 @@ function rewriteSentinelDocsUrls(
 	 * - Any other "/sentinel/:slug" URL is expected to be a "/docs" URL
 	 *   - We need to adjust these urls to be "/sentinel/docs/:slug"
 	 */
+
+	// Redirect /sentinel/downloads to /sentinel/install
+	if (inputUrl == '/sentinel/downloads' || inputUrl == '/sentinel/install') {
+		return '/sentinel/install'
+	}
+
 	const isBasePathExceptDocs = sentinelData.basePaths
 		.filter((p: string) => p !== 'docs')
 		.some(
@@ -220,11 +226,6 @@ function rewriteSentinelDocsUrls(
 				inputUrl == `/sentinel/${basePath}` ||
 				inputUrl.startsWith(`/sentinel/${basePath}/`)
 		)
-	// Redirect /sentinel/downloads to /sentinel/install
-	const isDownloadsUrl = inputUrl == '/sentinel/downloads'
-	if (isDownloadsUrl) {
-		return '/sentinel/install'
-	}
 	/**
 	 * We assume all other "/sentinel/*" URLs are intended to be docs routes,
 	 * which on the previous site were rendered to "/sentinel/:slug".


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-bugfix-sentinel-install-link-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1205890531436279/1206567499591204/f) 🎟️

## 🗒️ What

We had a special case of not rewriting /sentinel/docs/* links that were /sentinel/downloads links, and now we are extending that to /sentinel/install links as well.

## 🧪 Testing

- [ ] Visit [/sentinel/intro/getting-started/install](https://dev-portal-git-rn-bugfix-sentinel-install-link-hashicorp.vercel.app/sentinel/intro/getting-started/install) in preview
- [ ] Check that the mdx link `binary package` links to /sentinel/install


