### PR TITLE
chore: Prevent upload sourcemap script from running in product repo builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,11 @@ module.exports = withHashicorp({
 	webpack(config) {
 		config.plugins.push(HashiConfigPlugin())
 
-		if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'development') {
+		if (
+			typeof process.env.DATADOG_API_KEY !== 'undefined' &&
+			process.env.VERCEL_ENV &&
+			process.env.VERCEL_ENV !== 'development'
+		) {
 			config.devtool = 'hidden-source-map'
 		}
 

--- a/scripts/upload-source-maps.ts
+++ b/scripts/upload-source-maps.ts
@@ -9,6 +9,7 @@ import { execSync } from 'child_process'
  */
 const main = () => {
 	if (
+		typeof process.env.DATADOG_API_KEY === 'undefined' ||
 		typeof process.env.VERCEL_ENV === 'undefined' ||
 		process.env.VERCEL_ENV === 'development'
 	) {


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task](https://app.asana.com/0/1207660807251534/1207956118285656/f)

## 🗒️ What

- prevent the upload sourcemap script from running in product repo builds

## 🤷 Why

- Build will error because `DATADOG_API_KEY` is undefined. See example [here](https://vercel.com/hashicorp/boundary/21xAyGzcbf5K1ruTZt65PM3LtVQf#L395)
