### PR TITLE
Remove hvd guide name filter

### DIFF
--- a/src/views/validated-designs/__tests__/server.ts
+++ b/src/views/validated-designs/__tests__/server.ts
@@ -17,7 +17,7 @@ const mockedHvdCategoryGroups: HvdCategoryGroup[] = [
 		slug: 'terraform-operation-guides',
 		title: 'terraform operation guides',
 		description: 'description',
-		product: 'terraform',
+		productSlug: 'terraform',
 		guides: [
 			{
 				slug: 'terraform-operation-guides-adoption',
@@ -47,7 +47,7 @@ const mockedHvdCategoryGroups: HvdCategoryGroup[] = [
 		slug: 'terraform-integration-guides',
 		title: 'terraform integration guides',
 		description: 'description',
-		product: 'terraform',
+		productSlug: 'terraform',
 		guides: [
 			{
 				slug: 'terraform-integration-guides-run-task-prisma-cloud-by-palo-alto',

--- a/src/views/validated-designs/index.tsx
+++ b/src/views/validated-designs/index.tsx
@@ -52,7 +52,7 @@ export default function ValidatedDesignsLandingView({
 						className={s.categoryGroupContainer}
 					>
 						<section className={s.categoryGroupHeader}>
-							<IconTileLogo size="large" productSlug={category.product} />
+							<IconTileLogo size="large" productSlug={category.productSlug} />
 							<Heading
 								level={2}
 								size={400}

--- a/src/views/validated-designs/server.ts
+++ b/src/views/validated-designs/server.ts
@@ -96,10 +96,6 @@ export function getHvdCategoryGroups(): HvdCategoryGroup[] | null {
 		const pathParts = item.split('/')
 		const [product, category] = pathParts
 
-		if (!isProductSlug(product)) {
-			return
-		}
-
 		const metadata = loadMetadata(path.join(HVD_CONTENT_DIR, item))
 		if (!metadata) {
 			return
@@ -115,7 +111,10 @@ export function getHvdCategoryGroups(): HvdCategoryGroup[] | null {
 				slug,
 				title: metadata.title,
 				description: metadata.description,
-				product: product as Exclude<ProductSlug, 'sentinel'>,
+				productSlug: (isProductSlug(product) ? product : 'hcp') as Exclude<
+					ProductSlug,
+					'sentinel'
+				>,
 				guides: [],
 			})
 		} else if (isHvdMetadata) {
@@ -208,7 +207,7 @@ export async function getHvdGuidePropsFromSlug(
 	for (const categoryGroup of categoryGroups) {
 		for (const guide of categoryGroup.guides) {
 			if (guide.slug === guideSlug) {
-				validatedDesignsGuideProps.productSlug = categoryGroup.product
+				validatedDesignsGuideProps.productSlug = categoryGroup.productSlug
 
 				for (let index = 0; index < guide.pages.length; index++) {
 					const page = guide.pages[index]

--- a/src/views/validated-designs/types.ts
+++ b/src/views/validated-designs/types.ts
@@ -9,7 +9,7 @@ export interface HvdCategoryGroup {
 	slug: string // start of slug e.g. terraform-operation-guides-adoption, used to add to it's guides after the category group is created
 	title: string // from YAML
 	description: string // from YAML
-	product: Exclude<ProductSlug, 'sentinel'>
+	productSlug: Exclude<ProductSlug, 'sentinel'>
 	guides: HvdGuide[]
 }
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task - None small change](https://hashicorp.slack.com/archives/C05CCCMNUGN/p1712330353730979) 🎟️

## 🗒️ What

Currently HVD guides must be a Hashicorp product name, this PR removes that requirement.

## 🧪 Testing

1. Checkout this branch
2. Start the project (so HVD downloads)
3. Run this script in this repos root directory to create a newly, non-product named HVD guide:
`cp -r src/.extracted/hashicorp-validated-designs/content/vault src/.extracted/hashicorp-validated-designs/content/integration-patterns`

- [ ] Make sure HVD guide "Integration Patterns" renders
