### PR TITLE
chore: Refactor logic to resolve product name in revalidate endpoint

### DIFF
--- a/src/pages/api/revalidate.test.ts
+++ b/src/pages/api/revalidate.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { resolveProduct } from './revalidate'
+
+describe('resolveProduct', () => {
+	it('should return "terraform" for product names starting with "terraform-"', () => {
+		const productRepoName = 'terraform-cdk'
+		const result = resolveProduct(productRepoName)
+		expect(result).toBe('terraform')
+	})
+
+	it('should return "terraform" for "ptfe-releases"', () => {
+		const productRepoName = 'ptfe-releases'
+		const result = resolveProduct(productRepoName)
+		expect(result).toBe('terraform')
+	})
+
+	it('should return "hcp" for "hcp-docs"', () => {
+		const productRepoName = 'hcp-docs'
+		const result = resolveProduct(productRepoName)
+		expect(result).toBe('hcp')
+	})
+
+	it('should return the same product slug for other product names', () => {
+		const productRepoName = 'vault'
+		const result = resolveProduct(productRepoName)
+		expect(result).toBe(productRepoName)
+	})
+})

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -7,6 +7,24 @@ import type { NextApiRequest, NextApiResponse } from 'next/types'
 import { StatusCodes } from 'http-status-codes'
 import { validateToken } from 'lib/api-validate-token'
 import { cachedGetProductData } from 'lib/get-product-data'
+import { ProductSlug } from 'types/products'
+
+/**
+ * Resolves the product slug based on the given product name.
+ *
+ * @param product - The name of the product.
+ * @returns The corresponding product slug.
+ */
+export function resolveProduct(product: string): ProductSlug {
+	// Handle TF's sub-projects
+	if (product.startsWith('terraform-') || product === 'ptfe-releases') {
+		return 'terraform'
+	} else if (product === 'hcp-docs') {
+		return 'hcp'
+	} else {
+		return product as ProductSlug
+	}
+}
 
 /**
  * @TODO move this into the /api/revalidate dir and update the filename to something like 'docs'
@@ -31,15 +49,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
 		return
 	}
 
-	// Handle TF's sub-projects
-	let resolvedProduct = product
-	if (
-		resolvedProduct.startsWith('terraform-') ||
-		resolvedProduct === 'ptfe-releases'
-	) {
-		resolvedProduct = 'terraform'
-	}
-
+	const resolvedProduct = resolveProduct(product)
 	const productData = cachedGetProductData(resolvedProduct)
 
 	const navDataPrefixes = productData.rootDocsPaths.map(


### PR DESCRIPTION
## 🔗 Relevant links


- [Asana](https://app.asana.com/0/1206176289707208/1207661736742262/f)

## 🗒️ What

- Extracted logic to resolve product repo name to product slug into a function
  - added check for `hcp-docs`
- Added tests for `resolveProduct` function

## 🤷 Why

- This error comes up continuously and needs to be corrected. It only happens for `/api/revalidate` per Datadog logs (in ticket)
- Helps to remove unneeded noise from error alerts channel

## 🧪 Testing
- in your terminal, run this curl request:
```
curl -X POST "https://content.hashicorp.com/api/revalidate" \
     -H "Authorization: Bearer <REVALIDATE_TOKEN>" \
     -H "Content-Type: application/json" \
     -d '{"product": "hcp-docs"}'
```
You should see the following:
```
The page could not be found

NOT_FOUND
```


- check out branch locally
- run `npm start`
- in another terminal window, run this curl request
```
curl -X POST "https://dev-portal-git-heat-choreremove-hcp-docs-reval-ff5d41-hashicorp.vercel.app/api/revalidate" \
     -H "Authorization: Bearer <REVALIDATE_TOKEN>" \
     -H "Content-Type: application/json" \
     -d '{"product": "hcp-docs"}'
```

You should see an output containing the following structure:
```
[{"status":"fulfilled","value":"/hcp/docs/hcp"}...]
```