### PR TITLE
scaffold new open-api landing and operation views

### DIFF
--- a/src/lib/api-docs/parse-and-validate-open-api-schema.ts
+++ b/src/lib/api-docs/parse-and-validate-open-api-schema.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import OASNormalize from 'oas-normalize'
+import { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Given a fileString representing an OpenAPI schema specification,
+ * Return a parsed and validated OpenAPIV3 document.
+ *
+ * Note that there are multiple possible versions of OpenAPI schemas we
+ * may receive as input here. We use the `oas-normalize` package to
+ * convert the input to the latest version, and then dereference the
+ * schema to resolve any `$ref` references.
+ *
+ *
+ * The input OpenAPI specification can be in any of the following versions:
+ * - OpenAPI 2.0 (formerly known as Swagger)
+ * - OpenAPI 3.0
+ *
+ * Note as well  that the terminology associated with OpenAPI can be confusing.
+ * From the OpenAPI website:
+ * OpenAPI refers to the specification itself.
+ * Swagger refers to tooling for implementing the specification.
+ *
+ * However, this isn't always consistent, and Swagger is often used to refer
+ * to the specification as well, as that's how it was known for version 2.0.
+ */
+export async function parseAndValidateOpenApiSchema(
+	fileString: string,
+	massageSchemaForClient: (schema: OpenAPIV3.Document) => OpenAPIV3.Document = (
+		schema
+	) => schema
+): Promise<OpenAPIV3.Document> {
+	// Parse the fileString into raw JSON
+	const rawSchemaJson = JSON.parse(fileString)
+
+	// Validate the file string, and up-convert it to OpenAPI 3.0
+	const schemaJsonWithRefs = await new OASNormalize(rawSchemaJson).validate({
+		convertToLatest: true,
+	})
+	const massagedSchema = massageSchemaForClient(schemaJsonWithRefs)
+
+	/**
+	 * Dereference the schema.
+	 *
+	 * For context, in OpenAPI schemas, there are often pointers or references
+	 * to shared definitions within the schema. In JSON, these might look like:
+	 *
+	 * "schema": {
+	 * 		"$ref": "#/definitions/..."
+	 * }
+	 *
+	 * Example: https://github.com/hashicorp/hcp-specs/blob/e65c7e982b65ce408ab7e456049a4bf3d5fa7ce0/specs/cloud-vault-secrets/preview/2023-06-13/hcp.swagger.json#L28
+	 *
+	 * With the full schema file available, these references can be resolved
+	 * by looking up the referenced definition and replacing the reference.
+	 * For our purposes, it seems preferable to resolve these references
+	 * so that we can pass data to presentational components that do not need
+	 * to be aware of the full schema file in order to render the data.
+	 * After de-referencing, the schema might look like:
+	 *
+	 * "schema": {
+	 * 		"type": "object",
+	 * 		"properties": {
+	 * 			"some-referenced-stuff": "..."
+	 * 		}
+	 * }
+	 */
+	const schemaJson = await new OASNormalize(massagedSchema).deref()
+	// Return the dereferenced schema.
+	// We know it's OpenAPI 3.0, so we cast it to the appropriate type.
+	return schemaJson as OpenAPIV3.Document
+}

--- a/src/views/open-api-docs-preview-v2/index.tsx
+++ b/src/views/open-api-docs-preview-v2/index.tsx
@@ -44,7 +44,7 @@ function OpenApiDocsPreviewViewV2({
 		<>
 			<div style={{ isolation: 'isolate' }}>
 				{hasStaticProps ? (
-					<OpenApiDocsViewV2 _dev={staticProps._dev} />
+					<OpenApiDocsViewV2 {...staticProps} />
 				) : (
 					<>
 						<Head>

--- a/src/views/open-api-docs-preview-v2/server.ts
+++ b/src/views/open-api-docs-preview-v2/server.ts
@@ -79,7 +79,7 @@ export async function getServerSideProps({
 			`${BASE_URL}${API_ROUTE}?uniqueFileId=${uniqueFileId}`
 		)
 		previewData = response.status === 200 ? await response.json() : null
-		staticProps = getPropsFromPreviewData(previewData, operationSlug)
+		staticProps = await getPropsFromPreviewData(previewData, operationSlug)
 	} catch (e) {
 		console.log(`Ran into error fetching server-side props: ${e}`)
 	}

--- a/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
+++ b/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { getStaticProps } from 'views/open-api-docs-view-v2/server'
 // Types
 import type { OpenApiDocsViewV2Props } from 'views/open-api-docs-view-v2/types'
 import type { OpenApiPreviewV2InputValues } from '../components/open-api-preview-inputs'
@@ -14,17 +15,23 @@ import type { OpenApiPreviewV2InputValues } from '../components/open-api-preview
  *
  * Return static props for the appropriate OpenAPI docs view.
  *
- * TODO: this is just a placeholder for now.
+ * TODO: this is largely a placeholder for now.
+ * Will likely require a few more args to pass to getStaticProps, eg productData
+ * for example, but those types of details are not yet needed by the underlying
+ * view.
  */
-export default function getPropsFromPreviewData(
+export default async function getPropsFromPreviewData(
 	previewData: OpenApiPreviewV2InputValues | null,
 	operationSlug: string | null
-): OpenApiDocsViewV2Props | null {
+): Promise<OpenApiDocsViewV2Props | null> {
 	// If we don't have any preview data, we can't expect to generate valid props
 	if (!previewData) {
 		return null
 	}
 	// Use the incoming preview data to generate static props for the view
-	// TODO: this is just a placeholder for now.
-	return { _dev: { serverSideProps: { operationSlug, previewData } } }
+	return await getStaticProps({
+		basePath: '/open-api-docs-preview-v2',
+		operationSlug,
+		openApiJsonString: previewData.openApiJsonString,
+	})
 }

--- a/src/views/open-api-docs-view-v2/components/landing-content/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/landing-content/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+
+export interface LandingContentProps {
+	/**
+	 * TODO: discard once view can be identified without this
+	 */
+	_placeholder: any
+}
+
+/**
+ * TODO: implement this content area
+ */
+export default function LandingContent(props: LandingContentProps) {
+	return (
+		<>
+			<pre style={{ whiteSpace: 'pre-wrap' }}>
+				<code>{JSON.stringify(props, null, 2)}</code>
+			</pre>
+		</>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/landing-content/server.ts
+++ b/src/views/open-api-docs-view-v2/components/landing-content/server.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+import type { LandingContentProps } from '.'
+
+/**
+ * TODO: transform the schemaData into useful props
+ */
+export default async function getLandingContentProps(
+	schemaData: OpenAPIV3.Document
+): Promise<LandingContentProps> {
+	return {
+		_placeholder: {
+			viewToImplement: 'Landing view for OpenAPI spec',
+			schemaSample: schemaData.info,
+		},
+	}
+}

--- a/src/views/open-api-docs-view-v2/components/operation-content/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/operation-content/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+
+export interface OperationContentProps {
+	/**
+	 * TODO: discard once view can be identified without this
+	 */
+	_placeholder: any
+}
+
+/**
+ * TODO: implement this content area
+ */
+export default function OperationContent(props: OperationContentProps) {
+	return (
+		<>
+			<pre style={{ whiteSpace: 'pre-wrap' }}>
+				<code>{JSON.stringify(props, null, 2)}</code>
+			</pre>
+		</>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/operation-content/server.ts
+++ b/src/views/open-api-docs-view-v2/components/operation-content/server.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+import type { OperationContentProps } from '.'
+
+/**
+ * TODO: transform the schemaData into useful props
+ */
+export default async function getOperationContentProps(
+	operationSlug: string,
+	schemaData: OpenAPIV3.Document
+): Promise<OperationContentProps> {
+	return {
+		_placeholder: {
+			viewToImplement: `Operation view for ${operationSlug}`,
+			schemaSample: schemaData.info,
+		},
+	}
+}

--- a/src/views/open-api-docs-view-v2/index.tsx
+++ b/src/views/open-api-docs-view-v2/index.tsx
@@ -5,9 +5,11 @@
 
 // Layout
 import SidebarLayout from 'layouts/sidebar-layout'
+// Components
+import LandingContent from './components/landing-content'
+import OperationContent from './components/operation-content'
 // Types
 import type { OpenApiDocsViewV2Props } from './types'
-import Link from 'next/link'
 
 /**
  * Placeholder view component for a new OpenAPI docs setup.
@@ -15,40 +17,60 @@ import Link from 'next/link'
  * This new setup will split each operation into its own URL,
  * and render an overview page at the base URL.
  */
-export default function OpenApiDocsViewV2({ _dev }: OpenApiDocsViewV2Props) {
+export default function OpenApiDocsViewV2({
+	basePath,
+	navItems,
+	...restProps
+}: OpenApiDocsViewV2Props) {
 	return (
-		<SidebarLayout sidebarSlot="" mobileMenuSlot={null}>
-			<div style={{ padding: '24px', border: '1px solid magenta' }}>
-				<p>
-					{`This is a placeholder view for a new OpenAPI docs setup. It will split each operation into its own URL, and render an overview page at the base URL.`}
-				</p>
-				<p>
-					{`Later we'll transform the submitted OpenAPI JSON and other preview inputs into props for this page. For now, we're just reflecting them back, as shown below.`}
-				</p>
-				<p>{`Example operation links, to demo how "operationSlug" will be used in getServerSideProps to allow previewing of many pages:`}</p>
-				<ul>
-					<li>
-						<a href="/open-api-docs-preview-v2">Base URL</a>
-					</li>
-					<li>
-						<a href="/open-api-docs-preview-v2/ExampleOperationOne">
-							ExampleOperationOne
-						</a>
-					</li>
-					<li>
-						<a href="/open-api-docs-preview-v2/ExampleOperationTwo">
-							ExampleOperationTwo
-						</a>
-					</li>
-					<li>
-						<a href="/open-api-docs-preview-v2/ExampleOperationThree">
-							ExampleOperationThree
-						</a>
-					</li>
+		<SidebarLayout
+			sidebarSlot={
+				/**
+				 * TODO: refine generation of nav items, and then render them properly,
+				 * for now just messily rendering some links to enable navigation.
+				 *
+				 * Note: `next/link` will work in prod, since we'll be doing
+				 * `getStaticProps`... but in the preview tool, `next/link` seems to
+				 * make the preview experience janky, seemingly requiring reloads after
+				 * each navigation, maybe related to use of getServerSideProps? Not yet
+				 * sure how to resolve this, there's probably some clever solution that
+				 * might be possible...
+				 */
+				<ul style={{ margin: 0, border: '1px solid magenta' }}>
+					{navItems.map((navItem) => {
+						if (!('fullPath' in navItem)) {
+							return null
+						}
+						return (
+							<li key={navItem.fullPath}>
+								<a
+									href={navItem.fullPath}
+									style={{ color: navItem.isActive ? 'white' : undefined }}
+								>
+									{navItem.title}
+								</a>
+							</li>
+						)
+					})}
 				</ul>
-				<pre style={{ whiteSpace: 'pre-wrap' }}>
-					<code>{JSON.stringify(_dev, null, 2)}</code>
-				</pre>
+			}
+			/**
+			 * TODO: implement mobile menu. May be tempting to try to re-use the data
+			 * that feeds the sidebar, and this MAY be the right call, or MAY make
+			 * sense to have them a bit more separate (more flexibility in how we
+			 * present the sidebar, without having to disentangle all the complexity
+			 * of the mobile menu quite yet).
+			 */
+			mobileMenuSlot={null}
+		>
+			<div style={{ padding: '24px' }}>
+				<div style={{ border: '1px solid magenta' }}>
+					{'operationContentProps' in restProps ? (
+						<OperationContent {...restProps.operationContentProps} />
+					) : 'landingContentProps' in restProps ? (
+						<LandingContent {...restProps.landingContentProps} />
+					) : null}
+				</div>
 			</div>
 		</SidebarLayout>
 	)

--- a/src/views/open-api-docs-view-v2/server.ts
+++ b/src/views/open-api-docs-view-v2/server.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { getNavItems } from './utils/get-nav-items'
+import { parseAndValidateOpenApiSchema } from 'lib/api-docs/parse-and-validate-open-api-schema'
+// Utils
+import getOperationContentProps from './components/operation-content/server'
+import getLandingContentProps from './components/landing-content/server'
+// Types
+import type {
+	OpenApiDocsViewV2Props,
+	SharedProps,
+} from 'views/open-api-docs-view-v2/types'
+
+export async function getStaticProps({
+	basePath,
+	operationSlug,
+	openApiJsonString,
+}: {
+	basePath: string
+	operationSlug?: string
+	openApiJsonString: string
+}): Promise<OpenApiDocsViewV2Props> {
+	/**
+	 * Fetch, parse, and validate the OpenAPI schema for this version.
+	 */
+	const schemaData = await parseAndValidateOpenApiSchema(openApiJsonString)
+
+	/**
+	 * Gather props common to both the "landing" and "operation" views, namely:
+	 *
+	 * - basePath - base path from the dev dot URL, eg `/hcp/some-api-docs`
+	 * - navItems - links for the sidebar
+	 *
+	 * TODO: add breadcrumb bar. Or, could be done separately for each view,
+	 * if we have well-abstracted composable functions to build breadcrumbs?
+	 * (maybe already started, build breadcrumb from URL path segments?)
+	 *
+	 * TODO: version selector. Probably needs to come a little later, but
+	 * seems like something that would be duplicated pretty exactly between
+	 * the landing and operation views. That being said, maybe there's an
+	 * opportunity here to build a clever linking strategy so that we don't
+	 * link to 404s... most basic version might be "always link to the root of
+	 * the current version, and let the user navigate from there."... but more
+	 * complex version may end up meaning significant differences in the logic
+	 * to generate the version selector depending on landing vs operation view.
+	 */
+	const navItems = getNavItems(basePath, operationSlug, schemaData)
+	const sharedProps: SharedProps = { basePath, navItems }
+
+	/**
+	 * If we have an operation slug, build and return operation view props.
+	 * Otherwise, assume a landing view, and build and return landing view props.
+	 */
+	if (operationSlug) {
+		const operationContentProps = await getOperationContentProps(
+			operationSlug,
+			schemaData
+		)
+		return { ...sharedProps, operationContentProps }
+	} else {
+		const landingContentProps = await getLandingContentProps(schemaData)
+		return { ...sharedProps, landingContentProps }
+	}
+}

--- a/src/views/open-api-docs-view-v2/types.ts
+++ b/src/views/open-api-docs-view-v2/types.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { ProductSlug } from 'types/products'
 import { OperationContentProps } from './components/operation-content'
 import { LandingContentProps } from './components/landing-content'
 

--- a/src/views/open-api-docs-view-v2/types.ts
+++ b/src/views/open-api-docs-view-v2/types.ts
@@ -3,11 +3,36 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-export interface OpenApiDocsViewV2Props {
-	/**
-	 * _dev is a temporary placeholder for the props needed to render the new
-	 * OpenAPI docs view. It will be replaced with properly structured props
-	 * as the new views are implemented.
-	 */
-	_dev: $TSFixMe
+import { ProductSlug } from 'types/products'
+import { OperationContentProps } from './components/operation-content'
+import { LandingContentProps } from './components/landing-content'
+
+/**
+ * Nav items are used to render the sidebar.
+ *
+ * TODO: will likely need to be expanded once a more fully-featured sidebar
+ * is constructed. Older OpenAPI docs view may be useful for prior art, though
+ * we probably don't need to feel too tied to it.
+ */
+export type OpenApiNavItem = {
+	title: string
+	fullPath: string
+	isActive: boolean
 }
+
+/**
+ * Shared props are common to both the "landing" and "operation" views.
+ */
+export interface SharedProps {
+	basePath: string
+	navItems: OpenApiNavItem[]
+}
+
+/**
+ * OpenApiDocsViewV2 props are used to render either a "landing" view, which
+ * includes some introductory content to the API generally, or an "operation"
+ * view, which includes details about specific operations.
+ */
+export type OpenApiDocsViewV2Props =
+	| (SharedProps & { operationContentProps: OperationContentProps })
+	| (SharedProps & { landingContentProps: LandingContentProps })

--- a/src/views/open-api-docs-view-v2/utils/get-nav-items.ts
+++ b/src/views/open-api-docs-view-v2/utils/get-nav-items.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Utils
+import { wordBreakCamelCase } from './word-break-camel-case'
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+import type { OpenApiNavItem } from '../types'
+
+/**
+ * Build nav items for the OpenAPI view sidebar.
+ *
+ * We expect the sidebar navigation to be consistent across the landing view
+ * and the individual operation views.
+ *
+ * TODO: this is mostly placeholder for now, needs to be properly implemented.
+ */
+export function getNavItems(
+	baseUrl: string,
+	operationSlug,
+	openApiDocument: OpenAPIV3.Document
+): OpenApiNavItem[] {
+	/**
+	 * Initialize the navItems array with a link to the landing view
+	 */
+	const navItems: OpenApiNavItem[] = [
+		{
+			title: 'Landing',
+			fullPath: baseUrl,
+			isActive: !operationSlug,
+		},
+	]
+
+	/**
+	 * Iterate over all paths in the openApiDocument.
+	 * Each path can support many operations through different request types.
+	 */
+	for (const [_path, pathItemObject] of Object.entries(openApiDocument.paths)) {
+		for (const [type, operation] of Object.entries(pathItemObject)) {
+			// String values are apparently possible, but not sure how to support them
+			if (typeof operation === 'string') {
+				continue
+			}
+			// We only want operation objects.
+			if (!('operationId' in operation)) {
+				continue
+			}
+
+			// Push a nav item for this operation
+			const { operationId } = operation
+			navItems.push({
+				title: `[${type}] ${wordBreakCamelCase(operationId)}`,
+				fullPath: `${baseUrl}/${operationId}`,
+				isActive: operationSlug === operationId,
+			})
+		}
+	}
+
+	return navItems
+}

--- a/src/views/open-api-docs-view-v2/utils/word-break-camel-case.ts
+++ b/src/views/open-api-docs-view-v2/utils/word-break-camel-case.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/**
+ * Given a string, add zero-width spaces between lower and uppercase letters.
+ *
+ * This allows long camelCase or PascalCase strings to break at word boundaries.
+ * As an example, "VeryLongCamelCaseString" would otherwise not have clear
+ * word boundaries, and would risk either overflowing (without additional CSS)
+ * or breaking in strange places. Adding zero-width spaces allows the string
+ * to break at the casing-based word boundaries.
+ */
+export function wordBreakCamelCase(s: string) {
+	return s.replace(/([a-z])([A-Z])/g, '$1\u200B$2')
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Scaffolds in placeholder views for OpenAPI docs Landing and Operation content.

## 🤷 Why

To push forward on some work to improve our OpenAPI docs pages.

## 📸 Design Screenshots

### Landing view

| Before | After |
| - | - |
| ![landing-before](https://github.com/hashicorp/dev-portal/assets/4624598/244e2e1f-1767-443b-b670-0cf95d0b77e8) | ![landing-after](https://github.com/hashicorp/dev-portal/assets/4624598/bdbcb6de-d807-4d27-8312-74272041400f) |

### Operation view

| Before | After |
| - | - |
| ![operation-before](https://github.com/hashicorp/dev-portal/assets/4624598/c48895b7-aa16-49ef-b596-cbd675a3d46e) | ![operation-after](https://github.com/hashicorp/dev-portal/assets/4624598/ca746a5e-df93-4f90-b72e-6498bb8b2cf5) |

## 🧪 Testing

- [x] Visit [/open-api-docs-preview-v2]
    - Upload a valid OpenAPI spec, such as [the one for HCP Vault Secrets](https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-vault-secrets/stable/2023-06-13/hcp.swagger.json)
    - After submitting the form, the page should reload
    - Sidebar links should be scaffolded in, with placeholder content
    - Landing page should be scaffolded in, with placeholder content 
    - Operation page should be scaffolded in, with placeholder content 

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/799513369421962/1207339701271604/f
[preview]: https://dev-portal-git-zsopenapi-scaffold-operation-pages-hashicorp.vercel.app
[/open-api-docs-preview-v2]: https://dev-portal-git-zsopenapi-scaffold-operation-pages-hashicorp.vercel.app/open-api-docs-preview-v2
