### PR TITLE
demo script to fix openapi long description

### DIFF
--- a/scripts/openapi-protobuf-def-replacer.js
+++ b/scripts/openapi-protobuf-def-replacer.js
@@ -1,0 +1,1 @@
+console.log('hello world')

--- a/scripts/openapi-protobuf-def-replacer.js
+++ b/scripts/openapi-protobuf-def-replacer.js
@@ -1,1 +1,0 @@
-console.log('hello world')

--- a/scripts/openapi-scripts/fetch-github-file.js
+++ b/scripts/openapi-scripts/fetch-github-file.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+//@ts-check
+
+const { Octokit } = require('@octokit/core')
+const octokit = new Octokit({
+	auth: process.env.GITHUB_TOKEN,
+})
+
+/**
+ * Fetch a file from GitHub using the GitHub API.
+ *
+ * @param {Object} req
+ * @param {string} req.owner
+ * @param {string} req.repo
+ * @param {string} req.path
+ * @param {string} req.ref
+ * @returns {Promise<string>}
+ */
+async function fetchGithubFile({ owner, repo, path, ref }) {
+	const response = await octokit.request(
+		'GET /repos/{owner}/{repo}/contents/{path}',
+		{ owner, repo, path, ref }
+	)
+	if (response.status !== 200) {
+		throw new Error(
+			`Failed to fetch file from GitHub: ${JSON.stringify({
+				owner,
+				repo,
+				path,
+				ref,
+			})}. Response status code: ${response.status}.`
+		)
+	}
+	const data = /** @type {{ content: string }} */ (response.data)
+	const fileString = Buffer.from(data.content, 'base64').toString('utf-8')
+	return fileString
+}
+
+module.exports = fetchGithubFile

--- a/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
+++ b/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
@@ -1,0 +1,80 @@
+/**
+ * Note: requires GITHUB_TOKEN environment variable to be set.
+ * Run like:
+ * GITHUB_TOKEN=your_token_here node openapi-protobuf-def-replacer.js
+ */
+
+//@ts-check
+
+const fs = require('fs')
+const fetchGithubFile = require('./fetch-github-file')
+
+main()
+
+async function main() {
+	// Fetch the OpenAPI file (could read in local file here instead)
+	const openApiFileString = await fetchGithubFile({
+		owner: 'hashicorp',
+		repo: 'hcp-specs',
+		path: 'specs/cloud-vault-secrets/stable/2023-06-13/hcp.swagger.json',
+		ref: 'main',
+	})
+	// Parse the JSON
+	const openApiSpec = JSON.parse(openApiFileString)
+	/**
+	 * Clone the original spec, replacing the long descriptions in the
+	 * protobufAny definition with shorter ones
+	 */
+	const withNewProtobufDef = cloneAndModify(
+		openApiSpec,
+		['definitions', 'protobufAny', 'description'],
+		'A shorter description for protobufAny.'
+	)
+	const withNewProtobufTypeDef = cloneAndModify(
+		withNewProtobufDef,
+		['definitions', 'protobufAny', 'properties', '@type', 'description'],
+		'A shorter description for protobufAny type.'
+	)
+	// Write out the modified OpenAPI file
+	const jsonString = JSON.stringify(withNewProtobufTypeDef, null, 2)
+	fs.writeFileSync('modified.swagger.json', jsonString)
+}
+
+/**
+ * Given an object, a path to a value within the object,
+ * and a value to replace the existing value at that path,
+ * Return a cloned object with the value at the path replaced.
+ *
+ * If the key path does not exist in the object, throw an error.
+ *
+ * @param {Record<string, any>} object
+ * @param {string[]} keyPath
+ * @param {any} newValue
+ * @param {string[]} prevKeys
+ */
+function cloneAndModify(object, keyPath, newValue, prevKeys = []) {
+	// Base case: end of the key path, replace the value
+	if (keyPath.length === 0) {
+		return newValue
+	}
+	// Recursive case: clone the object and modify the next key, if it exists
+	const [firstKey, ...restKeys] = keyPath
+	// If the property we expect to access with this key doesn't exist,
+	// throw an error
+	if (!(firstKey in object)) {
+		throw new Error(
+			`Error: attempting to clone and modify object, but could not find value at key path ${[
+				...prevKeys,
+				firstKey,
+			].join('.')}. Exiting.`
+		)
+	}
+	// Otherwise, update the object, and return it
+	return {
+		...object,
+		[firstKey]: cloneAndModify(object[firstKey], restKeys, newValue, [
+			...prevKeys,
+			firstKey,
+		]),
+	}
+}

