### PR TITLE
TF recert logic wording added to developer page

### DIFF
--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -75,13 +75,13 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 #### Renew by passing a professional-level exam
 
-**_Unexpired_ Terraform Associate 002 or 003 credentials** 
+**_Unexpired_ Terraform Associate 002 or 003 credentials:** 
 
 When you pass the Terraform Authoring and Operations Professional exam, you will receive the professional-level credentials (badge and corresponding certificate). You will also extend the expiration of your Terraform Associate 002 or 003 credentials. 
 
 #### Renew by passing an associate-level exam
 
-**_Unexpired_ Terraform Associate 002 credential** 
+**_Unexpired_ Terraform Associate 002 credential:** 
 
 * You can take the Terraform Associate 003 exam starting 18 months after your previous exam date. 
 * You will receive a new, separate set of credentials that will reflect your recertification date. 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -75,9 +75,9 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 To renew any Terraform Associate certification, you will need to take and pass the Terraform Associate 003 exam or the Terraform Authoring & Operations Professional exam.
 
-**If you hold an *unexpired* Terraform Associate 002 certification:** You can take the 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam to recertify, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. The date of your credentials related to your Terraform Associate 002 certification will not be updated.
+**If you hold an *unexpired* Terraform Associate 002 certification:** You can take the Terraform Associate 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam to recertify, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. The date of your credentials related to your Terraform Associate 002 certification will not be updated.
 
-**If you hold an *unexpired* Terraform Associate 003 certification:** You can take the 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam, the expiration date on your credentials will be extended.
+**If you hold an *unexpired* Terraform Associate 003 certification:** You can take the Terraform Associate 003 exam again or take the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam, the expiration date on your credentials will be extended.
 
 **If you hold any *expired* Terraform Associate certification:** You are eligible to recertify at any time. When you pass the new exam, you will receive a new, separate set of credentials with a new expiration date.
 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -77,25 +77,25 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 **_Unexpired_ Terraform Associate 002 or 003 credentials** 
 
-When you pass the Terraform Authoring and Operations Professional exam, you will receive the professional-level credentials. You will also extend the expiration of your Terraform Associate 002 or 003 credentials. 
+When you pass the Terraform Authoring and Operations Professional exam, you will receive the professional-level credentials (badge and corresponding certificate). You will also extend the expiration of your Terraform Associate 002 or 003 credentials. 
 
 ### Renew by passing an associate-level exam
 
 **_Unexpired_ Terraform Associate 002 credential** 
 
 * You can take the Terraform Associate 003 exam starting 18 months after your previous exam date. 
-* When you pass the exam, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. 
-* The date of your credentials related to your Terraform Associate 002 certification will not be updated.
+* You will receive a new, separate set of credentials that will reflect your recertification date. 
+* The expiration date of Terraform Associate 002 credentials will not be updated.
 
 **_Unexpired_ Terraform Associate 003 credential:** 
 
 * You can retake the Terraform Associate 003 exam starting 18 months after your previous exam date. 
-* When you pass the exam, the expiration date on your credentials will be extended.
+* The expiration date on your credentials will be extended.
 
-**_Expired_ Terraform Associate credential:** 
+### Have an _expired_ Terraform Associate credential? 
 
-* You are eligible to recertify at any time. 
-* When you pass the exam, you will receive a new, separate set of credentials with a new expiration date.
+* You are eligible to recertify at any time by taking either the Associate or Professional-level exam. 
+* You will receive a new, separate set of credentials with a new expiration date.
 
 Have more questions? Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -81,6 +81,8 @@ To renew any Terraform Associate certification, you will need to take and pass t
 
 **If you hold any *expired* Terraform Associate certification:** You are eligible to recertify at any time. When you pass the new exam, you will receive a new, separate set of credentials with a new expiration date.
 
+Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
+
 ### Content Differences Between the 002 and 003 exams
 
 We updated the Terraform Associate 003 exam to account for how Terraform has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -73,11 +73,11 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 ## Renewing Your Certification
 
-To renew any Terraform Associate certification, you will need to take and pass the new Terraform Associate 003 exam.
+To renew any Terraform Associate certification, you will need to take and pass the Terraform Associate 003 exam or the Terraform Authoring & Operations Professional exam.
 
-**If you hold an *unexpired* Terraform Associate 002 certification:** You can take the new (003) exam starting 18 months after your previous exam date. When you pass the Terraform Associate 003 exam to recertify, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. The date of your credentials related to your Terraform Associate 002 certification will not be updated.
+**If you hold an *unexpired* Terraform Associate 002 certification:** You can take the 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam to recertify, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. The date of your credentials related to your Terraform Associate 002 certification will not be updated.
 
