### PR TITLE
hotfix: remove getProxiedProductSlug

### DIFF
--- a/src/pages/_error.jsx
+++ b/src/pages/_error.jsx
@@ -6,7 +6,6 @@
 import BaseLayout from 'layouts/base-layout'
 import MobileMenuLevelsGeneric from 'components/mobile-menu-levels-generic'
 import proxiedLayouts from 'layouts/_proxied-dot-io/dict'
-import { getProxiedProductSlug } from 'lib/env-checks'
 import ErrorViewSwitcher from 'views/error-view-switcher'
 // product data, needed to render top navigation
 import { productConfig } from 'lib/cms'
@@ -82,8 +81,7 @@ export async function getServerSideProps(ctx) {
 			? HOSTNAME_MAP[req.cookies['hc_dd_proxied_site']]
 			: null
 
-	const proxiedProductSlug =
-		ioPreviewProduct ?? getProxiedProductSlug(urlObj.hostname)
+	const proxiedProductSlug = ioPreviewProduct
 
 	// Determine which statusCode to show
 	const statusCode = res ? res.statusCode : err ? err.statusCode : 404


### PR DESCRIPTION
This is a quick fix to resolve the errors seen below:
![image](https://github.com/hashicorp/dev-portal/assets/20215887/bf525794-195a-4a64-a22c-f15f11163a97)

A following PR will remove the other proxy-related items such as `layouts/_proxied-dot-io`

### Verification
This [preview](https://dev-portal-4ukhhd7i5-hashicorp.vercel.app/waypoint/commands/v0.3.x/task-inspect?__vercel_draft=1) should not result in a 500 status compared to the [production](https://developer.hashicorp.com/waypoint/commands/v0.3.x/task-inspect) counterpart

