### PR TITLE
build-libs: add redirect for ipsw packer plugin

### DIFF
--- a/build-libs/integration-packer-redirects.js
+++ b/build-libs/integration-packer-redirects.js
@@ -369,6 +369,17 @@ const packerPluginIntegrations = [
 		],
 	},
 	{
+		enabled: true,
+		org: 'torarnv',
+		slug: 'ipsw',
+		components: [
+			{
+				type: TYPE_DATA_SOURCE,
+				newSlug: 'ipsw',
+			},
+		],
+	},
+	{
 		enabled: false,
 		org: 'kamatera',
 		slug: 'kamatera',


### PR DESCRIPTION
## 🔗 Relevant links

Related issue: https://github.com/hashicorp/packer/issues/12873

## 🗒️ What

The IPSW plugin was recently moved to integrations, and since we removed the old plugin system in Packer their docs were inaccessible.

This redirect should enable old-style plugin documentation links, and redirect them to the newly annointed documentation for IPSW.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
