### PR TITLE
fix: update repo-sync script for dev-portal-internal

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -137,7 +137,6 @@ jobs:
             console.log('Checking for merge conflicts')
             if (pull.mergeable_state === 'dirty') {
               console.log('Pull request has a conflict', pull.html_url)
-              await closePullRequest(pull_number)
               throw new Error('Pull request has a conflict, please resolve manually')
             }
             console.log('No detected merge conflicts')

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,136 +1,154 @@
 # Note this is almost fully copied from
 # https://github.com/github/docs/blob/main/.github/workflows/repo-sync.yml
-# with the exception of a few modifications.
+# with the exception of:
+# - the `cron` schedule
+# - the `if` condition to allow this to run only in `dev-portal-internal`
+# - the `source_repo` has been updated to `dev-portal`
+# - the PAT credentials are from our `hashibot-web` account. They're managed in
+#   the `dev-portal-internal` repository secrets.
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # https://crontab.guru/every-2-hours
-  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   repo-sync:
-    # disallow scheduled runs for public repo
-    if: ${{ !(github.event_name == 'schedule' && github.repository == 'hashicorp/dev-portal') }}
+    if: github.repository == 'hashicorp/dev-portal-internal'
+    name: Repo Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Check out repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Sync repo to branch
+        uses: repo-sync/github-sync@3832fe8e2be32372e1b3970bbae8e7079edeec88
         with:
-          persist-credentials: false
-      - name: repo-sync
-        uses: repo-sync/github-sync@3832fe8e2be32372e1b3970bbae8e7079edeec88 # v2.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-        with:
-          source_repo: ${{ secrets.SOURCE_REPO }} # https://${access_token}@github.com/github/the-other-repo.git
+          source_repo: https://${{ secrets.PAT_HASHIBOT_WEB_DEV_PORTAL_INTERNAL_SYNC }}@github.com/hashicorp/dev-portal.git
           source_branch: main
           destination_branch: repo-sync
-          github_token: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-      - name: Create pull request
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-        with:
-          source_branch: repo-sync
-          destination_branch: main
-          pr_title: 'repo sync'
-          pr_body: |
-            This is an automated pull request to sync changes between the public and private repos.
-            This pull request should be **merged** (not squashed) to preserve continuity across repos.
-            Please take care when merging
-          pr_label: automated-reposync-pr
-          github_token: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-          # This will exit 0 if there's no difference between `repo-sync`
-          # and `main`. And if so, no PR will be created.
-          pr_allow_empty: false
+          github_token: ${{ secrets.PAT_HASHIBOT_WEB_DEV_PORTAL_INTERNAL_SYNC }}
 
