### PR TITLE
[chore] Add new Vault Radar icon to HCP docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@apidevtools/json-schema-ref-parser": "^9.0.9",
 				"@happykit/flags": "^3.1.1",
 				"@hashicorp/design-system-tokens": "^1.9.0",
-				"@hashicorp/flight-icons": "^2.22.0",
+				"@hashicorp/flight-icons": "^3.0.0",
 				"@hashicorp/localstorage-polyfill": "^1.0.14",
 				"@hashicorp/mktg-global-styles": "^4.5.0",
 				"@hashicorp/mktg-logos": "^1.3.5",
@@ -166,7 +166,7 @@
 			},
 			"engines": {
 				"node": ">=18.17.0",
-				"npm": ">=v9.6.7"
+				"npm": ">=8.0.0"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -1460,9 +1460,9 @@
 			"integrity": "sha512-zmMpnKv4vulhVFVCpqf3oAAR5fQeDDnMxbeJIZllLFCgF2JFoL6C/Irghx4WnBAG8GkLs8CbxjPVtFjSYq+V8w=="
 		},
 		"node_modules/@hashicorp/flight-icons": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.22.0.tgz",
-			"integrity": "sha512-WEfF8rsubp+I3+sSwxvyzpySZL+Wt65UCuHJ+q+PBhd+pvUtMiWepGbiJ6Gs1R+fuRiFyQOga53uFBuarzKaIA=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-3.0.0.tgz",
+			"integrity": "sha512-gjI24oDuJQ3w1Obn6oghcopv7xsX/YcjjYaffhsN2BAYEQ83ywT1IiyN13RKdFG8Ufa+9h+o6Yi2e+jBVNNU/w=="
 		},
 		"node_modules/@hashicorp/localstorage-polyfill": {
 			"version": "1.0.14",
@@ -4380,6 +4380,11 @@
 				"react": ">=16.x"
 			}
 		},
+		"node_modules/@hashicorp/react-consent-manager/node_modules/@hashicorp/flight-icons": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.25.0.tgz",
+			"integrity": "sha512-BFR+xnC7hHgo9QahwFKXUCao4MJLYAnYBb9i924Wz6WAkyNey880nyULedh6J3z/lGx+7VVa7H/xnv4WSFyZyA=="
+		},
 		"node_modules/@hashicorp/react-content": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.3.0.tgz",
@@ -4438,6 +4443,11 @@
 				"@hashicorp/flight-icons": "^2.5.0",
 				"clsx": "^1.2.1"
 			}
+		},
+		"node_modules/@hashicorp/react-form-fields/node_modules/@hashicorp/flight-icons": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/flight-icons/-/flight-icons-2.25.0.tgz",
+			"integrity": "sha512-BFR+xnC7hHgo9QahwFKXUCao4MJLYAnYBb9i924Wz6WAkyNey880nyULedh6J3z/lGx+7VVa7H/xnv4WSFyZyA=="
 		},
 		"node_modules/@hashicorp/react-hashi-stack-menu": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"@apidevtools/json-schema-ref-parser": "^9.0.9",
 		"@happykit/flags": "^3.1.1",
 		"@hashicorp/design-system-tokens": "^1.9.0",
-		"@hashicorp/flight-icons": "^2.22.0",
+		"@hashicorp/flight-icons": "^3.0.0",
 		"@hashicorp/localstorage-polyfill": "^1.0.14",
 		"@hashicorp/mktg-global-styles": "^4.5.0",
 		"@hashicorp/mktg-logos": "^1.3.5",

--- a/src/content/hcp/docs-landing.json
+++ b/src/content/hcp/docs-landing.json
@@ -22,7 +22,7 @@
 			"path": "docs/vault-secrets"
 		},
 		{
-			"iconName": "vault-color",
+			"iconName": "vault-radar-color",
 			"name": "HCP Vault Radar",
 			"path": "docs/vault-radar"
 		},

--- a/src/content/supported-icons.tsx
+++ b/src/content/supported-icons.tsx
@@ -38,7 +38,7 @@ import { IconVault16 } from '@hashicorp/flight-icons/svg-react/vault-16'
 import { IconVmware16 } from '@hashicorp/flight-icons/svg-react/vmware-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
-import { IconVaultSecrets24 } from '@hashicorp/flight-icons/svg-react/vault-secrets-24'
+import { IconVaultSecrets16 } from '@hashicorp/flight-icons/svg-react/vault-secrets-16'
 import { IconVaultRadarColor16 } from '@hashicorp/flight-icons/svg-react/vault-radar-color-16'
 import ThemedAwsIcon from './themed-icons/aws-color'
 
