### PR TITLE
Use NODE_ENV

### DIFF
--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -41,7 +41,7 @@ function sendMessageToAllClients(obj: any): void {
 
 export async function POST() {
 	if (
-		process.env.VERCEL_ENV !== 'development' ||
+		process.env.NODE_ENV !== 'development' ||
 		process.env.HASHI_ENV !== 'unified-docs-sandbox'
 	) {
 		return new Response('Not Found', { status: 404 })
@@ -53,7 +53,7 @@ export async function POST() {
 
 export async function GET(req: NextRequest) {
 	if (
-		process.env.VERCEL_ENV !== 'development' ||
+		process.env.NODE_ENV !== 'development' ||
 		process.env.HASHI_ENV !== 'unified-docs-sandbox'
 	) {
 		return new Response('Not Found', { status: 404 })

--- a/src/layouts/base-layout/index.tsx
+++ b/src/layouts/base-layout/index.tsx
@@ -59,7 +59,7 @@ const BaseLayout = ({
 	const [showSkipLink, setShowSkipLink] = useState(false)
 
 	if (
-		process.env.VERCEL_ENV === 'development' &&
+		process.env.NODE_ENV === 'development' &&
 		process.env.HASHI_ENV === 'unified-docs-sandbox'
 	) {
 		useEffect(() => {


### PR DESCRIPTION
## 🔗 Relevant links

No preview link as this will purposely **only** work in local dev.

## 🗒️ What

Updates the **App Router API** route /api/refresh to use NODE_ENV as VERCEL_ENV isn't available client side.

## 🧪 Testing

1. Checkout this repo
2. Set the following envs
    1. `HASHI_ENV="unified-docs-sandbox"`
    2. `UNIFIED_DOCS_API="http://localhost:8080"`
    3. `NODE_ENV="development"`
4. [Checkout this PR from unified docs](https://github.com/hashicorp/web-unified-docs/pull/58)
5. Start both dev-portal and unified docs
    1. dev-portal: `npm run start`
    2. unified-docs: `npm run dev`
6. Visit a page
    1. e.g. `http://localhost:3000/terraform/cli`
7. Open the DevTools and make sure the Reload Client has connected
    1. e.g. `Reload Client ad581121-b944-495f-aed2-d65fc515b074 Connected`
8. Edit that page in Unified Docs
    1. example page is contained in: `content/terraform/v1.8.x/docs/cli/index.mdx`
9. The page should reload

