### PR TITLE
Default aria-describedby to null and only set when needed

### DIFF
--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -37,13 +37,15 @@ const Link = ({ children, href, opensInNewTab, ...restProps }: LinkProps) => {
 	/**
 	 * Generate the final link's `aria-describedby` prop.
 	 */
-	let ariaDescribedBy: LinkProps['aria-describedby'] = ''
+	let ariaDescribedBy: LinkProps['aria-describedby']
 	if (shouldRenderScreenReaderOnlyMessage) {
-		ariaDescribedBy += opensInNewTabLabelId
+		ariaDescribedBy = opensInNewTabLabelId
 	}
 
 	if (restProps['aria-describedby']?.length > 0) {
-		ariaDescribedBy += ` ${restProps['aria-describedby']}`
+		ariaDescribedBy = !ariaDescribedBy
+			? restProps['aria-describedby']
+			: `${ariaDescribedBy} ${restProps['aria-describedby']}`
 	}
 
 	return (


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-fixonly-set-aria-describedby-794e5c-hashicorp.vercel.app/hcp/docs/vault/what-is-hcp-vault/client) 🔎
- 🎟️ Asana task - None bug

## 🗒️ What

When changing aria-describedby to fix an undefined error last week, we introduce a new bug where we are adding an empty aria-describedby to a bunch of elements. This PR fixes that.

## 🧪 Testing

![Screenshot 2024-04-29 at 2 10 52 PM](https://github.com/hashicorp/dev-portal/assets/1957315/f9aae303-95b5-490d-9786-89ce08976e4f)

On the 

- [x] [In the current top bar](https://developer.hashicorp.com/hcp/docs/vault/what-is-hcp-vault/client) every link currently an empty aria-describedby. [Make sure that this PR removes that.](https://dev-portal-git-rn-fixonly-set-aria-describedby-794e5c-hashicorp.vercel.app/hcp/docs/vault/what-is-hcp-vault/client)