-      - name: Find pull request
-        uses: juliangruber/find-pull-request-action@3a4c7c62101755c3778d397dcb6a760a558992f1 # v1.8.0
-        id: find-pull-request
+      - name: Ship pull request
+        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          branch: repo-sync
-          base: main
-          author: hashibot-web
-          state: open
-
-      # Ensure the PR is up-to-date with main
-      - name: Update branch
-        if: ${{ steps.find-pull-request.outputs.number }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-          script: |
-            const mainHeadSha = await github.rest.git.getRef({
-              ...context.repo,
-              ref: 'heads/main'
-            })
-            console.log(`heads/main sha: ${mainHeadSha.data.object.sha}`)
-            const pull = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: parseInt(${{ steps.find-pull-request.outputs.number }})
-            })
-            console.log(`Pull request base sha: ${pull.data.base.sha}`)
-            if (mainHeadSha.data.object.sha !== pull.data.base.sha || pull.data.mergeable_state === 'behind') {
-              try {
-                const updateBranch = await github.rest.pulls.updateBranch({
-                  ...context.repo,
-                  pull_number: parseInt(${{ steps.find-pull-request.outputs.number }})
-                })
-                console.log(updateBranch.data.message)
-              } catch (error) {
-                // When the head branch is modified an error with status 422 is thrown
-                // We should retry one more time to update the branch
-                if (error.status === 422) {
-                  try {
-                    const updateBranch = await github.rest.pulls.updateBranch({
-                      ...context.repo,
-                      pull_number: parseInt(${{ steps.find-pull-request.outputs.number }})
-                    })
-                    console.log(updateBranch.data.message)
-                  } catch (error) {
-                    // Only retry once. We'll rely on the update branch workflow to update
-                    // this PR in the case of a second failure.
-                    console.log(`Retried updating the branch, but an error occurred: ${error}`)
-                  }
-                } else {
-                  // A failed branch update shouldn't fail this workflow.
-                  console.log(`An error occurred when updating the branch: ${error}`)
-                }
-              }
-            } else {
-              console.log(`Branch is already up-to-date`)
-            }
-
-      - name: Check pull request file count after updating
-        if: ${{ steps.find-pull-request.outputs.number }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: pr-files
-        env:
-          PR_NUMBER: ${{ steps.find-pull-request.outputs.number }}
-        with:
-          github-token: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
+          github-token: ${{ secrets.PAT_HASHIBOT_WEB_DEV_PORTAL_INTERNAL_SYNC }}
           result-encoding: string
           script: |
-            const { data: prFiles } = await github.rest.pulls.listFiles({
-              ...context.repo,
-              pull_number: process.env.PR_NUMBER,
+            const { owner, repo } = context.repo
+            const head = 'repo-sync'
+            const base = 'main'
+
+            async function closePullRequest(prNumber) {
+              console.log('Closing pull request', prNumber)
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'closed'
+              })
+              // Error loud here, so no try/catch
+              console.log('Closed pull request', prNumber)
+            }
+
+            console.log('Closing any existing pull requests')
+            const { data: existingPulls } = await github.rest.pulls.list({ owner, repo, head, base })
+            if (existingPulls.length) {
+              console.log('Found existing pull requests', existingPulls.map(pull => pull.number))
+              for (const pull of existingPulls) {
+                await closePullRequest(pull.number)
+              }
+              console.log('Closed existing pull requests')
+            }
+
+            try {
+              const { data } = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                head,
+                base,
+              })
+              const { files } = data
+              console.log(`File changes between ${head} and ${base}:`, files)
+              if (!files.length) {
+                console.log('No files changed, bailing')
+                return
+              }
+            } catch (err) {
+              console.error(`Unable to compute the files difference between ${head} and ${base}`, err.message)
+            }
+
+            console.log('Creating a new pull request')
+            const body = `
+            This is an automated pull request to sync changes between the public and private repos.
+            Our bot will merge this pull request automatically.
+            To preserve continuity across repos, _do not squash_ this pull request.
+            `
+            let pull, pull_number
+            try {
+              const response = await github.rest.pulls.create({
+                owner,
+                repo,
+                head,
+                base,
+                title: 'Repo sync',
+                body,
+              })
+              pull = response.data
+              pull_number = pull.number
+              console.log('Created pull request successfully', pull.html_url)
+            } catch (err) {
+              // Don't error/alert if there's no commits to sync
+              // Don't throw if > 100 pulls with same head_sha issue
+              if (err.message?.includes('No commits') || err.message?.includes('same head_sha')) {
+                console.log(err.message)
+                return
+              }
+              throw err
+            }
+
+            console.log('Locking conversations to prevent spam')
+            try {
+              await github.rest.issues.lock({
+                ...context.repo,
+                issue_number: pull_number,
+                lock_reason: 'spam'
+              })
+              console.log('Locked the pull request to prevent spam')
+            } catch (error) {
+              console.error('Failed to lock the pull request.', error)
+              // Don't fail the workflow
+            }
+
+            console.log('Counting files changed')
+            const { data: prFiles } = await github.rest.pulls.listFiles({ owner, repo, pull_number })
+            if (prFiles.length) {
+              console.log(prFiles.length, 'files have changed')
+            } else {
+              console.log('No files changed, closing')
+              await closePullRequest(pull_number)
+              return
+            }
+
+            console.log('Checking for merge conflicts')
+            if (pull.mergeable_state === 'dirty') {
+              console.log('Pull request has a conflict', pull.html_url)
+              await closePullRequest(pull_number)
+              throw new Error('Pull request has a conflict, please resolve manually')
+            }
+            console.log('No detected merge conflicts')
+
+            console.log('Merging the pull request')
+            // Admin merge pull request to avoid squash
+            await github.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number,
+              merge_method: 'merge',
             })
-            core.setOutput('count', (prFiles && prFiles.length || 0).toString())
-
-      # Sometimes after updating the branch, there aren't any remaining files changed.
-      # If not, we should close the PR instead of merging it and triggering deployments.
-      - name: Close the pull request if no files remain
-        if: ${{ steps.find-pull-request.outputs.number && steps.pr-files.outputs.count == '0' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-        run: |
-          gh pr close ${{ steps.find-pull-request.outputs.number }} --repo $GITHUB_REPOSITORY
-
-      # DANGER: ONLY AUTO MERGE INTERNAL PRs
-      - name: Admin merge the pull request
-        if: ${{ steps.find-pull-request.outputs.number && steps.pr-files.outputs.count != '0' && github.repository == 'hashicorp/dev-portal-internal' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
-          PR_NUMBER: ${{ steps.find-pull-request.outputs.number }}
-        run: |
-          gh pr merge $PR_NUMBER --admin --merge
+            // Error loud here, so no try/catch
+            console.log('Merged the pull request successfully')


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes up the `repo-sync` workflow so that our `dev-portal-internal` repo can resume syncing.

## 🛠️ How

- Updates the workflow to align with more recent work in the workflow we originally copied
- Updates the PAT being used, as I think the previous one had expired

## 🧪 Testing

- Check out the results of a test of this modified action, at https://github.com/hashicorp/dev-portal-internal/pull/342/
    - Note that since `repo-sync` hadn't been run in a while, that PR did require some manual merge conflict resolution. All the changes seemed like trivial content changes, so my approach was to default to whatever's on `dev-portal` `main`, and discard whatever conflicting changes were present in `dev-portal-internal` `main`.

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zsfix-internal-repo-sync-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1206176289707208/1207289625383844/f