### PR TITLE
enable hvd-docs hvd-preview branch on .services

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -36,6 +36,6 @@
 	"flags": {
 		"enable_datadog": true,
 		"enable_io_beta_cta": true,
-		"enable_hvd_on_hvd_preview_branch": false
+		"enable_hvd_on_preview_branch": false
 	}
 }

--- a/config/base.json
+++ b/config/base.json
@@ -35,6 +35,7 @@
 	},
 	"flags": {
 		"enable_datadog": true,
-		"enable_io_beta_cta": true
+		"enable_io_beta_cta": true,
+		"enable_hvd_on_hvd_preview_branch": false
 	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -8,5 +8,7 @@
 			"unifiedIndexName": "staging_DEVDOT_omni"
 		}
 	},
-	"flags": {}
+	"flags": {
+		"enable_hvd_on_hvd_preview_branch": true
+	}
 }

--- a/config/preview.json
+++ b/config/preview.json
@@ -9,6 +9,6 @@
 		}
 	},
 	"flags": {
-		"enable_hvd_on_hvd_preview_branch": true
+		"enable_hvd_on_preview_branch": true
 	}
 }

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -19,7 +19,7 @@ const __config = unflatten(getHashiConfig(envConfigPath))
 export const BASE_REPO_CONFIG = {
 	owner: 'hashicorp',
 	ref:
-		__config.flags.enable_hvd_on_hvd_preview_branch === true
+		__config.flags.enable_hvd_on_preview_branch === true
 			? 'hvd-preview'
 			: process.env.CURRENT_GIT_BRANCH || 'main',
 	repo: 'hvd-docs',

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -8,9 +8,20 @@ import path from 'path'
 import { fetchGithubArchiveZip } from 'lib/fetch-github-archive-zip'
 import { isDeployPreview } from 'lib/env-checks'
 
+import { unflatten } from 'flat'
+import { getHashiConfig } from '../config'
+
+const env = process.env.HASHI_ENV || 'development'
+const envConfigPath = path.join(process.cwd(), 'config', `${env}.json`)
+
+const __config = unflatten(getHashiConfig(envConfigPath))
+
 export const BASE_REPO_CONFIG = {
 	owner: 'hashicorp',
-	ref: process.env.CURRENT_GIT_BRANCH || 'main',
+	ref:
+		__config.flags.enable_hvd_on_hvd_preview_branch === true
+			? 'hvd-preview'
+			: process.env.CURRENT_GIT_BRANCH || 'main',
 	repo: 'hvd-docs',
 	contentPath: '/content',
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-featnew-hvd-preview-on-services-hashicorp.vercel.app) 🔎
- [Asana task]() 🎟️ - None this is a fast PR/Change

## 🗒️ What & 🛠️ How

We are adding a new config `enable_hvd_on_hvd_preview_branch` which downloads HVD content from the hvd repo `hvd-preview` branch and deploys it to `local preview` and `.staging`.

## 🤷 Why

The HVD team wants a non-local website that they can use to test and share out internally upcoming versions of HVD content.

## 🧪 Testing

- [ ] [Visit HVD Guide Vault: Operating Guide for Adoption on preview and it should start with the line "test of new deploy preview"](https://dev-portal-git-rn-featnew-hvd-preview-on-services-hashicorp.vercel.app/validated-designs/vault-operating-guides-adoption)
- [ ] Double check that the base config has the variable `enable_hvd_on_hvd_preview_branch` set to false
