### PR TITLE
check sentinel docs downloads redirect

### DIFF
--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -76,7 +76,7 @@ function getDocsDotHashiCorpRedirects() {
 		 * and with the `downloads` page above, we use a negative look-ahead.
 		 */
 		{
-			source: '/sentinel/:path((?!intro|downloads$).*)',
+			source: '/sentinel/:path((?!intro|downloads|install).*)',
 			destination: 'https://developer.hashicorp.com/sentinel/docs/:path*',
 			permanent: true,
 		},
@@ -91,6 +91,7 @@ function getDocsDotHashiCorpRedirects() {
 	const targetHosts = [
 		'docs.hashicorp.com',
 		'sentinel-launch-redirects-test.hashicorp.vercel.app',
+		'dev-portal-git-check-sentinel-docs-downloads-redirect-hashicorp.vercel.app',
 	]
 	/**
 	 * Build a regex-like string that matches any of the target hosts.

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -76,7 +76,7 @@ function getDocsDotHashiCorpRedirects() {
 		 * and with the `downloads` page above, we use a negative look-ahead.
 		 */
 		{
-			source: '/sentinel/:path((?!intro|downloads).*)',
+			source: '/sentinel/:path((?!intro|downloads$).*)',
 			destination: 'https://developer.hashicorp.com/sentinel/docs/:path*',
 			permanent: true,
 		},

--- a/build-libs/docs-dot-hashicorp-redirects.js
+++ b/build-libs/docs-dot-hashicorp-redirects.js
@@ -91,7 +91,6 @@ function getDocsDotHashiCorpRedirects() {
 	const targetHosts = [
 		'docs.hashicorp.com',
 		'sentinel-launch-redirects-test.hashicorp.vercel.app',
-		'dev-portal-git-check-sentinel-docs-downloads-redirect-hashicorp.vercel.app',
 	]
 	/**
 	 * Build a regex-like string that matches any of the target hosts.


### PR DESCRIPTION
- [Asana task](https://app.asana.com/0/1204759533834554/1206602376424254/f) 🎟️

According to the network request log the stages of redirecting were:
1. `docs.hashicorp.com/sentinel/downloads`
2. `docs.hashicorp.com/sentinel/install`
3. `developer.hashicorp.com/sentinel/docs/install`

Since the source of the redirect was technically `sentinel/install`, it did not meet the negative lookahead condition we had set. This PR updates the redirect so that `sentinel/install` is not included when redirecting a path to `sentinel/docs/:path`. We are not sure why docs.hashicorp.com is not redirecting to developer.hashicorp.com immediately but this PR targets the process as it behaves today.
