### PR TITLE
OpenAPI V2 - implement mobile menu

### DIFF
--- a/src/components/sidebar/components/sidebar-horizontal-rule/sidebar-horizontal-rule.module.css
+++ b/src/components/sidebar/components/sidebar-horizontal-rule/sidebar-horizontal-rule.module.css
@@ -8,4 +8,6 @@
 	color: var(--token-color-border-primary);
 	margin-bottom: 20px;
 	margin-top: 20px;
+	width: 100%;
+	flex-shrink: 0;
 }

--- a/src/views/open-api-docs-view-v2/index.tsx
+++ b/src/views/open-api-docs-view-v2/index.tsx
@@ -71,17 +71,18 @@ export default function OpenApiDocsViewV2({
 						{
 							levelButtonText: 'Previous',
 							content: (
-								<div style={{ border: '1px solid magenta' }}>
-									<pre>
-										<code>
-											{JSON.stringify(
-												{ placeholderFor: 'openApiMobileMenu' },
-												null,
-												2
-											)}
-										</code>
-									</pre>
-								</div>
+								<>
+									<OpenApiV2SidebarContents
+										landingLink={landingLink}
+										operationLinkGroups={operationLinkGroups}
+									/>
+									{resourceLinks.length > 0 ? (
+										<>
+											<SidebarHorizontalRule />
+											<SidebarResourceLinks resourceLinks={resourceLinks} />
+										</>
+									) : null}
+								</>
 							),
 						},
 					]}

--- a/src/views/open-api-docs-view-v2/index.tsx
+++ b/src/views/open-api-docs-view-v2/index.tsx
@@ -6,10 +6,15 @@
 // Layout
 import SidebarLayout from 'layouts/sidebar-layout'
 // Components
+import {
+	mobileMenuLevelMain,
+	mobileMenuLevelProduct,
+} from '@components/mobile-menu-levels/level-components'
 import { OpenApiV2SidebarContents } from './components/sidebar'
 import { SidebarHorizontalRule } from '@components/sidebar/components'
 import { SidebarResourceLinks } from './components/sidebar-resource-links'
 import LandingContent from './components/landing-content'
+import MobileMenuLevels from '@components/mobile-menu-levels'
 import OperationContent from './components/operation-content'
 import SidebarBackToLink from '@components/sidebar/components/sidebar-back-to-link'
 // Types
