### PR TITLE
removes boundary/hcp-getting-started

### DIFF
--- a/src/content/hcp/tutorials-sidebar.json
+++ b/src/content/hcp/tutorials-sidebar.json
@@ -4,10 +4,6 @@
 			"name": "HCP Boundary",
 			"items": [
 				{
-					"name": "Quickstart",
-					"collectionSlug": "boundary/hcp-getting-started"
-				},
-				{
 					"name": "Administration",
 					"collectionSlug": "boundary/hcp-administration"
 				}

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -135,7 +135,6 @@
 				}
 			],
 			"featuredCollectionSlugs": [
-				"boundary/hcp-getting-started",
 				"boundary/get-started-community",
 				"boundary/hcp-administration"
 			]


### PR DESCRIPTION
## 🔗 Relevant links

- [tutorials landing preview link](https://dev-portal-git-rab-boundary-remove-hcp-getting-started-hashicorp.vercel.app/tutorials) 🔎
- [HCP tutorials landing preview link](https://dev-portal-git-rab-boundary-remove-hcp-getting-started-hashicorp.vercel.app/hcp) 🔎
- [Jira task](https://hashicorp.atlassian.net/browse/SPE-754?atlOrigin=eyJpIjoiZTRkNDdjOWQ3MGFlNDRhZGJkZjBkODg4YmQ4OGU1NDIiLCJwIjoiaiJ9) 🎟️

## 🗒️ What

This PR removes the boundary/hcp-getting-started collection links from the dev-portal tutorials/ landing page.

## 🤷 Why

Boundary is renaming the `hcp-getting-started` collection to `get-started-hcp` to help improve SEO. This PR should be merged prior to [tutorials PR 2060](https://github.com/hashicorp/tutorials/pull/2060) to allow the vercel preview to build with the new dev-portal image.

The collection will be added back to the tutorials/ landing page after the collection renaming is complete.

## 🛠️ How

I updated the following files to remove all references to `boundary/hcp-getting-started`:

- src/content/hcp/tutorials-sidebar.json
- src/content/boundary/tutorials-landing.json

## 🧪 Testing

My local preview renders the /tutorials and hcp/tutorials endpoints correctly.