### PR TITLE
Add rehype code highlighting to HVD docs

### DIFF
--- a/src/views/validated-designs/server.ts
+++ b/src/views/validated-designs/server.ts
@@ -19,6 +19,7 @@ import { rewriteStaticHVDAssetsPlugin } from 'lib/remark-plugins/rewrite-static-
 import grayMatter from 'gray-matter'
 import { ProductSlug } from 'types/products'
 import { OutlineLinkItem } from 'components/outline-nav/types'
+import { rehypeCodePlugins } from 'lib/rehype-code-plugins'
 
 const basePath = '/validated-designs'
 
@@ -233,6 +234,7 @@ export async function getHvdGuidePropsFromSlug(
 									[remarkPluginAnchorLinkData, { anchorLinks }],
 									rewriteStaticHVDAssetsPlugin,
 								],
+								rehypePlugins: [...rehypeCodePlugins],
 							},
 						})
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-chorehvd-code-highlighting-hashicorp.vercel.app/validated-designs/) 🔎
- Asana task - None Chore 🎟️

## 🗒️ What

Add the same rehype code syntax highlighting we add to tutorials and api docs to HVD docs. Not all codeblocks for HVD have their language set, so this won't have a big effect at first.

## 📸 Screenshots

| before | after |
|-|-|
| ![Screenshot 2024-04-15 at 11 45 33 AM](https://github.com/hashicorp/dev-portal/assets/1957315/e131e905-fe3d-417e-bf68-3b9dea7ef1f4) | ![Screenshot 2024-04-15 at 11 45 08 AM](https://github.com/hashicorp/dev-portal/assets/1957315/1b0be0a0-3840-48dc-a7d7-677e737068e1) |


## 🧪 Testing

- [ ] [Check to make sure that syntax highlighting is working.](https://dev-portal-git-rn-chorehvd-code-highlighting-hashicorp.vercel.app/validated-designs/terraform-solution-design-guides-terraform-enterprise-fdo/private-cloud-installation#run-a-health-check)