### PR TITLE
bug fix: Add check that path exists for options.jsonFilePath

### DIFF
--- a/src/pages/vagrant/install/vmware/index.tsx
+++ b/src/pages/vagrant/install/vmware/index.tsx
@@ -11,7 +11,7 @@ import { generateGetStaticProps } from 'views/product-downloads-view/server'
 const getStaticProps = generateGetStaticProps(vagrantData as ProductData, {
 	installName: 'Vagrant VMware Utility',
 	releaseSlug: 'vagrant-vmware-utility',
-	jsonFilePath: `src/content/${vagrantData.slug}/install-vmware-landing.json`,
+	jsonFilePath: 'src/content/vagrant/install-vmware-landing.json',
 })
 
 export { getStaticProps }

--- a/src/views/product-downloads-view/server.ts
+++ b/src/views/product-downloads-view/server.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import fs from 'fs'
-import path from 'path'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { ProductData } from 'types/products'
 import { generateStaticProps as generateReleaseStaticProps } from 'lib/fetch-release-data'
 import { stripUndefinedProperties } from 'lib/strip-undefined-props'
@@ -41,23 +41,20 @@ const generateGetStaticProps = (
 		props: ProductDownloadsViewStaticProps
 		revalidate: number
 	}> => {
-		/**
-		 * Fetch page content
-		 *
-		 * Note: could consider other content sources. For now, JSON.
-		 * Asana task: https://app.asana.com/0/1100423001970639/1201631159784193/f
-		 */
-		let jsonFilePath = path.join(
+		let jsonFilePath = join(
 			process.cwd(),
 			`src/content/${product.slug}/install-landing.json`
 		)
 
 		if (options.jsonFilePath) {
-			jsonFilePath = path.join(process.cwd(), options.jsonFilePath)
+			const staticPath = join(process.cwd(), options.jsonFilePath)
+			if (existsSync(staticPath)) {
+				jsonFilePath = staticPath
+			}
 		}
 
 		const CONTENT: RawProductDownloadsViewContent = JSON.parse(
-			fs.readFileSync(jsonFilePath, 'utf8')
+			readFileSync(jsonFilePath, 'utf8')
 		)
 
 		const {

--- a/src/views/product-downloads-view/server.ts
+++ b/src/views/product-downloads-view/server.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import fs from 'node:fs/promises'
 import { join } from 'node:path'
 import { ProductData } from 'types/products'
 import { generateStaticProps as generateReleaseStaticProps } from 'lib/fetch-release-data'
@@ -47,15 +47,12 @@ const generateGetStaticProps = (
 		)
 
 		if (options.jsonFilePath) {
-			const staticPath = join(process.cwd(), options.jsonFilePath)
-			if (existsSync(staticPath)) {
-				jsonFilePath = staticPath
-			}
+			jsonFilePath = join(process.cwd(), options.jsonFilePath)
 		}
 
-		const CONTENT: RawProductDownloadsViewContent = JSON.parse(
-			readFileSync(jsonFilePath, 'utf8')
-		)
+		const file = await fs.readFile(jsonFilePath, 'utf8')
+
+		const CONTENT: RawProductDownloadsViewContent = JSON.parse(file)
 
 		const {
 			doesNotHavePackageManagers,

--- a/src/views/product-downloads-view/server.ts
+++ b/src/views/product-downloads-view/server.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import fs from 'node:fs/promises'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { ProductData } from 'types/products'
 import { generateStaticProps as generateReleaseStaticProps } from 'lib/fetch-release-data'
@@ -47,12 +47,15 @@ const generateGetStaticProps = (
 		)
 
 		if (options.jsonFilePath) {
-			jsonFilePath = join(process.cwd(), options.jsonFilePath)
+			const staticPath = join(process.cwd(), options.jsonFilePath)
+			if (existsSync(staticPath)) {
+				jsonFilePath = staticPath
+			}
 		}
 
-		const file = await fs.readFile(jsonFilePath, 'utf8')
-
-		const CONTENT: RawProductDownloadsViewContent = JSON.parse(file)
+		const CONTENT: RawProductDownloadsViewContent = JSON.parse(
+			readFileSync(jsonFilePath, 'utf8')
+		)
 
 		const {
 			doesNotHavePackageManagers,


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1207947026228781/1207624641466040/f)

## 🗒️ What

- Add a check that the file path exists to prevent the error `ENOENT: no such file or directory, open '/var/task/src/content/vagrant/install-vmware-landing.json'`

## 🤷 Why

- Reduce noise in error logs

# Testing 
Client side navigation triggers this error, as you can see in the recording below. Tested in staging, the client-side navigation triggers the error. In the second part of the recording, you can see that the same client-side navigation in the preview does not trigger the same error.

https://github.com/user-attachments/assets/ce09706a-4b6c-4529-b22b-8996b12e9b41



## to test it yourself
- Visit [this page](https://dev-portal-git-heat-chorefix-vmware-prefetch-error-hashicorp.vercel.app/vagrant/install)
- scroll down to the VMWare Utility CTA (Screenshot) and click "explore"
  > <img width="1207" alt="Screenshot 2024-08-21 at 17 51 25" src="https://github.com/user-attachments/assets/3299cd41-6ea0-4ed3-b326-1fb86173dcfc">
   
- the page should render as expected, with no [error logs](https://go.hashi.co/vmware-error-logs)