### PR TITLE
feat: differentiate the $ prefix in shell-session

### DIFF
--- a/src/lib/syntax-highlighting/theme.ts
+++ b/src/lib/syntax-highlighting/theme.ts
@@ -112,6 +112,10 @@ export const theme: ThemeRegistrationResolved = {
 			settings: { foreground: 'var(--hds-code-block-color-punctuation)' },
 		},
 		{
+			scope: ['punctuation.separator.prompt.shell-session'],
+			settings: { foreground: 'var(--hds-code-block-color-cyan)' },
+		},
+		{
 			scope: [
 				'markup.underline.link',
 				'punctuation.definition.metadata.markdown',


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-dscode-block-shell-prefix-hashicorp.vercel.app/consul/tutorials/get-started-kubernetes/kubernetes-gs-ingress#explore-ingress-into-the-demo-application) 🔎
- [Asana task](https://app.asana.com/0/1206176289707208/1207317287440394/f) 🎟️

## 🗒️ What

This PR adds a specific selector to the `$` prefix in `shell-session` CodeBlocks to differentiate it from the surrounding text.

## 🤷 Why

Our Shiki theme does not currently differentiate the prefix `$` in `shell-session` CodeBlocks, whereas previously Prism did.

## 🛠️ How

Added a specific grammar selector that colors `punctuation.separator.prompt.shell-session` with `var(--hds-code-block-color-cyan)`.

## 📸 Design Screenshots

![image](https://github.com/hashicorp/dev-portal/assets/88163/3b89b00c-c56d-4fe0-9181-8ac3256e670e)

## 🧪 Testing

- Go to [preview](https://dev-portal-git-dscode-block-shell-prefix-hashicorp.vercel.app/consul/tutorials/get-started-kubernetes/kubernetes-gs-ingress#explore-ingress-into-the-demo-application)
- Ensure that the leading `$` is a light blue color.
