### PR TITLE
Chore: Update `Footer`

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -39,7 +39,7 @@ const FOOTER_ITEMS: FooterItem[] = [
 	},
 	{
 		type: 'link',
-		href: 'https://www.hashicorp.com/security',
+		href: 'https://www.hashicorp.com/trust/security',
 		text: 'Security',
 	},
 	{
@@ -56,6 +56,11 @@ const FOOTER_ITEMS: FooterItem[] = [
 		type: 'link',
 		href: 'https://www.hashicorp.com/trade-controls',
 		text: 'Trade Controls',
+	},
+	{
+		type: 'link',
+		href: 'https://www.hashicorp.com/trust/accessibility',
+		text: 'Accessibility',
 	},
 	{
 		type: 'link',


### PR DESCRIPTION
## 🔗 Relevant links


- [Preview link](https://dev-portal-git-preschoreupdate-footer-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1207484854701350/1205890709355283/f) 🎟️

## 🗒️ What

This Pull request: 
- Adds a link to our [Accessibility guidelines](https://www.hashicorp.com/trust/accessibility)
- Updates the security link to go directly to `https://www.hashicorp.com/trust/accessibility` instead of having to use the redirect

## 🤷 Why

Per US and EU regulations, there should be specific documentation available on accessibility. 
Guidance: This is typically present in the form of an accessibility statement. See https://helios.hashicorp.design/about/accessibility-statement/ for an example. The W3C provides a template through WAI-ARIA: https://www.w3.org/WAI/planning/statements/generator/#create

## 📸 Design Screenshots

### Before

#### Desktop
<img width="2035" alt="Screenshot 2024-06-17 at 11 40 06 AM" src="https://github.com/hashicorp/dev-portal/assets/90055250/1c9fd380-6be3-4492-a686-d0859f1df62f">

#### Mobile
<img width="700" alt="Screenshot 2024-06-17 at 11 43 18 AM" src="https://github.com/hashicorp/dev-portal/assets/90055250/be84f774-05e3-4e5c-87a2-64b39f30dfa1">


### After 

#### Desktop 
<img width="2035" alt="Screenshot 2024-06-17 at 11 41 14 AM" src="https://github.com/hashicorp/dev-portal/assets/90055250/fa0a434f-43be-4ad4-9539-f12c84d975cd">

#### Mobile
 
<img width="616" alt="Screenshot 2024-06-17 at 11 44 28 AM" src="https://github.com/hashicorp/dev-portal/assets/90055250/ee1746df-bdb9-480b-b566-6c90cec64e18">

(out of scope but it could be worth using a gridbox down the line to get some consistent alignment going on the links)

## 🧪 Testing

- [ ] Verify that the footer still maintains it's styling at different breakpoints
- [ ] Click the accessibility link. 
- [ ] Verify that it takes you to https://www.hashicorp.com/trust/accessibility without opening a new tab
- [ ] Click the Security link
- [ ]  Verify that it takes you to https://www.hashicorp.com/trust/security without opening a new tab