### PR TITLE
chore: change sourcemap to hidden

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,7 +56,7 @@ module.exports = withHashicorp({
 		config.plugins.push(HashiConfigPlugin())
 
 		if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'development') {
-			config.devtool = 'source-map'
+			config.devtool = 'hidden-source-map'
 		}
 
 		return config

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import { ReactElement, useEffect } from 'react'
+import { ReactElement } from 'react'
 
 // Global imports
 import BaseLayout from 'layouts/base-layout'
@@ -20,13 +20,6 @@ import {
 import s from './homepage.module.css'
 
 function HomePageView(): ReactElement {
-	useEffect(() => {
-		const timer = setTimeout(() => {
-			throw new Error('This is a new test error thrown after 5 seconds')
-		}, 5000)
-
-		return () => clearTimeout(timer) // Cleanup the timer on component unmount
-	}, [])
 	return (
 		<BaseLayout mobileMenuSlot={<MobileMenuLevelsGeneric />}>
 			<div className={s.root}>

--- a/src/views/homepage/index.tsx
+++ b/src/views/homepage/index.tsx
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 
 // Global imports
 import BaseLayout from 'layouts/base-layout'
@@ -20,6 +20,13 @@ import {
 import s from './homepage.module.css'
 
 function HomePageView(): ReactElement {
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			throw new Error('This is a new test error thrown after 5 seconds')
+		}, 5000)
+
+		return () => clearTimeout(timer) // Cleanup the timer on component unmount
+	}, [])
 	return (
 		<BaseLayout mobileMenuSlot={<MobileMenuLevelsGeneric />}>
 			<div className={s.root}>


### PR DESCRIPTION
## 🗒️ What

- change devtool value to `hidden-source-map` to fix 404 error

## Before

<img width="1245" alt="Screenshot 2024-07-29 at 19 44 08" src="https://github.com/user-attachments/assets/bd7f795c-d54a-4178-9e90-b31b11415a26">

## After
![Screenshot 2024-07-29 at 19 36 07](https://github.com/user-attachments/assets/2edf900b-31c2-4ecc-a04c-21a5b8cebc38)
(no sourcemap found instead of 404)
- You can see in [this previous deployment](https://dev-portal-fs7cudo0n-hashicorp.vercel.app/) that the message of "no sourcemap found" is expected

### Testing
- visit [this page](https://dev-portal-git-heat-chorefix-sourcemap-404-hashicorp.vercel.app/)
- open console and wait for error `Uncaught Error: This is a new test error thrown after 5 seconds` to appear
- visit rum error logs [here](https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40application.id%3A40a2019f-88ad-4076-ab52-ffd074064eed%20-%40error.source%3Anetwork%20%40session.type%3Auser%20%225%20seconds%22&agg_m=count&agg_m_source=base&agg_t=count&cols=&fromUser=false&refresh_mode=sliding&track=rum&viz=stream&from_ts=1721691907477&to_ts=1722296707477&live=true)
- You should see an error log matching your timestamp 
