### PR TITLE
chore(deps): update to next 14.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
 				"mdast-util-to-string": "^2.0.0",
 				"moize": "^6.1.0",
 				"ms": "^2.1.3",
-				"next": "^14.1.3",
+				"next": "^14.2.1",
 				"next-auth": "^4.23.1",
 				"next-query-params": "^4.1.0",
 				"next-sitemap": "^3.1.21",
@@ -6480,9 +6480,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.3.tgz",
-			"integrity": "sha512-LALu0yIBPRiG9ANrD5ncB3pjpO0Gli9ZLhxdOu6ZUNf3x1r3ea1rd9Q+4xxUkGrUXLqKVK9/lDkpYIJaCJ6AHQ==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.1.tgz",
+			"integrity": "sha512-kGjnjcIJehEcd3rT/3NAATJQndAEELk0J9GmGMXHSC75TMnvpOhONcjNHbjtcWE5HUQnIHy5JVkatrnYm1QhVw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6495,9 +6495,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz",
-			"integrity": "sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.1.tgz",
+			"integrity": "sha512-dAdWndgdQi7BK2WSXrx4lae7mYcOYjbHJUhvOUnJjMNYrmYhxbbvJ2xElZpxNxdfA6zkqagIB9He2tQk+l16ew==",
 			"cpu": [
 				"x64"
 			],
@@ -6510,9 +6510,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz",
-			"integrity": "sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.1.tgz",
+			"integrity": "sha512-2ZctfnyFOGvTkoD6L+DtQtO3BfFz4CapoHnyLTXkOxbZkVRgg3TQBUjTD/xKrO1QWeydeo8AWfZRg8539qNKrg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6525,9 +6525,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz",
-			"integrity": "sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.1.tgz",
+			"integrity": "sha512-jazZXctiaanemy4r+TPIpFP36t1mMwWCKMsmrTRVChRqE6putyAxZA4PDujx0SnfvZHosjdkx9xIq9BzBB5tWg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6540,9 +6540,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz",
-			"integrity": "sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.1.tgz",
+			"integrity": "sha512-VjCHWCjsAzQAAo8lkBOLEIkBZFdfW+Z18qcQ056kL4KpUYc8o59JhLDCBlhg+hINQRgzQ2UPGma2AURGOH0+Qg==",
 			"cpu": [
 				"x64"
 			],
@@ -6555,9 +6555,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz",
-			"integrity": "sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.1.tgz",
+			"integrity": "sha512-7HZKYKvAp4nAHiHIbY04finRqjeYvkITOGOurP1aLMexIFG/1+oCnqhGogBdc4lao/lkMW1c+AkwWSzSlLasqw==",
 			"cpu": [
 				"x64"
 			],
@@ -6570,9 +6570,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz",
-			"integrity": "sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.1.tgz",
+			"integrity": "sha512-YGHklaJ/Cj/F0Xd8jxgj2p8po4JTCi6H7Z3Yics3xJhm9CPIqtl8erlpK1CLv+HInDqEWfXilqatF8YsLxxA2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -6585,9 +6585,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz",
-			"integrity": "sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.1.tgz",
+			"integrity": "sha512-o+ISKOlvU/L43ZhtAAfCjwIfcwuZstiHVXq/BDsZwGqQE0h/81td95MPHliWCnFoikzWcYqh+hz54ZB2FIT8RA==",
 			"cpu": [
 				"ia32"
 			],
@@ -6600,9 +6600,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz",
-			"integrity": "sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.1.tgz",
+			"integrity": "sha512-GmRoTiLcvCLifujlisknv4zu9/C4i9r0ktsA8E51EMqJL4bD4CpO7lDYr7SrUxCR0tS4RVcrqKmCak24T0ohaw==",
 			"cpu": [
 				"x64"
 			],
@@ -7155,19 +7155,18 @@
 			"dev": true
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-			"integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
-			"dev": true,
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
+			"integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
+			"devOptional": true,
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.28.0"
+				"playwright": "1.43.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@radix-ui/react-compose-refs": {
@@ -11249,10 +11248,11 @@
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+			"integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
 			"dependencies": {
+				"@swc/counter": "^0.1.3",
 				"tslib": "^2.4.0"
 			}
 		},
