### PR TITLE
chore: Replace datadog_api_key with dd_api_key

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,7 +56,7 @@ module.exports = withHashicorp({
 		config.plugins.push(HashiConfigPlugin())
 
 		if (
-			typeof process.env.DATADOG_API_KEY !== 'undefined' &&
+			typeof process.env.DD_API_KEY !== 'undefined' &&
 			process.env.VERCEL_ENV &&
 			process.env.VERCEL_ENV !== 'development'
 		) {

--- a/scripts/upload-source-maps.ts
+++ b/scripts/upload-source-maps.ts
@@ -9,7 +9,7 @@ import { execSync } from 'child_process'
  */
 const main = () => {
 	if (
-		typeof process.env.DATADOG_API_KEY === 'undefined' ||
+		typeof process.env.DD_API_KEY === 'undefined' ||
 		typeof process.env.VERCEL_ENV === 'undefined' ||
 		process.env.VERCEL_ENV === 'development'
 	) {


### PR DESCRIPTION
## 🗒️ What

- Fix check for `DATADOG_API_KEY` by replacing it with `DD_API_KEY`

## 🤷 Why

- this check stopped sourcemaps from being uploaded. The `@datadog-ci` command requires `DATADOG_API_KEY`, but in our code base it is `DD_API_KEY`. 
