### PR TITLE
fix: remove breadcrumbs without links

### DIFF
--- a/src/components/breadcrumb-bar/index.tsx
+++ b/src/components/breadcrumb-bar/index.tsx
@@ -27,17 +27,16 @@ function BreadcrumbBar({
 	// For now, we want to strictly require that all
 	// breadcrumb link URLs, if present, are relative rather
 	// than absolute links
-	links
-		.filter((l) => Boolean(l.url))
-		.forEach((l) => {
-			if (isAbsoluteUrl(l.url)) {
-				throw new Error(
-					`Absolute URL passed to BreadcrumbBar: "${JSON.stringify(
-						l
-					)}". Please ensure all "link.url" values are relative links.`
-				)
-			}
-		})
+	const filteredLinks = links.filter((l) => Boolean(l.url))
+	filteredLinks.forEach((l) => {
+		if (isAbsoluteUrl(l.url)) {
+			throw new Error(
+				`Absolute URL passed to BreadcrumbBar: "${JSON.stringify(
+					l
+				)}". Please ensure all "link.url" values are relative links.`
+			)
+		}
+	})
 	// Now that we're sure all links are relative,
 	// we can render the breadcrumb links
 
@@ -47,7 +46,7 @@ function BreadcrumbBar({
 		{
 			'@context': 'https://schema.org',
 			'@type': 'BreadcrumbList',
-			itemListElement: links
+			itemListElement: filteredLinks
 				// remove items without a url
 				.filter((e) => !!e.url)
 				.map((link, index) => ({
@@ -69,7 +68,7 @@ function BreadcrumbBar({
 				/>
 			</Head>
 			<ol className={s.listRoot}>
-				{links.map(({ title, url, isCurrentPage }) => {
+				{filteredLinks.map(({ title, url, isCurrentPage }) => {
 					const cleanTitle = title.replace(/<[^>]+>/g, '')
 					const Elem = url && !isCurrentPage ? InternalLink : 'span'
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-featbreadcrumbs-hashicorp.vercel.app/terraform/enterprise/v202404-1/releases/2024/v202402-1) 🔎
- [Asana task](https://app.asana.com/0/1206176289707208/1207746622331000/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR fixes the breadcrumbs bar so it does not show items without urls. The reason it is showing them is because a `forEach` was chained after the `filter` and that does not work as intended in javascript. I changed it so the `forEach` is on the new array that is formed from the `filter` method.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to [prod](https://developer.hashicorp.com/terraform/enterprise/v202404-1/releases/2024/v202402-1)
2. Notice that the 2018 and 2024 breadcrumbs are not clickable
3. Go to [preview](https://dev-portal-git-leah-featbreadcrumbs-hashicorp.vercel.app/terraform/enterprise/v202404-1/releases/2024/v202402-1)
4. The 2018 and 2024 links are no longer in the breadcrumbs

