### PR TITLE
avoid bad links in version dropdowns

### DIFF
--- a/src/components/docs-version-switcher/index.tsx
+++ b/src/components/docs-version-switcher/index.tsx
@@ -73,6 +73,12 @@ const DocsVersionSwitcher = ({
 		selectedOption = options.find(
 			(option: VersionSelectItem) => option.isLatest === true
 		)
+		// In some edge cases, there may be no latest version, such as for
+		// versioned docs that no longer exist in the latest version. For these
+		// cases, fallback to selecting the first option.
+		if (!selectedOption) {
+			selectedOption = options[0]
+		}
 	}
 
 	const projectNameForLabel = setProjectForAriaLabel(

--- a/src/views/docs-view/utils/get-valid-versions.ts
+++ b/src/views/docs-view/utils/get-valid-versions.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Types
+import type { VersionSelectItem } from '../loaders/remote-content'
+
+const CONTENT_API_URL = process.env.MKTG_CONTENT_API
+const VERSIONS_ENDPOINT = '/api/content-versions'
+
+/**
+ * Given a list of all possible versions, as well as a document path and
+ * content repo identifier for our content API,
+ * Return a filter list of versions that includes only those versions
+ * where this document exists.
+ *
+ * To determine in which versions this document exists, we make a request
+ * to a content API that returns a list of strings representing known versions.
+ * We use this to filter out unknown versions from our incoming version list.
+ */
+export async function getValidVersions(
+	/**
+	 * An array of version select items representing all possible versions for
+	 * the content source repository in question (`productSlugForLoader`).
+	 * May be undefined or empty if versioned docs are not enabled, for example
+	 * during local preview.
+	 */
+	versions: VersionSelectItem[],
+	/**
+	 * A identifier for the document, consumable by our content API.
+	 * For markdown documents, this is `doc#` followed by the full path of the
+	 * document within the content source repository.
+	 */
+	fullPath: string,
+	/**
+	 * The product slug for the document, consumable by our content API.
+	 * The naming here is difficult, as the actual function here is to identify
+	 * specific content source repositories. These are often but not always
+	 * product slugs. For example Terraform has multiple content source repos
+	 * for different parts of the product.
+	 */
+	productSlugForLoader: string
+): Promise<VersionSelectItem[]> {
+	// If versions are falsy or empty, we can skip the API calls and return []
+	if (!versions || versions.length === 0) return []
+	try {
+		// Build the URL to fetch known versions of this document
+		const validVersionsUrl = new URL(VERSIONS_ENDPOINT, CONTENT_API_URL)
+		validVersionsUrl.searchParams.set('product', productSlugForLoader)
+		validVersionsUrl.searchParams.set('fullPath', fullPath)
+		// Fetch known versions of this document
+		const response = await fetch(validVersionsUrl.toString())
+		const { versions: knownVersions } = await response.json()
+		// Apply the filter, and return the valid versions
+		return versions.filter((option) => knownVersions.includes(option.version))
+	} catch (error) {
+		console.error(
+			`[docs-view/server] error fetching known versions for "${productSlugForLoader}" document "${fullPath}". Falling back to showing all versions.`,
+			error
+		)
+		return versions
+	}
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR modifies our versioned documentation dropdown to avoid rendering any links that will 404. To accomplish this, we use the new docs content API `content-versions` endpoint introduced in https://github.com/hashicorp/mktg-content-workflows/pull/460.

## 🤷 Why

Rendering links that 404 makes for a confusing user experience, and adds a lot of noise to our 404 logging, and also seems to have a significant negative SEO impact. It also looks bad in tools like [ahrefs](https://ahrefs.com/).

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![before](https://github.com/hashicorp/dev-portal/assets/4624598/5b27af37-1c58-4c5a-8572-30551bae3506) | ![after](https://github.com/hashicorp/dev-portal/assets/4624598/96e27275-f20b-42ce-9c9f-6dd0e170da73) |

## 🧪 Testing

- [ ] Visit any docs page, and try any link in any version dropdown. None of them should 404.
    - For example, [/vault/docs/sync] should only show links to `v1.16.x` and `v1.15.x` in the version dropdown on the latest version of the page. Neither of those links should 404.
    - As another example, [/nomad/api-docs/jobs] should show _many_ versions in the version dropdown. None of the version links shown should 404.

## 💭 Anything else?

Likely makes sense to merge [mktg-content-workflows#463 - increase efficiency of content-versions with single-property query](https://github.com/hashicorp/mktg-content-workflows/pull/463) before merging this PR.

[task]: https://app.asana.com/0/799513369421962/1207661960981096/f
[preview]: https://dev-portal-git-zsavoid-bad-links-in-version-dropdown-hashicorp.vercel.app/
[/vault/docs/sync]: https://dev-portal-git-zsavoid-bad-links-in-version-dropdown-hashicorp.vercel.app/vault/docs/sync
[/nomad/api-docs/jobs]: https://dev-portal-git-zsavoid-bad-links-in-version-dropdown-hashicorp.vercel.app/nomad/api-docs/jobs