### PR TITLE
Only show aria-controls when specific sidebar menu is open

### DIFF
--- a/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
+++ b/src/components/sidebar/components/sidebar-nav-menu-item/index.tsx
@@ -245,7 +245,7 @@ const SidebarNavSubmenuItem = ({ item }: SidebarNavMenuItemProps) => {
 	return (
 		<>
 			<button
-				aria-controls={listId}
+				aria-controls={isOpen ? listId : null}
 				aria-expanded={isOpen}
 				className={s.sidebarNavMenuItem}
 				id={buttonId}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-featfix-aria-controls-in-sidebar-hashicorp.vercel.app/hcp/docs/vault/what-is-hcp-vault/client) 🔎
- [Asana task](https://app.asana.com/0/1205890709355230/1206539228551239/f) 🎟️

## 🗒️ What

Only show `aria-controls` when specific sidebar menu is open. (Because we hide the element that has that ID when the menu item is not opened.)

## 🧪 Testing

![Screenshot 2024-04-29 at 2 51 45 PM](https://github.com/hashicorp/dev-portal/assets/1957315/d6d5b7ee-c58d-4118-b609-28c8ff282279)

- [ ] When sidebar menu item is not opened there should be no `aria-controls` property on the element. (Because we hide the element that has that ID when the menu item is not opened.)
