### PR TITLE
Remove Waypoint docs side nav

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -203,12 +203,6 @@ async function buildDevPortalRedirects() {
 			destination: '/waypoint',
 			permanent: true,
 		},
-		{
-			source: '/waypoint/docs/:slug',
-			destination:
-				'https://github.com/hashicorp/waypoint/tree/main/website/content/docs',
-			permanent: true,
-		},
 		/**
 		/**
 		 * Redirect for Integration Component rework.

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -203,6 +203,12 @@ async function buildDevPortalRedirects() {
 			destination: '/waypoint',
 			permanent: true,
 		},
+		{
+			source: '/waypoint/docs/:slug',
+			destination:
+				'https://github.com/hashicorp/waypoint/tree/main/website/content/docs',
+			permanent: true,
+		},
 		/**
 		/**
 		 * Redirect for Integration Component rework.

--- a/src/views/product-root-docs-path-landing/server.ts
+++ b/src/views/product-root-docs-path-landing/server.ts
@@ -146,6 +146,22 @@ const getStaticProps = async (context: GetStaticPropsContext) => {
 	}
 
 	/**
+	 * TODO: Remove this when (HCP) Waypoint IA is updated
+	 */
+	if (product.slug === 'waypoint') {
+		getStaticPropsResult.props.layoutProps['sidebarNavDataLevels'] =
+			getStaticPropsResult.props.layoutProps.sidebarNavDataLevels.map(
+				(navLevel) => {
+					delete navLevel.menuItems
+					return {
+						...navLevel,
+						showFilterInput: false,
+					}
+				}
+			)
+	}
+
+	/**
 	 * Grab the outline from the MDX content, if applicable.
 	 *
 	 * Note we slice off the first outline item, we expect it to be an <h1 />,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-heat-choreremove-waypoint-docs-sidebar-hashicorp.vercel.app/waypoint/docs) 
- [Asana task](https://app.asana.com/0/0/1206697393359303/f)

## 🗒️ What

- Added a little bit of custom logic to remove `menuItems` from docs sidebar. The docs sidebar nav comes from the product repo; however, Waypoint has been archived so [this file](https://github.com/hashicorp/waypoint/blob/main/website/data/docs-nav-data.json) cannot be edited 

I also considered adding a request to check if the repo was archived or not, but decided against it as it would another request for a temporary change. The final decision for how to structure Waypoint & HCP Waypoint docs is TBD, and until it is, this is a intermediary change.

## 🤷 Why

Part of the Waypoint restructuring IA

## 🧪 Testing

- Visit the [Waypoint docs landing page](https://dev-portal-git-heat-choreremove-waypoint-docs-sidebar-hashicorp.vercel.app/waypoint/docs). It should match the screenshot below:
<img width="1266" alt="Screenshot 2024-03-11 at 20 20 59" src="https://github.com/hashicorp/dev-portal/assets/55773810/924fa4d5-a7a4-4b57-9de3-4d1f22891ab8">

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
