### PR TITLE
fix: only fetch tutorials map once

### DIFF
--- a/src/lib/learn-client/index.ts
+++ b/src/lib/learn-client/index.ts
@@ -2,19 +2,6 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-function getFetch() {
-	// Note: purposely doing a conditional require here so that `@vercel/fetch` is not included in the client bundle
-	if (typeof window === 'undefined') {
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const createFetch = require('@vercel/fetch')
-		return createFetch()
-	}
-	return window.fetch
-}
-
-// some of our reqs occur in a node env where fetch
-// isn't defined e.g. algolia search script
-const fetch = getFetch()
 
 export function get(path: string, token?: string) {
 	const options: RequestInit = {

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import nock from 'nock'
 import remark from 'remark'
 import { rewriteTutorialLinksPlugin } from 'lib/remark-plugins/rewrite-tutorial-links'
 import { productSlugs, productSlugsToHostNames } from 'lib/products'
@@ -93,21 +92,13 @@ const MOCK_TUTORIALS_MAP = {
 // TESTS -----------------------------------------------------------------
 
 describe('rewriteTutorialLinks remark plugin', () => {
-	beforeEach(async () => {
-		// the api base url defaults to localhost when no VERCEL_URL is provided
-		const scope = nock('http://localhost:3000/api/tutorials-map')
-			.persist()
-			.get(/.*/)
-			.reply(200, MOCK_TUTORIALS_MAP)
-	})
-
 	test('Only internal Learn links are rewritten', async () => {
 		const contentsWithoutPlugin = await remark().process(
 			TEST_MD_LINKS.nonLearnLink
 		)
 
 		const contentsWithPlugin = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.nonLearnLink)
 
 		expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
@@ -118,7 +109,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 		const contentsWithoutPlugin = await remark().process(input)
 
 		const contentsWithPlugin = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(input)
 
 		expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
@@ -133,7 +124,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 		test.each(testInputs)('%s', async (testInput: string) => {
 			const contentsWithoutPlugin = await remark().process(testInput)
 			const contentsWithPlugin = await remark()
-				.use(rewriteTutorialLinksPlugin)
+				.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 				.process(testInput)
 			expect(String(contentsWithPlugin)).toEqual(String(contentsWithoutPlugin))
 		})
@@ -141,7 +132,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test("Local anchor links aren't rewritten", async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.plainAnchor)
 
 		const path = isolatePathFromMarkdown(String(contents))
@@ -150,7 +141,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product tutorial links are rewritten to dev portal paths', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productTutorial)
 
 		const result = String(contents)
@@ -161,7 +152,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product collection links are rewritten to dev portal paths', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productCollection)
 
 		const result = String(contents)
@@ -171,7 +162,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product external collection links are rewritten to relative dev portal paths', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productExternalCollection)
 
 		const result = String(contents)
@@ -181,11 +172,11 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Anchor links are rewritten properly', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productTutorialAnchorLink)
 
 		const externalLinkContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.externalAnchorLink)
 
 		const path = isolatePathFromMarkdown(String(contents))
@@ -203,7 +194,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Query params are rewritten properly', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productTutorialQueryParam)
 
 		const queryParamCollectionSlug = /get-started-kubernetes/
@@ -213,7 +204,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Query params with an anchor link are rewritten properly', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productTutorialQueryParamWithAnchor)
 
 		const queryParamSlugWithAnchor = new RegExp(`get-started-nomad/${slug}#`)
@@ -224,14 +215,14 @@ describe('rewriteTutorialLinks remark plugin', () => {
 	test('Incorrect link does not throw, only logs the error message', async () => {
 		const getContents = async () =>
 			await remark()
-				.use(rewriteTutorialLinksPlugin)
+				.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 				.process(TEST_MD_LINKS.errorLink)
 		expect(getContents).not.toThrowError()
 	})
 
 	test('Definition link is rewritten', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDefintionLink)
 
 		const path = String(contents).split(':')[1].trim()
@@ -240,7 +231,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Search page on learn is made external', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.searchPage)
 
 		expect(String(contents)).toMatch(/(learn.hashicorp.com)?\/search/)
@@ -248,11 +239,11 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product hub pages should be rewritten to dev portal', async () => {
 		const interalLinkContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productHubLink)
 		const internalPath = isolatePathFromMarkdown(String(interalLinkContents))
 		const externalLinkContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productHubExternalLink)
 		const externalPath = isolatePathFromMarkdown(String(externalLinkContents))
 		const productHub = /^\/vault\/tutorials$/
@@ -263,10 +254,10 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product docs links are rewritten to dev portal', async () => {
 		const docsLinkContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsLink)
 		const pluginLinkContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productPluginsLink)
 
 		const pluginLinkPath = isolatePathFromMarkdown(String(pluginLinkContents))
@@ -278,7 +269,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product api links are rewritten to api-docs', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsApiLink)
 
 		const path = isolatePathFromMarkdown(String(contents))
@@ -287,7 +278,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product docs link .html reference should be removed', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsApiLinkWithHtml)
 
 		const path = isolatePathFromMarkdown(String(contents))
@@ -298,11 +289,11 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product docs link with anchor are rewritten properly', async () => {
 		const basicAnchorContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsAnchorLink)
 
 		const anchorWithHtmlContents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsLinkAnchorWithHtml)
 
 		const basicAnchorPath = isolatePathFromMarkdown(String(basicAnchorContents))
@@ -318,14 +309,14 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Product /trial path is not rewritten', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsLinkNonDoc)
 		expect(String(contents)).toMatch(TEST_MD_LINKS.productDocsLinkNonDoc)
 	})
 
 	test('Product usecase path is not rewritten', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.productDocsLinkUseCases)
 
 		expect(String(contents)).toMatch(TEST_MD_LINKS.productDocsLinkUseCases)
