### PR TITLE
chore: Remove References to `networking-automation`

### DIFF
--- a/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
@@ -40,7 +40,7 @@ const CertificationContentCardLink = ({
 
 	const handleClick = () => {
 		trackCertificationCardLinkClicked({
-			linkPath: href,
+			linkPath: baseHref,
 			productSlug: product.slug,
 		})
 	}

--- a/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
@@ -6,15 +6,10 @@
 import { trackCertificationCardLinkClicked } from 'views/tutorials-landing/analytics'
 import { type CertificationContentCardLinkProps } from '../types'
 import ContentCardLink from '../content-card-link'
-import networkingAutomationGraphic from './img/consul.svg'
 import infrastructionAutomationGraphic from './img/terraform.svg'
 import securityAutomationGraphic from './img/vault.svg'
 
 const CERTIFICATION_PROGRAM_SLUGS_TO_BACKGROUND_IMAGES = {
-	'networking-automation': {
-		url: networkingAutomationGraphic,
-		lightOrDark: 'dark',
-	},
 	'infrastructure-automation': {
 		url: infrastructionAutomationGraphic,
 		lightOrDark: 'dark',

--- a/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
@@ -32,10 +32,11 @@ const CertificationContentCardLink = ({
 	 * Special case for the consul certification to link to it's specfic header
 	 * {@link https://developer.hashicorp.com/certifications/security-automation#consul-associate-(003)-details}
 	 */
+	const baseHref = `/certifications/${certification.slug}`
 	const href =
 		product.name === 'Consul'
-			? `/certifications/${certification.slug}#consul-associate-(003)-details`
-			: `/certifications/${certification.slug}`
+			? `${baseHref}#consul-associate-(003)-details`
+			: baseHref
 
 	const handleClick = () => {
 		trackCertificationCardLinkClicked({

--- a/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
+++ b/src/components/tutorials-landing-view/certification-content-card-link/index.tsx
@@ -28,7 +28,14 @@ const CertificationContentCardLink = ({
 		CERTIFICATION_PROGRAM_SLUGS_TO_BACKGROUND_IMAGES[certification.slug]
 	const title = certification.title
 	const description = certification.description
-	const href = `/certifications/${certification.slug}`
+	/**
+	 * Special case for the consul certification to link to it's specfic header
+	 * {@link https://developer.hashicorp.com/certifications/security-automation#consul-associate-(003)-details}
+	 */
+	const href =
+		product.name === 'Consul'
+			? `/certifications/${certification.slug}#consul-associate-(003)-details`
+			: `/certifications/${certification.slug}`
 
 	const handleClick = () => {
 		trackCertificationCardLinkClicked({

--- a/src/components/tutorials-landing-view/docs.mdx
+++ b/src/components/tutorials-landing-view/docs.mdx
@@ -56,7 +56,7 @@ peerComponents:
 				'The Terraform Associate certification is for Cloud Engineers specializing in operations, IT, or development who know the basic concepts and skills associated with Terraform.',
 		},
 		{
-			slug: 'networking-automation',
+			slug: 'security-automation',
 			title: 'Verify your Networking Automation skills',
 			description:
 				'The Consul Associate Certification is for Site Reliability Engineers, Solutions Architects, DevOps professionals, or other Cloud Engineers who know the basic concepts and skills to build, secure, and maintain HashiCorp Consul Community Edition.',

--- a/src/components/tutorials-landing-view/types.ts
+++ b/src/components/tutorials-landing-view/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { ProductSlug } from 'types/products'
+import { ProductName, ProductSlug } from 'types/products'
 import { Collection } from 'lib/learn-client/types'
 import { type BadgeProps } from 'components/badge'
 import { CardLinkProps } from 'components/card-link'
@@ -40,6 +40,7 @@ interface CertificationContentCardLinkProps {
 		description: string
 	}
 	product: {
+		name: ProductName
 		slug: ProductSlug
 	}
 }

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -74,7 +74,7 @@
 			"certificationProgram": {
 				"slug": "security-automation",
 				"title": "Get certified: Security automation",
-				"description": "Validate your cloud security skills by studying for and passing the Consul Associate certification exam."
+				"description": "Validate your service networking skills by studying for and passing the Consul Associate certification exam."
 			}
 		},
 		"nomad": {

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -72,7 +72,7 @@
 				"consul/get-started-vms"
 			],
 			"certificationProgram": {
-				"slug": "security-automation",
+				"slug": "security-automation#consul-associate-(003)-details",
 				"title": "Get certified: Security automation",
 				"description": "Validate your service networking skills by studying for and passing the Consul Associate certification exam."
 			}

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -73,7 +73,7 @@
 			],
 			"certificationProgram": {
 				"slug": "security-automation",
-				"title": "Get certified: Security automation",
+				"title": "Get certified: Network automation",
 				"description": "Validate your service networking skills by studying for and passing the Consul Associate certification exam."
 			}
 		},

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -72,7 +72,7 @@
 				"consul/get-started-vms"
 			],
 			"certificationProgram": {
-				"slug": "security-automation#consul-associate-(003)-details",
+				"slug": "security-automation",
 				"title": "Get certified: Security automation",
 				"description": "Validate your service networking skills by studying for and passing the Consul Associate certification exam."
 			}

--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -72,9 +72,9 @@
 				"consul/get-started-vms"
 			],
 			"certificationProgram": {
-				"slug": "networking-automation",
-				"title": "Get certified: Networking automation",
-				"description": "Validate your networking automation skills by studying for and passing the Consul Associate certification exam."
+				"slug": "security-automation",
+				"title": "Get certified: Security automation",
+				"description": "Validate your cloud security skills by studying for and passing the Consul Associate certification exam."
 			}
 		},
 		"nomad": {

--- a/src/views/certifications/components/gradient-card/gradient-card.module.css
+++ b/src/views/certifications/components/gradient-card/gradient-card.module.css
@@ -106,17 +106,6 @@
 		);
 	}
 
-	&.theme-networking-automation {
-		--shadow-background: linear-gradient(90deg, #ffb2b8 0%, #c74fb8 100%);
-		--gradient-border-background: radial-gradient(
-			36.05% 120.87% at 3.06% 4.48%,
-			#e33d82 0%,
-			#eb98a1 16.29%,
-			#94337b 44.27%,
-			rgba(250, 250, 250, 0) 100%
-		);
-	}
-
 	&.theme-security-automation {
 		--shadow-background: linear-gradient(90deg, #ffe58c 0%, #f26b63 100%);
 		--gradient-border-background: radial-gradient(

--- a/src/views/certifications/content/schemas/landing-page.ts
+++ b/src/views/certifications/content/schemas/landing-page.ts
@@ -13,7 +13,6 @@ import { z } from 'zod'
  */
 const ProgramSlugSchema = z.enum([
 	'infrastructure-automation',
-	'networking-automation',
 	'security-automation',
 ])
 

--- a/src/views/certifications/content/utils/program-slug-map.ts
+++ b/src/views/certifications/content/utils/program-slug-map.ts
@@ -13,7 +13,7 @@ export const certificationProgramSlugMap: Record<
 	CertificationProductSlug,
 	ProgramSlug
 > = {
-	consul: 'networking-automation',
+	consul: 'security-automation',
 	terraform: 'infrastructure-automation',
 	vault: 'security-automation',
 }

--- a/src/views/certifications/views/[slug]/components/program-hero/index.tsx
+++ b/src/views/certifications/views/[slug]/components/program-hero/index.tsx
@@ -26,7 +26,6 @@ import { HeroProps } from 'components/landing-hero/components/hero/types'
 const programHeroForeground: Record<ProgramSlug, HeroProps['foreground']> = {
 	'security-automation': 'dark',
 	'infrastructure-automation': 'light',
-	'networking-automation': 'light',
 }
 
 /**

--- a/src/views/certifications/views/[slug]/components/program-hero/program-hero.module.css
+++ b/src/views/certifications/views/[slug]/components/program-hero/program-hero.module.css
@@ -57,8 +57,4 @@
 	&.theme-security-automation {
 		--background-image: url('./assets/security-hero.svg');
 	}
-
-	&.theme-networking-automation {
-		--background-image: url('./assets/networking-hero.svg');
-	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://vercel.live/link/dev-portal-git-preschoreupdate-hrefs-hashicorp.vercel.app?page=%2Ftutorials%3FvercelThreadId%3DJtNOO&via=in-app-copy-link) 🔎
- [Asana task](https://app.asana.com/0/1207484854701350/1207436782605801/f) 🎟️

## 🗒️ What

This is PR is a follow up to https://github.com/hashicorp/dev-portal/pull/2472 
It gets rid of the references to `/networking-automation` in favor of the updated [`/security-automation`](https://dev-portal-git-preschoreupdate-hrefs-hashicorp.vercel.app/certifications/security-automation) page

See comments for more detailed notes on code changes


## Testing
1. Open Preview Link
2. Navigate to `/tutorials`
3. Click on the Consul Certification Card
4. Verify that it correctly opens the page on the appropriate consul certification details header

## 🎁 Additional
These are just some things worth noting. 
- I opted to keep this redirect included for the purpose of old links laying around on external sites
https://github.com/hashicorp/dev-portal/blob/704c5c1ba41db02efb0504c91ea9c11504540d7c/build-libs/redirects.js#L208-L210

- I had a hunch to also search for `/network-automation` (removes the "ing" from networking) and found this
https://github.com/hashicorp/dev-portal/blob/704c5c1ba41db02efb0504c91ea9c11504540d7c/src/content/tutorials-landing.json#L181-L186

Is that something worth including in this PR? 
