### PR TITLE
fix: keyboard covers content on mobile safari

### DIFF
--- a/src/components/dialog/dialog.module.css
+++ b/src/components/dialog/dialog.module.css
@@ -18,14 +18,16 @@
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	height: 100vh;
+	/* stylelint-disable-next-line unit-no-unknown */
+	height: 100dvh;
 	justify-content: center;
 	padding: 24px;
 	width: 100vw;
 
 	&.bottom {
 		padding: 0;
-		height: 80vh;
+		/* stylelint-disable-next-line unit-no-unknown */
+		height: 80dvh;
 		width: 100%;
 		position: fixed;
 		bottom: 0;

--- a/src/components/dialog/dialog.module.css
+++ b/src/components/dialog/dialog.module.css
@@ -18,16 +18,14 @@
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	/* stylelint-disable-next-line unit-no-unknown */
-	height: 100dvh;
+	height: 100vh;
 	justify-content: center;
 	padding: 24px;
 	width: 100vw;
 
 	&.bottom {
 		padding: 0;
-		/* stylelint-disable-next-line unit-no-unknown */
-		height: 80dvh;
+		height: 80vh;
 		width: 100%;
 		position: fixed;
 		bottom: 0;

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import { useEffect, useState } from 'react'
 import { DialogOverlay, DialogContent } from '@reach/dialog'
 import '@reach/dialog/styles.css'
 import {
@@ -13,7 +14,6 @@ import {
 import classNames from 'classnames'
 import { DialogProps } from './types'
 import s from './dialog.module.css'
-import { useEffect, useState } from 'react'
 
 const AnimatedDialogOverlay = slimMotion(DialogOverlay)
 
@@ -70,11 +70,7 @@ export default function Dialog({
 					<div
 						key="contentWrapper"
 						className={classNames(s.contentWrapper, s[variant])}
-						style={
-							variant === 'bottom'
-								? { paddingBottom: padding }
-								: { paddingBottom: '0px' }
-						}
+						style={variant === 'bottom' ? { paddingBottom: padding } : null}
 					>
 						<DialogContent
 							aria-describedby={ariaDescribedBy}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -13,6 +13,7 @@ import {
 import classNames from 'classnames'
 import { DialogProps } from './types'
 import s from './dialog.module.css'
+import { useEffect, useState } from 'react'
 
 const AnimatedDialogOverlay = slimMotion(DialogOverlay)
 
@@ -33,6 +34,7 @@ export default function Dialog({
 	variant = 'modal',
 }: DialogProps) {
 	const shouldReduceMotion = useReducedMotion()
+	const [padding, setPadding] = useState('0px')
 
 	const overlayMotionProps = {
 		variants: overlayVariants,
@@ -41,6 +43,19 @@ export default function Dialog({
 		exit: 'hidden',
 		transition: { duration: shouldReduceMotion ? 0 : 0.3 },
 	}
+
+	useEffect(() => {
+		const handleResize = () => {
+			setPadding(
+				(window.innerHeight - window.visualViewport.height).toString() + 'px'
+			)
+		}
+
+		window.visualViewport.addEventListener('resize', handleResize)
+
+		return () =>
+			window.visualViewport.removeEventListener('resize', handleResize)
+	}, [])
 
 	return (
 		<AnimatePresence>
@@ -55,6 +70,11 @@ export default function Dialog({
 					<div
 						key="contentWrapper"
 						className={classNames(s.contentWrapper, s[variant])}
+						style={
+							variant === 'bottom'
+								? { paddingBottom: padding }
+								: { paddingBottom: '0px' }
+						}
 					>
 						<DialogContent
 							aria-describedby={ariaDescribedBy}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-fixsafari-keyboard-height-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1206176289707208/1203910935802336/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
In mobile safari, the keyboard is covering up the content in the search dialog. You can't scroll to see the bottom of the list. This PR fixes this issue using the `visiualViewport` information and events on the `window` object. When the visualViewport gets resized (like when the keyboard pops up), the bottom padding amount will get adjusted to the difference between the actual screen size and the screen size that is visible when the keyboard is open.

## 📸 Design Screenshots
Before

https://github.com/user-attachments/assets/abc21437-6c37-4153-9876-dbde02368576


After

https://github.com/user-attachments/assets/dd094bc1-2f3c-47e1-8d62-c9b8579e054c



<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

**_NOTE:_** In order to test the actual changes, an apple device with safari is necessary. I've attached videos from my iphone for reference. The regular browser can be used for testing to make sure there aren't any visual regressions across environments. If you don't have an iphone, let me know and I can re-assign the PR review or show you on my phone

1. Go to [preview](https://dev-portal-git-leah-fixsafari-keyboard-height-hashicorp.vercel.app/)
2. Click the search button on the top bar
3. Verify that you can scroll to the bottom of the list of options while the keyboard is open and closed
