### PR TITLE
fix: render correct codetabs names

### DIFF
--- a/src/lib/rehype-code-plugins.ts
+++ b/src/lib/rehype-code-plugins.ts
@@ -18,6 +18,9 @@ export const rehypeCodePlugins: Pluggable[] = [
 			...defaultShikiOptions,
 			transformers: [
 				{
+					pre(node) {
+						node.properties.class = [`language-${this.options.lang}`]
+					},
 					code(node) {
 						// Remove the last line if it's just whitespace
 						const lastChild = node.children[node.children.length - 1]


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR updates our MDX CodeTabs component to correctly render language names and static names (when provided).

## 🛠️ How

1. Add the expected `language-<language>` class to the `pre` element.
2. Override the generated heading when `tabs` is provided.

## 🧪 Testing

- Go to [preview](https://dev-portal-git-dscodeblock-tabs-static-hashicorp.vercel.app/consul/tutorials/implement-multi-tenancy/kubernetes-admin-partitions)
- Ensure that the first CodeTabs instance has tabs for "HTTPS" and "SSH".
- Ensure that the second CodeTabs instance (under the heading "Consul Enterprise values files") has tabs for "Server" and "Client".
- Go to [preview](https://dev-portal-git-dscodeblock-tabs-static-hashicorp.vercel.app/vault/docs/platform/k8s/vso/sources/vault/auth/gcp)
- Ensure that the first CodeTabs instance has tabs for "Shell" and "HCL".
