### PR TITLE
chore: update GitHub Actions workflows to node 20

### DIFF
--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Sync `staging`
         run: |
           git config user.name github-actions

--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Sync `staging`
         run: |
           git config user.name github-actions

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@10.2.3
+      - name: Install npm@9.6.4
         run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@9.6.4
-        run: npm install --global npm@10.2.3
+      - name: Install npm@8
+        run: npm install --global npm@8
       - name: Install dependencies
         run: npm ci
       - name: Cache .io sites, docs paths, and tutorial paths

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -7,12 +7,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
-      - name: Install npm@8
-        run: npm install --global npm@8
+      - name: Install npm@9.6.7
+        run: npm install --global npm@9.6.7
       - name: Install dependencies
         run: npm ci
       - name: Cache .io sites, docs paths, and tutorial paths

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -7,8 +7,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
       - name: Install npm@8

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install npm@9.6.7
-        run: npm install --global npm@9.6.7
+          node-version: 20
+      - name: Install npm@10.2.3
+        run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci
       - name: Cache .io sites, docs paths, and tutorial paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: 'Run Tests 🧪'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
 
@@ -26,10 +26,10 @@ jobs:
     name: 'Lint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20
 
       - run: npm ci
       - run: npm run test:ci
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: 'Run Tests 🧪'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
 
