### PR TITLE
feat: use native fetch

### DIFF
--- a/scripts/generate-tutorial-variant-map.ts
+++ b/scripts/generate-tutorial-variant-map.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import createFetch from '@vercel/fetch'
 import path from 'path'
 import fs from 'fs'
 import {
@@ -11,8 +10,6 @@ import {
 	ApiTutorialLite,
 	ApiTutorialVariantOption,
 } from 'lib/learn-client/api/api-types'
-
-const fetch = createFetch()
 
 async function fetchTutorialsWithVariants() {
 	const params = new URLSearchParams({ hasVariants: '1' })

--- a/src/lib/integrations-api-client/standard-client.ts
+++ b/src/lib/integrations-api-client/standard-client.ts
@@ -3,19 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const fetch = getFetch()
-
-function getFetch() {
-	// Note: purposely doing a conditional require here so that
-	// `@vercel/fetch` is not included in the client bundle
-	if (typeof window === 'undefined') {
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const createFetch = require('@vercel/fetch')
-		return createFetch()
-	}
-	return window.fetch
-}
-
 export interface BaseModel {
 	id: string
 	created_at: string


### PR DESCRIPTION
## 🗒️ What

This PR removes unnecessary usage of `@vercel/fetch`.

## 🤷 Why

Something has happened on Vercel, resulting in HTTP requests made via `@vercel/fetch` to fail, with a `queryA ETIMEOUT`. `@vercel/fetch` was useful back in the Node v16 days, but now we have native global `fetch`, so we don't need to use it.

## 🛠️ How

Currently two instances of `@vercel/fetch` were breaking builds. Those have been removed, and the respective logic now relies on the global `fetch` object instead of `@vercel/fetch`.
