### PR TITLE
updates boundary/community- tutorial links

### DIFF
--- a/src/content/boundary/install-landing.json
+++ b/src/content/boundary/install-landing.json
@@ -1,7 +1,7 @@
 {
 	"featuredTutorialsSlugs": [
 		"boundary/oidc-auth0",
-		"boundary/oss-vault-cred-brokering-quickstart",
+		"boundary/community-vault-cred-brokering-quickstart",
 		"boundary/hcp-manage-workers",
 		"boundary/hcp-ssh-cred-injection",
 		"boundary/oidc-idp-groups",

--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -26,8 +26,8 @@
 			},
 			{
 				"icon": "hcp",
-				"text": "Boundary OSS Quick Start",
-				"url": "/boundary/tutorials/oss-getting-started"
+				"text": "Boundary Community Edition Quick Start",
+				"url": "/boundary/tutorials/community-getting-started"
 			}
 		]
 	},
@@ -73,10 +73,10 @@
 			"type": "tutorial_cards",
 			"tutorialSlugs": [
 				"boundary/oidc-auth0",
-				"boundary/oss-vault-cred-brokering-quickstart",
+				"boundary/community-vault-cred-brokering-quickstart",
 				"boundary/hcp-manage-workers",
 				"boundary/hcp-ssh-cred-injection",
-				"boundary/oss-manage-targets",
+				"boundary/community-manage-targets",
 				"boundary/oidc-idp-groups"
 			]
 		}


### PR DESCRIPTION
## 🔗 Relevant links

- [Boundary landing preview link](https://dev-portal-git-boundary-community-links-hashicorp.vercel.app/boundary)
- [Boundary install preview link](https://dev-portal-git-boundary-community-links-hashicorp.vercel.app/boundary/install) 🔎
- [SPE Jira task](https://hashicorp.atlassian.net/browse/SPE-780?atlOrigin=eyJpIjoiNTMyMDg1ZWQ3Mzc0NDgzN2JhMTNlZDJjMDk3N2RkNDQiLCJwIjoiaiJ9) 🎟️

## 🗒️ What

This PR updates the Boundary product landing and install pages with new tutorial links.

## 🤷 Why

Boundary is removing all references to `oss` in tutorial slugs and renaming them to `community`. This PR should be merged prior to [tutorials PR XXX]() to allow the vercel preview to build with the new dev-portal image.

## 🛠️ How

I updated the following files with new boundary tutorial links:

- src/content/boundary/install-landing.json
- src/content/boundary/product-landing.json

## 🧪 Testing

I built the dev-portal image locally with these changes and used it to test my local tutorials build, which renders correctly.