### PR TITLE
fix: don't strip style definitions for integrations

### DIFF
--- a/src/lib/remark-plugins/rehype-sanitize/index.ts
+++ b/src/lib/remark-plugins/rehype-sanitize/index.ts
@@ -49,6 +49,12 @@ const schema = deepmerge(defaultSchema, {
 			 * Ref: https://github.com/syntax-tree/hast-util-sanitize#attributes
 			 */
 			['data-text-content', /[\w\-\s]+/],
+			/**
+			 * We enable `style` attributes for all elements so that syntax
+			 * highlighting can be applied via Shiki. We limit them just to the
+			 * format emitted by Shiki.
+			 */
+			['style', /^color:var\(--hds-code-block-color-[a-z\-]*\)$/],
 		],
 	},
 })


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR allows `style` attributes in Integrations READMEs, which is required for syntax highlighting to work.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

- [ ] Go to [preview](/packer/integrations/hashicorp/qemu/latest/components/builder/qemu)
- [ ] Ensure code blocks have syntax highlighting