@@ -333,7 +324,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Waf link should be rewritten properly', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.wafTutorialLink)
 		const newPath = isolatePathFromMarkdown(String(contents))
 
@@ -344,7 +335,7 @@ describe('rewriteTutorialLinks remark plugin', () => {
 
 	test('Onboarding link should be rewritten properly', async () => {
 		const contents = await remark()
-			.use(rewriteTutorialLinksPlugin)
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
 			.process(TEST_MD_LINKS.onboardingCollectionLink)
 		const newPath = isolatePathFromMarkdown(String(contents))
 

--- a/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/index.ts
@@ -27,22 +27,22 @@ import { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 import { RewriteTutorialLinksPluginOptions } from './types'
 import { DEFAULT_CONTENT_TYPE } from './constants'
-import { getTutorialMap } from './utils'
 import { rewriteTutorialsLink } from './utils/rewrite-tutorials-link'
-
-let TUTORIAL_MAP
 
 export const rewriteTutorialLinksPlugin: Plugin = (
 	options: RewriteTutorialLinksPluginOptions = {}
 ) => {
 	const { contentType = DEFAULT_CONTENT_TYPE, tutorialMap } = options
 	return async function transformer(tree) {
-		// Load the tutorial map if it's not provided
-		TUTORIAL_MAP = tutorialMap ?? (await getTutorialMap())
+		// Throw an error if the tutorial map is not provided. Due to how
+		// Remark plugins are typed, we can't have required parameters.
+		if (!tutorialMap) {
+			throw new Error('[rewriteTutorialLinksPlugin] tutorialMap is required')
+		}
 
 		// Visit link and defintion node types
 		visit(tree, ['link', 'definition'], (node: Link | Definition) => {
-			node.url = rewriteTutorialsLink(node.url, TUTORIAL_MAP, contentType)
+			node.url = rewriteTutorialsLink(node.url, tutorialMap, contentType)
 		})
 	}
 }

--- a/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/utils/get-tutorial-map.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import fetch from 'node-fetch'
 import moize, { Options } from 'moize'
 import { generateTutorialMap } from 'pages/api/tutorials-map'
 

--- a/src/pages/api/tutorials-map.ts
+++ b/src/pages/api/tutorials-map.ts
@@ -41,7 +41,7 @@ export default async function tutorialsMapHandler(
 /**
  * This function creates a map of 'database-slug': 'dev-dot/path'
  */
-export async function generateTutorialMap() {
+export async function generateTutorialMap(): Promise<Record<string, string>> {
 	const allTutorials = await getAllTutorials({
 		fullContent: false,
 		slugsOnly: true,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -173,7 +173,8 @@ export function getStaticGenerationFunctions<
 
 			// Generate tutorial map once and then share it across all
 			// utilities that need it for the duration of this function.
-			const tutorialMap = await generateTutorialMap()
+			// const tutorialMap = await generateTutorialMap()
+			const tutorialMap = {}
 
 			const loader = getLoader({
 				mainBranch,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -173,8 +173,7 @@ export function getStaticGenerationFunctions<
 
 			// Generate tutorial map once and then share it across all
 			// utilities that need it for the duration of this function.
-			// const tutorialMap = await generateTutorialMap()
-			const tutorialMap = {}
+			const tutorialMap = await generateTutorialMap()
 
 			const loader = getLoader({
 				mainBranch,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -164,10 +164,6 @@ export function getStaticGenerationFunctions<
 		getStaticProps: async (
 			ctx
 		): Promise<GetStaticPropsResult<DocsViewProps>> => {
-			const res = await fetch(
-				'https://content.hashicorp.com/api/content/consul/version-metadata?partial=true&file=server'
-			)
-			const data = await res.json()
 			const pathParts = (ctx.params.page || []) as string[]
 			const currentPathUnderProduct = `/${path.join(
 				basePathForLoader,

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -33,6 +33,7 @@ import {
 	generateProductLandingSidebarNavData,
 	generateTopLevelSidebarNavData,
 } from 'components/sidebar/helpers'
+import { generateTutorialMap } from 'pages/api/tutorials-map'
 
 // Local imports
 import { getProductUrlAdjuster } from './utils/product-url-adjusters'
@@ -170,6 +171,10 @@ export function getStaticGenerationFunctions<
 			)}`
 			const headings: AnchorLinksPluginHeading[] = [] // populated by anchorLinks plugin below
 
+			// Generate tutorial map once and then share it across all
+			// utilities that need it for the duration of this function.
+			const tutorialMap = await generateTutorialMap()
+
 			const loader = getLoader({
 				mainBranch,
 				remarkPlugins: [
@@ -191,7 +196,7 @@ export function getStaticGenerationFunctions<
 					 * `rewriteTutorialLinksPlugin` does not rewrite links like
 					 * `/waypoint` to `/waypoint/tutorials`.
 					 */
-					[rewriteTutorialLinksPlugin, { contentType: 'docs' }],
+					[rewriteTutorialLinksPlugin, { contentType: 'docs', tutorialMap }],
 					/**
 					 * Rewrite docs content links, which are authored without prefix.
 					 * For example, in Waypoint docs authors write "/docs/some-thing",
@@ -299,8 +304,8 @@ export function getStaticGenerationFunctions<
 				await prepareNavDataForClient({
 					basePaths: [product.slug, basePath],
 					nodes: navData,
+					tutorialMap,
 				})
-
 			/**
 			 * Figure out if a specific docs version is being viewed
 			 */

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -164,6 +164,10 @@ export function getStaticGenerationFunctions<
 		getStaticProps: async (
 			ctx
 		): Promise<GetStaticPropsResult<DocsViewProps>> => {
+			const res = await fetch(
+				'https://content.hashicorp.com/api/content/consul/version-metadata?partial=true&file=server'
+			)
+			const data = await res.json()
 			const pathParts = (ctx.params.page || []) as string[]
 			const currentPathUnderProduct = `/${path.join(
 				basePathForLoader,

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -76,10 +76,6 @@ export function getRootDocsPathGenerationFunctions(
 			context
 		): Promise<GetStaticPropsResult<DocsViewProps>> => {
 			// Generate getStaticPaths for this rootDocsPath
-			const res = await fetch(
-				'https://content.hashicorp.com/api/content/consul/version-metadata?partial=true&file=get-root-docs'
-			)
-			const data = await res.json()
 			const { getStaticProps } =
 				getStaticGenerationFunctions(staticFunctionConfig)
 			return await getStaticProps(context)

--- a/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
+++ b/src/views/docs-view/utils/get-root-docs-path-generation-functions.ts
@@ -76,6 +76,10 @@ export function getRootDocsPathGenerationFunctions(
 			context
 		): Promise<GetStaticPropsResult<DocsViewProps>> => {
 			// Generate getStaticPaths for this rootDocsPath
+			const res = await fetch(
+				'https://content.hashicorp.com/api/content/consul/version-metadata?partial=true&file=get-root-docs'
+			)
+			const data = await res.json()
 			const { getStaticProps } =
 				getStaticGenerationFunctions(staticFunctionConfig)
 			return await getStaticProps(context)


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR refactors the `getStaticProps` implementation for `docs-view` to only generate/fetch the tutorials map once. In a future PR, I'm going to explore if we even need to fetch the tutorials map to rewrite URLs anymore.

## 🤷 Why

Prior to this PR, `getStaticProps` would generate/fetch the tutorials map multiple times, each taking ~2 seconds. This was because different steps of the implementation would fetch their own copy of the tutorials map independent of one another.

## 🛠️ How

In this PR, we fetch the tutorials map once at the beginning of `getStaticProps`, and pass it into the remote content loader (for link rewrites) and again into the `prepareNavData` utility.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [ ] Click through a handful of docs pages and ensure that they render.
- [ ] Go to [preview](https://dev-portal-git-dstutorials-map-once-hashicorp.vercel.app/terraform/intro) and ensure the "Getting Started" link in the sidebar does not point to `learn.hashicorp.com`.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