@@ -26,10 +26,10 @@ jobs:
     name: 'Lint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # vv9.0.0
         with:
           days-before-pr-stale: 20
           days-before-pr-close: 5

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # vv9.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           days-before-pr-stale: 20
           days-before-pr-close: 5

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,17 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Emulate ARM Processor
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@2a1a44ac4aa01993040736bd95bb470da1a38365 # v2.9.0
-
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Login to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -38,7 +37,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -50,7 +49,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       # Emulate ARM Processor
       - name: Set up QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       # Login against a Docker registry
       # https://github.com/docker/login-action
       - name: Login to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -49,7 +49,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Get PR number
         id: get-pr-number
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -48,7 +48,7 @@ jobs:
       - name: Get list of PR files
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
         id: get-lists-of-pr-files
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ steps.get-pr-number.outputs.result }}
           MDX_DIRECTORY: ${{ inputs.mdx-directory }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Checkout dev-portal
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: 'hashicorp/dev-portal'
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check out branch with content changes
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           path: 'content-repo'
           repository: '${{ inputs.repo-owner }}/${{ inputs.repo-name }}'

--- a/.github/workflows/docs-content-check-legacy-links-format.yml
+++ b/.github/workflows/docs-content-check-legacy-links-format.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Checkout dev-portal
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           repository: 'hashicorp/dev-portal'
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check out branch with content changes
         if: ${{ steps.get-pr-number.outputs.result != 'false' }}
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           path: 'content-repo'
           repository: '${{ inputs.repo-owner }}/${{ inputs.repo-name }}'

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install --global npm@latest
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@c5482d70ec8706408996e31ac94075030694993f # v1.8.32
+        uses: bahmutov/npm-install@5653d39101a041a30cc58572d6bd566b90a6de20 # v1.8.38
 
       - name: Restore next build
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -18,10 +18,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up node
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
 
@@ -32,7 +32,7 @@ jobs:
         uses: bahmutov/npm-install@c5482d70ec8706408996e31ac94075030694993f # v1.8.32
 
       - name: Restore next build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         id: restore-build-cache
         env:
           cache-name: cache-next-build
@@ -54,13 +54,13 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: bundle
           path: .next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         if: success() && github.event.number
         with:
           workflow: nextjs_bundle_analysis.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Get comment body
         id: get-comment-body
         if: success() && github.event.number
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           result-encoding: string
           script: |
@@ -96,7 +96,7 @@ jobs:
             core.setOutput('body', comment)
 
       - name: Find Comment
-        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
+        uses: peter-evans/find-comment@d5fe37641ad8451bdd80312415672ba26c86575e # v3.0.0
         if: success() && github.event.number
         id: fc
         with:
@@ -104,14 +104,14 @@ jobs:
           body-includes: '<!-- __NEXTJS_BUNDLE -->'
 
       - name: Create Comment
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         if: success() && github.event.number && steps.fc.outputs.comment-id == 0
         with:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         if: success() && github.event.number && steps.fc.outputs.comment-id != 0
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
+          node-version: 20
 
       - name: Install latest npm
         run: npm install --global npm@latest

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -18,10 +18,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Set up node
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
 
@@ -29,10 +29,10 @@ jobs:
         run: npm install --global npm@latest
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@5653d39101a041a30cc58572d6bd566b90a6de20 # v1.8.38
+        uses: bahmutov/npm-install@237ded403e6012a48281f4572eab0c8eafe55b3f # v1.10.1
 
       - name: Restore next build
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         id: restore-build-cache
         env:
           cache-name: cache-next-build
@@ -54,13 +54,13 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: bundle
           path: .next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         if: success() && github.event.number
         with:
           workflow: nextjs_bundle_analysis.yml
@@ -96,7 +96,7 @@ jobs:
             core.setOutput('body', comment)
 
       - name: Find Comment
-        uses: peter-evans/find-comment@d5fe37641ad8451bdd80312415672ba26c86575e # v3.0.0
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         if: success() && github.event.number
         id: fc
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,12 +6,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
-      - name: Install npm@8
-        run: npm install --global npm@8
+      - name: Install npm@9.6.7
+        run: npm install --global npm@9.6.7
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright
@@ -20,7 +20,7 @@ jobs:
         run: npm run test:e2e
         env:
           E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@9.6.4
-        run: npm install --global npm@10.2.3
+      - name: Install npm@8
+        run: npm install --global npm@8
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@10.2.3
+      - name: Install npm@9.6.4
         run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install npm@9.6.7
-        run: npm install --global npm@9.6.7
+          node-version: 20
+      - name: Install npm@10.2.3
+        run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,8 +6,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
       - name: Install npm@8
@@ -20,7 +20,7 @@ jobs:
         run: npm run test:e2e
         env:
           E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
-      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/register-preview-url.yml
+++ b/.github/workflows/register-preview-url.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@9.6.4
-        run: npm install --global npm@10.2.3
+      - name: Install npm@8
+        run: npm install --global npm@8
       - name: Install dependencies
         run: npm ci
       - name: Add Preview URL to CloudIDP

--- a/.github/workflows/register-preview-url.yml
+++ b/.github/workflows/register-preview-url.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: 20
-      - name: Install npm@10.2.3
+      - name: Install npm@9.6.4
         run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/register-preview-url.yml
+++ b/.github/workflows/register-preview-url.yml
@@ -21,8 +21,8 @@ jobs:
           echo "Deployed State: ${{ github.event.deployment_status.state }}" >> $GITHUB_STEP_SUMMARY
           echo "target_url: ${{ github.event.deployment_status.target_url }}" >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
       - name: Install npm@8

--- a/.github/workflows/register-preview-url.yml
+++ b/.github/workflows/register-preview-url.yml
@@ -21,12 +21,12 @@ jobs:
           echo "Deployed State: ${{ github.event.deployment_status.state }}" >> $GITHUB_STEP_SUMMARY
           echo "target_url: ${{ github.event.deployment_status.target_url }}" >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version-file: '.nvmrc'
-      - name: Install npm@8
-        run: npm install --global npm@8
+      - name: Install npm@9.6.7
+        run: npm install --global npm@9.6.7
       - name: Install dependencies
         run: npm ci
       - name: Add Preview URL to CloudIDP

--- a/.github/workflows/register-preview-url.yml
+++ b/.github/workflows/register-preview-url.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install npm@9.6.7
-        run: npm install --global npm@9.6.7
+          node-version: 20
+      - name: Install npm@10.2.3
+        run: npm install --global npm@10.2.3
       - name: Install dependencies
         run: npm ci
       - name: Add Preview URL to CloudIDP

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ !(github.event_name == 'schedule' && github.repository == 'hashicorp/dev-portal') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           persist-credentials: false
       - name: repo-sync

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -4,7 +4,7 @@
 
 on:
   schedule:
-    - cron: "0 */2 * * *" # https://crontab.guru/every-2-hours
+    - cron: '0 */2 * * *' # https://crontab.guru/every-2-hours
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     if: ${{ !(github.event_name == 'schedule' && github.repository == 'hashicorp/dev-portal') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
       - name: repo-sync
@@ -32,7 +32,7 @@ jobs:
         with:
           source_branch: repo-sync
           destination_branch: main
-          pr_title: "repo sync"
+          pr_title: 'repo sync'
           pr_body: |
             This is an automated pull request to sync changes between the public and private repos.
             This pull request should be **merged** (not squashed) to preserve continuity across repos.
@@ -56,7 +56,7 @@ jobs:
       # Ensure the PR is up-to-date with main
       - name: Update branch
         if: ${{ steps.find-pull-request.outputs.number }}
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
           script: |
@@ -103,7 +103,7 @@ jobs:
 
       - name: Check pull request file count after updating
         if: ${{ steps.find-pull-request.outputs.number }}
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: pr-files
         env:
           PR_NUMBER: ${{ steps.find-pull-request.outputs.number }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		]
 	},
 	"engines": {
-		"npm": ">=8.0.0",
+		"npm": ">=v9.6.7",
 		"node": ">=18.17.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		]
 	},
 	"engines": {
-		"npm": ">=v9.6.7",
+		"npm": ">=8.0.0",
 		"node": ">=18.17.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Updates all GitHub Actions avoid Node 16, using versions approved based on security recommendations.

## 🛠️ How

To start, I swiped all the work from #2335 - Thanks Heat! 🙌 

Then, referenced the `security-tsccr` repo to update all actions to their latest approved versions:

```sh
actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
bahmutov/npm-install@237ded403e6012a48281f4572eab0c8eafe55b3f # v1.10.1
dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
```


## 🧪 Testing

- [x] 👀 Look through the [workflows run off of this branch](https://github.com/hashicorp/dev-portal/actions?query=branch%3Azs.update-gha-node-20)
    - Ensure none of them are showing the `Node.js 16 actions are deprecated` warning
- [x] 👯 Check that previews from the content repositories still work
    - I've got a PR that checks this over in [vault#26885 - chore: test dev-portal GitHub Actions update to Node 20](https://github.com/hashicorp/vault/pull/26885)
    - How it works: the PR above modifies the `website-start.sh` and `website-build.sh` scripts to `checkout` the `dev-portal` branch that makes the changes we want to validate (`zs.update-gha-node-20`). We update `website-start.sh` so we can validate local previews. We update `website-build.sh` and push up a PR to the content repo so that we can validate deploy previews.
    - Here's the [deploy preview](https://vault-git-zstest-gha-node-20-hashicorp.vercel.app/) from the above PR
- [x] 👯 Check that previews from the `tutorials` repository will still work
    - To test this locally, I first cloned down the `tutorials` repo, adjacent to my local copy of the `dev-portal` repo. I hadn't used Docker in while so running `make` and making sure local preview worked even _before_ making any changes felt helpful.
    - To get the `tutorials` repo to use the local `dev-portal` work, I updated the `learn-frontend` section of the `docker-compose.yaml` file. In that file, I removed `image: hashicorp/dev-portal:latest`, which pulls an image from Docker hub (which should be [the latest image we've published from main](https://github.com/hashicorp/dev-portal/blob/da762e8c95c78c40ad7c46edbd8fbbf07ad475f4/.github/workflows/docker_publish.yml#L49)). I replaced that like with a `build` section, with `context: ../dev-portal` (the path to the adjacent repo). From there, running `make` showed changes I'd made locally in `dev-portal`, and the preview server seemed to work fine when I checked out changes made in this branch (`zs.update-gha-node-20`).

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsupdate-gha-node-20-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1206176289707208/1207233798525119/f