### PR TITLE
fix: account for releases without builds

### DIFF
--- a/src/views/docs-view/utils/get-latest-vagrant-vmware-version.ts
+++ b/src/views/docs-view/utils/get-latest-vagrant-vmware-version.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { getLatestVersionFromVersions } from 'lib/fetch-release-data'
+import {
+	getLatestVersionFromVersions,
+	type ReleasesAPIResponse,
+} from 'lib/fetch-release-data'
 import { makeFetchWithRetry } from 'lib/fetch-with-retry'
 
 /**
@@ -27,7 +30,7 @@ export async function getLatestVagrantVmwareVersion(): Promise<string> {
 		},
 	})
 		.then((res) => res.json())
-		.then((result) => {
-			return getLatestVersionFromVersions(Object.keys(result.versions))
+		.then((result: ReleasesAPIResponse) => {
+			return getLatestVersionFromVersions(Object.values(result.versions))
 		})
 }

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -312,8 +312,8 @@ export const sortAndFilterReleaseVersions = ({
 	releaseVersions: Record<string, ReleaseVersion>
 	isEnterpriseMode: boolean
 }): ReleaseVersion[] => {
-	const filteredVersionStrings = Object.keys(releaseVersions).filter(
-		(version: string) => {
+	const filteredVersionStrings = Object.values(releaseVersions)
+		.filter(({ version, builds }) => {
 			// Filter out invalid semver
 			const isInvalidSemver = semverValid(version) == null
 			if (isInvalidSemver) {
@@ -323,6 +323,12 @@ export const sortAndFilterReleaseVersions = ({
 			// Filter out prereleases
 			const isPrerelease = semverPrerelease(version) !== null
 			if (isPrerelease) {
+				return false
+			}
+
+			// Filter out releases without builds
+			const hasBuilds = builds && builds.length > 0
+			if (!hasBuilds) {
 				return false
 			}
 
@@ -337,8 +343,9 @@ export const sortAndFilterReleaseVersions = ({
 				const { build } = semverParse(version)
 				return build.length === 0
 			}
-		}
-	)
+		})
+		.map(({ version }) => version)
+
 	const sortedVersionStrings = semverRSort(filteredVersionStrings)
 	const sortedAndFilteredVersions = sortedVersionStrings.map(
 		(version: string) => releaseVersions[version]


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR updates our code that processes releases from the ofificial HashiCorp Releases API to account for versions that have no builds.

## 🤷 Why

Currently the "latest" (according to semver) release of Vault enterprise has a `builds` value set to `null`, which breaks code that expects `builds` to always be an array.

## 🛠️ How

By checking both the `version` string and `builds` property to calculate the latest version as the latest version with builds according to semver.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [x] Confirm the [Vault Install Enterprise](https://dev-portal-git-dsfix-ent-builds-hashicorp.vercel.app/vault/install/enterprise) page reports 1.15.6 as the latest version

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
