### PR TITLE
fix: announce page transitions

### DIFF
--- a/src/components/route-announcer/index.tsx
+++ b/src/components/route-announcer/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * Note: this file is a near-duplicate of NextJS's included
+ * route announcer:
+ *
+ * https://github.com/vercel/next.js/blob/v14.2.1/packages/next/src/client/route-announcer.tsx
+ *
+ * It seems that `aria-live="assertive"`, as used there, results
+ * in the announcement not being read out at all (at least in some
+ * basic testing). This version uses `aria-live="polite"` instead,
+ * which seems to work as expected, with route changes being
+ * announced consistently.
+ */
+
+import React from 'react'
+import { useRouter } from 'next/router'
+
+const nextjsRouteAnnouncerStyles: React.CSSProperties = {
+	border: 0,
+	clip: 'rect(0 0 0 0)',
+	height: '1px',
+	margin: '-1px',
+	overflow: 'hidden',
+	padding: 0,
+	position: 'absolute',
+	top: 0,
+	width: '1px',
+
+	// https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+	whiteSpace: 'nowrap',
+	wordWrap: 'normal',
+}
+
+export const RouteAnnouncer = () => {
+	const { asPath } = useRouter()
+	const [routeAnnouncement, setRouteAnnouncement] = React.useState('')
+
+	// Only announce the path change, but not for the first load because screen
+	// reader will do that automatically.
+	const previouslyLoadedPath = React.useRef(asPath)
+
+	// Every time the path changes, announce the new page’s title following this
+	// priority: first the document title (from head), otherwise the first h1, or
+	// if none of these exist, then the pathname from the URL. This methodology is
+	// inspired by Marcy Sutton’s accessible client routing user testing. More
+	// information can be found here:
+	// https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
+	React.useEffect(
+		() => {
+			console.log('asPath changed!')
+			console.log({
+				asPath,
+				previouslyLoadedPath: previouslyLoadedPath.current,
+			})
+			// If the path hasn't change, we do nothing.
+			if (previouslyLoadedPath.current === asPath) return
+			previouslyLoadedPath.current = asPath
+
+			if (document.title) {
+				console.log(
+					`setting routeAnnouncement to document.title: ${document.title}`
+				)
+				setRouteAnnouncement(document.title)
+			} else {
+				const pageHeader = document.querySelector('h1')
+				const content = pageHeader?.innerText ?? pageHeader?.textContent
+
+				console.log(`setting routeAnnouncement to content: ${content}`)
+				setRouteAnnouncement(content || asPath)
+			}
+		},
+		// TODO: switch to pathname + query object of dynamic route requirements
+		[asPath]
+	)
+
+	return (
+		<p
+			aria-live="assertive"
+			id="__next-route-announcer_debug__"
+			role="alert"
+			style={nextjsRouteAnnouncerStyles}
+		>
+			{routeAnnouncement}
+		</p>
+	)
+}
+
+export default RouteAnnouncer

--- a/src/components/route-announcer/index.tsx
+++ b/src/components/route-announcer/index.tsx
@@ -74,7 +74,7 @@ export const RouteAnnouncer = () => {
 
 	return (
 		<p
-			aria-live="assertive"
+			aria-live="polite"
 			id="__next-route-announcer_debug__"
 			role="alert"
 			style={nextjsRouteAnnouncerStyles}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -40,6 +40,7 @@ import { AIFeatureToast } from 'components/chatbox/ai-feature-toast'
 // Local imports
 import './style.css'
 import '@hashicorp/react-design-system-components/src/design-system-components.scss'
+import RouteAnnouncer from '@components/route-announcer'
 
 if (typeof window !== 'undefined' && process.env.AXE_ENABLED) {
 	import('react-dom').then((ReactDOM) => {
@@ -94,6 +95,7 @@ export default function App({
 									<CurrentProductProvider currentProduct={currentProduct}>
 										<CodeTabsProvider>
 											<HeadMetadata {...pageProps.metadata} />
+											<RouteAnnouncer />
 											<LazyMotion
 												features={() =>
 													import('lib/framer-motion-features').then(


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Attempts to fix issue where some page transitions are not announced to screen readers.

> **Note**: WIP, in the midst of updating this PR, as it's now focused on ensuring page transitions are announced, rather than focus management during page transitions.

## 🤷 Why

The `RouteAnnouncer` built in to NextJS doesn't seem to function as expected in our use case, at least in some basic testing. It seems like this _might_ be related to `aria-live="assertive"` being used, rather than `aria-live="polite"`... at least in local testing, I seem to get more consistent page transition announcements when using `aria-live="polite"`... yet also occasionally get duplicate announcements (maybe this is just cause I've duplicated the `__next-route-announcer__` element though).

You can see in the first half of the video, with `aria-live="assertive"`, route announcements seem to be working at first, but then stop working. In the second half of the video, I switch to `aria-live="polite"`, and route announcements seem to be working more consistently.

https://github.com/hashicorp/dev-portal/assets/4624598/61bab98b-e887-4acc-84b7-53e3e7f4995c

This PR is an attempt to see if we can resolve the issue without diving into NextJS internals... but it seems like a sticky one, while there might be slight improvements, I seem to be getting inconsistent results and either missing or duplicate route announcements no matter what approach I try to take.

## 🛠️ How

- Pulls in the NextJS `RouteAnnouncer` code, includes it in `_app.tsx`
- Switches `aria-live="assertive"` to `aria-live="polite"

## 🧪 Testing

- [ ] Visit [upstream], confirm the issue exists
    - Quick example: [upstream/packer/docs/hcp]
    - For example, enable VoiceOver in macOS, navigate between sidebar items in docs (which are most often client-side page transitions),and confirm that during some client-side page transitions, the new page title is not announced
- [ ] 🚧 Visit the [preview], confirm page transitions are consistently announced exactly once (not actually working yet)
    - Quick example: [/packer/docs/hcp]
    - For example, enable VoiceOver in macOS, navigate between sidebar items in docs (which are most often client-side page transitions), and confirm that page transitions are consistently announced 

[task]: https://app.asana.com/0/1205890709355230/1205890709355271/f
[upstream]: https://developer.hashicorp.com
[upstream/packer/docs/hcp]: https://developer.hashicorp.com/packer/docs/hcp
[preview]: https://dev-portal-git-zsreset-focus-on-transition-hashicorp.vercel.app/
[/packer/docs/hcp]: https://dev-portal-git-zsreset-focus-on-transition-hashicorp.vercel.app/packer/docs/hcp