### PR TITLE
Fix a bug when setting aria-describedby

### DIFF
--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -37,12 +37,13 @@ const Link = ({ children, href, opensInNewTab, ...restProps }: LinkProps) => {
 	/**
 	 * Generate the final link's `aria-describedby` prop.
 	 */
-	let ariaDescribedBy: LinkProps['aria-describedby']
+	let ariaDescribedBy: LinkProps['aria-describedby'] = ''
 	if (shouldRenderScreenReaderOnlyMessage) {
-		ariaDescribedBy = opensInNewTabLabelId
+		ariaDescribedBy += opensInNewTabLabelId
 	}
+
 	if (restProps['aria-describedby']?.length > 0) {
-		ariaDescribedBy = ` ${restProps['aria-describedby']}`
+		ariaDescribedBy += ` ${restProps['aria-describedby']}`
 	}
 
 	return (

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -39,10 +39,10 @@ const Link = ({ children, href, opensInNewTab, ...restProps }: LinkProps) => {
 	 */
 	let ariaDescribedBy: LinkProps['aria-describedby']
 	if (shouldRenderScreenReaderOnlyMessage) {
-		ariaDescribedBy += opensInNewTabLabelId
+		ariaDescribedBy = opensInNewTabLabelId
 	}
 	if (restProps['aria-describedby']?.length > 0) {
-		ariaDescribedBy += ` ${restProps['aria-describedby']}`
+		ariaDescribedBy = ` ${restProps['aria-describedby']}`
 	}
 
 	return (


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-fixproduct-nav-open-in-a11y-hashicorp.vercel.app/terraform) 🔎
- [Asana task](https://app.asana.com/0/1205890709355230/1205890709355241/f) 🎟️

## 🗒️ What

Because of a bug, namely using += instead of = on a undefined variable, when setting `ariaDescribedBy` some information was not showing up in the accessibility tree. (In this case "opens in new window")

## 🧪 Testing

- [ ] [Make sure that "registry ▶️" link in the navbar](https://dev-portal-git-rn-fixproduct-nav-open-in-a11y-hashicorp.vercel.app/terraform) has the accessible description of: "(opens in new tab)"

You can view an element accessible tree properties by following this screenshot:
![Screenshot 2024-04-24 at 4 05 09 PM](https://github.com/hashicorp/dev-portal/assets/1957315/456f8c49-a1eb-46d5-a5d2-3bc25e4d4bee)


