### PR TITLE
Create custom dev reload api route

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -240,7 +240,8 @@ function splitRedirectsByType(redirects) {
 		const isGlobRedirect = ['(', ')', '{', '}', ':', '*', '+', '?'].some(
 			(char) => redirect.source.includes(char)
 		)
-		const hasCondition = redirect.has?.length > 0
+
+		const hasCondition = redirect.has && redirect.has.length > 0
 		if (isGlobRedirect || hasCondition) {
 			complexRedirects.push(redirect)
 		} else {

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -240,8 +240,7 @@ function splitRedirectsByType(redirects) {
 		const isGlobRedirect = ['(', ')', '{', '}', ':', '*', '+', '?'].some(
 			(char) => redirect.source.includes(char)
 		)
-
-		const hasCondition = redirect.has && redirect.has.length > 0
+		const hasCondition = redirect.has?.length > 0
 		if (isGlobRedirect || hasCondition) {
 			complexRedirects.push(redirect)
 		} else {

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -22,6 +22,10 @@ function addClient(id: string, res: ClientRes): void {
 }
 
 function removeClient(id: string): void {
+	if (!clients.length) {
+		return
+	}
+
 	const index = clients.findIndex((client) => client.id === id)
 	if (index !== -1) {
 		clients.splice(index, 1)

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -40,7 +40,7 @@ function sendMessageToAllClients(obj: any): void {
 }
 
 export async function POST() {
-	if (process.env.NODE_ENV !== 'development') {
+	if (process.env.VERCEL_ENV !== 'development') {
 		return new Response('Not Found', { status: 404 })
 	}
 
@@ -49,7 +49,7 @@ export async function POST() {
 }
 
 export async function GET(req: NextRequest) {
-	if (process.env.NODE_ENV !== 'development') {
+	if (process.env.VERCEL_ENV !== 'development') {
 		return new Response('Not Found', { status: 404 })
 	}
 

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -40,7 +40,10 @@ function sendMessageToAllClients(obj: any): void {
 }
 
 export async function POST() {
-	if (process.env.VERCEL_ENV !== 'development') {
+	if (
+		process.env.VERCEL_ENV !== 'development' ||
+		process.env.HASHI_ENV !== 'unified-docs-sandbox'
+	) {
 		return new Response('Not Found', { status: 404 })
 	}
 
@@ -49,7 +52,10 @@ export async function POST() {
 }
 
 export async function GET(req: NextRequest) {
-	if (process.env.VERCEL_ENV !== 'development') {
+	if (
+		process.env.VERCEL_ENV !== 'development' ||
+		process.env.HASHI_ENV !== 'unified-docs-sandbox'
+	) {
 		return new Response('Not Found', { status: 404 })
 	}
 

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server'
+
+type Client = {
+	id: string
+	res: any
+}
+
+const clients: Client[] = []
+
+function addClient(id: string, res: any): void {
+	clients.push({ id, res })
+}
+
+function removeClient(id: string): void {
+	const index = clients.findIndex((client) => client.id === id)
+	if (index !== -1) {
+		clients.splice(index, 1)
+	}
+}
+
+function sendMessageToAllClients(obj: any): void {
+	const jsonData = `data: ${JSON.stringify(obj)}\n\n`
+	for (const client of clients) {
+		client.res.write(jsonData)
+	}
+}
+
+export async function POST() {
+	if (process.env.NODE_ENV !== 'development') {
+		return new Response('Not Found', { status: 404 })
+	}
+
+	sendMessageToAllClients({ reload: true })
+	return new Response('Reload sent to all clients')
+}
+
+export async function GET(req: NextRequest) {
+	if (process.env.NODE_ENV !== 'development') {
+		return new Response('Not Found', { status: 404 })
+	}
+
+	const { searchParams } = new URL(req.url)
+	const clientId = searchParams.get('id')
+
+	if (!clientId) {
+		return new Response('ID is required', { status: 400 })
+	}
+
+	const { readable, writable } = new TransformStream()
+	const writer = writable.getWriter()
+	const encoder = new TextEncoder()
+
+	addClient(clientId, {
+		write: (message: string) => writer.write(encoder.encode(message)),
+		end: () => writer.close(),
+	})
+
+	req.signal.addEventListener('abort', () => {
+		console.log(`Reload Client ${clientId} Disconnected`)
+		removeClient(clientId)
+		writer.close()
+	})
+
+	// Send to start the connection
+	writer.write(encoder.encode('data: \n\n'))
+
+	return new Response(readable, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive',
+		},
+	})
+}

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -5,14 +5,19 @@
 
 import { NextRequest } from 'next/server'
 
+type ClientRes = {
+	write: (message: string) => void
+	end: () => void
+}
+
 type Client = {
 	id: string
-	res: any
+	res: ClientRes
 }
 
 const clients: Client[] = []
 
-function addClient(id: string, res: any): void {
+function addClient(id: string, res: ClientRes): void {
 	clients.push({ id, res })
 }
 

--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { NextRequest } from 'next/server'
 
 type Client = {

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -68,13 +68,16 @@ const BaseLayout = ({
 			}
 
 			eventSource.onmessage = (event) => {
-				const data = event.data && JSON.parse(event?.data)
-
-				if (data.reload) {
-					console.log('Reload Client Reloading Page')
-					window.location.reload()
+				try {
+				  const data = event.data && JSON.parse(event?.data)
+  
+				  if (data.reload) {
+					  console.log('Reload Client Reloading Page')
+					  window.location.reload()
+				  }
+				} catch (err) {
+					console.error('Error parsing message data:', err);
 				}
-			}
 
 			eventSource.onerror = () => {
 				eventSource.close()

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -58,7 +58,7 @@ const BaseLayout = ({
 	useScrollPercentageAnalytics()
 	const [showSkipLink, setShowSkipLink] = useState(false)
 
-	if (process.env.VERCEL_ENV === 'development') {
+	if (process.env.VERCEL_ENV === 'development' && process.env.HASHI_ENV === 'unified-docs-sandbox') {
 		useEffect(() => {
 			const clientId = crypto.randomUUID()
 			const eventSource = new EventSource(`/api/refresh?id=${clientId}`)

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -6,7 +6,7 @@
 // Third-party imports
 import classNames from 'classnames'
 import AlertBanner from '@hashicorp/react-alert-banner'
-import { HTMLAttributes, useState } from 'react'
+import { HTMLAttributes, useEffect, useState } from 'react'
 
 // HashiCorp imports
 import usePageviewAnalytics from '@hashicorp/platform-analytics'
@@ -57,6 +57,34 @@ const BaseLayout = ({
 	usePostHogPageAnalytics()
 	useScrollPercentageAnalytics()
 	const [showSkipLink, setShowSkipLink] = useState(false)
+
+	if (process.env.NODE_ENV === 'development') {
+		useEffect(() => {
+			const clientId = crypto.randomUUID()
+			const eventSource = new EventSource(`/api/refresh?id=${clientId}`)
+
+			eventSource.onopen = () => {
+				console.log(`Reload Client ${clientId} Connected`)
+			}
+
+			eventSource.onmessage = (event) => {
+				const data = event.data && JSON.parse(event?.data)
+
+				if (data.reload) {
+					console.log('Reload Client Reloading Page')
+					window.location.reload()
+				}
+			}
+
+			eventSource.onerror = () => {
+				eventSource.close()
+			}
+
+			return () => {
+				eventSource.close()
+			}
+		}, [])
+	}
 
 	return (
 		<CommandBarProvider>

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -58,7 +58,7 @@ const BaseLayout = ({
 	useScrollPercentageAnalytics()
 	const [showSkipLink, setShowSkipLink] = useState(false)
 
-	if (process.env.NODE_ENV === 'development') {
+	if (process.env.VERCEL_ENV === 'development') {
 		useEffect(() => {
 			const clientId = crypto.randomUUID()
 			const eventSource = new EventSource(`/api/refresh?id=${clientId}`)

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -58,7 +58,10 @@ const BaseLayout = ({
 	useScrollPercentageAnalytics()
 	const [showSkipLink, setShowSkipLink] = useState(false)
 
-	if (process.env.VERCEL_ENV === 'development' && process.env.HASHI_ENV === 'unified-docs-sandbox') {
+	if (
+		process.env.VERCEL_ENV === 'development' &&
+		process.env.HASHI_ENV === 'unified-docs-sandbox'
+	) {
 		useEffect(() => {
 			const clientId = crypto.randomUUID()
 			const eventSource = new EventSource(`/api/refresh?id=${clientId}`)
@@ -69,15 +72,19 @@ const BaseLayout = ({
 
 			eventSource.onmessage = (event) => {
 				try {
-				  const data = event.data && JSON.parse(event?.data)
-  
-				  if (data.reload) {
-					  console.log('Reload Client Reloading Page')
-					  window.location.reload()
-				  }
+					const data = event.data && JSON.parse(event?.data)
+
+					if (data.reload) {
+						console.log('Reload Client Reloading Page')
+						// this is a naive approach to reloading the page data,
+						// we should be sending the url that changed and
+						// only reload if thats the current page
+						window.location.reload()
+					}
 				} catch (err) {
-					console.error('Error parsing message data:', err);
+					console.error('Error parsing message data:', err)
 				}
+			}
 
 			eventSource.onerror = () => {
 				eventSource.close()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
 			"@build-libs/*": ["../build-libs/*"],
 			"@components/*": ["components/*"]
 		},
-		"types": ["vitest/globals", "@testing-library/jest-dom"]
+		"types": ["vitest/globals", "@testing-library/jest-dom"],
+		"strictNullChecks": false
 	},
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
 	"exclude": ["node_modules", "scripts/migrate-io/templates"]


### PR DESCRIPTION
## 🔗 Relevant links

No preview link as this will purposely **only** work in local dev.

## 🗒️ What

Creates a new **App Router API** route /api/refresh that keeps a connection open on clients so that when they are send the reload message they can reload their webpage.

This makes editing documents in Unified Docs a much better experience.

## 🧪 Testing

1. Checkout this repo
2. Set the following envs
    1. `HASHI_ENV="unified-docs-sandbox"`
    2. `UNIFIED_DOCS_API="http://localhost:8080"`
3. [Checkout this PR from unified docs](https://github.com/hashicorp/web-unified-docs/pull/58)
4. Start both dev-portal and unified docs
    1. dev-portal: `npm run start`
    2. unified-docs: `npm run dev`
5. Visit a page
    1. e.g. `http://localhost:3000/terraform/cli`)
6. Open the DevTools and make sure the Reload Client has connected
    1. e.g. `Reload Client ad581121-b944-495f-aed2-d65fc515b074 Connected`
7. Edit that page in Unified Docs
    1. example page is contained in: `content/terraform/v1.8.x/docs/cli/index.mdx`
8. The page should reload

