### PR TITLE
bug fix: Change versions to validVersions to prevent 404s

### DIFF
--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -440,7 +440,7 @@ export function getStaticGenerationFunctions<
 				},
 				projectName: projectName || null,
 				versions:
-					!hideVersionSelector && hasMeaningfulVersions ? versions : null,
+					!hideVersionSelector && hasMeaningfulVersions ? validVersions : null,
 			}
 
 			return {


### PR DESCRIPTION
## 🗒️ What

- `versions` should be `validVersions` to prevent docs versions dropdown from containing links that return a 404

## 🤷 Why

- regression & bad UX

