### PR TITLE
Rab boundary add community links

### DIFF
--- a/src/content/boundary/install-landing.json
+++ b/src/content/boundary/install-landing.json
@@ -1,6 +1,7 @@
 {
 	"featuredTutorialsSlugs": [
 		"boundary/oidc-auth0",
+		"boundary/community-vault-cred-brokering-quickstart",
 		"boundary/hcp-manage-workers",
 		"boundary/hcp-ssh-cred-injection",
 		"boundary/oidc-idp-groups",

--- a/src/content/boundary/product-landing.json
+++ b/src/content/boundary/product-landing.json
@@ -23,6 +23,11 @@
 				"icon": "hcp",
 				"text": "HCP Boundary Quick Start",
 				"url": "/boundary/tutorials/hcp-getting-started"
+			},
+			{
+				"icon": "boundary-color",
+				"text": "Boundary Community Edition Quick Start",
+				"url": "/boundary/tutorials/get-started-community"
 			}
 		]
 	},
@@ -68,8 +73,10 @@
 			"type": "tutorial_cards",
 			"tutorialSlugs": [
 				"boundary/oidc-auth0",
+				"boundary/community-vault-cred-brokering-quickstart",
 				"boundary/hcp-manage-workers",
 				"boundary/hcp-ssh-cred-injection",
+				"boundary/aws-session-rec-vault",
 				"boundary/oidc-idp-groups"
 			]
 		}

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -136,7 +136,7 @@
 			],
 			"featuredCollectionSlugs": [
 				"boundary/hcp-getting-started",
-				"boundary/community-getting-started",
+				"boundary/get-started-community",
 				"boundary/hcp-administration"
 			]
 		},

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -136,6 +136,7 @@
 			],
 			"featuredCollectionSlugs": [
 				"boundary/hcp-getting-started",
+				"boundary/community-getting-started",
 				"boundary/hcp-administration"
 			]
 		},


### PR DESCRIPTION
## 🔗 Relevant links

- [tutorials landing preview link](https://dev-portal-git-rab-boundary-add-community-links-hashicorp.vercel.app/tutorials)
- [Boundary landing preview link](https://dev-portal-git-rab-boundary-add-community-links-hashicorp.vercel.app/boundary)
- [Boundary install preview link](https://dev-portal-git-rab-boundary-add-community-links-hashicorp.vercel.app/boundary/install) 🔎
- [SPE Jira task](https://hashicorp.atlassian.net/browse/SPE-780?atlOrigin=eyJpIjoiNTMyMDg1ZWQ3Mzc0NDgzN2JhMTNlZDJjMDk3N2RkNDQiLCJwIjoiaiJ9) 🎟️

## 🗒️ What

This PR adds the boundary/community-* tutorial links back to the Boundary product landing and install pages.

## 🤷 Why

This PR follows up on [2432](https://github.com/hashicorp/dev-portal/pull/2432) and [2433](https://github.com/hashicorp/dev-portal/pull/2433) by adding back the boundary community edition links.

Boundary is removing all references to `oss` in tutorial slugs and renaming them to `community'. [Tutorials PR 2045](https://github.com/hashicorp/tutorials/pull/2045) completed the renaming, and all new slugs are live on devdot.

## 🛠️ How

I updated the following files to remove the boundary tutorial links:

- src/content/tutorials-landing.json
- src/content/boundary/install-landing.json
- src/content/boundary/product-landing.json

## 🧪 Testing

