### PR TITLE
Remove Vault Radar card

### DIFF
--- a/src/content/vault/docs-landing.json
+++ b/src/content/vault/docs-landing.json
@@ -17,11 +17,6 @@
 					"iconName": "vault-secrets-color",
 					"text": "HCP Vault Secrets",
 					"url": "/hcp/docs/vault-secrets"
-				},
-				{
-					"iconName": "vault-radar-color",
-					"text": "HCP Vault Radar",
-					"url": "/hcp/docs/vault-radar"
 				}
 			]
 		},


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎


## 🗒️ What

This PR removed the `HCP Vault Radar` card that was added to the Vault docs home.

## 🤷 Why

R&D management team decided to "_Move HCP Vault Radar to be a standalone product_".

For HashiConf, Vault Radar will be **public beta** instead of GA.



## 📸 Design Screenshots

![image](https://github.com/user-attachments/assets/f762c7f5-ac27-4a20-9dda-8c209a05e32d)
