### PR TITLE
fix: broken icon on tutorials landing

### DIFF
--- a/src/views/tutorials-landing/img/play-custom.svg
+++ b/src/views/tutorials-landing/img/play-custom.svg
@@ -1,9 +1,14 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M2 3.54195C2 0.75696 5.05246 -0.935072 7.39376 0.552093L20.7096 9.01014C22.8943 10.3979 22.8943 13.6021 20.7096 14.9899L7.39376 23.4479C5.05245 24.9351 2 23.243 2 20.458V3.54195ZM5.78439 3.11483C5.44991 2.90238 5.01385 3.1441 5.01385 3.54195V20.458C5.01385 20.8559 5.44992 21.0976 5.78438 20.8852L19.1002 12.4271C19.4123 12.2289 19.4123 11.7711 19.1002 11.5729L5.78439 3.11483Z" fill="url(#paint0_linear_814_44405)"/>
+<g clip-path="url(#clip0_2_2)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2 3.54195C2 0.756959 5.05246 -0.935072 7.39376 0.552093L20.7096 9.01014C22.8943 10.3979 22.8943 13.6021 20.7096 14.9899L7.39376 23.4479C5.05245 24.9351 2 23.243 2 20.458V3.54195ZM5.78439 3.11483C5.44991 2.90238 5.01385 3.1441 5.01385 3.54195V20.458C5.01385 20.8559 5.44992 21.0976 5.78438 20.8852L19.1002 12.4271C19.4123 12.2289 19.4123 11.7711 19.1002 11.5729L5.78439 3.11483Z" fill="url(#paint0_linear_2_2)"/>
+</g>
 <defs>
-<linearGradient id="paint0_linear_814_44405" x1="17.2611" y1="1.6077" x2="4.36822" y2="20.5409" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear_2_2" x1="17.2611" y1="1.6077" x2="4.36822" y2="20.5409" gradientUnits="userSpaceOnUse">
 <stop stop-color="#B5D9FA"/>
 <stop offset="1" stop-color="#1A5EE5"/>
 </linearGradient>
+<clipPath id="clip0_2_2">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
 </defs>
 </svg>


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Fixes an issue on [/tutorials] where an SVG icon is not displayed as expected.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/dd401633-f8e3-4c8d-812d-165c5a161505) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/2296f74c-b9b4-456e-81c6-47b1d97b8572) |

## 🧪 Testing

- [ ] Visit [/tutorials], the icon beside `Byte-sized video demonstrations` about halfway down the page should be visible

[task]: https://app.asana.com/0/1206176289707208/1207349252120013/f
[preview]: https://dev-portal-git-zsfix-tutorial-landing-svg-hashicorp.vercel.app/
[/tutorials]: https://dev-portal-git-zsfix-tutorial-landing-svg-hashicorp.vercel.app/tutorials