### PR TITLE
Update the Vault docs home to add HVS and Vault Radar

### DIFF
--- a/src/content/vault/docs-landing.json
+++ b/src/content/vault/docs-landing.json
@@ -3,6 +3,30 @@
 	"marketingContentBlocks": [
 		{
 			"type": "section-heading",
+			"title": "HCP Vault products"
+		},
+		{
+			"type": "icon-card-grid",
+			"cards": [
+				{
+					"iconName": "vault-color",
+					"text": "HCP Vault Dedicated",
+					"url": "/hcp/docs/vault/what-is-hcp-vault"
+				},
+				{
+					"iconName": "vault-secrets-color",
+					"text": "HCP Vault Secrets",
+					"url": "/hcp/docs/vault-secrets"
+				},
+				{
+					"iconName": "vault-radar-color",
+					"text": "HCP Vault Radar",
+					"url": "/hcp/docs/vault-radar"
+				}
+			]
+		},
+		{
+			"type": "section-heading",
 			"title": "Use Cases"
 		},
 		{


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-vault-update-doc-home-hashicorp.vercel.app/vault/docs) 🔎
- [Jira ticket](https://hashicorp.atlassian.net/browse/SPE-938) 🎟️ 


## 🗒️ What

This PR updates the Vault docs landing page to link to HCP Vault docs pages.


## 🤷 Why

The concern was raised that users land on the **Vault** pages instead of **HCP** to look the docs for:

- HCP Vault Dedicated
- HCP Vault Secrets
- HCP Vault Radar

Today, we don't do a good job linking to HCP docs. Users have to read the "What is Vault?" page to find any links to HCP Vault Dedicated. 

As for HVS and Vault Radar, we don't have any mentioning of them. 

## 📸 Design Screenshots

Adding a card for each HCP product docs, navigate the users to the correct page on DevDot.

![image](https://github.com/user-attachments/assets/2e547e04-6945-4196-b5a8-1b66d05ef440)


