### PR TITLE
Change HashiConf alert banner expiration date to Oct 16th

### DIFF
--- a/src/data/alert-banner.json
+++ b/src/data/alert-banner.json
@@ -6,6 +6,6 @@
 		"url": "https://live.hashiconf.com",
 		"text": "Now streaming live from Boston!",
 		"linkText": "Attend for free",
-		"expirationDate": "2024-10-15T16:31:00.000Z"
+		"expirationDate": "2024-10-16T16:31:00.000Z"
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->
- [Preview](https://dev-portal-git-heat-hashiconfadd-day-two-banner-hashicorp.vercel.app/)
- [Asana task](https://app.asana.com/0/1207947026228781/1208503549555255/f) 🎟️

## 🗒️ What

- alert banner to watch live stream of HashiConf on October 16th, 2024 8:30 am - 12:30 pm EDT
