### PR TITLE
[chore] Add redirect for waypoint/commands/:slug

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -183,6 +183,12 @@ async function buildDevPortalRedirects() {
 			permanent: true,
 		},
 		{
+			source: '/waypoint/commands/:slug',
+			destination:
+				'https://github.com/hashicorp/waypoint/tree/main/website/content/commands',
+			permanent: true,
+		},
+		{
 			source: '/waypoint/integrations',
 			destination: '/waypoint',
 			permanent: true,


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task](https://app.asana.com/0/1206176289707208/1207325959967185/f)

## 🗒️ What

- Add redirect for `redirect for waypoint/commands/:slug`

## 🤷 Why

- those pages are no longer relevant to Waypoint documentation as the non-HCP version has been deprecated
- missed in original Waypoint deprecation work

## 🧪 Testing

1. Visit waypoint/commands/login in [production](https://developer.hashicorp.com/waypoint/commands/login)
1. See that it returns a 404 page
1. Visit waypoint/commands/login with [this preview link](https://dev-portal-git-heat-choreadd-waypoint-redirect-hashicorp.vercel.app/waypoint/commands/login)
1. You should be redirected to the [Waypoint GH repo commands directory](https://github.com/hashicorp/waypoint/tree/main/website/content/commands)