-**If you hold an *unexpired* Terraform Associate 003 certification:** You can take the new exam starting 18 months after your previous exam date. When you pass the new exam, the expiration date on your credentials will be extended.
+**If you hold an *unexpired* Terraform Associate 003 certification:** You can take the 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam, the expiration date on your credentials will be extended.
 
 **If you hold any *expired* Terraform Associate certification:** You are eligible to recertify at any time. When you pass the new exam, you will receive a new, separate set of credentials with a new expiration date.
 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -73,15 +73,31 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 ## Renewing Your Certification
 
-To renew any Terraform Associate certification, you will need to take and pass the Terraform Associate 003 exam or the Terraform Authoring & Operations Professional exam.
+### Renew by passing a professional-level exam
 
-**If you hold an *unexpired* Terraform Associate 002 certification:** You can take the Terraform Associate 003 exam or the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam to recertify, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. The date of your credentials related to your Terraform Associate 002 certification will not be updated.
+**_Unexpired_ Terraform Associate 002 or 003 credentials** 
 
-**If you hold an *unexpired* Terraform Associate 003 certification:** You can take the Terraform Associate 003 exam again or take the Terraform Authoring & Operations Professional exam starting 18 months after your previous exam date. When you pass either exam, the expiration date on your credentials will be extended.
+When you pass the Terraform Authoring and Operations Professional exam, you will receive the professional-level credentials. You will also extend the expiration of your Terraform Associate 002 or 003 credentials. 
 
-**If you hold any *expired* Terraform Associate certification:** You are eligible to recertify at any time. When you pass the new exam, you will receive a new, separate set of credentials with a new expiration date.
+### Renew by passing an associate-level exam
 
-Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
+**_Unexpired_ Terraform Associate 002 credential** 
+
+* You can take the Terraform Associate 003 exam starting 18 months after your previous exam date. 
+* When you pass the exam, you will receive a new, separate set of credentials (badge and corresponding certificate) that will reflect your recertification date. 
+* The date of your credentials related to your Terraform Associate 002 certification will not be updated.
+
+**_Unexpired_ Terraform Associate 003 credential:** 
+
+* You can retake the Terraform Associate 003 exam starting 18 months after your previous exam date. 
+* When you pass the exam, the expiration date on your credentials will be extended.
+
+**_Expired_ Terraform Associate credential:** 
+
+* You are eligible to recertify at any time. 
+* When you pass the exam, you will receive a new, separate set of credentials with a new expiration date.
+
+Have more questions? Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
 
 ### Content Differences Between the 002 and 003 exams
 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -73,13 +73,13 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 ## Renewing Your Certification
 
-### Renew by passing a professional-level exam
+#### Renew by passing a professional-level exam
 
 **_Unexpired_ Terraform Associate 002 or 003 credentials** 
 
 When you pass the Terraform Authoring and Operations Professional exam, you will receive the professional-level credentials (badge and corresponding certificate). You will also extend the expiration of your Terraform Associate 002 or 003 credentials. 
 
-### Renew by passing an associate-level exam
+#### Renew by passing an associate-level exam
 
 **_Unexpired_ Terraform Associate 002 credential** 
 
@@ -92,12 +92,12 @@ When you pass the Terraform Authoring and Operations Professional exam, you will
 * You can retake the Terraform Associate 003 exam starting 18 months after your previous exam date. 
 * The expiration date on your credentials will be extended.
 
-### Have an _expired_ Terraform Associate credential? 
+#### Have an _expired_ Terraform Associate credential? 
 
 * You are eligible to recertify at any time by passing the Terraform Associate 003 exam. 
 * You will receive a new, separate set of credentials with a new expiration date.
 
-Have more questions? Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
+Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).
 
 ### Content Differences Between the 002 and 003 exams
 

--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -94,7 +94,7 @@ When you pass the Terraform Authoring and Operations Professional exam, you will
 
 ### Have an _expired_ Terraform Associate credential? 
 
-* You are eligible to recertify at any time by taking either the Associate or Professional-level exam. 
+* You are eligible to recertify at any time by passing the Terraform Associate 003 exam. 
 * You will receive a new, separate set of credentials with a new expiration date.
 
 Have more questions? Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).


### PR DESCRIPTION
## 🔗 Relevant links


- [Preview link](https://dev-portal-git-TFPro_GoLiveUpdates-hashicorp.vercel.app/certifications/infrastructure-automation) 🔎
- [Asana task](https://app.asana.com/0/1204533745817604/1206583690938205/f) 🎟️

## 🗒️ What
Included the new TF Pro exam in the recertification logic section of the TF Assoc 003 page

## 🤷 Why
When TF Pro launches, it becomes part of the recert path for Assoc

