### PR TITLE
Revert "Remove "Edit on GitHub" link from terraform docs"

### DIFF
--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -418,9 +418,9 @@ export function getStaticGenerationFunctions<
 			 * Note: If we need more granularity here, we could change this to be
 			 * part of `rootDocsPath` configuration in `src/data/<product>.json`.
 			 */
-			const isPublicContentRepo = !['hcp', 'sentinel', 'terraform'].includes(
-				product.slug
-			)
+			const isHcp = product.slug == 'hcp'
+			const isSentinel = product.slug == 'sentinel'
+			const isPublicContentRepo = !isHcp && !isSentinel
 			if (isPublicContentRepo) {
 				layoutProps.githubFileUrl = githubFileUrl
 			}


### PR DESCRIPTION
This PR reverts hashicorp/dev-portal#2540, which was overly broad in it's scope when hiding the "Edit on GitHub" link at the bottom of dev docs. This caused the link to disappear for all Terraform products rather than just Terraform Enterprise(the intended target). 

[A ticket to re-do this logic with narrower scope has been opened](https://app.asana.com/0/1207947026228781/1208226840548303/f)