### PR TITLE
[WAYP-2783] Add support for a "hidden" tag for api-docs

### DIFF
--- a/src/views/open-api-docs-view/utils/get-operation-props.ts
+++ b/src/views/open-api-docs-view/utils/get-operation-props.ts
@@ -51,6 +51,10 @@ export async function getOperationProps(
 				continue
 			}
 
+			if (operation.tags?.includes('hidden')) {
+				continue
+			}
+
 			// Create a slug for this operation
 			const operationSlug = slugify(operation.operationId)
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-900sskf54-hashicorp.vercel.app/) 🔎
- [WAYP-2783](https://hashicorp.atlassian.net/browse/WAYP-2783) 🎟️

## 🗒️ What

This allows us to tag RPCs as `hidden` to prevent them appearing in API docs.

Looks like this in practice:

```proto
rpc UI_LoadProductBanner(UI.LoadProductBannerRequest) returns (UI.LoadProductBannerResponse) {
  option (google.api.http) = {
    get: "/waypoint/2023-08-18/namespace/{namespace.id}/ui/product-banner"
  };
  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
    tags: ["WaypointService", "hidden"]
  };
}
```

## 🤷 Why

We have a set of specialized RPCs in cloud-waypoint-service that are designed only to be used by the UI. We were hoping we could mark these as [internal](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/examples/internal/proto/examplepb/visibility_rule_echo_service.proto#L25) but we realized that means they don’t end up in the generated Swagger at all, and thus don’t make it to our generated API client. At Emily Persson’s wise suggestion, we are opting to tag these APIs with `hidden` instead, and add some special handling here to ignore methods with that tag.

## 🛠️ How

As you’ll see from the diff, this is a small patch to `getOperationProps` that skips over methods with the `hidden` tag.

## 📸 Design Screenshots

N/A

## 🧪 Testing

1. [Visit the api-doc preview page](https://dev-portal-900sskf54-hashicorp.vercel.app/open-api-docs-preview)
2. Paste the contents of [Waypoint’s Swagger](https://raw.githubusercontent.com/hashicorp/cloud-waypoint-service/c3b03b9755f275acf827dddaf4e17f08a86df10b/proto-public/20230818/swagger/hcp.swagger.json?token=GHSAT0AAAAAACWJHL3BIJCAMYKR25J7O7A6ZXC5HVA) [^1] into the Schema source field
3. Verify that none of the `UI_`-prefixed methods show up


## 📓 Docs

Question to the reviewer: I’d like to document this tag somewhere. Where’s the best place to do so?

[^1]: This is the Swagger from https://github.com/hashicorp/cloud-waypoint-service/pull/1390

[WAYP-2783]: https://hashicorp.atlassian.net/browse/WAYP-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