### PR TITLE
(chore) update dependabot auto reviewer assignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
       # Allow updates for HashiCorp packages
       - dependency-name: '@hashicorp/*'
     reviewers:
-      - 'hashicorp/web-platform'
+      - 'hashicorp/web-presence'


### PR DESCRIPTION
This PR updates reviewers for all dependabot PRs from @hashicorp/web-platform to @hashicorp/web-presence

I've created the same PR for the monorepo https://github.com/hashicorp/web/pull/1897