### PR TITLE
Clean up docker file to modern standards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM docker.mirror.hashicorp.services/node:18.18.2-alpine AS deps
+FROM docker.mirror.hashicorp.services/node:18-buster AS deps
 
-RUN apk add --update --no-cache \
+RUN apt-get update
+
+RUN apt-get install -y -q \
 	autoconf \
 	automake \
-	bash \
-	git \
 	g++ \
 	libtool \
-	libc6-compat \
-	libjpeg-turbo-dev \
+	musl \
+	libjpeg62-turbo-dev \
 	libpng-dev \
-	make \
 	nasm
 
 WORKDIR /app
@@ -25,7 +24,7 @@ RUN npm install -g npm@9.8.1
 # - see https://github.com/imagemin/optipng-bin/issues/118
 RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install
 
-FROM docker.mirror.hashicorp.services/node:18-alpine AS builder
+FROM docker.mirror.hashicorp.services/node:18-buster AS builder
 
 RUN npm install -g npm@9.8.1
 


### PR DESCRIPTION
## 🔗 Relevant links

- Preview link - **None no website changes** 🔎
- Asana task - **None dev chore** 🎟️

## 🗒️ What

This PR updates our content-preview docker image in order to:
1. Fix a current build failure with our base image, `docker.mirror.hashicorp.services/node:18-alpine`, not existing
2. Moves us from using alpine to using debian as our base image distro

## 🧪 Testing

**Note: You will have to checkout this PR in order to build the correct docker image**

- [ ] Build the docker image locally: `docker build -t dev-portal:local .`
- [ ] Run the docker image locally: `docker run -t -i -p 3000:3000 dev-portal:local`
(The` -t -i` params allow the container to be exited through `Ctrl-C`)