### PR TITLE
style: cookies dg-banner

### DIFF
--- a/src/lib/consent-manager/component.tsx
+++ b/src/lib/consent-manager/component.tsx
@@ -20,8 +20,29 @@ type ConsentManagerProps = {
 	gtmId: string
 }
 export const ConsentManager = ({ gtmId }: ConsentManagerProps) => {
+	const STYLE_ID = 'dg-consent-custom-style'
+
 	useEffect(() => {
 		const cleanupFn = onDatagrailMount(() => {
+			const styleNode = document.createElement('style')
+			styleNode.id = STYLE_ID
+			styleNode.innerHTML = `
+			/*
+				Hack to provide custom styles to the consent banner.
+				This method is necessary since the consent banner is loaded in a shadow DOM.
+				docs: https://docs.datagrail.io/docs/consent/consent-banner-customization
+			*/
+
+			:host(.dg-consent-banner) .dg-main-content {
+				overflow-y: auto;
+			}
+			.language-dropdown-menu {
+				overflow: auto;
+				color-scheme: light;
+			}
+			`
+			document.head.appendChild(styleNode)
+
 			if (!hasConfiguredConsent()) {
 				showBanner()
 			}
@@ -43,6 +64,10 @@ export const ConsentManager = ({ gtmId }: ConsentManagerProps) => {
 		return () => {
 			cleanupFn()
 			removeDatagrailEventListeners()
+			const styleNode = document.getElementById(STYLE_ID)
+			if (styleNode) {
+				styleNode.remove()
+			}
 		}
 	}, [])
 

--- a/src/lib/consent-manager/utils.ts
+++ b/src/lib/consent-manager/utils.ts
@@ -39,21 +39,6 @@ const MOUNT_TIMEOUT_MS = 5000
 export const onDatagrailMount = (callback: () => void): (() => void) => {
 	if (!isOnClient()) return () => {}
 
-	const styleNode = document.createElement('style')
-	styleNode.id = 'dg-consent-custom-style'
-	styleNode.innerHTML = `
-  /*
-    Hack to provide custom styles to the consent banner.
-	This method is necessary since the consent banner is loaded in a shadow DOM.
-	docs: https://docs.datagrail.io/docs/consent/consent-banner-customization
-  */
-
-	:host(.dg-consent-banner) .dg-main-content {
-		overflow-y: auto;
-	}
-	`
-	document.head.appendChild(styleNode)
-
 	// if datagrail has already mounted, we can invoke the callback immediately
 	if (datagrailHasMounted()) {
 		callback()


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-presdg-bannerstyling-hashicorp.vercel.app/?vercelToolbarCode=cW4QxZO562Iedlv) 🔎
- [Asana task](https://app.asana.com/0/1207484854701350/1208634233952599/f) 🎟️

## 🗒️ What

Adjusts the styling of the Datagrail scrollbar
1. Removes the forced scroll so that we only get a scrollbar if we need one
2. Uses the default light scroll bar instead of the dark to better match the styling of the pop up

## Before
<img width="429" alt="dev-portal-before" src="https://github.com/user-attachments/assets/c94e81ad-0812-4d7d-97ff-bad59d9bc58c">

## After

<img width="421" alt="dev-portal-after" src="https://github.com/user-attachments/assets/884d05a8-6424-4ca0-932f-45b1a0277bda">

Simulated long list for when more translations get added

<img width="418" alt="dev-portal-after-longlist" src="https://github.com/user-attachments/assets/bd71d0f6-0638-4e8f-80b4-38f5f8c1e214">

## Testing 🧪 

> [!NOTE] 
> Cookies won't persist since we are in preview

- [x] Open the preview
- [x] Open the consent banner
- [x] Verify that it still works
- [x] Verify that "_after_" styling is now applied