### PR TITLE
Create vault-associate-003.mdx

### DIFF
--- a/src/content/certifications/exam-faqs/vault-associate-002.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-002.mdx
@@ -6,6 +6,13 @@
 - Basic understanding of on-premises or cloud architecture
 - Basic level of security understanding
 
+## Which Exam to Take
+
+ You can use either version of the exam to validate your Vault knowledge at the associate level. Vault Associate 002 is currently available, and the [Vault Associate 003 certification](/certifications/security-automation#vault-associate-003-details) will launch in early 2025. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
+
+- Vault Associate 002: Exam available now.
+- Vault Associate 003: Coming January 2025. The Vault Associate 002 exam will no longer be available to take once Vault 003 is released.
+
 ## Exam Details
 
 |                     |                                                                                   |
@@ -103,11 +110,28 @@ Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/
 
 ## Renewing Your Certification
 
-To renew your Vault Associate certification, you will need to take and pass the Vault Associate or Vault Operations Professional exam.
+### Renew by passing a professional-level exam
 
-**If you hold an *unexpired* Vault Associate certification there are two ways to recertify:**
-1. You can take the same Vault Associate exam again starting 18 months after your previous exam date. When you pass the exam, the expiration date on your credentials will be extended. 
-2. You can take the [Vault Operations Professional](/certifications/security-automation#vault-operations-professional-details) exam starting 18 months after your previous exam date. When you pass the exam, you will receive a new set of credentials for the Vault Operations Professional certification, and the expiration date will be extended on your Vault Associate credentials.
+**_Unexpired_ Vault Associate 002 or 003 credentials:**
 
-**If you hold an *expired* Vault Associate certification:** You can take the same Vault Associate exam again at any time. When you pass the exam, you will receive a new, second set of credentials with a new expiration date. 
+When you pass the Vault Operations Professional exam, you will receive the professional-level credentials (badge and corresponding certificate). You will also extend the expiration of your Vault Associate 002 or 003 credentials.
 
+### Renew by passing an associate-level exam
+
+**_Unexpired_ Vault Associate 002 credential:**
+
+* You can take the Vault Associate 003 exam starting 18 months after your previous exam date.
+* You will receive a new, separate set of credentials that will reflect your recertification date.
+* The expiration date of Vault Associate 002 credentials will not be updated.
+
+**_Unexpired_ Vault Associate 003 credential:**
+
+* You can retake the Vault Associate 003 exam starting 18 months after your previous exam date.
+* The expiration date on your credentials will be extended.
+
+### Have an expired Vault Associate credential?
+
+* You are eligible to recertify at any time by passing the Vault Associate 003 exam.
+* You will receive a new, separate set of credentials with a new expiration date.
+
+Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -2,8 +2,8 @@
 
 ## Exam Availability
 
-November 2024 - Scheduling opens for Vault Associate 003.
-January 2025 - Vault Associate 003 exam is available to take and Vault Associate 002 is retired.
+- November 2024 - Scheduling opens for Vault Associate 003.
+- January 2025 - Vault Associate 003 exam is available to take and Vault Associate 002 is retired.
 
 ## Which Exam to Take
 

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -1,16 +1,19 @@
 <!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
 
 ## Exam Availability
-Coming soon!
+
+November 2024 - Scheduling opens for Vault Associate 003.
+January 2025 - Vault Associate 003 exam is available to take and Vault Associate 002 is retired.
 
 ## Which Exam to Take
-You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
 
-- Vault Associate 002: Exam available now
-- Vault Associate 003: Coming early 2025. The Vault Associate 002 exam will no longer be available to take once Vault 003 is released.
+You can use either version of the exam to validate your Vault knowledge at the associate level. The [Vault Associate 002 certification](/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
 
+- Vault Associate 002: Exam available now.
+- Vault Associate 003: Coming January 2025. The Vault Associate 002 exam will no longer be available to take once Vault 003 is released.
 
 ## Content Differences Between Exam Versions
+
 We updated the Vault Associate 003 exam to account for how Vault has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.
 
 The Vault Associate (003) tests on Vault version 1.16 and now includes HCP Vault content.
@@ -19,6 +22,26 @@ The Vault Associate (003) tests on Vault version 1.16 and now includes HCP Vault
 | -- | ----------------------------------------------------------------------- |
 | 8e | Differentiate between self-managed and HashiCorp-managed Vault clusters |
 | 9b | Describe the Vaults Secrets Operator                                    |
+
+|    | **(002) objectives now covered in other objectives in (003)**           |
+| -- | ----------------------------------------------------------------------- |
+| 6  | 1 - Authentication methods |
+|    | 2 - Vault policies |
+|    | 5 - Secrets engines |                                  
+|    | 7 - Vault architecture fundamentals                                  |
+| 7  | 1 - Authentication methods |
+|    | 2 - Vault policies                                    |
+|    | 5 - Secrets engines                                         |
+| 8  | 1 - Authentication methods |
+|    | 5 - Secrets engines |
+| 9  | 1 - Authentication methods |
+|    | 5 - Secrets engines |
+|    | 7 - Vault architecture fundamentals |
+|    | 8 - Vault deployment architecture |
+|    | 9 - Access management architecture |
+| 10 | 5 - Secrets engines |
+|    | 6 - Encryption as a service |
+
 
 ## Prerequisites
 

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -6,6 +6,10 @@ Coming soon!
 ## Which Exam to Take
 You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
 
+- Vault Associate 002: Exam available now
+- Vault Associate 003: Coming early 2025. The Vault Associate 002 exam will no longer be available to take once Vault 003 is released.
+
+
 ## Content Differences Between Exam Versions
 We updated the Vault Associate 003 exam to account for how Vault has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.
 

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -1,7 +1,7 @@
 <!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
 
 ## Exam Availability
-Release date January 6 2025
+Coming soon!
 
 ## Which Exam to Take
 You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -4,7 +4,7 @@
 Release date January 6 2025
 
 ## Which Exam to Take
-You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](https://developer.hashicorp.com/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
+You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
 
 ## Content Differences Between Exam Versions
 We updated the Vault Associate 003 exam to account for how Vault has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -1,0 +1,123 @@
+<!-- Each "## Heading Two" section in this document will be used to populate an FAQ item -->
+
+## Exam Availability
+Release date January 6 2025
+
+## Which Exam to Take
+You can use either exam to validate Vault knowledge at the associate level. The [Vault Associate 002 certification](https://developer.hashicorp.com/certifications/security-automation#vault-associate-002-details) is still relevant and will be accepted as validation of Vault knowledge until the badge’s expiration date. You can hold both the Vault Associate 002 and Vault Associate 003 at the same time.
+
+## Content Differences Between Exam Versions
+We updated the Vault Associate 003 exam to account for how Vault has grown, and to accommodate future growth. The changes are primarily a reorganization and rewording of the 002 exam objectives. More significant changes are listed below.
+
+The Vault Associate (003) tests on Vault version 1.16 and now includes HCP Vault content.
+
+|    | **NEW topics covered in (003)**                                         |
+| -- | ----------------------------------------------------------------------- |
+| 8e | Differentiate between self-managed and HashiCorp-managed Vault clusters |
+| 9b | Describe the Vaults Secrets Operator                                    |
+
+## Prerequisites
+
+- Basic terminal skills
+- Basic understanding of on-premises or cloud architecture
+- Basic level of security understanding
+
+This exam is a suggested prerequisite for the Vault Operations Professional exam. Intermediate and advanced topics should be reserved for the Professional-level exams.
+
+## Exam Details
+
+|                     |                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------- |
+| **Assessment Type** | Multiple choice                                                                   |
+| **Format**          | Online proctored                                                                  |
+| **Duration**        | 1 hour                                                                            |
+| **Price**           | $70.50 USD, plus locally applicable taxes and fees. Free retake **not included**. |
+| **Language**        | English                                                                           |
+| **Expiration**      | 2 years                                                                           |
+
+## Exam Objectives
+
+|       |                                                                                   |
+| ----- | --------------------------------------------------------------------------------- |
+| **1** | **Authentication methods**                                                        |
+| 1a    | Define the purpose of authentication methods                                      |
+| 1b    | Choose an authentication method based on use case                                 |
+| 1c    | Explain the difference between human vs. system authentication methods            |
+| 1d    | Define the purpose of identities and groups                                       |
+| 1e    | Authenticate to Vault using the API, CLI, and UI                                  |
+| 1f    | Configure authentication methods using the API, CLI, and UI                       |
+| **2** | **Vault policies**                                                                |
+| 2a    | Explain the value of Vault policies                                               |
+| 2b    | Describe Vault policy syntax: path                                                |
+| 2c    | Describe Vault policy syntax: capabilities                                        |
+| 2d    | Choose a Vault policy based on requirements                                       |
+| 2e    |  Configure Vault policies using the UI and CLI                                    |
+| **3** | **Vault tokens**                                                                  |
+| 3a    | Choose between service and batch tokens based on use case                         |
+| 3b    | Describe root token uses and lifecycle                                            |
+| 3c    | Explain the purpose of token accessors                                            |
+| 3d    | Explain the impact of time-to-live                                                |
+| 3e    | Explain orphaned tokens                                                           |
+| 3f    | Describe how to create tokens based on need                                       |
+| **4** | **Vault leases**                                                                  |
+| 4a    | Explain the purpose of a lease ID                                                 |
+| 4b    | Describe how to renew leases                                                      |
+| 4c    | Describe how to revoke leases                                                     |
+| **5** | **Secrets engines**                                                               |
+| 5a    | Choose a secrets engine based on use case                                         |
+| 5b    | Compare and contrast dynamic secrets vs. static secrets, and know their use cases |
+| 5c    | Describe the uses of transit secrets engine                                       |
+| 5d    | Describe the purpose of secrets engines                                           |
+| 5e    | Describe the use of response wrapping                                             |
+| 5f    | Explain the value of short-lived, dynamically generated secrets                   |
+| 5g    | Enable secrets engines using the CLI and UI                                       |
+| 5h    | Access Vault secrets using the CLI, API, and UI                                   |
+| **6** | **Encryption as a service**                                                       |
+| 6a    | Encrypt and decrypt secrets                                                       |
+| 6b    | Rotate the encryption key                                                         |
+| **7** | **Vault deployment architecture**                                                 |
+| 7a    | Describe how Vault encrypts data                                                  |
+| 7b    | Explain how to seal and unseal Vault                                              |
+| 7c    | Configure environment variables                                                   |
+| **8** | **Vault deployment architecture**                                                 |
+| 8a    | Explain cluster strategy for self-managed and HashiCorp-managed Vault clusters    |
+| 8b    | Explain the uses of storage backends                                              |
+| 8c    | Explain the uses of Shamir secret sharing and unsealing                           |
+| 8d    | Explain the uses of disaster recovery and performance replication                 |
+| 8e    | Differentiate between self-managed and HashiCorp-managed Vault clusters           |
+| **9** | **Access management architecture**                                                |
+| 9a    | Describe the Vault Agent                                                          |
+| 9b    | Describe the Vault Secrets Operator                                               |
+
+
+## Requirements for Attending an Exam
+
+Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/en-us/sections/26234702018573) for taking HashiCorp certification exams.
+
+## Renewing Your Certification
+
+### Renew by passing a professional-level exam
+
+**_Unexpired_ Vault Associate 002 or 003 credentials:**
+
+When you pass the Vault Operations Professional exam, you will receive the professional-level credentials (badge and corresponding certificate). You will also extend the expiration of your Vault Associate 002 or 003 credentials.
+
+### Renew by passing an associate-level exam
+
+**_Unexpired_ Vault Associate 002 credential:**
+
+* You can take the Vault Associate 003 exam starting 18 months after your previous exam date.
+* You will receive a new, separate set of credentials that will reflect your recertification date.
+* The expiration date of Vault Associate 002 credentials will not be updated.
+
+**_Unexpired_ Vault Associate 003 credential:**
+
+* You can retake the Vault Associate 003 exam starting 18 months after your previous exam date.
+* The expiration date on your credentials will be extended.
+
+### Have an expired Vault Associate credential?
+
+* You are eligible to recertify at any time by passing the Vault Associate 003 exam.
+* You will receive a new, separate set of credentials with a new expiration date.
+
+Learn more about recertification in our [Knowledgebase](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/9677396620941).

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -22,7 +22,7 @@ The Vault Associate (003) tests on Vault version 1.16 and now includes HCP Vault
 - Basic understanding of on-premises or cloud architecture
 - Basic level of security understanding
 
-This exam is a suggested prerequisite for the Vault Operations Professional exam. Intermediate and advanced topics should be reserved for the Professional-level exams.
+This exam is a suggested prerequisite for the Vault Operations Professional exam. Intermediate and advanced topics are reserved for the Professional-level exams.
 
 ## Exam Details
 

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -2,7 +2,7 @@
 	"title": "Security Automation",
 	"summary": {
 		"heading": "Security<br />Automation Certifications",
-		"description": "Earn the Vault Associate to validate your knowledge of the concepts, skills, and use cases associated with Vault Community Edition. Ready to demonstrate your advanced Vault skills in production? Successfully complete a lab-based exam and earn the Vault Operations Professional certification."
+		"description": "Earn the Vault Associate to validate your knowledge of the concepts, skills, and use cases associated with Vault Community Edition and HCP Vault. Ready to demonstrate your advanced Vault skills in production? Successfully complete a lab-based exam and earn the Vault Operations Professional certification."
 	},
 	"hero": {
 		"heading": "Security<br />Automation Certification",
@@ -26,7 +26,7 @@
 			"examCode": "003",
 			"productSlug": "vault",
 			"versionTested": "Vault 1.16",
-			"description": "Vault Associate 003 is a new version of the Vault Associate exam and will be available in 2025. Compare the differences between the 002 and 003 exam versions below. Begin preparing for this exam now, and look for registration information soon!",
+			"description": "Vault Associate 003 is a new version of the Vault Associate exam and will be available in 2025. Compare the differences between the 002 and 003 exam versions below. Begin preparing for this exam now, and look for registration information soon! The Vault Associate 003 will still be for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
 			"links": {
 				"prepare": "/vault/tutorials/associate-cert-003"
 			},

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -22,6 +22,17 @@
 			"faqSlug": "vault-associate-002"
 		},
 		{
+			"title": "Vault Associate",
+			"examCode": "003",
+			"productSlug": "vault",
+			"versionTested": "Vault 1.16",
+			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"links": {
+				"prepare": "/vault/tutorials/associate-cert-003"
+			},
+			"faqSlug": "vault-associate-003"
+		},
+		{
 			"title": "Vault Operations Professional",
 			"examTier": "pro",
 			"productSlug": "vault",

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -14,7 +14,7 @@
 			"examCode": "002",
 			"productSlug": "vault",
 			"versionTested": "Vault 1.6.0 and higher",
-			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"description": "Vault Associate 002 is currently available but will be replaced by Vault Associate 003 in 2025. Compare the differences between the 002 and 003 exam versions below. The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
 			"links": {
 				"prepare": "/vault/tutorials/associate-cert",
 				"register": "https://cp.certmetrics.com/hashicorp/en/login"
@@ -26,7 +26,7 @@
 			"examCode": "003",
 			"productSlug": "vault",
 			"versionTested": "Vault 1.16",
-			"description": "The Vault Associate certification is for Cloud Engineers specializing in security, development, or operations who know the basic concepts, skills, and use cases associated with Vault. You understand what Vault Enterprise features exist and can differentiate between Enterprise and Community Edition. You will be best prepared for this exam if you have professional experience using Vault in production, but performing the exam objectives in a personal demo environment may be sufficient.",
+			"description": "Vault Associate 003 is a new version of the Vault Associate exam and will be available in 2025. Compare the differences between the 002 and 003 exam versions below. Begin preparing for this exam now, and look for registration information soon!",
 			"links": {
 				"prepare": "/vault/tutorials/associate-cert-003"
 			},


### PR DESCRIPTION
Added body to /certifications/security-automation page. 

Added new accordion section with the content differences between exams so this information isn't further obfuscated under a different accordion menu. In previous versions it was under "which exam to take", but it feels cleaner to have it in its own section

## 🔗 Relevant links

- [Preview link](https://dev-portal-git-AshNorman-va003-body-hashicorp.vercel.app/certifications/security-automation) 🔎
- [Asana task](https://app.asana.com/0/1207927636763096/1208344084881594) 🎟️

## 🗒️ What
Added new VA003's body on the /networking-automation page.  

## 🤷 Why
VA003 is being announced 

## 💭 Anything else?

Reviewers, I double checked the changes, but please please triple check to be sure everything is accurate. Thank you!!!! The Asana task (linked above) lists everything that should be on there, it just might be in a different order.