### PR TITLE
Load HVD from singleton and double check to make sure content builds

### DIFF
--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -71,7 +71,7 @@ function getHvdExtractionStatus() {
 		}
 
 		// Skip extraction in deploy previews
-		if (isDeployPreview()) {
+		if (isDeployPreview('hvd-docs')) {
 			resolve({ status: 'success' })
 			return
 		}
@@ -89,8 +89,6 @@ function getHvdExtractionStatus() {
 
 		// Extract HVD repo contents into the `src/content` directory
 		try {
-			throw new Error('Not implemented')
-
 			// Fetch a zip archive of the repo contents
 			const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
 			/**
@@ -139,8 +137,6 @@ function getHvdExtractionStatus() {
 
 			resolve({ status: 'success' })
 		} catch (error) {
-			resolve({ status: 'failure' })
-
 			/**
 			 * When authors are running locally from content repos,
 			 * we want to ignore errors.
@@ -153,10 +149,9 @@ function getHvdExtractionStatus() {
 				console.log(
 					`Note: HVD content was not extracted, and will not be built. If you need to work on HVD content, please ensure a valid GITHUB_TOKEN is present in your environment variables. Error: ${error}`
 				)
-				return
 			}
 
-			throw error
+			resolve({ status: 'failure' })
 		}
 	})
 

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -98,7 +98,7 @@ export const extractingHvdContent = new Promise<{
 		// Move the convolutedly named folder out of temp, rename it predictably
 		const convolutedName = fs.readdirSync(tempDestination)[0]
 		const convolutedDir = path.join(tempDestination, convolutedName)
-		fs.renameSync(convolutedDir, HVD_REPO_DIR)
+		fs.cpSync(convolutedDir, HVD_REPO_DIR, { recursive: true, force: true })
 
 		// Clean up the temporary directory
 		fs.rmSync(tempDestination, { recursive: true, force: true })

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -78,6 +78,8 @@ function getHvdExtractionStatus() {
 
 		// Extract HVD repo contents into the `src/content` directory
 		try {
+			throw new Error('HVD content extraction is disabled')
+
 			// Clear out the target directory, may be present from previous runs
 			if (fs.existsSync(HVD_REPO_DIR)) {
 				fs.rmSync(HVD_REPO_DIR, {

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -47,102 +47,121 @@ export const HVD_FINAL_IMAGE_ROOT_DIR = '.extracted/hvd'
 
 const alreadyLoadedDevEnvKey = 'ALREADY_LOADED_HVD_IN_DEV'
 
-/**
- * This script extracts HVD content from the `hvd-docs` repo into the local filesystem that `dev-portal` can access.
- */
-export const extractingHvdContent = new Promise<{
+let hvdExtractionStatus: null | Promise<{
 	status: 'success' | 'failure'
-}>(async (resolve, _) => {
-	console.warn('extractingHvdContent promise fired')
+}>
 
-	// Skip extraction if content has already been loaded in development.
-	// This is unique to development, because in development SSR is rerun on every request
-	if (env === 'development' && process.env[alreadyLoadedDevEnvKey] === 'true') {
-		resolve({ status: 'success' })
-		return
+// wrap HVD extraction in a singleton to avoid multiple extractions
+function getHvdExtractionStatus() {
+	console.warn('getHvdExtractionStatus singleton')
+	if (hvdExtractionStatus) {
+		return hvdExtractionStatus
 	}
 
-	// Skip extraction in deploy previews
-	if (isDeployPreview()) {
-		resolve({ status: 'success' })
-		return
-	}
+	hvdExtractionStatus = new Promise<{
+		status: 'success' | 'failure'
+	}>(async (resolve, _) => {
+		console.warn('getHvdExtractionStatus promise creation')
 
-	// Clear out the target directory, may be present from previous runs
-	if (fs.existsSync(HVD_REPO_DIR)) {
-		fs.rmSync(HVD_REPO_DIR, {
-			recursive: true,
-			force: true,
-		})
-	}
-
-	// Ensure an enclosing content directory exists for HVD content
-	fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
-
-	// Extract HVD repo contents into the `src/content` directory
-	try {
-		// Fetch a zip archive of the repo contents
-		const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
-		/**
-		 * Write out the content.
-		 *
-		 * Note that initially, we expect the extracted content to be nested in a
-		 * directory with a convoluted name including the repo org, name, and sha.
-		 * We shift some content to avoid this convolution.
-		 */
-
-		// Extract into a temporary directory initially, we'll clean this up
-		const tempDestination = HVD_REPO_DIR + '_temp'
-		contentZip.extractAllTo(tempDestination, true)
-
-		// Move the convolutedly named folder out of temp, rename it predictably
-		const convolutedName = fs.readdirSync(tempDestination)[0]
-		const convolutedDir = path.join(tempDestination, convolutedName)
-		fs.cpSync(convolutedDir, HVD_REPO_DIR, { recursive: true, force: true })
-
-		// Clean up the temporary directory
-		fs.rmSync(tempDestination, { recursive: true, force: true })
-
-		/**
-		 * Copy all image files into the `public` directory,
-		 * preserving the directory structure.
-		 */
-		const imageLocation = path.join(HVD_REPO_DIR, 'public')
-		const imageDestination = path.join(
-			process.cwd(),
-			'public/',
-			HVD_FINAL_IMAGE_ROOT_DIR
-		)
-		fs.cpSync(imageLocation, imageDestination, { recursive: true, force: true })
-
-		if (env === 'development') {
-			console.log(
-				'Loaded HVD content. Note this content will not be updated until "npm run start" is run again.'
-			)
-
-			// This is a hack to preserve some state between server restarts, as we cannot rely on JS variables persisting across restarts
-			process.env[alreadyLoadedDevEnvKey] = 'true'
-		}
-
-		resolve({ status: 'success' })
-	} catch (error) {
-		resolve({ status: 'failure' })
-
-		/**
-		 * When authors are running locally from content repos,
-		 * we want to ignore errors.
-		 *
-		 * In all other scenarios, we want errors related to HVD content to
-		 * surface. This does mean that anyone running `hashicorp/dev-portal`
-		 * locally will need to have a valid `GITHUB_TOKEN`.
-		 */
-		if (process.env.IS_CONTENT_PREVIEW) {
-			console.log(
-				`Note: HVD content was not extracted, and will not be built. If you need to work on HVD content, please ensure a valid GITHUB_TOKEN is present in your environment variables. Error: ${error}`
-			)
+		// Skip extraction if content has already been loaded in development.
+		// This is unique to development, because in development SSR is rerun on every request
+		if (
+			env === 'development' &&
+			process.env[alreadyLoadedDevEnvKey] === 'true'
+		) {
+			resolve({ status: 'success' })
 			return
 		}
 
-		throw error
-	}
-})
+		// Skip extraction in deploy previews
+		if (isDeployPreview()) {
+			resolve({ status: 'success' })
+			return
+		}
+
+		// Clear out the target directory, may be present from previous runs
+		if (fs.existsSync(HVD_REPO_DIR)) {
+			fs.rmSync(HVD_REPO_DIR, {
+				recursive: true,
+				force: true,
+			})
+		}
+
+		// Ensure an enclosing content directory exists for HVD content
+		fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
+
+		// Extract HVD repo contents into the `src/content` directory
+		try {
+			// Fetch a zip archive of the repo contents
+			const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
+			/**
+			 * Write out the content.
+			 *
+			 * Note that initially, we expect the extracted content to be nested in a
+			 * directory with a convoluted name including the repo org, name, and sha.
+			 * We shift some content to avoid this convolution.
+			 */
+
+			// Extract into a temporary directory initially, we'll clean this up
+			const tempDestination = HVD_REPO_DIR + '_temp'
+			contentZip.extractAllTo(tempDestination, true)
+
+			// Move the convolutedly named folder out of temp, rename it predictably
+			const convolutedName = fs.readdirSync(tempDestination)[0]
+			const convolutedDir = path.join(tempDestination, convolutedName)
+			fs.cpSync(convolutedDir, HVD_REPO_DIR, { recursive: true, force: true })
+
+			// Clean up the temporary directory
+			fs.rmSync(tempDestination, { recursive: true, force: true })
+
+			/**
+			 * Copy all image files into the `public` directory,
+			 * preserving the directory structure.
+			 */
+			const imageLocation = path.join(HVD_REPO_DIR, 'public')
+			const imageDestination = path.join(
+				process.cwd(),
+				'public/',
+				HVD_FINAL_IMAGE_ROOT_DIR
+			)
+			fs.cpSync(imageLocation, imageDestination, {
+				recursive: true,
+				force: true,
+			})
+
+			if (env === 'development') {
+				console.log(
+					'Loaded HVD content. Note this content will not be updated until "npm run start" is run again.'
+				)
+
+				// This is a hack to preserve some state between server restarts, as we cannot rely on JS variables persisting across restarts
+				process.env[alreadyLoadedDevEnvKey] = 'true'
+			}
+
+			resolve({ status: 'success' })
+		} catch (error) {
+			resolve({ status: 'failure' })
+
+			/**
+			 * When authors are running locally from content repos,
+			 * we want to ignore errors.
+			 *
+			 * In all other scenarios, we want errors related to HVD content to
+			 * surface. This does mean that anyone running `hashicorp/dev-portal`
+			 * locally will need to have a valid `GITHUB_TOKEN`.
+			 */
+			if (process.env.IS_CONTENT_PREVIEW) {
+				console.log(
+					`Note: HVD content was not extracted, and will not be built. If you need to work on HVD content, please ensure a valid GITHUB_TOKEN is present in your environment variables. Error: ${error}`
+				)
+				return
+			}
+
+			throw error
+		}
+	})
+
+	return hvdExtractionStatus
+}
+
+export { getHvdExtractionStatus }

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -76,19 +76,19 @@ function getHvdExtractionStatus() {
 			return
 		}
 
-		// Clear out the target directory, may be present from previous runs
-		if (fs.existsSync(HVD_REPO_DIR)) {
-			fs.rmSync(HVD_REPO_DIR, {
-				recursive: true,
-				force: true,
-			})
-		}
-
-		// Ensure an enclosing content directory exists for HVD content
-		fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
-
 		// Extract HVD repo contents into the `src/content` directory
 		try {
+			// Clear out the target directory, may be present from previous runs
+			if (fs.existsSync(HVD_REPO_DIR)) {
+				fs.rmSync(HVD_REPO_DIR, {
+					recursive: true,
+					force: true,
+				})
+			}
+
+			// Ensure an enclosing content directory exists for HVD content
+			fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
+
 			// Fetch a zip archive of the repo contents
 			const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
 			/**

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -78,8 +78,6 @@ function getHvdExtractionStatus() {
 
 		// Extract HVD repo contents into the `src/content` directory
 		try {
-			throw new Error('HVD content extraction is disabled')
-
 			// Clear out the target directory, may be present from previous runs
 			if (fs.existsSync(HVD_REPO_DIR)) {
 				fs.rmSync(HVD_REPO_DIR, {

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -89,6 +89,8 @@ function getHvdExtractionStatus() {
 
 		// Extract HVD repo contents into the `src/content` directory
 		try {
+			throw new Error('Not implemented')
+
 			// Fetch a zip archive of the repo contents
 			const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
 			/**

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -33,6 +33,8 @@ const HVD_REPO_DIR = path.join(
 	'src/.extracted/hashicorp-validated-designs'
 )
 
+const ALREADY_LOADED_HVD_IN_DEV = 'ALREADY_LOADED_HVD_IN_DEV'
+
 /**
  * Detect whether we are in the hashicorp/hvd-docs repo directly
  * and if so use the local path defined in the build or start script.
@@ -45,15 +47,12 @@ export const HVD_CONTENT_DIR =
 
 export const HVD_FINAL_IMAGE_ROOT_DIR = '.extracted/hvd'
 
-const alreadyLoadedDevEnvKey = 'ALREADY_LOADED_HVD_IN_DEV'
-
+// wrap HVD extraction in a singleton to avoid multiple extractions
 let hvdExtractionStatus: null | Promise<{
 	status: 'success' | 'failure'
 }>
 
-// wrap HVD extraction in a singleton to avoid multiple extractions
 function getHvdExtractionStatus() {
-	console.warn('getHvdExtractionStatus singleton')
 	if (hvdExtractionStatus) {
 		return hvdExtractionStatus
 	}
@@ -61,13 +60,11 @@ function getHvdExtractionStatus() {
 	hvdExtractionStatus = new Promise<{
 		status: 'success' | 'failure'
 	}>(async (resolve, _) => {
-		console.warn('getHvdExtractionStatus promise creation')
-
 		// Skip extraction if content has already been loaded in development.
 		// This is unique to development, because in development SSR is rerun on every request
 		if (
 			env === 'development' &&
-			process.env[alreadyLoadedDevEnvKey] === 'true'
+			process.env[ALREADY_LOADED_HVD_IN_DEV] === 'true'
 		) {
 			resolve({ status: 'success' })
 			return
@@ -135,7 +132,7 @@ function getHvdExtractionStatus() {
 				)
 
 				// This is a hack to preserve some state between server restarts, as we cannot rely on JS variables persisting across restarts
-				process.env[alreadyLoadedDevEnvKey] = 'true'
+				process.env[ALREADY_LOADED_HVD_IN_DEV] = 'true'
 			}
 
 			resolve({ status: 'success' })

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -57,9 +57,12 @@ function getHvdExtractionStatus() {
 		return hvdExtractionStatus
 	}
 
+	console.warn('getHvdExtractionStatus singleton')
+
 	hvdExtractionStatus = new Promise<{
 		status: 'success' | 'failure'
 	}>(async (resolve, _) => {
+		console.warn('hvdExtractionStatus promise started')
 		// Skip extraction if content has already been loaded in development.
 		// This is unique to development, because in development SSR is rerun on every request
 		if (

--- a/scripts/extract-hvd-content.ts
+++ b/scripts/extract-hvd-content.ts
@@ -79,19 +79,19 @@ function getHvdExtractionStatus() {
 			return
 		}
 
+		// Clear out the target directory, may be present from previous runs
+		if (fs.existsSync(HVD_REPO_DIR)) {
+			fs.rmSync(HVD_REPO_DIR, {
+				recursive: true,
+				force: true,
+			})
+		}
+
+		// Ensure an enclosing content directory exists for HVD content
+		fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
+
 		// Extract HVD repo contents into the `src/content` directory
 		try {
-			// Clear out the target directory, may be present from previous runs
-			if (fs.existsSync(HVD_REPO_DIR)) {
-				fs.rmSync(HVD_REPO_DIR, {
-					recursive: true,
-					force: true,
-				})
-			}
-
-			// Ensure an enclosing content directory exists for HVD content
-			fs.mkdirSync(HVD_REPO_DIR, { recursive: true })
-
 			// Fetch a zip archive of the repo contents
 			const contentZip = await fetchGithubArchiveZip(BASE_REPO_CONFIG)
 			/**

--- a/src/pages/validated-designs/[...slug]/index.tsx
+++ b/src/pages/validated-designs/[...slug]/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { extractingHvdContent } from '@scripts/extract-hvd-content'
+import { getHvdExtractionStatus } from '@scripts/extract-hvd-content'
 import ValidatedDesignGuideView from 'views/validated-designs/guide'
 import {
 	getHvdCategoryGroups,
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 		fallback: false,
 	}
 
-	const extractionResults = await extractingHvdContent
+	const extractionResults = await getHvdExtractionStatus()
 	if (extractionResults.status === 'failure') {
 		return failureState
 	}
@@ -46,7 +46,7 @@ export async function getStaticProps(context) {
 		notFound: true,
 	}
 
-	const extractionResults = await extractingHvdContent
+	const extractionResults = await getHvdExtractionStatus()
 	if (extractionResults.status === 'failure') {
 		return failureState
 	}

--- a/src/pages/validated-designs/index.tsx
+++ b/src/pages/validated-designs/index.tsx
@@ -10,6 +10,8 @@ import { getHvdExtractionStatus } from '@scripts/extract-hvd-content'
 export async function getStaticProps() {
 	const extractionResults = await getHvdExtractionStatus()
 	if (extractionResults.status === 'failure') {
+		throw new Error('Failed to extract HVD content')
+
 		return {
 			notFound: true,
 		}

--- a/src/pages/validated-designs/index.tsx
+++ b/src/pages/validated-designs/index.tsx
@@ -5,10 +5,10 @@
 
 import { getHvdCategoryGroups } from 'views/validated-designs/server'
 import ValidatedDesignsLandingView from 'views/validated-designs'
-import { extractingHvdContent } from '@scripts/extract-hvd-content'
+import { getHvdExtractionStatus } from '@scripts/extract-hvd-content'
 
 export async function getStaticProps() {
-	const extractionResults = await extractingHvdContent
+	const extractionResults = await getHvdExtractionStatus()
 	if (extractionResults.status === 'failure') {
 		return {
 			notFound: true,

--- a/src/pages/validated-designs/index.tsx
+++ b/src/pages/validated-designs/index.tsx
@@ -10,7 +10,10 @@ import { getHvdExtractionStatus } from '@scripts/extract-hvd-content'
 export async function getStaticProps() {
 	const extractionResults = await getHvdExtractionStatus()
 	if (extractionResults.status === 'failure') {
-		throw new Error('Failed to extract HVD content')
+		if (!process.env.IS_CONTENT_PREVIEW) {
+			// We need to throw an error here because next.js does not fail to build when modules, such as getHvdExtractionStatus, error out
+			throw new Error('Failed to extract HVD content')
+		}
 
 		return {
 			notFound: true,


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task - None bug](url) 🎟️

## 🗒️ What & 🤷 Why

When HVD content was failing to build it was not erroring out the whole next.js build, even thought the HVD module was throwing. So now we throw during getStaticProps on failure.

We also made sure that HVD content is only loading once by wrapping it in a singleton.

## 🧪 Testing

- [ ] Check to make sure that HVD content is building and rendering



