### PR TITLE
TF Assoc 003: Added content differences table

### DIFF
--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -2,7 +2,7 @@
 ## Prerequisites
 
 - Basic terminal skills
-- Basic understanding of on premises and cloud architecture;
+- Basic understanding of on premises and cloud architecture
 
 ## Exam Details
 
@@ -80,3 +80,17 @@ To renew any Terraform Associate certification, you will need to take and pass t
 **If you hold an *unexpired* Terraform Associate 003 certification:** You can take the new exam starting 18 months after your previous exam date. When you pass the new exam, the expiration date on your credentials will be extended.
 
 **If you hold any *expired* Terraform Associate certification:** You are eligible to recertify at any time. When you pass the new exam, you will receive a new, separate set of credentials with a new expiration date.
+
+### Content Differences Between the 002 and 003 exams
+
+We updated the Terraform Associate 003 exam to account for how Terraform has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.
+
+| #  | Objective Description                                                                      | Status in Terraform Associate 003                                           |
+|----|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| 3e | Explain when to use and not use provisioners and when to use local-exec or remote-exec | REMOVED                                                                     |
+| 4  | Use Terraform outside of core workflow                                                     | `terraform taint` removed, other topics reorganized                         |
+| 6b | Initialize a Terraform working directory (`terraform init`)                                | Includes questions about `terraform.lock.hcl`                               |
+| 7  | Implement and maintain state                                                               | Cloud integration authentication, and cloud backends added                  |
+| 8a | Demonstrate use of variables and outputs                                                   | Covers sensitive variables and outputs' relationship to exposure on the CLI |
+| 8g | ~~Configure~~ resource using a `dynamic` block                                             | Use cases for `dynamic` block are still tested in objective 8               |
+| 9  | Understand Terraform Cloud capabilities                                                    | Restructured to accommodate the current and future state of Terraform Cloud |


### PR DESCRIPTION
Added the delta between exams info back to the page; fixed some small typos


- [Preview link](https://dev-portal-git-certs_TFassoc_updates-hashicorp.vercel.app/certifications/infrastructure-automation) 🔎

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why
User input from the Edu offsite prompted the change to make it easier  for 002 credential holders to study for recertification 

## 🧪 Testing

- [ ] Check the wording
- [ ] Check formatting

