### PR TITLE
Add diff syntax highlighting

### DIFF
--- a/src/components/dev-dot-content/mdx-components/mdx-code-blocks/index.tsx
+++ b/src/components/dev-dot-content/mdx-components/mdx-code-blocks/index.tsx
@@ -69,9 +69,13 @@ function CodeBlockConfig({
 	lineNumbers,
 	hideClipboard,
 }: CodeBlockConfigProps) {
+	// This is only used for debugging purposes as we use shiki to assign the language tokens and styles
+	const propsOfFristChild = propsOfFirstChild(children)
+
 	return (
 		<CodeBlock
 			className={className}
+			language={propsOfFristChild?.language as string}
 			value={childrenOfFirstChild(childrenOfFirstChild(children))}
 			isStandalone={!hasBarAbove}
 			title={heading ?? filename ?? ''}
@@ -216,6 +220,19 @@ function childrenOfFirstChild(children: ReactNode): ReactNode {
 		'props' in firstElement
 	) {
 		return firstElement.props.children
+	}
+
+	throw new Error('First element of children is not an object with props')
+}
+
+function propsOfFirstChild(children: ReactNode): Record<string, unknown> {
+	const firstElement = Children.toArray(children)[0]
+	if (
+		firstElement &&
+		typeof firstElement === 'object' &&
+		'props' in firstElement
+	) {
+		return firstElement.props
 	}
 
 	throw new Error('First element of children is not an object with props')

--- a/src/lib/rehype-code-plugins.ts
+++ b/src/lib/rehype-code-plugins.ts
@@ -19,7 +19,9 @@ export const rehypeCodePlugins: Pluggable[] = [
 			transformers: [
 				{
 					pre(node) {
+						// stripped out during the render phase, as our current CodeBlock component has it's own pre tag
 						node.properties.class = [`language-${this.options.lang}`]
+						node.properties.language = this.options.lang
 					},
 					code(node) {
 						// Remove the last line if it's just whitespace

--- a/src/lib/rehype-code-plugins.ts
+++ b/src/lib/rehype-code-plugins.ts
@@ -43,6 +43,16 @@ export const rehypeCodePlugins: Pluggable[] = [
 							this.addClassToHast(node, 'empty-line')
 						}
 					},
+					span(node, _line: number, col: number) {
+						// prevent user-select on the start +/- in diff lines
+						if (this.options.lang === 'diff' && col === 0) {
+							const firstChild = node.children[0] as any
+
+							if (['-', '+'].includes(firstChild?.value)) {
+								node.properties.style += '; user-select: none;'
+							}
+						}
+					},
 					preprocess(code, options) {
 						// Shiki language codes are all lowercase.
 						options.lang = options.lang.toLowerCase()

--- a/src/lib/syntax-highlighting/index.ts
+++ b/src/lib/syntax-highlighting/index.ts
@@ -10,6 +10,8 @@ import sentinelGrammar from './languages/sentinel.tmGrammar.json'
 // Shiki's TypeScript types are broken, so we silence the error with `any`.
 const sentinel = { ...sentinelGrammar, name: 'sentinel' } as any
 
+// !! Note: the syntax highlighting is done through the theme, which is a textmate grammar which define token scope. You can inspect textmate scope in VSCode executing the command `Developer: Inspect Editor Tokens and Scopes` !!
+
 // This function is used to highlight code blocks on the product install pages.
 export async function highlightString(
 	code: string,

--- a/src/lib/syntax-highlighting/theme.ts
+++ b/src/lib/syntax-highlighting/theme.ts
@@ -135,5 +135,23 @@ export const theme: ThemeRegistrationResolved = {
 			],
 			settings: { foreground: 'var(--hds-code-block-color-keyword)' },
 		},
+		// Diff
+		{
+			scope: ['markup.deleted'],
+			settings: { foreground: 'var(--hds-code-block-color-deleted)' },
+		},
+		{
+			scope: ['markup.inserted'],
+			settings: { foreground: 'var(--hds-code-block-color-green)' },
+		},
+		{
+			scope: [
+				'punctuation.definition.deleted.diff',
+				'punctuation.definition.inserted.diff',
+			],
+			settings: { foreground: 'var(--hds-code-block-color-token)' },
+		},
+		// TODO: We should map our code block colors to the correct scope:
+		// https://github.com/hashicorp/design-system/blob/2c3c9a6a317255c3c8e22d72aa327eeaa7ccc7f3/packages/components/src/styles/components/code-block/theme.scss#L8
 	],
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-fixadd-diff-syntax-highlighting-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1205890531436279/1207516355156788/f) 🎟️

## 🗒️ What

Adding syntax highlighting to diff code blocks.

## 📸 Design Screenshots

![Screenshot 2024-06-07 at 1 03 40 PM](https://github.com/hashicorp/dev-portal/assets/1957315/b100fbf6-d589-405d-8e43-cfe6278b0c62)


## 🧪 Testing


- [x] Make sure the the diff codeblock on the page [terraform/tutorials/configuration-language/count#refactor-the-ec2-configuration](https://dev-portal-git-rn-fixadd-diff-syntax-highlighting-hashicorp.vercel.app/terraform/tutorials/configuration-language/count#refactor-the-ec2-configuration) is highlighted

