### PR TITLE
Remove GH link from resources nav section for Waypoint

### DIFF
--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -42,7 +42,9 @@ const COMMUNITY_LINKS_BY_PRODUCT: { [key in ProductSlug]: string } = {
 	waypoint: 'https://discuss.hashicorp.com/c/waypoint/51',
 }
 
-const GITHUB_LINKS_BY_PRODUCT_SLUG: { [key in ProductSlug]: string } = {
+const GITHUB_LINKS_BY_PRODUCT_SLUG: {
+	[key in Exclude<ProductSlug, 'waypoint'>]: string
+} = {
 	boundary: 'https://github.com/hashicorp/boundary',
 	consul: 'https://github.com/hashicorp/consul',
 	hcp: DEFAULT_GITHUB_LINK,
@@ -52,7 +54,6 @@ const GITHUB_LINKS_BY_PRODUCT_SLUG: { [key in ProductSlug]: string } = {
 	terraform: 'https://github.com/hashicorp/terraform',
 	vagrant: 'https://github.com/hashicorp/vagrant',
 	vault: 'https://github.com/hashicorp/vault',
-	waypoint: 'https://github.com/hashicorp/waypoint',
 }
 
 /**
@@ -150,12 +151,16 @@ function generateResourcesNavItems(
 			title: 'Support',
 			href: DEFAULT_SUPPORT_LINK,
 		},
-		{
-			title: 'GitHub',
-			href: productSlug
-				? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
-				: DEFAULT_GITHUB_LINK,
-		},
+		...(productSlug !== 'waypoint'
+			? [
+					{
+						title: 'GitHub',
+						href: productSlug
+							? GITHUB_LINKS_BY_PRODUCT_SLUG[productSlug]
+							: DEFAULT_GITHUB_LINK,
+					},
+			  ]
+			: []),
 		...additionalResources,
 	]
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-choreremove-github-link-wa-76488f-hashicorp.vercel.app/waypoint) 🔎
- [Asana task](https://app.asana.com/0/0/1206697393359304/f) 🎟️

## 🗒️ What

- Remove GitHub link from resources section of sidebar nav

## 🤷 Why

Part of Waypoint IA restructuring

## 🧪 Testing
1. Visit Waypoint landing [page](https://dev-portal-git-heat-choreremove-github-link-wa-76488f-hashicorp.vercel.app/waypoint). The GitHub link should not be in the "resources" section of the sidebar nav.
2. Visit Waypoint docs [page](https://dev-portal-git-heat-choreremove-github-link-wa-76488f-hashicorp.vercel.app/waypoint/docs). The GitHub link should not be in the "resources" section of the sidebar nav.
3. Visit specific docs [page](https://dev-portal-git-heat-choreremove-github-link-wa-76488f-hashicorp.vercel.app/waypoint/docs/runner/config). The GitHub link should not be in the "resources" section of the sidebar nav.

<img width="1175" alt="Screenshot 2024-02-29 at 17 55 03" src="https://github.com/hashicorp/dev-portal/assets/55773810/af7fccbd-a9bf-44d1-8f14-65384fa25514">

