### PR TITLE
Add integrationsConfig back in to Waypoint data to fix build error

### DIFF
--- a/src/data/waypoint.json
+++ b/src/data/waypoint.json
@@ -57,5 +57,8 @@
 			"path": "docs",
 			"includeMDXSource": true
 		}
-	]
+	],
+	"integrationsConfig": {
+		"description": "A curated collection of official, partner, and community Waypoint Integrations."
+	}
 }


### PR DESCRIPTION
Add integrations config back in to fix build error

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-heat-chorefix-integration-confi-582ef6-hashicorp.vercel.app/waypoint)
- [Failed deployment](https://vercel.com/hashicorp/dev-portal/CdyFUDfo23AC9Ud9pHhJZQCufuDh)

## 🗒️ What

- Just add it back in because I don't want to add logic that may cause a regression for a valid integration page
```
TypeError: Cannot read properties of undefined (reading 'description')
    at p (/vercel/path0/.next/server/pages/[productSlug]/integrations.js:1:36313)
```
## 🤷 Why

To fix the build error that won't quit


