### PR TITLE
Remove docs versions switcher from Waypoint

### DIFF
--- a/src/pages/waypoint/docs/[...page].tsx
+++ b/src/pages/waypoint/docs/[...page].tsx
@@ -8,7 +8,8 @@ import { getRootDocsPathGenerationFunctions } from 'views/docs-view/utils/get-ro
 
 const { getStaticPaths, getStaticProps } = getRootDocsPathGenerationFunctions(
 	'waypoint',
-	'docs'
+	'docs',
+	{ hideVersionSelector: true }
 )
 
 export { getStaticProps, getStaticPaths }

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -437,7 +437,6 @@ export function getStaticGenerationFunctions<
 				versions:
 					!hideVersionSelector &&
 					!isReleaseNotesPage(currentPathUnderProduct) && // toggle version dropdown
-					product.slug !== 'waypoint' && // remove version dropdown for Waypoint
 					hasMeaningfulVersions
 						? versions
 						: null,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -437,6 +437,7 @@ export function getStaticGenerationFunctions<
 				versions:
 					!hideVersionSelector &&
 					!isReleaseNotesPage(currentPathUnderProduct) && // toggle version dropdown
+					product.slug !== 'waypoint' && // remove version dropdown for Waypoint
 					hasMeaningfulVersions
 						? versions
 						: null,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-choreremove-version-dropdown-hashicorp.vercel.app/waypoint/docs) 🔎
- [Asana task](https://app.asana.com/0/1206225787851796/1206697393359305/f) 🎟️

## 🗒️ What

- Remove docs version switcher from Waypoint

## 🤷 Why

- Part of Waypoint IA restructuring

## 🧪 Testing

1. Visit Waypoint docs landing [page](https://dev-portal-git-heat-choreremove-version-dropdown-hashicorp.vercel.app/waypoint/docs).
2. There should be no version switcher in heading like in [prod](https://developer.hashicorp.com/waypoint/docs)
##

1. Visit a specific docs [page](https://dev-portal-git-heat-choreremove-version-dropdown-hashicorp.vercel.app/waypoint/docs/upgrading/compatibility)
2. There should be no version switcher like there is in [prod](https://developer.hashicorp.com/waypoint/docs/upgrading/compatibility)

##
1. Visit the Nomad docs [page](https://dev-portal-git-heat-choreremove-version-dropdown-hashicorp.vercel.app/nomad/docs)
2. The version switcher should be visible

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
