### PR TITLE
Set up preview tool for split page OpenAPI docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 .next
 out
+.tmp
 .env*.local
 .vercel
 _temp-migrations/
@@ -19,4 +20,3 @@ public/.extracted/
 sitemap-0.xml
 sitemap.xml
 robots.txt
-

--- a/src/pages/api/open-api-docs-preview-v2.ts
+++ b/src/pages/api/open-api-docs-preview-v2.ts
@@ -45,18 +45,19 @@ const MAX_FILE_AGE_MS = 1000 * 60 * 60 * MAX_FILE_AGE_HOURS
  *   the page or navigates to a new URL. This is particularly necessary as we're
  *   trying to render a multi-page preview, with operations on separate URLs.
  */
-export default async function handler(
-	req: NextApiRequest,
-	res: NextApiResponse
-) {
-	if (req.method === 'POST') {
-		return handlePost(req, res)
-	} else if (req.method === 'GET') {
-		return handleGet(req, res)
-	} else {
-		res.setHeader('Allow', ['POST', 'GET'])
-		res.status(405).json({ error: 'Method not allowed' })
-	}
+const reqHandlers = {
+  POST: handlePost,
+  GET: handleGet,
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const handle = reqHandlers[req.method];
+  if (handle) {
+    return handle(req, res);
+  } else {
+    res.setHeader('Allow', Object.keys(reqHandlers));
+    res.status(405).json({ error: 'Method not allowed' });
+  }
 }
 
 /**

--- a/src/pages/api/open-api-docs-preview-v2.ts
+++ b/src/pages/api/open-api-docs-preview-v2.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+// Types
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { OpenApiPreviewV2InputValues } from 'views/open-api-docs-preview-v2/components/open-api-preview-inputs'
+
+/**
+ * Setup for temporary file storage
+ */
+// Determine if we're deploying to Vercel, this affects the temporary directory
+const IS_VERCEL_DEPLOY = process.env.VERCEL_ENV !== 'development'
+// Determine the temporary directory to use, based on Vercel deploy or not
+const TMP_DIR = IS_VERCEL_DEPLOY ? '/tmp' : path.join(process.cwd(), '.tmp')
+// Ensure the temporary directory exists, so we can stash files
+if (!fs.existsSync(TMP_DIR)) {
+	fs.mkdirSync(TMP_DIR)
+}
+// Set the maximum age for a file in the temporary directory
+const MAX_FILE_AGE_HOURS = 1
+const MAX_FILE_AGE_MS = 1000 * 60 * 60 * MAX_FILE_AGE_HOURS
+
+/**
+ * This API route is meant to be used in conjunction with the OpenAPI preview
+ * page, which allows authors to preview OpenAPI specs in a multi-page format.
+ *
+ * The preview page is _not_ deployed in production, and is meant to be
+ * accessed from: https://develop.hashicorp.services/open-api-docs-preview-v2
+ *
+ * This API route:
+ *
+ * - Handles `POST` requests with preview data. Preview data is generally some
+ *   OpenAPI spec JSON, plus additional configuration - everything needed to
+ *   build a multi-page preview of the OpenAPI documentation. We save this
+ *   preview data to a temporary file with a unique ID. We return the unique
+ *   ID, so that it can be used in subsequent requests to retrieve the data.
+ *
+ * - Handles `GET` requests with a unique file ID. These requests allow pages
+ *   to retrieve previously stored preview data, even if the end user reloads
+ *   the page or navigates to a new URL. This is particularly necessary as we're
+ *   trying to render a multi-page preview, with operations on separate URLs.
+ */
+export default async function handler(
+	req: NextApiRequest,
+	res: NextApiResponse
+) {
+	if (req.method === 'POST') {
+		return handlePost(req, res)
+	} else if (req.method === 'GET') {
+		return handleGet(req, res)
+	} else {
+		res.setHeader('Allow', ['POST', 'GET'])
+		res.status(405).json({ error: 'Method not allowed' })
+	}
+}
+
+/**
+ * Handle POST requests
+ *
+ * This function is responsible for:
+ * - Writing the POST'ed data to a temporary file
+ * - Returning the unique file ID to the client
+ */
+async function handlePost(req, res) {
+	// Parse the request body, which we expect to be preview data
+	const previewData = JSON.parse(req.body)
+
+	/**
+	 * Try writing out the static props to a new file in the `tmp` folder.
+	 *
+	 * If successful, we return a newly generated unique file ID to the client.
+	 * If unsuccessful, we return an error message.
+	 */
+	try {
+		const timestamp = Date.now()
+		const uniqueFileId = `ts${timestamp}_${randomUUID()}`
+		const newTempFile = getTempFilePath(TMP_DIR, uniqueFileId)
+		fs.writeFileSync(newTempFile, JSON.stringify(previewData, null, 2))
+		res.status(200).json({ uniqueFileId })
+	} catch (error) {
+		res.status(500).json({ error: error.toString() })
+	}
+}
+
+/**
+ * Handle GET requests, attempting to read stored props from `/tmp`.
+ *
+ * We also delete old files in the temporary directory on every request
+ * received to this endpoint, to ensure files don't hang around any longer
+ * than they need to for author previewing purposes.
+ */
+async function handleGet(req, res) {
+	// Delete old files in the temporary directory, to keep it clean.
+	deleteOldFiles(TMP_DIR, MAX_FILE_AGE_MS)
+
+	/**
+	 * Extract a unique file ID from the request query, if possible.
+	 * This allows multiple authors to work with different files, and provides
+	 * some level of protection against random public access of these files
+	 * (not the best security ever, but better than nothing).
+	 */
+	const uniqueFileId = req.query.uniqueFileId as string | undefined
+	// We require a unique file ID in order to read a previously stored file
+	if (!uniqueFileId) {
+		res.status(404).json({ error: 'No unique file ID provided.' })
+		return
+	}
+	// If we have a unique file ID, attempt to read the props from the file
+	const tempFile = getTempFilePath(TMP_DIR, uniqueFileId)
+	// If the file doesn't exist, we can return early with that info
+	if (!fs.existsSync(tempFile)) {
+		res.status(404).json({ error: `File not found at "${tempFile}".` })
+		return
+	}
+	// Otherwise, attempt to read the file
+	const [err, data] = readJsonFile(tempFile)
+	// If we failed to read props, return an error
+	if (err !== null) {
+		res.status(500).json({ error: `Failed to read JSON file "${tempFile}".` })
+		return
+	}
+	// Otherwise, we have successfully read in props, return them
+	res.status(200).json(data)
+	return
+}
+
+/**
+ * Given the path to a directory,
+ * read in the filenames of all files in that directory.
+ *
+ * If the filename contains the pattern `ts(\d+)_`, then parse the digits
+ * as a timestamp, representing the milliseconds since the Unix epoch.
+ * If the file is older than the provided maxAgeMs, delete the file.
+ */
+function deleteOldFiles(directoryPath: string, maxAgeMs: number) {
+	const files = fs.readdirSync(directoryPath)
+	files.forEach((file) => {
+		const match = file.match(/ts(\d+)_/)
+		if (match === null) {
+			return
+		}
+		const timestamp = parseInt(match[1], 10)
+		const fileAgeMs = Date.now() - timestamp
+		if (fileAgeMs > maxAgeMs) {
+			console.log(`Deleting old file: ${file}`)
+			fs.unlinkSync(`${directoryPath}/${file}`)
+		}
+	})
+}
+
+/**
+ * Given a file path to a JSON file, attempt to read in the file.
+ * If successful, return [null, data], where `data` is the parsed JSON.
+ * Otherwise, return [err, null], where `err` describes the failure.
+ */
+function readJsonFile(filePath): [string, null] | [null, any] {
+	try {
+		const fileString = fs.readFileSync(filePath, 'utf8')
+		return [null, JSON.parse(fileString)]
+	} catch (error) {
+		return [
+			`Error: readJsonFile on "${filePath}" failed. Details: ${error.toString()}`,
+			null,
+		]
+	}
+}
+
+/**
+ * Given a temporary directory and a unique file ID, return a standard file path
+ */
+function getTempFilePath(tempDir, uniqueFileId) {
+	return `${tempDir}/open-api-docs-view-props_${uniqueFileId}.json`
+}

--- a/src/pages/api/open-api-docs-preview-v2.ts
+++ b/src/pages/api/open-api-docs-preview-v2.ts
@@ -108,7 +108,7 @@ async function handleGet(req, res) {
 	const uniqueFileId = req.query.uniqueFileId as string | undefined
 	// We require a unique file ID in order to read a previously stored file
 	if (!uniqueFileId) {
-		res.status(404).json({ error: 'No unique file ID provided.' })
+		res.status(422).json({ error: 'No unique file ID provided.' })
 		return
 	}
 	// If we have a unique file ID, attempt to read the props from the file

--- a/src/pages/open-api-docs-preview-v2/[[...page]].tsx
+++ b/src/pages/open-api-docs-preview-v2/[[...page]].tsx
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import OpenApiDocsPreviewViewV2 from 'views/open-api-docs-preview-v2'
+import { getServerSideProps } from 'views/open-api-docs-preview-v2/server'
+
+export { getServerSideProps }
+export default OpenApiDocsPreviewViewV2

--- a/src/views/open-api-docs-preview-v2/components/file-string-input/file-string-input.module.css
+++ b/src/views/open-api-docs-preview-v2/components/file-string-input/file-string-input.module.css
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.helperText {
+	color: var(--token-form-helper-text-color);
+}

--- a/src/views/open-api-docs-preview-v2/components/file-string-input/index.tsx
+++ b/src/views/open-api-docs-preview-v2/components/file-string-input/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { useId, type ChangeEvent } from 'react'
+import s from './file-string-input.module.css'
+
+/**
+ * Render a very basic file input.
+ *
+ * This is a temporary solution until we have a React version of FileInput
+ * set up, which we'd likely do in the `web` monorepo.
+ *
+ * For now, this felt sufficient for an internal preview tool for OpenAPI specs.
+ */
+export function FileStringInput({
+	label,
+	helperText,
+	accept,
+	setValue,
+}: {
+	label: string
+	helperText?: string
+	accept: string
+	setValue: (fileString: string) => void
+}) {
+	const id = useId()
+
+	function handleFileInputChange(e: ChangeEvent<HTMLInputElement>) {
+		const fileReader = new FileReader()
+		fileReader.readAsText(e.target.files[0], 'UTF-8')
+		fileReader.onload = (e: ProgressEvent<FileReader>) =>
+			setValue(e.target.result.toString())
+	}
+
+	return (
+		<div className={s.root}>
+			<div>
+				<label htmlFor={id}>{label}</label>
+				{helperText ? <div className={s.helperText}>{helperText}</div> : null}
+			</div>
+			<input
+				id={id}
+				type="file"
+				accept={accept}
+				onChange={handleFileInputChange}
+			/>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/index.tsx
+++ b/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/index.tsx
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Third-party
+import { useEffect, useState } from 'react'
+import classNames from 'classnames'
+// Components
+import Button from 'components/button'
+import InlineAlert from 'components/inline-alert'
+import { CheckboxField } from 'components/form/field-controls'
+// Inputs
+import { FileStringInput } from '../file-string-input'
+import { TextareaInput } from '../textarea-input'
+// Utils
+import { fetchOpenApiStaticProps } from './utils/fetch-open-api-static-props'
+// Constants
+import { COOKIE_ID } from '../../constants'
+// Styles
+import s from './open-api-preview-inputs.module.css'
+
+export interface OpenApiPreviewV2InputValues {
+	openApiJsonString: string
+	openApiDescription: string
+	groupOperationsByPath: boolean
+}
+
+/**
+ * Render a fixed panel container with inputs that allow control over the
+ * static props for `OpenApiDocsView`.
+ */
+export function OpenApiPreviewInputs({
+	defaultValues,
+	defaultCollapsed = true,
+}: {
+	defaultValues?: OpenApiPreviewV2InputValues
+	defaultCollapsed?: boolean
+}) {
+	const [error, setError] = useState<{
+		title: string
+		description: string
+		error: string
+	}>()
+	const [isLoading, setIsLoading] = useState(false)
+	const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed)
+	const [inputValues, setInputValues] = useState<OpenApiPreviewV2InputValues>({
+		openApiJsonString: '',
+		openApiDescription: '',
+		groupOperationsByPath: false,
+		...defaultValues,
+	})
+
+	/**
+	 * Helper to set a specific input data value.
+	 */
+	function setInputValue(
+		key: keyof OpenApiPreviewV2InputValues,
+		value: unknown
+	) {
+		setInputValues((p: OpenApiPreviewV2InputValues) => ({ ...p, [key]: value }))
+	}
+
+	/**
+	 * Whenever an input value changes, reset the submission error
+	 */
+	useEffect(() => {
+		if (error) {
+			setError(undefined)
+		}
+		// Note: intentionally not using exhaustive deps, reset based on input only
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [inputValues])
+
+	/**
+	 * Pre-fill the description markdown when a new OpenAPI JSON string is set.
+	 */
+	useEffect(() => {
+		// Avoid overwriting an in-progress description.
+		if (inputValues.openApiDescription !== '') {
+			return
+		}
+		try {
+			// try to parse the input JSON, and set the description accordingly
+			const parsed = JSON.parse(inputValues.openApiJsonString)
+			const parsedValue = parsed?.info?.description
+			if (parsedValue && inputValues.openApiDescription !== parsedValue) {
+				setInputValue('openApiDescription', parsedValue)
+			}
+		} catch (e) {
+			// do nothing if parsing fails, error will come up on submission
+		}
+	}, [inputValues])
+
+	/**
+	 * Fetch static props for the page and update state when
+	 * the provided `inputValues` is submitted via a button activation.
+	 */
+	async function updateStaticProps() {
+		setIsLoading(true)
+		const [err, result] = await fetchOpenApiStaticProps(inputValues)
+		if (err) {
+			setError(err)
+		} else {
+			// Set a cookie with the unique file id
+			document.cookie = `${COOKIE_ID}=${result.uniqueFileId}`
+			// Reload the page, triggering a new fetch of getServerSideProps
+			window.location.reload()
+		}
+		setIsLoading(false)
+	}
+
+	/**
+	 * Render the input panel
+	 */
+	return (
+		<div className={classNames(s.root, { [s.isCollapsed]: isCollapsed })}>
+			<div className={s.scrollableContent}>
+				<div className={s.inputs}>
+					<FileStringInput
+						label="OpenAPI File"
+						helperText='Upload your OpenAPI specification file, in ".json" format.'
+						accept=".json"
+						setValue={(v: string) => setInputValue('openApiJsonString', v)}
+					/>
+					<Button
+						className={s.generateButton}
+						text={isLoading ? 'Loading...' : 'Generate preview'}
+						size="large"
+						onClick={() => updateStaticProps()}
+					/>
+					{error ? (
+						<InlineAlert
+							color="critical"
+							title={error.title}
+							description={
+								<>
+									<div>{error.description}</div>
+									<pre style={{ whiteSpace: 'pre-wrap' }}>
+										<code>{error.error}</code>
+									</pre>
+								</>
+							}
+						/>
+					) : null}
+					<CheckboxField
+						label="Group operations by path"
+						helperText="By default, operations are organized by their first tag, which is expected to correspond to a service name. In some cases, spec files may have only a single tag, in which case this option can be used to group operations by their paths instead."
+						checked={inputValues.groupOperationsByPath}
+						onChange={() =>
+							setInputValue(
+								'groupOperationsByPath',
+								!inputValues.groupOperationsByPath
+							)
+						}
+					/>
+					<TextareaInput
+						label="Schema source"
+						helperText="Test out edits to the uploaded OpenAPI specification file."
+						value={inputValues.openApiJsonString}
+						setValue={(v: string) => setInputValue('openApiJsonString', v)}
+					/>
+					<TextareaInput
+						label="Description Markdown"
+						helperText='Enter markdown here to override the "schema.info.description" field of your schema.'
+						value={inputValues.openApiDescription}
+						setValue={(v: string) => setInputValue('openApiDescription', v)}
+					/>
+				</div>
+			</div>
+			<div className={s.collapseButtonLayout}>
+				<button
+					className={s.collapseButton}
+					onClick={() => setIsCollapsed((p: boolean) => !p)}
+				>
+					{isCollapsed ? 'Show' : 'Hide'} preview inputs
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/open-api-preview-inputs.module.css
+++ b/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/open-api-preview-inputs.module.css
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	--highlight-color: var(--token-color-foreground-highlight);
+	--border-width: 4px;
+
+	background: var(--token-color-surface-primary);
+	border-left: var(--border-width) solid var(--highlight-color);
+	bottom: 0;
+	position: fixed;
+	right: var(--border-width);
+	top: 0;
+	transition: transform 0.3s;
+	width: min(80vw, 800px);
+
+	&.isCollapsed {
+		transform: translateX(100%);
+	}
+}
+
+.scrollableContent {
+	overflow: auto;
+	padding: 1rem;
+	max-height: 100%;
+}
+
+.inputs {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.collapseButtonLayout {
+	position: absolute;
+	top: 50%;
+	right: 100%;
+	transform: translateY(-50%);
+}
+
+.collapseButton {
+	padding: 2rem;
+	border-top-left-radius: 50%;
+	border-bottom-left-radius: 50%;
+	border: none;
+	background: var(--highlight-color);
+	color: black;
+	cursor: pointer;
+}
+
+.generateButton {
+	flex-shrink: 0;
+
+	/* Swap blue and purple to match the --highlight-color */
+	--token-color-palette-blue-200: var(--token-color-foreground-highlight);
+	--token-color-palette-blue-300: var(--token-color-palette-purple-300);
+	--token-color-palette-blue-400: var(--token-color-palette-purple-400);
+}

--- a/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/utils/fetch-open-api-static-props.ts
+++ b/src/views/open-api-docs-preview-v2/components/open-api-preview-inputs/utils/fetch-open-api-static-props.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Constants
+import { API_ROUTE } from '../../../constants'
+// Types
+import type { OpenApiDocsViewProps } from 'views/open-api-docs-view/types'
+import type { OpenApiPreviewV2InputValues } from '..'
+
+// If we fail to fetch props, we'll return an error object
+type Error = {
+	title: string
+	description: string
+	error: string
+}
+
+/**
+ * Fetch static props for the page and update state when
+ * the provided `inputValues` is submitted via a button activation.
+ */
+export async function fetchOpenApiStaticProps(
+	inputValues: OpenApiPreviewV2InputValues
+): Promise<[Error, null] | [null, { uniqueFileId: string }]> {
+	try {
+		const result = await fetch(API_ROUTE, {
+			method: 'POST',
+			body: JSON.stringify(inputValues),
+		})
+		const resultData = await result.json()
+		if (resultData.error) {
+			return [
+				{
+					title: 'Failed to generate page data',
+					description:
+						'An error occured while attempting to generate page data from the provided inputs. Please ensure the provided schema is a valid OpenAPI specification in JSON format. Please also ensure the provided description is valid markdown.',
+					error: resultData.error,
+				},
+				null,
+			]
+		} else {
+			return [
+				null,
+				resultData as { staticProps: OpenApiDocsViewProps; uniqueFileId },
+			]
+		}
+	} catch (error) {
+		return [
+			{
+				title: 'Failed to generate page data',
+				description:
+					"An unexpected error occurred while attempting to generate page data from the provided inputs. Please ensure the provided schema is a valid OpenAPI specification in JSON format. Please also ensure the provided description is valid markdown. And reach out to the team in #proj-dev-portal if this still isn't working!",
+				error: error.toString(),
+			},
+			null,
+		]
+	}
+}

--- a/src/views/open-api-docs-preview-v2/components/textarea-input/index.tsx
+++ b/src/views/open-api-docs-preview-v2/components/textarea-input/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { ChangeEvent, useId } from 'react'
+import s from './textarea-input.module.css'
+
+/**
+ * A basic unstyled textarea input.
+ *
+ * This is a temporary solution for being able to input and edit long file
+ * strings. Ideally, we'd use something like `codemirror` instead, but for now,
+ * this felt sufficient for an internal preview tool for OpenAPI specs.
+ */
+export function TextareaInput({
+	label,
+	helperText,
+	value,
+	setValue,
+}: {
+	label: string
+	helperText?: string
+	value: string
+	setValue: (value) => void
+}) {
+	const id = useId()
+	return (
+		<div className={s.root}>
+			<div>
+				<label htmlFor={id}>{label}</label>
+				{helperText ? <div className={s.helperText}>{helperText}</div> : null}
+			</div>
+			<textarea
+				id={id}
+				value={value}
+				className={s.textarea}
+				onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+					setValue(e.target.value)
+				}
+			/>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-preview-v2/components/textarea-input/textarea-input.module.css
+++ b/src/views/open-api-docs-preview-v2/components/textarea-input/textarea-input.module.css
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.helperText {
+	color: var(--token-form-helper-text-color);
+}
+
+.textarea {
+	width: 100%;
+	resize: vertical;
+	min-height: 200px;
+}

--- a/src/views/open-api-docs-preview-v2/constants.ts
+++ b/src/views/open-api-docs-preview-v2/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Set up some constants
+ */
+export const COOKIE_ID = 'open-api-docs-preview-v2_unique-file-id'
+export const API_ROUTE = '/api/open-api-docs-preview-v2'
+export const DYNAMIC_PARAM = 'page'

--- a/src/views/open-api-docs-preview-v2/index.tsx
+++ b/src/views/open-api-docs-preview-v2/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Layout
+import SidebarLayout from 'layouts/sidebar-layout'
+// Components
+import {
+	OpenApiPreviewInputs,
+	OpenApiPreviewV2InputValues,
+} from 'views/open-api-docs-preview-v2/components/open-api-preview-inputs'
+// Types
+import type { OpenApiDocsViewV2Props } from 'views/open-api-docs-view-v2/types'
+import OpenApiDocsViewV2 from 'views/open-api-docs-view-v2'
+import Head from 'next/head'
+
+export interface OpenApiDocsPreviewV2Props {
+	staticProps?: OpenApiDocsViewV2Props
+	previewData?: OpenApiPreviewV2InputValues
+	hasStaticProps: boolean
+}
+
+/**
+ * Render an OpenAPI docs view alongside preview inputs.
+ *
+ * Preview inputs allow users to upload form data, which includes a JSON spec,
+ * and then reload the page to see OpenAPI docs views rendered with that data.
+ *
+ * Under the hood, we're using an `/api` route to receive the form data, assign
+ * it a unique ID, stash it in a temporary file, and then return the unique ID
+ * to the client, where it's then stored in a cookie. On subsequent requests,
+ * our `getServerSideProps` for the dynamic preview routes reads the unique ID
+ * from the cookie, fetches the temporary file, transforms the spec JSON and
+ * related form data into static props, and then returns those static props so
+ * that the appropriate OpenAPI view can be rendered.
+ */
+function OpenApiDocsPreviewViewV2({
+	staticProps,
+	previewData,
+	hasStaticProps,
+}: OpenApiDocsPreviewV2Props) {
+	return (
+		<>
+			<div style={{ isolation: 'isolate' }}>
+				{hasStaticProps ? (
+					<OpenApiDocsViewV2 _dev={staticProps._dev} />
+				) : (
+					<>
+						<Head>
+							<title>OpenAPI Preview Tool | HashiCorp Developer</title>
+						</Head>
+						<SidebarLayout sidebarSlot="" mobileMenuSlot={null}>
+							<div style={{ padding: '24px', maxWidth: '35em' }}>
+								<h1>OpenAPI Preview Tool</h1>
+								<p>
+									{`Please use the input form on this page to upload your spec. After submitting the form, the page should reload and display a preview.`}
+								</p>
+							</div>
+						</SidebarLayout>
+					</>
+				)}
+			</div>
+			<OpenApiPreviewInputs
+				defaultCollapsed={hasStaticProps}
+				defaultValues={previewData}
+			/>
+		</>
+	)
+}
+
+export default OpenApiDocsPreviewViewV2

--- a/src/views/open-api-docs-preview-v2/server.ts
+++ b/src/views/open-api-docs-preview-v2/server.ts
@@ -17,7 +17,7 @@ import { OpenApiDocsPreviewV2Props } from '.'
  * We expect the `HASHI_ENV` environment variable to be set to `production`
  * only if we're actually in production.
  */
-const IS_PRODUCTION = process.env.HASHI_ENV === 'production'
+const IS_PRODUCTION = process.env.VERCEL_ENV === 'production'
 
 /**
  * For reference on Vercel system environment variables, see:

--- a/src/views/open-api-docs-preview-v2/server.ts
+++ b/src/views/open-api-docs-preview-v2/server.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Utilities
+import getPropsFromPreviewData from './utils/get-props-from-preview-data'
+// Constants
+import { COOKIE_ID, API_ROUTE, DYNAMIC_PARAM } from './constants'
+// Types
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import type { OpenApiDocsViewV2Props } from 'views/open-api-docs-view-v2/types'
+import type { OpenApiPreviewV2InputValues } from './components/open-api-preview-inputs'
+import { OpenApiDocsPreviewV2Props } from '.'
+
+/**
+ * We expect the `HASHI_ENV` environment variable to be set to `production`
+ * only if we're actually in production.
+ */
+const IS_PRODUCTION = process.env.HASHI_ENV === 'production'
+
+/**
+ * For reference on Vercel system environment variables, see:
+ * https://vercel.com/docs/projects/environment-variables/system-environment-variables
+ *
+ * Note: we assume port 3000 for local development... there may be edge cases
+ * where NextJS decides to start on a different port (eg if 3000 is in use),
+ * but I couldn't find a way to detect that, and for now, this seems sufficient.
+ */
+const IS_VERCEL_DEPLOY = process.env.VERCEL_ENV !== 'development'
+const BASE_URL = IS_VERCEL_DEPLOY
+	? `https://${process.env.VERCEL_URL}`
+	: 'http://localhost:3000'
+
+/**
+ * Get server side props for an OpenAPIDocsPreviewV2 view.
+ *
+ * On initial load, we expect the `uniqueFileId` cookie to be empty, and we'll
+ * return `null` for both `previewData` and `staticProps`.
+ *
+ * We expect the user to upload some preview data to an API route. The preview
+ * data is given a unique ID and stored in a temporary file, and the unique ID
+ * is returned to the client and stored in a cookie.
+ *
+ * On subsequent loads, we expect the `uniqueFileId` cookie to be set. We use
+ * this ID to retrieve preview data from the aforementioned API route. After
+ * retrieving the preview data, we transform it into props we can use to render
+ * a view component, and we return those props.
+ */
+export async function getServerSideProps({
+	params,
+	req,
+}: GetServerSidePropsContext): Promise<
+	GetServerSidePropsResult<OpenApiDocsPreviewV2Props>
+> {
+	/**
+	 * In production, return a 404 not found for this page.
+	 * In other environments (local, preview, and staging), show the page.
+	 */
+	if (IS_PRODUCTION) {
+		return { notFound: true }
+	}
+	// Determine which specific operation we're trying to render, if any
+	const dynamicParams = params?.[DYNAMIC_PARAM]
+	const operationSlug = dynamicParams?.length ? dynamicParams[0] : null
+
+	// Try to grab the unique ID from the cookie
+	const uniqueFileId = req.cookies[COOKIE_ID]
+
+	/**
+	 * Fetch the static props from our API route, which will read in a tmp
+	 * file based on the provided `uniqueFileId`. If this file does not
+	 * exist, we return `null` (and the user must re-upload their preview data).
+	 */
+	let previewData: OpenApiPreviewV2InputValues = null
+	let staticProps: OpenApiDocsViewV2Props | null = null
+	try {
+		const response = await fetch(
+			`${BASE_URL}${API_ROUTE}?uniqueFileId=${uniqueFileId}`
+		)
+		previewData = response.status === 200 ? await response.json() : null
+		staticProps = getPropsFromPreviewData(previewData, operationSlug)
+	} catch (e) {
+		console.log(`Ran into error fetching server-side props: ${e}`)
+	}
+
+	/**
+	 * Return data. Note that both `staticProps` and `previewData` may be `null`,
+	 * such as on initial loads of this page, when no `uniqueId` cookie is set.
+	 */
+	return {
+		props: {
+			hasStaticProps: !!staticProps,
+			previewData,
+			staticProps,
+		},
+	}
+}

--- a/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
+++ b/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { OpenApiDocsViewV2Props } from 'views/open-api-docs-view-v2/types'
+import type { OpenApiPreviewV2InputValues } from '../components/open-api-preview-inputs'
+
+/**
+ * Given preview data submitted by the user, which includes OpenAPI JSON,
+ * and given an optional operation slug that indicates whether to render
+ * a view for a specific operation,
+ *
+ * Return static props for the appropriate OpenAPI docs view.
+ *
+ * TODO: this is just a placeholder for now.
+ */
+export default function getPropsFromPreviewData(
+	previewData: OpenApiPreviewV2InputValues | null,
+	operationSlug: string | null
+): OpenApiDocsViewV2Props | null {
+	// If we don't have any preview data, we can't expect to generate valid props
+	if (!previewData) {
+		return null
+	}
+	// Use the incoming preview data to generate static props for the view
+	// TODO: this is just a placeholder for now.
+	return { _dev: { serverSideProps: { operationSlug, previewData } } }
+}

--- a/src/views/open-api-docs-view-v2/index.tsx
+++ b/src/views/open-api-docs-view-v2/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Layout
+import SidebarLayout from 'layouts/sidebar-layout'
+// Types
+import type { OpenApiDocsViewV2Props } from './types'
+import Link from 'next/link'
+
+/**
+ * Placeholder view component for a new OpenAPI docs setup.
+ *
+ * This new setup will split each operation into its own URL,
+ * and render an overview page at the base URL.
+ */
+export default function OpenApiDocsViewV2({ _dev }: OpenApiDocsViewV2Props) {
+	return (
+		<SidebarLayout sidebarSlot="" mobileMenuSlot={null}>
+			<div style={{ padding: '24px', border: '1px solid magenta' }}>
+				<p>
+					{`This is a placeholder view for a new OpenAPI docs setup. It will split each operation into its own URL, and render an overview page at the base URL.`}
+				</p>
+				<p>
+					{`Later we'll transform the submitted OpenAPI JSON and other preview inputs into props for this page. For now, we're just reflecting them back, as shown below.`}
+				</p>
+				<p>{`Example operation links, to demo how "operationSlug" will be used in getServerSideProps to allow previewing of many pages:`}</p>
+				<ul>
+					<li>
+						<a href="/open-api-docs-preview-v2">Base URL</a>
+					</li>
+					<li>
+						<a href="/open-api-docs-preview-v2/ExampleOperationOne">
+							ExampleOperationOne
+						</a>
+					</li>
+					<li>
+						<a href="/open-api-docs-preview-v2/ExampleOperationTwo">
+							ExampleOperationTwo
+						</a>
+					</li>
+					<li>
+						<a href="/open-api-docs-preview-v2/ExampleOperationThree">
+							ExampleOperationThree
+						</a>
+					</li>
+				</ul>
+				<pre style={{ whiteSpace: 'pre-wrap' }}>
+					<code>{JSON.stringify(_dev, null, 2)}</code>
+				</pre>
+			</div>
+		</SidebarLayout>
+	)
+}

--- a/src/views/open-api-docs-view-v2/types.ts
+++ b/src/views/open-api-docs-view-v2/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+export interface OpenApiDocsViewV2Props {
+	/**
+	 * _dev is a temporary placeholder for the props needed to render the new
+	 * OpenAPI docs view. It will be replaced with properly structured props
+	 * as the new views are implemented.
+	 */
+	_dev: $TSFixMe
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Implements a new OpenAPI preview tool, at  [/open-api-docs-preview-v2]. 

## 🤷 Why

The perceived value of this tool is:

- Provide a way for authors to quickly preview changes to OpenAPI specs. With authored content being a very key part of the value of these pages, and the interaction between the authored content and our rendering of that content being just as important, we want to create a tight feedback loop so that we can work closely with teams working on OpenAPI specs.

- Provide a way for `developer.hashicorp.com` web engineers to iterate on the new OpenAPI docs view, testing changes across many products, without having to set up new page routes and content source `.json` file fetching for every new product or new change.

Backing up a bit, we've chosen to split OpenAPI docs onto multiple pages, with one page for each operation, because single-page OpenAPI docs do not feel ideal.

From a platform perspective, the content can sometimes get long enough, or rather data-heavy enough, that incremental static regeneration fails due to response size limits on Vercel serverless functions. We've already seen some pretty bad failures due to this issue - see 🎟 [OpenAPI docs - Loading previous version doesn't seem to work anymore](https://app.asana.com/0/1207339219333499/1207348698328018/f) for example.

As well, from a UX perspective, the only clear advantage of a single long page is the ability to `⌘ + F` on the page to find content. Long pages already have issues with responsiveness, and this will only get worse as we introduce more useful, feature-rich OpenAPI docs. We're confident that we can implement a better search experience, by indexing OpenAPI docs content in our unified index (we're not currently doing this!). And we're confident that separate pages per operation will ultimately be a better experience for users, and a better foundation from which we can implement better OpenAPI docs.

As an example of what we consider to be a well-executed implementation of a separate page per operation, see https://test-hcp-vs.readme.io/reference/settier.

## 🛠️ How

- Creates a new `/api` route. This route accepts `POST` requests from the preview form, and saves the `POST`'d data with a unique ID, returning the ID to the client. It also accepts `GET` requests, with unique ID query parameter, to allow later retrieval of the stored data.
- Creates a new `views/open-api-docs-view-v2`. This is just a placeholder for now, the focus of this PR is on setting up a preview workflow, so the new view itself is only stubbed in.
- Copies & modifies the existing preview view to create `views/open-api-docs-preview-view-v2`. While this isn't too different from the existing work, and shares some components unchanged, the intent is to migrate to the new view and delete the old view & preview tool. With this in mind, shared code has been copied rather than abstracted, to avoid intertwining things and to make it easier to identify and delete the "old stuff" later.

## 📸 Design Screenshots

https://github.com/hashicorp/dev-portal/assets/4624598/27af9866-06c6-4da1-88ee-d4698c54a30f

## 🧪 Testing

- [ ] Visit [/open-api-docs-preview-v2], and test that the preview flow works
    - On initial load, you should see an empty state prompting you to fill out the preview form
    - Fill out the preview form, and submit it
    - After submitting the preview form, the page should reload
    - After the page reloads, you should see your submitted preview data transformed into server-generated props. Soon this will be an actually useful preview, but for now, to keep the scope of this PR reasonable, it's just placeholder.
    - Delete the cookie starting with `open-api-docs-preview-v2`. After deleting this cookie and reloading the page, you should be back to the started point. The preview data you previously uploaded still exists on the server (for now), but without the unique ID that was stored in the cookie, there's no way to retrieve it.

> **Note**: You can upload an actual OpenAPI spec if you'd like, but arbitrary JSON data also works for now, since we're not yet doing anything with the data, just showing the preview flow.

## 💭 Anything else?

Not at the moment!

[preview]: https://dev-portal-git-zssplit-page-api-docs-preview-hashicorp.vercel.app/
[task]: https://app.asana.com/0/1207339219333499/1207339701271604/f
[/open-api-docs-preview-v2]: https://dev-portal-git-zssplit-page-api-docs-preview-hashicorp.vercel.app/open-api-docs-preview-v2