### PR TITLE
Add VA003 tile to security-automation.json

### DIFF
--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -28,8 +28,7 @@
 			"versionTested": "Vault 1.16",
 			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
 			"links": {
-				"prepare": "/vault/tutorials/associate-cert-003",
-				"register": "https://cp.certmetrics.com/hashicorp/en/login"
+				"prepare": "/vault/tutorials/associate-cert-003"
 			},
 			"faqSlug": "vault-associate-003"
 		},

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -28,7 +28,7 @@
 			"versionTested": "Vault 1.16",
 			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
 			"links": {
-				"prepare": "/vault/tutorials/associate-cert",
+				"prepare": "/vault/tutorials/associate-cert-003",
 				"register": "https://cp.certmetrics.com/hashicorp/en/login"
 			},
 			"faqSlug": "vault-associate-003"

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -22,6 +22,18 @@
 			"faqSlug": "vault-associate-002"
 		},
 		{
+			"title": "Vault Associate",
+			"examCode": "003",
+			"productSlug": "vault",
+			"versionTested": "Vault 1.16",
+			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"links": {
+				"prepare": "/vault/tutorials/associate-cert",
+				"register": "https://cp.certmetrics.com/hashicorp/en/login"
+			},
+			"faqSlug": "vault-associate-003"
+		},
+		{
 			"title": "Vault Operations Professional",
 			"examTier": "pro",
 			"productSlug": "vault",


### PR DESCRIPTION
## 🔗 Relevant links
- [Preview link](https://dev-portal-git-AshNorman-VA003-add-landingpage-tile-hashicorp.vercel.app/certifications/security-automation) 🔎 (gosh I hope I did that right)

- [Asana task](https://app.asana.com/0/1207927636763096/1208344084881594) 🎟️

## 🗒️ What
Added a tile for Vault Associate 003.

## 🤷 Why
New version of the Vault Associate, version 003, will be announced Wednesday, September 25th.

## 🛠️ How
@eganhashicorp showed me how to update this page, I followed her instructions and tutorial in the [Certifications knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/30303655784077-Updating-GitHub-for-certification-web-properties).


## 💭 Anything else?
This page will be updated twice more:

1. November 8th to add registration link.
2. January 6th to remove VA002's tile when it is retired.
