### PR TITLE
feat: replace next/router with next/navigation in Docs View

### DIFF
--- a/src/views/docs-view/index.tsx
+++ b/src/views/docs-view/index.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-import { useRouter } from 'next/router'
+import { usePathname } from 'next/navigation'
 import { useCurrentProduct } from 'contexts'
 import classNames from 'classnames'
 import { getVersionFromPath } from 'lib/get-version-from-path'
@@ -46,7 +46,7 @@ const DocsView = ({
 	outlineItems,
 	pageHeading,
 }: DocsViewProps) => {
-	const { asPath } = useRouter()
+	const pathname = usePathname()
 	const currentProduct = useCurrentProduct()
 	const { compiledSource, scope } = mdxSource
 	const docsMdxComponents = getDocsMdxComponents(currentProduct.slug)
@@ -107,7 +107,7 @@ const DocsView = ({
 					headingSlot={headingSlot}
 				/>
 			) : null}
-			<NoIndexTagIfVersioned isVersioned={!!getVersionFromPath(asPath)} />
+			<NoIndexTagIfVersioned isVersioned={!!getVersionFromPath(pathname)} />
 			<DevDotContent
 				mdxRemoteProps={{
 					compiledSource,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR replaces an instance of `next/router` with the equivalent version of `next/navigation`.

## 🤷 Why

`next/router` does not expose the same values between App Router and Pages Router. As a way of slowly preparing the codebase to migrate to App Router, PRs like this will replace instances of `useRouter` with their new versions from `next/navigation`. This includes `usePathname` and `useSearchParams`. These PRs are intended to be small and easily testable; given the complexity of Dev Portal, we shouldn't try to replace all instances in one go.

This PR modifies a check in our Docs View that controls whether a no-index tag is rendered.

## 🛠️ How

Replaced `const { pathname } = useRouter()` with `const pathname = usePathname()`.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

1. Go to [preview](https://dev-portal-git-dsnext-navigation-docs-view-hashicorp.vercel.app/terraform/language/v1.4.x/data-sources)
2. Open the console and paste `document.querySelector('meta[name="robots"]').outerHTML`
3. Confirm that the output is `<meta name="robots" content="noindex, nofollow">`

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
