### PR TITLE
Remove "Edit on GitHub" link from terraform docs

### DIFF
--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -418,7 +418,9 @@ export function getStaticGenerationFunctions<
 			 * Note: If we need more granularity here, we could change this to be
 			 * part of `rootDocsPath` configuration in `src/data/<product>.json`.
 			 */
-			const isPublicContentRepo = !['hcp', 'sentinel'].includes(product.slug)
+			const isPublicContentRepo = !['hcp', 'sentinel', 'terraform'].includes(
+				product.slug
+			)
 			if (isPublicContentRepo) {
 				layoutProps.githubFileUrl = githubFileUrl
 			}

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -418,9 +418,7 @@ export function getStaticGenerationFunctions<
 			 * Note: If we need more granularity here, we could change this to be
 			 * part of `rootDocsPath` configuration in `src/data/<product>.json`.
 			 */
-			const isHcp = product.slug == 'hcp'
-			const isSentinel = product.slug == 'sentinel'
-			const isPublicContentRepo = !isHcp && !isSentinel
+			const isPublicContentRepo = !['hcp', 'sentinel'].includes(product.slug)
 			if (isPublicContentRepo) {
 				layoutProps.githubFileUrl = githubFileUrl
 			}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link]() 🔎


## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This PR removes the "Edit this page on GitHub" link at the bottom of the terraform docs as those pages are _not_ editable on GitHub. 

![image](https://github.com/user-attachments/assets/938de459-fac7-4044-b845-0877155126e1)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

It was drawn to our attention by Rose Wittkower in [this thread](https://hashicorp.slack.com/archives/C5FSPUGDS/p1723236157918749) who had been alerted to it by a customer who had clicked the link and been sent to a GitHub 404 page.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
It was pointed out in [a thread in #web-presence](https://hashicorp.slack.com/archives/C058H0MULTE/p1723236567773119) by @nandereck (shoutout to Nels for quickly finding that block!) that the conditional rendering could simply be changed here to hide that link for terraform (as well as sentinel and HCP).

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- [ ] Go to https://developer.hashicorp.com/terraform/enterprise and scroll to the bottom of the page
- [ ] See "Edit this page on GitHub" link
- [ ] Go to <preview link> and scroll to the bottom of the page
- [ ] The "Edit this page on GitHub" link should be gone
- [ ] Go to <preview link> and scroll to the bottom of the page
- [ ] The "Edit this page on GitHub" link should still be there

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208047374048357