### PR TITLE
bug fix: fix index.mdx nav items not resolving for api-docs & docs 

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -209,6 +209,11 @@ async function buildDevPortalRedirects() {
 			destination: '/certifications/security-automation',
 			permanent: true,
 		},
+		{
+			source: '/:path*/index',
+			destination: '/:path*',
+			permanent: true,
+		},
 		/**
 		 * Redirects from our former Packer Plugin library to our
 		 * new integrations library for Packer,

--- a/next.config.js
+++ b/next.config.js
@@ -70,7 +70,16 @@ module.exports = withHashicorp({
 			JSON.stringify(simpleRedirects, null, 2),
 			'utf-8'
 		)
-		return complexRedirects
+		return (
+			[...complexRedirects],
+			[
+				{
+					source: '/:path*/index',
+					destination: '/:path*',
+					permanent: true,
+				},
+			]
+		)
 	},
 	env: {
 		ASSET_API_ENDPOINT: process.env.ASSET_API_ENDPOINT,

--- a/next.config.js
+++ b/next.config.js
@@ -70,16 +70,7 @@ module.exports = withHashicorp({
 			JSON.stringify(simpleRedirects, null, 2),
 			'utf-8'
 		)
-		return (
-			[...complexRedirects],
-			[
-				{
-					source: '/:path*/index',
-					destination: '/:path*',
-					permanent: true,
-				},
-			]
-		)
+		return complexRedirects
 	},
 	env: {
 		ASSET_API_ENDPOINT: process.env.ASSET_API_ENDPOINT,

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -162,7 +162,7 @@ async function prepareNavNodeForClient({
 		 * we could add a warning or error here, or resolve this
 		 * through content conformance efforts.
 		 */
-		const pathWithIndexFix = node.path.endsWith('/index') ? '' : node.path
+		const pathWithIndexFix = node.path.endsWith('/index') ? '' : node.path // TODO: Remove this stopgap once this task is complete https://app.asana.com/0/1207947026228781/1208077887539354/f
 		const preparedItem = {
 			...node,
 			path: pathWithIndexFix,

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -162,7 +162,7 @@ async function prepareNavNodeForClient({
 		 * we could add a warning or error here, or resolve this
 		 * through content conformance efforts.
 		 */
-		const pathWithIndexFix = node.path == 'index' ? '' : node.path
+		const pathWithIndexFix = node.path.endsWith('/index') ? '' : node.path
 		const preparedItem = {
 			...node,
 			path: pathWithIndexFix,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- Preview link
- [Asana task](https://app.asana.com/0/1207947026228781/1207968736025985/f)

## 🗒️ What

- Refactor logic to remove `/index` from nav nodes because when a user clicks on the link, it sends them to a 404 page
- Add redirect to `next.config.js` for paths that end with `/index`

## 🤷 Why

- fix 404s in ahrefs found [here](https://app.ahrefs.com/site-audit/4163982/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2Ccompliant%2CincomingAllLinks%2Corigin&current=12-08-2024T231641M0400&filterId=28daa554b6921b6c6742b8b3f34bbf51&issueId=c64dae3f-d0f4-11e7-8ed1-001e67ed4656&sorting=-incomingAllLinks&st=index)

## 🧪 Testing

All of these paths should resolve:

- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.19/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.14/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.18/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.15/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.16/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.17/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.10/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.12/index"
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.13/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/docs/v2.2.11/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.10.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.9.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.8.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.7.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.6.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.18.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.17.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.5.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.16.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.15.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/api-docs/v1.4.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.13.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.14.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.11.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.12.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.9.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.10.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/commands/v1.8.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.7.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/tools/v1.7.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/tools/v1.4.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/tools/v1.5.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/tools/v1.6.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.6.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.5.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/api-docs/v1.11.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/api-docs/v1.12.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/api-docs/v1.9.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/api-docs/v1.10.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/api-docs/v1.8.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.4.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.2.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.3.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.0.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v1.1.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v0.11.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/nomad/api-docs/v0.12.x/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/terraform/language/functions/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.14/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.11/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.13/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.18/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.16/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.15/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.12/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.17/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.19/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vagrant/intro/v2.2.10/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.13.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.11.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.14.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.12.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.15.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.16.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/docs/commands/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/v0.13.x/concepts/domain-model/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/v0.15.x/concepts/domain-model/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/v0.14.x/concepts/domain-model/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/docs/v1.12.x/agent/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.10.x/concepts/integrated-storage/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.15.x/proxy/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/concepts/domain-model/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/docs/v1.11.x/agent/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/hcp/docs/vault-radar/cli/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.4.x/enterprise/entropy-augmentation/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/v0.9.x/oss/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/consul/docs/v1.13.x/agent/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/boundary/docs/v0.12.x/concepts/domain-model/index
- https://dev-portal-git-heat-chorefix-index-nav-item-hashicorp.vercel.app/vault/docs/v1.14.x/proxy/index
