### PR TITLE
Reduce speed insights sample rate

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -105,7 +105,7 @@ export default function App({
 												<Toaster />
 												<AIFeatureToast />
 												<ReactQueryDevtools />
-												<SpeedInsights sampleRate={0.2} />
+												<SpeedInsights sampleRate={0.05} />
 											</LazyMotion>
 										</CodeTabsProvider>
 									</CurrentProductProvider>


### PR DESCRIPTION
## 🗒️ What

Dials down our Vercel speed insights sample rate

## 🤷 Why

Control overage spend a bit

## 🛠️ How

Changed [sample rate prop](https://vercel.com/docs/speed-insights/package#samplerate)

## 💭 Anything else?