@@ -27,6 +32,7 @@ export default function OpenApiDocsViewV2({
 	landingLink,
 	operationLinkGroups,
 	resourceLinks,
+	productData,
 	...restProps
 }: OpenApiDocsViewV2Props) {
 	//
@@ -57,7 +63,30 @@ export default function OpenApiDocsViewV2({
 			 * present the sidebar, without having to disentangle all the complexity
 			 * of the mobile menu quite yet).
 			 */
-			mobileMenuSlot={null}
+			mobileMenuSlot={
+				<MobileMenuLevels
+					levels={[
+						mobileMenuLevelMain(),
+						mobileMenuLevelProduct(productData),
+						{
+							levelButtonText: 'Previous',
+							content: (
+								<div style={{ border: '1px solid magenta' }}>
+									<pre>
+										<code>
+											{JSON.stringify(
+												{ placeholderFor: 'openApiMobileMenu' },
+												null,
+												2
+											)}
+										</code>
+									</pre>
+								</div>
+							),
+						},
+					]}
+				/>
+			}
 		>
 			<div style={{ padding: '24px' }}>
 				<div style={{ border: '1px solid magenta' }}>

--- a/src/views/open-api-docs-view-v2/server.ts
+++ b/src/views/open-api-docs-view-v2/server.ts
@@ -15,6 +15,7 @@ import {
 } from './utils/get-operation-objects'
 import { wordBreakCamelCase } from './utils/word-break-camel-case'
 import { groupItemsByKey } from './utils/group-items-by-key'
+import { cachedGetProductData } from 'lib/get-product-data'
 // Types
 import type {
 	OpenApiDocsViewV2Props,
@@ -40,6 +41,11 @@ export async function getStaticProps({
 	backToLink,
 	resourceLinks = [],
 }: OpenApiDocsViewV2Config): Promise<OpenApiDocsViewV2Props> {
+	/**
+	 * Grab product data for this context
+	 */
+	const productData = cachedGetProductData(theme)
+
 	/**
 	 * Fetch, parse, and validate the OpenAPI schema for this version.
 	 */
@@ -104,6 +110,7 @@ export async function getStaticProps({
 		backToLink,
 		landingLink,
 		operationLinkGroups,
+		productData,
 		resourceLinks: resourceLinks.map((item) => {
 			return { ...item, isExternal: isAbsoluteUrl(item.href) }
 		}),

--- a/src/views/open-api-docs-view-v2/types.ts
+++ b/src/views/open-api-docs-view-v2/types.ts
@@ -8,7 +8,7 @@ import type { LandingContentProps } from './components/landing-content'
 import type { OpenAPIV3 } from 'openapi-types'
 import type { OperationContentProps } from './components/operation-content'
 import type { OperationObject } from './utils/get-operation-objects'
-import type { ProductSlug } from 'types/products'
+import type { ProductData, ProductSlug } from 'types/products'
 
 /**
  * Shared props are common to both the "landing" and "operation" views.
@@ -33,6 +33,7 @@ export interface SharedProps {
 			isActive: boolean
 		}[]
 	}[]
+	productData: ProductData
 	resourceLinks?: {
 		text: string
 		href: string


### PR DESCRIPTION
> [!NOTE]
> This PR is based off of #2594. We likely want to finalize and merge #2594 before handling this PR, at which point we can rebase this PR onto `main`.

## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Builds out the mobile menu for our new version of OpenAPI docs view.

## 🤷 Why

We have a practice of reflecting sidebar navigation in the collapsed navigation we display on narrow viewports, known as our "mobile menu". This PR ensures the OpenAPI V2 view follows this practice.

## 🛠️ How

- Slots components built in #2594 into the mobile menu slot setup previously constructed for OpenAPI docs pages

## 📸 Design Screenshots

Group by `tag` example, with [HCP Consul Central][hcp-consul-central-spec] (note the `Before` menu is `null`):

| Before | After |
| - | - |
| ![hcp-consul-mobile-menu-before](https://github.com/user-attachments/assets/5245a3ba-37ed-4e28-8b48-71bbcce109bc) | ![hcp-consul-mobile-menu-after](https://github.com/user-attachments/assets/e8dbfa5e-09dd-4009-a7ac-203c10060cdc) |

Group by `path` example, with [HCP Vault Secrets][hcp-vault-secrets-spec] (note the `Before` menu is `null`):

| Before | After |
| - | - |
| ![hcp-vault-mobile-menu-before](https://github.com/user-attachments/assets/74208741-01db-4dd0-a233-23074ca024f7) | ![hcp-vault-mobile-menu-after](https://github.com/user-attachments/assets/37836da5-1b1b-444e-8ac9-806136b970cf) |

## 🧪 Testing

- [x] Test out a spec with "group by path" using the preview tool at [/open-api-docs-preview-v2]
    - For example, compare an upload of the [HCP Vault Secrets][hcp-vault-secrets-spec] with the mobile menu in the upstream [/hcp/api-docs/vault-secrets](https://developer.hashicorp.com/hcp/api-docs/vault-secrets)
- [x] Test out a spec with "group by tag" using the preview tool at [/open-api-docs-preview-v2]
    - For example, compare an upload of the [HCP Consul Central][hcp-consul-central-spec] with the mobile menu in the upstream [/hcp/api-docs/consul](https://developer.hashicorp.com/hcp/api-docs/consul)

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1207339219333499/1208623494154127/f
[preview]: https://dev-portal-git-zsopen-api-v2-mobile-nav-hashicorp.vercel.app
[/open-api-docs-preview-v2]: https://dev-portal-git-zsopen-api-v2-mobile-nav-hashicorp.vercel.app/open-api-docs-preview-v2
[hcp-consul-central-spec]: https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-global-network-manager-service/preview/2023-10-10/hcp.swagger.json
[hcp-vault-secrets-spec]: https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-vault-secrets/stable/2023-06-13/hcp.swagger.json