### PR TITLE
fix: prevent nbsp characters from being manually copied

### DIFF
--- a/src/lib/rehype-code-plugins.ts
+++ b/src/lib/rehype-code-plugins.ts
@@ -27,9 +27,7 @@ export const rehypeCodePlugins: Pluggable[] = [
 						if (
 							lastChild.type === 'element' &&
 							lastChild.tagName === 'span' &&
-							lastChild.children.length === 1 &&
-							lastChild.children[0].type === 'text' &&
-							lastChild.children[0].value === '\xa0'
+							lastChild.children.length === 0
 						) {
 							node.children.pop()
 						}
@@ -37,9 +35,10 @@ export const rehypeCodePlugins: Pluggable[] = [
 						this.addClassToHast(node, `language-${this.options.lang}`)
 					},
 					line(node, line) {
-						// If the line is empty, add a non-breaking space
+						// If the line is empty, add a class so we can target
+						// it with CSS.
 						if (node.tagName === 'span' && node.children.length === 0) {
-							node.children.push({ type: 'text', value: '\xa0' })
+							this.addClassToHast(node, 'empty-line')
 						}
 					},
 					preprocess(code, options) {

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -288,3 +288,8 @@ and negative margin.
 	font-size: 12px;
 	background: white;
 }
+
+/* Used to render blank lines in code blocks, but prevent them from being copied. */
+.hds-code-block__code .empty-line::after {
+	content: ' ';
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR switches blank lines in our CodeBlocks to use a CSS pseudo element, which won't be copied when the user manually selects content to copy.

## 🤷 Why

Due to the way we split lines, empty lines aren't properly retained. We need to manually insert those blank lines, which requires that we give them some content so they take up space. Previously, we used the `nbsp;` character, but this creates issues when code is copied and pasted, since some languages don't allow this specific character.

## 🛠️ How

This PR switches the approach somewhat, by targeting empty lines via a specific CSS class. This class uses the `:after` pseudo element to render a space character, which isn't copied to the clipboard when a user selects code.

Unfortunately, since the blank lines have no content (not even a line terminating character), blank lines are not preserved when copied manually (they are when using the copy button). We can iterate and fix this later, but right now the important thing is preventing unsupported characters from ending up in our users' code.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [ ] Go to [preview](https://dev-portal-git-dscodeblock-nbsp-hashicorp.vercel.app/terraform/language/meta-arguments/depends_on)
- [ ] Manually select the code in the code block and copy it to your clipboard.
- [ ] Open the console in your web browser.
- [ ] Type the first character of a template literal string <code>`</code>
- [ ] Paste the code
- [ ] Type the closing template literal symbol <code>`</code>
- [ ] Type `.includes('\xa0')`
- [ ] Press enter
- [ ] Ensure the output is `false` (meaning the string does not contain the non-breaking space character).
