### PR TITLE
fix(open-api-docs): fix overflowing descriptions

### DIFF
--- a/src/views/open-api-docs-view/components/property-details/index.tsx
+++ b/src/views/open-api-docs-view/components/property-details/index.tsx
@@ -205,7 +205,7 @@ function TreeContent({
 					/>
 				</div>
 			)}
-			<div>{children}</div>
+			<div className={s.treeChildren}>{children}</div>
 		</div>
 	)
 }

--- a/src/views/open-api-docs-view/components/property-details/property-details.module.css
+++ b/src/views/open-api-docs-view/components/property-details/property-details.module.css
@@ -24,8 +24,15 @@ Common styles
 	 to be added here. */
 .description {
 	color: var(--token-color-foreground-faint);
+	width: 100%;
+	overflow-wrap: break-word;
+
 	& p {
 		margin: 0;
+	}
+
+	& pre {
+		white-space: pre-wrap;
 	}
 }
 
@@ -183,4 +190,9 @@ Tree content styling
 		border-bottom-style: solid;
 		border-bottom-left-radius: 4px;
 	}
+}
+
+.treeChildren {
+	width: 0;
+	flex-grow: 1;
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue where some long descriptions in OpenAPI docs views would sometimes overlap into adjacent layout space.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/d89c14e4-eeba-45d1-ae9b-1477e4d912a6) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/7b4aa63f-b028-4002-afb0-a0f9153132bb) |

## 🧪 Testing

- [ ] Visit the [an API docs page upstream][upstream/hcp/api-docs/vault-secrets]
    - Confirm the issue exists, at smaller viewport widths, the descriptions for `Default error response` properties overflow into the sticky column
- [ ] Visit the preview's [/hcp/api-docs/vault-secrets]
    - Even at smaller viewport widths, the descriptions should be contained in their layout area

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/799513369421962/1207309674701468/f
[preview]: https://dev-portal-git-zsopen-api-fix-markdown-overlap-hashicorp.vercel.app/
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsopen-api-fix-markdown-overlap-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[upstream/hcp/api-docs/vault-secrets]: https://developer.hashicorp.com/hcp/api-docs/vault-secrets