### PR TITLE
Tutorials: removes missed boundary/oss link from tutorials landing page

### DIFF
--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -136,7 +136,6 @@
 			],
 			"featuredCollectionSlugs": [
 				"boundary/hcp-getting-started",
-				"boundary/oss-getting-started",
 				"boundary/hcp-administration"
 			]
 		},


### PR DESCRIPTION
## 🔗 Relevant links

- [Tutorials landing preview link](https://dev-portal-4mk385c2k-hashicorp.vercel.app/tutorials)🔎
- [SPE Jira task](https://hashicorp.atlassian.net/browse/SPE-780?atlOrigin=eyJpIjoiNTMyMDg1ZWQ3Mzc0NDgzN2JhMTNlZDJjMDk3N2RkNDQiLCJwIjoiaiJ9) 🎟️

## 🗒️ What

This PR removes a missed boundary/oss-* tutorial link from the tutorials landing page.

## 🤷 Why

Boundary is removing all references to `oss` in tutorial slugs and renaming them to `community`. This PR should be merged prior to [tutorials PR 2045](https://github.com/hashicorp/tutorials/pull/2045) to allow the vercel preview to build with the new dev-portal image.

These tutorials will be added back to the product, install, and tutorials landing pages after the tutorial renaming is complete.

## 🛠️ How

I updated the following files to remove the boundary tutorial links:

- src/content/tutorials-landing.json
## 🧪 Testing

I built the dev-portal image locally with these changes and used it to test my local tutorials build, which renders correctly.