### PR TITLE
implement adr-001 env changes for unified docs

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,58 @@ NEXT_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY=2cd9898a6c253bfa3965d2b62a4f7f3d
 # which takes precedence over the NEXT_PUBLIC_ALGOLIA_INDEX env var.
 # NEXT_PUBLIC_ALGOLIA_INDEX=product_WAYPOINT
 
-MKTG_CONTENT_API="https://content.hashicorp.com"
+#
+# EXISTING DOCS API
+#
+# `content.hashicorp.com`, deployed from `mktg-content-workflows`, is currently
+# used to provide docs content to `dev-portal`.
+#
+# We intend to migrate away from this use, and adopt our new unified docs
+# service, which is backed by a single content repository. We want to approach
+# this migration incrementally. This `MKTG_CONTENT_DOCS_API` environment
+# variable is intended for use during migration, allowing not-yet-migrated
+# content sources to continue using the existing `content.hashicorp.com` API.
+#
+# Once we've fully migrated to use `UNIFIED_DOCS_API`, we'll be able to remove
+# this environment variable.
+MKTG_CONTENT_DOCS_API="https://content.hashicorp.com"
+
+#
+# NEW UNIFIED DOCS API
+#
+# The new unified docs service is a single content repository that serves
+# documentation content for all HashiCorp products. This service is intended to
+# replace the docs endpoints of the existing `content.hashicorp.com` API.
+
+# More details on how we intend to build the new unified docs API can be found
+# in ADRs in the `web-presence-experimental-docs` repository. One example:
+# https://github.com/hashicorp/web-presence-experimental-docs/pull/9
+#
+# This environment variable is intended for use during and after migration.
+# To opt-in a content source to be served from the new unified docs service,
+# in theory, we should be able to update that content source's uses of
+# `MKTG_CONTENT_DOCS_API` to instead use `UNIFIED_DOCS_API`. In practice, there
+# are as of 2024-08-19 still many changes to be made to make this transition
+# possible. This environment variable is being set up with the intent of being
+# used to test and to later enable this type of migration.
+UNIFIED_DOCS_API="https://web-presence-experimental-docs.vercel.app/"
+
+#
+# DOCS STATIC PATHS FROM ANALYTICS API
+#
+# The `content.hashicorp.com` API contains services other than docs content.
+# Specifically, it contains an endpoint that allows us to determine the subset
+# of documentation pages that we want to render at build time, based on
+# page view analytics.
+#
+# For this "static paths from analytics" purpose, we do not have a replacement
+# in mind in the short-term.
+#
+# We could potentially migrate the existing service to some other location,
+# perhaps refactoring it (as it probably needs updates). However, we also have
+# the option to leave this service alone for now, which may help us focus on the
+# more critical parts of the migration to our new unified docs service.
+DOCS_STATIC_PATHS_API="https://content.hashicorp.com"
 
 # Note: check .env.local.example for additional required env vars
 

