### PR TITLE
Always show border when active for user login menu

### DIFF
--- a/src/components/navigation-header/navigation-header.module.css
+++ b/src/components/navigation-header/navigation-header.module.css
@@ -107,7 +107,8 @@
 	background-color: transparent;
 	color: var(--token-color-foreground-high-contrast);
 
-	&:hover {
+	&:hover,
+	&[aria-expanded='true'] {
 		border-color: var(--token-color-palette-neutral-200);
 	}
 
@@ -120,7 +121,7 @@
 	@nest html[data-theme='dark'] & {
 		color: var(--token-color-foreground-strong);
 
-		&:hover {
+		&:hover, &[aria-expanded='true'] {
 			border-color: var(--token-color-border-strong);
 		}
 	}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-feata11y-login-menu-active-border-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1205890709355230/1205890709355281/f) 🎟️

## 🗒️ What

Always show user menu border when open.


## 🧪 Testing

![Screenshot 2024-04-29 at 11 16 25 AM](https://github.com/hashicorp/dev-portal/assets/1957315/b599e996-7bb2-4b8f-bbf5-b9f1e0751300)

- [ ] When the user menu is open, it should always show it's border. (both in light and dark mode.)

