### PR TITLE
Check active heading IDs before calculating distance

### DIFF
--- a/src/lib/hash-links/use-active-section.ts
+++ b/src/lib/hash-links/use-active-section.ts
@@ -1,5 +1,3 @@
-'use client'
-
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0

--- a/src/lib/hash-links/use-active-section.ts
+++ b/src/lib/hash-links/use-active-section.ts
@@ -1,3 +1,5 @@
+'use client'
+
 /**
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0

--- a/src/lib/hash-links/use-active-section.ts
+++ b/src/lib/hash-links/use-active-section.ts
@@ -91,16 +91,26 @@ export function useActiveSection(
 
 				if (visibleHeadings.current.size > 0) {
 					// Find the heading closest to the top of the viewport
-					let shortestDistance
-					let closestHeading
+					let shortestDistance = null
+					let closestHeading = null
 					visibleHeadings.current.forEach((headingId) => {
 						const targetElement = document.getElementById(headingId)
+
+						if (targetElement == null) {
+							return
+						}
+
 						const distance = targetElement.getBoundingClientRect().bottom
 						if (!closestHeading || distance < shortestDistance) {
 							closestHeading = headingId
 							shortestDistance = distance
 						}
 					})
+
+					if (!closestHeading) {
+						return
+					}
+
 					const activeSectionSlug = findMatchingSectionSlug(closestHeading)
 					setActiveSection(activeSectionSlug)
 				} else if (previousY.current && scrollTrend === 'up') {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1207660807251534/1207935781668949/f) 🎟️
- [Datadog error logs](https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40session.id%3A11fb182a-98bd-4ca0-a375-7ff2f18d688a&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAZEBE67iRtyO_gAAAAAAAAAYAAAAAEFaRUJFOWNYQUFBbV9OVWZpTk1JZXdBQQAAACQAAAAAMDE5MTAxY2ItODE2MS00MDE0LWFmMjYtMTlkM2EwMGM5YmEx&fromUser=false&refresh_mode=paused&track=rum&viz=stream&from_ts=1722296352842&to_ts=1722306363403&live=false) 🎟️

## 🗒️ What

When we are calculating the distance of the top heading in a doc, to mark it as the "active heading", we are assuming that each headingID will exist. This PR adds guards to that code to skip over headingIDs we cannot find, and also makes sure that we never pass `findMatchingSectionSlug` a `null`.

I believe this could happen in two situations:
1. This library is running before the browser has finished painting all of the headings for a doc.
2. During a SPA change this library is running and checking previous headingIDs

I believe **2.** is the most likely the most common situation and that seems to be born out in the [error logs](https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40session.id%3A11fb182a-98bd-4ca0-a375-7ff2f18d688a&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAZEBE67iRtyO_gAAAAAAAAAYAAAAAEFaRUJFOWNYQUFBbV9OVWZpTk1JZXdBQQAAACQAAAAAMDE5MTAxY2ItODE2MS00MDE0LWFmMjYtMTlkM2EwMGM5YmEx&fromUser=false&refresh_mode=paused&track=rum&viz=stream&from_ts=1722296352842&to_ts=1722306363403&live=false). (Happening after a SPA transition.)

## 🧪 Testing

- [ ] App builds without issue, as I was unable to reproduce with some of the listed URLs in the bug repo:

1. start on the page: [terraform/cli/run](https://developer.hashicorp.com/terraform/cli/run)
2. SPA transition (click on "destroy" in the sidebar) to the page: [terraform/cli/commands/destroy](https://developer.hashicorp.com/terraform/cli/commands/destroy)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207935781668949