--- a/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
+++ b/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
@@ -28,12 +28,12 @@ async function main() {
 	const withNewProtobufDef = cloneAndModify(
 		openApiSpec,
 		['definitions', 'protobufAny', 'description'],
-		'A shorter description for protobufAny.'
+		'An arbitrary serialized message. Visit the [protobufAny documentation](https://protobuf.dev/reference/protobuf/google.protobuf/#any) for more information.'
 	)
 	const withNewProtobufTypeDef = cloneAndModify(
 		withNewProtobufDef,
 		['definitions', 'protobufAny', 'properties', '@type', 'description'],
-		'A shorter description for protobufAny type.'
+		'A URL that describes the type of the serialized message.'
 	)
 	// Write out the modified OpenAPI file
 	const jsonString = JSON.stringify(withNewProtobufTypeDef, null, 2)

--- a/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
+++ b/scripts/openapi-scripts/openapi-protobuf-def-replacer.js
@@ -57,10 +57,9 @@ function cloneAndModify(object, keyPath, newValue, prevKeys = []) {
 	if (keyPath.length === 0) {
 		return newValue
 	}
-	// Recursive case: clone the object and modify the next key, if it exists
+	// Recursive case: clone the object and modify the value at the next key
 	const [firstKey, ...restKeys] = keyPath
-	// If the property we expect to access with this key doesn't exist,
-	// throw an error
+	// If the property we expect to access with this key doesn't exist, bail out
 	if (!(firstKey in object)) {
 		throw new Error(
 			`Error: attempting to clone and modify object, but could not find value at key path ${[
@@ -69,7 +68,7 @@ function cloneAndModify(object, keyPath, newValue, prevKeys = []) {
 			].join('.')}. Exiting.`
 		)
 	}
-	// Otherwise, update the object, and return it
+	// Otherwise, property at key does exist. Recurse to modify it.
 	return {
 		...object,
 		[firstKey]: cloneAndModify(object[firstKey], restKeys, newValue, [


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task][task] 🎟️

## 🗒️ What

Demo of a script to modify an OpenAPI spec file, in order to alleviate issues caused by super-long descriptions.

## 🛠️ How

Script is written for `node`, and also fetches the API spec from GitHub rather than reading a local file, so probably not directly useful, but figure this might be a good start. Heck, maybe this could end up being a GitHub Actions workflow that we run on a particular target repo (say `hcp-specs`) in order to modify definitions just for the context of consumption by `dev-portal`.

For some context, based on a quick skim of the [gRPC-Gateway documentation](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_openapi_output/) (thanks Heat for surfacing this!), I could see some options to [remove default responses](https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/customizing_openapi_output/#disable-default-responses), but no option to modify definitions (other than through code comments, which seems like it might not work in the case of a lower-level definition such as `protobufAny`). I figure maybe we'll need a custom script of some kind to do this kind of "post-API-spec-generation" cleanup.

That being said, if it's possible to fix the long descriptions through code comment modification or configuration of the OpenAPI spec generation tools, that seems like it'd be preferable.

## 📸 Design Screenshots 

https://github.com/hashicorp/dev-portal/assets/4624598/8ad74a6c-0f91-464f-a4aa-c6a8d7c34bf1


[task]: https://app.asana.com/0/1207339219333499/1206421574792631/f
