### PR TITLE
chore: remove bugsnag keys

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -72,8 +72,6 @@ module.exports = withHashicorp({
 	env: {
 		ASSET_API_ENDPOINT: process.env.ASSET_API_ENDPOINT,
 		AXE_ENABLED: process.env.AXE_ENABLED || false,
-		BUGSNAG_CLIENT_KEY: '06718db5e1d75829801baa0b4ca2fb7b',
-		BUGSNAG_SERVER_KEY: 'b32b4487b5dc72b32f51c8fe33641a43',
 		DEV_IO: process.env.DEV_IO,
 		PREVIEW_FROM_REPO: process.env.PREVIEW_FROM_REPO,
 		ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS || false,


### PR DESCRIPTION
Bugsnag isn't used, so this PR removes the keys. The env vars aren't referenced in code anywhere else, so this should be all that is needed. 