@@ -86,7 +86,7 @@ export const SUPPORTED_ICONS = {
 	// vault's brand color changes between light and dark mode
 	'vault-color': <IconVault16 color={`var(--token-color-vault-brand)`} />,
 	'vault-secrets-color': (
-		<IconVaultSecrets24 color={`var(--token-color-vault-brand)`} />
+		<IconVaultSecrets16 color={`var(--token-color-vault-brand)`} />
 	),
 	'vault-radar-color': <IconVaultRadarColor16 />,
 	vmware: <IconVmware16 />,

--- a/src/content/supported-icons.tsx
+++ b/src/content/supported-icons.tsx
@@ -39,6 +39,7 @@ import { IconVmware16 } from '@hashicorp/flight-icons/svg-react/vmware-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
 import { IconVaultSecrets24 } from '@hashicorp/flight-icons/svg-react/vault-secrets-24'
+import { IconVaultRadar16 } from '@hashicorp/flight-icons/svg-react/vault-radar-16'
 import ThemedAwsIcon from './themed-icons/aws-color'
 
 /**
@@ -86,6 +87,9 @@ export const SUPPORTED_ICONS = {
 	'vault-color': <IconVault16 color={`var(--token-color-vault-brand)`} />,
 	'vault-secrets-color': (
 		<IconVaultSecrets24 color={`var(--token-color-vault-brand)`} />
+	),
+	'vault-radar-color': (
+		<IconVaultRadar16 color={`var(--token-color-vault-brand)`} />
 	),
 	vmware: <IconVmware16 />,
 	'waypoint-color': <IconWaypointColor16 />,

--- a/src/content/supported-icons.tsx
+++ b/src/content/supported-icons.tsx
@@ -39,7 +39,7 @@ import { IconVmware16 } from '@hashicorp/flight-icons/svg-react/vmware-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
 import { IconVaultSecrets16 } from '@hashicorp/flight-icons/svg-react/vault-secrets-16'
-import { IconVaultRadarColor16 } from '@hashicorp/flight-icons/svg-react/vault-radar-color-16'
+import { IconVaultRadarSquareColor16 } from '@hashicorp/flight-icons/svg-react/vault-radar-square-color-16'
 import ThemedAwsIcon from './themed-icons/aws-color'
 
 /**
@@ -88,7 +88,7 @@ export const SUPPORTED_ICONS = {
 	'vault-secrets-color': (
 		<IconVaultSecrets16 color={`var(--token-color-vault-brand)`} />
 	),
-	'vault-radar-color': <IconVaultRadarColor16 />,
+	'vault-radar-color': <IconVaultRadarSquareColor16 />,
 	vmware: <IconVmware16 />,
 	'waypoint-color': <IconWaypointColor16 />,
 	wrench: <IconWrench16 />,

--- a/src/content/supported-icons.tsx
+++ b/src/content/supported-icons.tsx
@@ -39,7 +39,7 @@ import { IconVmware16 } from '@hashicorp/flight-icons/svg-react/vmware-16'
 import { IconWaypointColor16 } from '@hashicorp/flight-icons/svg-react/waypoint-color-16'
 import { IconWrench16 } from '@hashicorp/flight-icons/svg-react/wrench-16'
 import { IconVaultSecrets24 } from '@hashicorp/flight-icons/svg-react/vault-secrets-24'
-import { IconVaultRadar16 } from '@hashicorp/flight-icons/svg-react/vault-radar-16'
+import { IconVaultRadarColor16 } from '@hashicorp/flight-icons/svg-react/vault-radar-color-16'
 import ThemedAwsIcon from './themed-icons/aws-color'
 
 /**
@@ -88,9 +88,7 @@ export const SUPPORTED_ICONS = {
 	'vault-secrets-color': (
 		<IconVaultSecrets24 color={`var(--token-color-vault-brand)`} />
 	),
-	'vault-radar-color': (
-		<IconVaultRadar16 color={`var(--token-color-vault-brand)`} />
-	),
+	'vault-radar-color': <IconVaultRadarColor16 />,
 	vmware: <IconVmware16 />,
 	'waypoint-color': <IconWaypointColor16 />,
 	wrench: <IconWrench16 />,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->
- [Figma](https://www.figma.com/file/wK7R3TaPjnjQPkunh31GMn/Brand-identity-updates?type=design&node-id=1-503&mode=design&t=LRBtvjqPFn5MSoFq-0)
- [Preview link](https://dev-portal-git-heat-choreupdate-vault-radar-card-hashicorp.vercel.app/hcp/docs) 🔎
- [Asana task](https://app.asana.com/0/1205855506449349/1206365912448323/f) 🎟️

## 🗒️ What

- Add the new Vault Radar logo

## 🤷 Why

- Need to change the logo on the Vault Radar card on the HCP docs landing page from the Vault logo to the Vault Radar logo

## 🛠️ How

- Updated `@hashicorp/flight-icons` packages to access the new Vault Radar logo
- Added Vault Radar icon to supported icons

## 🧪 Testing

- Visit the HCP docs [preview page](https://dev-portal-git-heat-choreupdate-vault-radar-card-hashicorp.vercel.app/hcp/docs)
- The logo for HCP Vault Radar should match the screenshot below:
<img width="575" alt="Screenshot 2024-02-15 at 16 49 31" src="https://github.com/hashicorp/dev-portal/assets/55773810/6f8df24d-ecb3-491d-ab97-c35a38293bd5">

## 💭 Anything else?
The fill color in light mode _intentionally_ does **not** match the mocks as they use a new Vault brand colour (`#FFCF25`)
