### PR TITLE
Update consent manager to include a11y fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@hashicorp/react-alert-banner": "^7.1.0",
 				"@hashicorp/react-button": "^6.3.1",
 				"@hashicorp/react-code-block": "^6.6.0",
-				"@hashicorp/react-consent-manager": "^9.2.0",
+				"@hashicorp/react-consent-manager": "^9.2.1",
 				"@hashicorp/react-content": "^8.3.0",
 				"@hashicorp/react-design-system-components": "0.0.0-nightly.3d21315",
 				"@hashicorp/react-design-system-tokens": "0.0.0-nightly.3d21315",
@@ -5091,14 +5091,14 @@
 			}
 		},
 		"node_modules/@hashicorp/react-consent-manager": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-9.2.0.tgz",
-			"integrity": "sha512-8s39zw/TLgpN9Nmj1gm5zZlePb5EAthV47ThDm9x8sqqSU3wjGBCeLtq73+MHU5b+gHiSCnEOqRmVIIdYXuT9A==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-9.2.1.tgz",
+			"integrity": "sha512-hSACUNQGB5yEX0iBzeXsVpCYn1Pgq0qF5Q/p0hQf7w8kfVDymxtLTnHoMcgcz5i+4x2iI+7JL9EwTWcpz9gERg==",
 			"dependencies": {
 				"@hashicorp/flight-icons": "^2.5.0",
 				"@hashicorp/platform-util": "^0.2.0",
 				"@hashicorp/react-button": "^6.2.0",
-				"@hashicorp/react-toggle": "^5.0.0",
+				"@hashicorp/react-toggle": "^5.1.1",
 				"classnames": "^2.3.1",
 				"js-cookie": "^2.2.1"
 			},
@@ -5540,9 +5540,9 @@
 			}
 		},
 		"node_modules/@hashicorp/react-toggle": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-toggle/-/react-toggle-5.1.0.tgz",
-			"integrity": "sha512-2/Xl85aSlcDvInS3kFETRyhPI9VH4bPcvY4naUzx9mCQg2CT1AGaa8RUAAf6Kwj+rhCWV1GlqGG5Sym31kgfAw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-toggle/-/react-toggle-5.1.1.tgz",
+			"integrity": "sha512-NQblEYk6SIHzaek/aeD3RuCCsvFwSiPCELbuKtjqMHnE+ZdNeq7rQ4/b6OPft+FhzDOAQS4zS9JmvyFMDwi6RQ==",
 			"dependencies": {
 				"classnames": "^2.3.1"
 			},

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@hashicorp/react-alert-banner": "^7.1.0",
 		"@hashicorp/react-button": "^6.3.1",
 		"@hashicorp/react-code-block": "^6.6.0",
-		"@hashicorp/react-consent-manager": "^9.2.0",
+		"@hashicorp/react-consent-manager": "^9.2.1",
 		"@hashicorp/react-content": "^8.3.0",
 		"@hashicorp/react-design-system-components": "0.0.0-nightly.3d21315",
 		"@hashicorp/react-design-system-tokens": "0.0.0-nightly.3d21315",


### PR DESCRIPTION
[🔍 Preview](https://dev-portal-git-rn-fixconsent-modal-a11y-hashicorp.vercel.app/)

🎟️ Asana Tasks
- [[TF VPAT A11Y] Cookie manager modal does not respond to the ESC key](https://app.asana.com/0/1205890709355230/1205890709355251/f)
- [[TF VPAT A11Y] Cookie manager modal has multiple banner landmarks](https://app.asana.com/0/1205890709355230/1205890709355253/f)
- [[TF VPAT A11Y] Consent manager - Indistinguishable “see more” buttons](https://app.asana.com/0/1205890709355230/1205890709355259/f)
- [[TF VPAT A11Y] Switch toggles missing accessible name](https://app.asana.com/0/1205890709355230/1205890709355261/f)
- [[TF VPAT A11Y] Switches missing keyboard interactions](https://app.asana.com/0/1205890709355230/1205890709355249/f)

## Description

Pull in the new version of consent manager, which fixes a variety of accessibility issues:
- Toggles missing accessible names
- see more/less button missing accessible name
- allowing ESC to close the dialog
- removing unneeded headers

### Testing 🚀

1. [Load the preview in an incognito window](https://dev-portal-git-rn-fixconsent-modal-a11y-hashicorp.vercel.app/) (so you can open the consent manager)
2. Test the following
    1. `esc` closes the modal
    2. `tab` is "focus trapped" in the modal and will not exit it
    3. The more/less and toggle buttons now have accessible names
    4. The toggle button responds to both `space` and `enter`
    5. The modal no longer has any `<header>` tags within it
