### PR TITLE
demo fix for ptfe version handling

### DIFF
--- a/src/views/docs-view/utils/semver-to-tfe-version.ts
+++ b/src/views/docs-view/utils/semver-to-tfe-version.ts
@@ -1,0 +1,17 @@
+import semver from 'semver'
+
+/**
+ * Expects a string like `v2022.7.1`;
+ * Returns a string like `v202207-1`;
+ *
+ * If the input is not a valid semver, returns the input unchanged
+ */
+export function semverToTfeVersion(input: string): string {
+	if (semver.valid(input)) {
+		const { major, minor, patch } = semver.coerce(input)!
+		return `v${major}${String(minor).padStart(2, '0')}-${patch}`
+	}
+
+	// passthrough
+	return input
+}


### PR DESCRIPTION
This is a debug & demo PR. Actual fix is in [mktg-content-workflows#464 - normalize content-versions to expected format for ptfe](https://github.com/hashicorp/mktg-content-workflows/pull/464).  

Intent is to close this PR once [mktg-content-workflows#464 - normalize content-versions to expected format for ptfe](https://github.com/hashicorp/mktg-content-workflows/pull/464) is approved & merged.