### PR TITLE
introduce unified-docs-sandbox config env

### DIFF
--- a/config/unified-docs-sandbox.json
+++ b/config/unified-docs-sandbox.json
@@ -1,0 +1,26 @@
+{
+	"extends": "base",
+	"io_sites": {
+		"max_static_paths": 1
+	},
+	"dev_dot": {
+		"max_static_paths": 1
+	},
+	"learn": {
+		"max_static_paths": 1
+	},
+	"flags": {
+		"unified_docs_migrated_repos": [
+			"ptfe-releases",
+			"terraform",
+			"terraform-cdk",
+			"terraform-docs-agents",
+			"terraform-docs-common",
+			"terraform-plugin-framework",
+			"terraform-plugin-log",
+			"terraform-plugin-mux",
+			"terraform-plugin-sdk",
+			"terraform-plugin-testing"
+		]
+	}
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Introduces a new `config/unified-docs-sandbox.json` environment, with the `"unified_docs_migrated_repos"` flag set to load Terraform content from the new unified docs API.

## 🤷 Why

To allow development and deploy previews from within the `hashicorp/web-unified-docs` repo to load Terraform content from the API at the URL specified by the env variable `UNIFIED_DOCS_API`, while loading content for all other products from the API at the URL specified by `MKTG_CONTENT_API` (ie `content.hashicorp.com`).

## 🧪 Testing

- [ ] Visit the [preview], in particular [/terraform/docs], and ensure nothing has changed in the context of deploys from here within `dev-portal`
- [ ] Pull this branch down locally, set `HASHI_ENV` to `unified-docs-sandbox`, and `/terraform/docs` should load from the API at the URL specified by the env variable `UNIFIED_DOCS_API`

## 💭 Anything else?

To use this new environment via `make` in `hashicorp/web-unified-docs`, we'll need to add `HASHI_ENV=unified-docs-sandbox` to the [environment configuration for `dev-portal` image](https://github.com/hashicorp/web-unified-docs/blob/2829bb8914d090467e5da6a70ccafd4868b51781/docker-compose.yaml#L9).

[task]: https://app.asana.com/0/1207899860738460/1208622445371537/f
[preview]: https://dev-portal-git-zsadd-unified-docs-config-env-hashicorp.vercel.app
[/terraform/docs]: https://dev-portal-git-zsadd-unified-docs-config-env-hashicorp.vercel.app/terraform/docs