@@ -29378,12 +29378,12 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.1.3.tgz",
-			"integrity": "sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.1.tgz",
+			"integrity": "sha512-SF3TJnKdH43PMkCcErLPv+x/DY1YCklslk3ZmwaVoyUfDgHKexuKlf9sEfBQ69w+ue8jQ3msLb+hSj1T19hGag==",
 			"dependencies": {
-				"@next/env": "14.1.3",
-				"@swc/helpers": "0.5.2",
+				"@next/env": "14.2.1",
+				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
 				"graceful-fs": "^4.2.11",
@@ -29397,24 +29397,28 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.1.3",
-				"@next/swc-darwin-x64": "14.1.3",
-				"@next/swc-linux-arm64-gnu": "14.1.3",
-				"@next/swc-linux-arm64-musl": "14.1.3",
-				"@next/swc-linux-x64-gnu": "14.1.3",
-				"@next/swc-linux-x64-musl": "14.1.3",
-				"@next/swc-win32-arm64-msvc": "14.1.3",
-				"@next/swc-win32-ia32-msvc": "14.1.3",
-				"@next/swc-win32-x64-msvc": "14.1.3"
+				"@next/swc-darwin-arm64": "14.2.1",
+				"@next/swc-darwin-x64": "14.2.1",
+				"@next/swc-linux-arm64-gnu": "14.2.1",
+				"@next/swc-linux-arm64-musl": "14.2.1",
+				"@next/swc-linux-x64-gnu": "14.2.1",
+				"@next/swc-linux-x64-musl": "14.2.1",
+				"@next/swc-win32-arm64-msvc": "14.2.1",
+				"@next/swc-win32-ia32-msvc": "14.2.1",
+				"@next/swc-win32-x64-msvc": "14.2.1"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
+				"@playwright/test": "^1.41.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@playwright/test": {
 					"optional": true
 				},
 				"sass": {
@@ -29546,9 +29550,9 @@
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"node_modules/next/node_modules/@next/env": {
-			"version": "14.1.3",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.3.tgz",
-			"integrity": "sha512-VhgXTvrgeBRxNPjyfBsDIMvgsKDxjlpw4IAUsHCX8Gjl1vtHUYRT3+xfQ/wwvLPDd/6kqfLqk9Pt4+7gysuCKQ=="
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.1.tgz",
+			"integrity": "sha512-qsHJle3GU3CmVx7pUoXcghX4sRN+vINkbLdH611T8ZlsP//grzqVW87BSUgOZeSAD4q7ZdZicdwNe/20U2janA=="
 		},
 		"node_modules/nextjs-bundle-analysis": {
 			"version": "0.5.0-canary.1",
@@ -31860,16 +31864,47 @@
 				"pathe": "^1.1.0"
 			}
 		},
-		"node_modules/playwright-core": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-			"integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
-			"dev": true,
+		"node_modules/playwright": {
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
+			"integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+			"devOptional": true,
+			"dependencies": {
+				"playwright-core": "1.43.1"
+			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
+			"integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+			"devOptional": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
 		"mdast-util-to-string": "^2.0.0",
 		"moize": "^6.1.0",
 		"ms": "^2.1.3",
-		"next": "^14.1.3",
+		"next": "^14.2.1",
 		"next-auth": "^4.23.1",
 		"next-query-params": "^4.1.0",
 		"next-sitemap": "^3.1.21",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -41,11 +41,11 @@ import { AIFeatureToast } from 'components/chatbox/ai-feature-toast'
 import './style.css'
 
 if (typeof window !== 'undefined' && process.env.AXE_ENABLED) {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	const ReactDOM = require('react-dom')
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	const axe = require('@axe-core/react')
-	axe(React, ReactDOM, 1000)
+	import('react-dom').then((ReactDOM) => {
+		import('@axe-core/react').then((axe) => {
+			axe.default(React, ReactDOM, 1000)
+		})
+	})
 }
 
 initializeUTMParamsCapture()


### PR DESCRIPTION
## 🗒️ What

This PR updates `next` to the latest version, `14.2.1`.

## 🤷 Why

[Next.js 14.2](https://nextjs.org/blog/next-14-2#turbopack-for-development-release-candidate) comes with support for `next dev --turbo`, which offers improved performance for the development server. While we're not compatible with `--turbo` yet, updating to 14.2 before will make tracking down incompatibilities easier since 14.1 had a bunch of Turbopack issues.

## 🧪 Testing

Since this is a Next.js update, the best way to test is simply to click around on the site and make sure nothing looks broken.
