### PR TITLE
[chore]: bump @hashicorp/design-system-tokens version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@actions/core": "^1.9.1",
 				"@apidevtools/json-schema-ref-parser": "^9.0.9",
 				"@happykit/flags": "^3.1.1",
-				"@hashicorp/design-system-tokens": "^1.9.0",
+				"@hashicorp/design-system-tokens": "^2.1.0",
 				"@hashicorp/flight-icons": "^3.0.0",
 				"@hashicorp/localstorage-polyfill": "^1.0.14",
 				"@hashicorp/mktg-global-styles": "^4.5.0",
@@ -1925,9 +1925,9 @@
 			}
 		},
 		"node_modules/@hashicorp/design-system-tokens": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-1.9.0.tgz",
-			"integrity": "sha512-zmMpnKv4vulhVFVCpqf3oAAR5fQeDDnMxbeJIZllLFCgF2JFoL6C/Irghx4WnBAG8GkLs8CbxjPVtFjSYq+V8w=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@hashicorp/design-system-tokens/-/design-system-tokens-2.1.0.tgz",
+			"integrity": "sha512-8SFUmRsX9v9pCc1Oq+zZGAmZGLxdZ6WnVEvwOzPAswlUTxBPa5zdoKdKEOPw8Xr3j142Mie6WVk2SMTV9EjQIQ=="
 		},
 		"node_modules/@hashicorp/flight-icons": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@actions/core": "^1.9.1",
 		"@apidevtools/json-schema-ref-parser": "^9.0.9",
 		"@happykit/flags": "^3.1.1",
-		"@hashicorp/design-system-tokens": "^1.9.0",
+		"@hashicorp/design-system-tokens": "^2.1.0",
 		"@hashicorp/flight-icons": "^3.0.0",
 		"@hashicorp/localstorage-polyfill": "^1.0.14",
 		"@hashicorp/mktg-global-styles": "^4.5.0",


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Preview link
- Asana task

## 🗒️ What

- Update the version to sync the current vault brand colour. 

## 🤷 Why

- 4/22 rebrand
  - HCP Vault Dedicated logo is using the old brand colour (`#FFD814`) for Vault instead the new one (`#FFCF25`)
