### PR TITLE
Remove Waypoint from integrations list in production.json

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,6 @@
 		"auth": {
 			"idp_url": "https://auth.idp.hashicorp.com"
 		},
-		"product_slugs_with_integrations": ["vault", "waypoint", "nomad", "packer"]
+		"product_slugs_with_integrations": ["vault", "nomad", "packer"]
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-bug-fixwaypoint-integrations-hashicorp.vercel.app/waypoint) 🔎
- [Asana task](https://app.asana.com/0/1206225787851796/1206707955223703/f) 🎟️

## 🗒️ What

- Remove `waypoint` from `product_slugs_with_integrations` in production.json

## 🤷 Why

- This was causing integrations to still show in nav, sidebar and landing page

## 🧪 Testing

- Visit [Waypoint landing page](https://dev-portal-git-heat-bug-fixwaypoint-integrations-hashicorp.vercel.app/waypoint). See that integrations is gone

## 💭 Anything else?

nay