--- a/docs/decisions/adr-001-env-changes-for-unified-docs.md
+++ b/docs/decisions/adr-001-env-changes-for-unified-docs.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/next.config.js
+++ b/next.config.js
@@ -80,7 +80,7 @@ module.exports = withHashicorp({
 		ENABLE_VERSIONED_DOCS: process.env.ENABLE_VERSIONED_DOCS || false,
 		HASHI_ENV: process.env.HASHI_ENV || 'development',
 		IS_CONTENT_PREVIEW: process.env.IS_CONTENT_PREVIEW,
-		MKTG_CONTENT_API: process.env.MKTG_CONTENT_API,
+		MKTG_CONTENT_DOCS_API: process.env.MKTG_CONTENT_DOCS_API,
 		// TODO: determine if DevDot needs this or not
 		SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
 		POSTHOG_PROJECT_API_KEY:

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -37,7 +37,7 @@ function getContentApiDimensions(
 	url: string
 ): { width: number; height: number } | null {
 	// We only care about Content API urls
-	if (!url.startsWith(process.env.MKTG_CONTENT_API)) {
+	if (!url.startsWith(process.env.MKTG_CONTENT_DOCS_API)) {
 		return null
 	}
 	const urlParams = new URL(url).searchParams

--- a/src/lib/__tests__/get-static-paths-from-analytics.test.ts
+++ b/src/lib/__tests__/get-static-paths-from-analytics.test.ts
@@ -9,11 +9,11 @@ import { getStaticPathsFromAnalytics } from 'lib/get-static-paths-from-analytics
 
 import staticPathsResultFixture from './__fixtures__/static_paths_waypoint_docs.json'
 
-process.env.MKTG_CONTENT_API = 'https://content.hashicorp.com'
+process.env.DOCS_STATIC_PATHS_API = 'https://content.hashicorp.com'
 
 describe('getStaticPathsFromAnalytics', () => {
 	test('fetches static paths from the analytics endpoint - no valid paths', async () => {
-		nock(process.env.MKTG_CONTENT_API)
+		nock(process.env.DOCS_STATIC_PATHS_API)
 			.get('/api/static_paths')
 			.query({
 				product: 'developer',
@@ -33,7 +33,7 @@ describe('getStaticPathsFromAnalytics', () => {
 	})
 
 	test('fetches static paths from the analytics endpoint - filters with valid paths', async () => {
-		nock(process.env.MKTG_CONTENT_API)
+		nock(process.env.DOCS_STATIC_PATHS_API)
 			.get('/api/static_paths')
 			.query({
 				product: 'developer',

--- a/src/lib/fetch-content-api-file-string.js
+++ b/src/lib/fetch-content-api-file-string.js
@@ -5,7 +5,7 @@
 
 const fetchFileString = require('./fetch-file-string')
 
-const API_URL = process.env.MKTG_CONTENT_API || `https://content.hashicorp.com`
+const API_URL = process.env.MKTG_CONTENT_DOCS_API
 const API_ASSETS = `/api/assets`
 async function fetchContentApiFileString({ product, filePath, version }) {
 	const [p, v, fp] = [product, version, filePath].map(encodeURIComponent)

--- a/src/lib/get-static-paths-from-analytics.ts
+++ b/src/lib/get-static-paths-from-analytics.ts
@@ -46,7 +46,7 @@ export async function getStaticPathsFromAnalytics<Params = BaseParams>({
 }: GetStaticPathsFromAnalyticsOptions<Params>): Promise<StaticPaths<Params>> {
 	const endpoint = new URL(
 		`/api/static_paths?product=developer&param=${param}&limit=${limit}&path_prefix=${pathPrefix}`,
-		process.env.MKTG_CONTENT_API
+		process.env.DOCS_STATIC_PATHS_API
 	)
 
 	const { result } = await fetch(endpoint.toString()).then((res) => res.json())

--- a/src/lib/remark-plugins/remark-image-dimensions/index.ts
+++ b/src/lib/remark-plugins/remark-image-dimensions/index.ts
@@ -23,7 +23,7 @@ export const remarkPluginInjectImageDimensions: Plugin = (): Transformer => {
 			 * to transform the src URLs from local file paths to mktg-content-api urls
 			 * See: src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
 			 */
-			if (node.url.startsWith(process.env.MKTG_CONTENT_API)) {
+			if (node.url.startsWith(process.env.MKTG_CONTENT_DOCS_API)) {
 				imageNodesForDimensions.push(node)
 			}
 		})

--- a/src/lib/remark-plugins/remark-rewrite-assets.ts
+++ b/src/lib/remark-plugins/remark-rewrite-assets.ts
@@ -27,7 +27,7 @@ export function remarkRewriteAssets(args: {
 				const originalUrl = node.url
 				const asset = path.posix.join(...getAssetPathParts(originalUrl))
 
-				const url = new URL(`${process.env.MKTG_CONTENT_API}/api/assets`)
+				const url = new URL(`${process.env.MKTG_CONTENT_DOCS_API}/api/assets`)
 				url.searchParams.append('asset', asset)
 				url.searchParams.append('version', version)
 				url.searchParams.append('product', product)

--- a/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
+++ b/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
@@ -21,7 +21,8 @@ import { Node } from 'unist'
 import { Image, Definition } from 'mdast'
 
 // This env is set for local docker previews by a custom asset server,
-// otherwise we use the content api for previews / prod
+// otherwise we use the content api for previews / prod.
+// This is used for local and deploy preview modes from the `tutorials` repo.
 const ASSET_API_ENDPOINT =
 	process.env.ASSET_API_ENDPOINT ||
 	`${process.env.MKTG_CONTENT_DOCS_API}/api/assets`

--- a/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
+++ b/src/lib/remark-plugins/rewrite-static-tutorials-assets/index.ts
@@ -23,7 +23,8 @@ import { Image, Definition } from 'mdast'
 // This env is set for local docker previews by a custom asset server,
 // otherwise we use the content api for previews / prod
 const ASSET_API_ENDPOINT =
-	process.env.ASSET_API_ENDPOINT || `${process.env.MKTG_CONTENT_API}/api/assets`
+	process.env.ASSET_API_ENDPOINT ||
+	`${process.env.MKTG_CONTENT_DOCS_API}/api/assets`
 
 /**
  * @TODO write tests for this plugin - https://app.asana.com/0/1202097197789424/1204921235104809

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -7,7 +7,7 @@ import { makeSitemapField } from './helpers'
 
 export async function allDocsFields() {
 	const getDocsPaths = await fetch(
-		`${process.env.MKTG_CONTENT_API}/api/all-docs-paths`
+		`${process.env.MKTG_CONTENT_DOCS_API}/api/all-docs-paths`
 	)
 	const { result: docsResult } = await getDocsPaths.json()
 	return docsResult.map((page: { path: string; created_at: string }) =>

--- a/src/views/docs-view/loaders/__tests__/remote-content.test.ts
+++ b/src/views/docs-view/loaders/__tests__/remote-content.test.ts
@@ -41,7 +41,7 @@ describe('RemoteContentLoader', () => {
 
 		nock.disableNetConnect()
 
-		scope = nock(process.env.MKTG_CONTENT_API)
+		scope = nock(process.env.MKTG_CONTENT_DOCS_API)
 	})
 
 	afterAll(() => {

--- a/src/views/docs-view/loaders/content-api/content-api.test.ts
+++ b/src/views/docs-view/loaders/content-api/content-api.test.ts
@@ -19,7 +19,7 @@ describe('contentApi', () => {
 
 	beforeEach(() => {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		scope = nock(process.env.MKTG_CONTENT_API!)
+		scope = nock(process.env.MKTG_CONTENT_DOCS_API!)
 	})
 
 	describe('fetchDocument', () => {

--- a/src/views/docs-view/loaders/content-api/index.ts
+++ b/src/views/docs-view/loaders/content-api/index.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const MKTG_CONTENT_API = process.env.MKTG_CONTENT_API
+const MKTG_CONTENT_DOCS_API = process.env.MKTG_CONTENT_DOCS_API
 
 // Courtesy helper for warning about missing env vars during development
 const checkEnvVarsInDev = () => {
 	if (process.env.NODE_ENV === 'development') {
-		if (!MKTG_CONTENT_API) {
+		if (!MKTG_CONTENT_DOCS_API) {
 			const message = [
 				'Missing environment variable required to fetch remote content:',
-				'  - `MKTG_CONTENT_API`',
+				'  - `MKTG_CONTENT_DOCS_API`',
 				'Reach out to #team-web-platform to get the proper value.',
 			].join('\n')
 			throw new Error(message)
@@ -34,7 +34,7 @@ export async function fetchNavData(
 	checkEnvVarsInDev()
 
 	const fullPath = `nav-data/${version}/${basePath}`
-	const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
+	const url = `${MKTG_CONTENT_DOCS_API}/api/content/${product}/${fullPath}`
 
 	const response = await fetch(url)
 
@@ -52,7 +52,7 @@ export async function fetchDocument(
 ): Promise<any> {
 	checkEnvVarsInDev()
 
-	const url = `${MKTG_CONTENT_API}/api/content/${product}/${fullPath}`
+	const url = `${MKTG_CONTENT_DOCS_API}/api/content/${product}/${fullPath}`
 	const response = await fetch(url)
 
 	if (response.status !== 200) {
@@ -66,7 +66,7 @@ export async function fetchDocument(
 export async function fetchVersionMetadataList(product: string) {
 	checkEnvVarsInDev()
 
-	const url = `${MKTG_CONTENT_API}/api/content/${product}/version-metadata?partial=true`
+	const url = `${MKTG_CONTENT_DOCS_API}/api/content/${product}/version-metadata?partial=true`
 	const response = await fetch(url)
 
 	if (response.status !== 200) {

--- a/src/views/docs-view/utils/get-valid-versions.ts
+++ b/src/views/docs-view/utils/get-valid-versions.ts
@@ -6,7 +6,7 @@
 // Types
 import type { VersionSelectItem } from '../loaders/remote-content'
 
-const CONTENT_API_URL = process.env.MKTG_CONTENT_API
+const CONTENT_API_URL = process.env.MKTG_CONTENT_DOCS_API
 const VERSIONS_ENDPOINT = '/api/content-versions'
 
 /**


### PR DESCRIPTION
This PR implements #2548.

In more detail, this PR introduces three new environment variables:

- `DOCS_STATIC_PATHS_API` - will be set to <https://content.hashicorp.com> initially. Intent is to scope work around this functionality separately from the unified docs API migration.
- `MKTG_CONTENT_DOCS_API` - will be set to <https://content.hashicorp.com> initially. Docs functions that are not yet migrated will use this env variable.
- `UNIFIED_DOCS_API` - will be set to point to our new unified docs API, currently <https://web-presence-experimental-docs.vercel.app/>. The migration process will be to switch individual docs sections to use this new variable.

This PR also removes the existing `MKTG_CONTENT_API` env variable, as with the introduction of the above environment variables, it is now unused.