### PR TITLE
add operation content to OpenAPI v2 template

### DIFF
--- a/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
+++ b/src/views/open-api-docs-preview-v2/utils/get-props-from-preview-data.ts
@@ -7,12 +7,15 @@ import { getStaticProps } from 'views/open-api-docs-view-v2/server'
 // Utils
 import { getOperationGroupKeyFromPath } from 'views/open-api-docs-view-v2/utils/get-operation-group-key-from-path'
 import { schemaTransformShortenHcp } from 'views/open-api-docs-view-v2/schema-transforms/schema-transform-shorten-hcp'
+import { schemaTransformComponent } from 'views/open-api-docs-view-v2/schema-transforms/schema-transform-component'
+import { shortenProtobufAnyDescription } from 'views/open-api-docs-view-v2/schema-transforms/shorten-protobuf-any-description'
 // Types
 import type {
 	OpenApiDocsViewV2Props,
 	OpenApiDocsViewV2Config,
 } from 'views/open-api-docs-view-v2/types'
 import type { OpenApiPreviewV2InputValues } from '../components/open-api-preview-inputs'
+import { schemaModComponent } from 'views/open-api-docs-view/utils/massage-schema-utils'
 
 /**
  * Given preview data submitted by the user, which includes OpenAPI JSON,
@@ -38,7 +41,23 @@ export default async function getPropsFromPreviewData(
 	// and prefer to have content updates made at the content source... but
 	// some shims are used often enough that they feel worth including in the
 	// preview too. Namely, shortening to `HCP` in the spec title.
-	const schemaTransforms = [schemaTransformShortenHcp]
+	const schemaTransforms = [
+		schemaTransformShortenHcp,
+		(schema) => {
+			return schemaTransformComponent(
+				schema,
+				'protobufAny',
+				shortenProtobufAnyDescription
+			)
+		},
+		(schema) => {
+			return schemaTransformComponent(
+				schema,
+				'google.protobuf.Any',
+				shortenProtobufAnyDescription
+			)
+		},
+	]
 	// Build page configuration based on the input values
 	const pageConfig: OpenApiDocsViewV2Config = {
 		basePath: '/open-api-docs-preview-v2',

--- a/src/views/open-api-docs-view-v2/components/content-with-permalink/content-with-permalink.module.css
+++ b/src/views/open-api-docs-view-v2/components/content-with-permalink/content-with-permalink.module.css
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	--permalink-opacity: 0;
+
+	display: flex;
+	gap: 8px;
+	align-items: center;
+
+	&:hover {
+		--permalink-opacity: 1;
+	}
+}
+
+.permalink {
+	--icon-color: var(--token-color-foreground-action);
+
+	composes: g-focus-ring-from-box-shadow from global;
+	border-radius: 6px;
+	display: flex;
+	opacity: var(--permalink-opacity);
+	padding: 4px;
+
+	@media (prefers-reduced-motion: no-preference) {
+		transition: opacity 0.2s ease;
+	}
+
+	&:hover {
+		--icon-color: var(--token-color-foreground-action-hover);
+
+		opacity: 1;
+		box-shadow: var(--token-surface-mid-box-shadow);
+	}
+
+	&:focus-visible {
+		--icon-color: var(--token-color-foreground-action-active);
+
+		opacity: 1;
+		background: var(--token-color-surface-faint);
+	}
+}
+
+.permalinkIcon {
+	color: var(--permalink-icon-color);
+}

--- a/src/views/open-api-docs-view-v2/components/content-with-permalink/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/content-with-permalink/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Link from 'next/link'
+import { IconLink16 } from '@hashicorp/flight-icons/svg-react/link-16'
+// Types
+import type { PropsWithChildren } from 'react'
+// Styles
+import s from './content-with-permalink.module.css'
+import classNames from 'classnames'
+
+/**
+ * Renders the provided `children` alongside a permalink `<a />` element.
+ *
+ * `ariaLabel` is required to ensure the permalink element has meaningful
+ * text for screen readers. For simple use cases where `children` is a
+ * string, the `ariaLabel` can be passed the same value as `children`.
+ * For more complex use cases, the consumer should determine what text
+ * would be appropriate to pass to `ariaLabel`.
+ *
+ * Note that this component does _not_ handle placing the provided `id`
+ * in the DOM. It requires the consumer to place the `id` on an appropriate
+ * element, typically an element rendered in the provided `children`.
+ */
+export function ContentWithPermalink({
+	id,
+	ariaLabel,
+	children,
+	className,
+}: PropsWithChildren<{ id: string; className?: string; ariaLabel: string }>) {
+	return (
+		<div className={classNames(s.root, className)}>
+			{children}
+			<Link className={s.permalink} aria-label={ariaLabel} href={`#${id}`}>
+				<IconLink16 className={s.permalinkIcon} />
+			</Link>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/operation-content/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/operation-content/index.tsx
@@ -3,25 +3,78 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// Components
+import Badge from 'components/badge'
+// Local components
+import { OperationSections } from '../operation-sections'
+import { OperationExamples } from '../operation-examples'
+import { OperationDetails } from '../operation-details'
 // Types
-import type { OpenAPIV3 } from 'openapi-types'
+import type { PropertyDetailsSectionProps } from '../operation-details'
+// Styles
+import s from './style.module.css'
 
 export interface OperationContentProps {
+	heading: string
+	operationId: string
+	tags: string[]
+	slug: string
+	type: string
+	path: {
+		full: string
+		truncated: string
+	}
+	requestData: PropertyDetailsSectionProps
+	responseData: PropertyDetailsSectionProps
+	summary?: string
 	/**
-	 * TODO: discard once view can be identified without this
+	 * Syntax-highlighted HTML that represents the URL path, with
+	 * word breaks to allow long URLs to wrap to multiple lines.
 	 */
-	_placeholder: any
+	urlPathForCodeBlock: string
 }
 
 /**
- * TODO: implement this content area
+ * Operations are specific request types to specific endpoints.
+ * They form the basis of OpenAPI docs pages.
  */
-export default function OperationContent(props: OperationContentProps) {
+export interface OperationProps {
+	slug: string
+	type: string
+}
+
+/**
+ * Render detailed content for an individual operation.
+ */
+export default function OperationContent({
+	heading,
+	slug,
+	type,
+	path,
+	urlPathForCodeBlock,
+	requestData,
+	responseData,
+}: OperationContentProps) {
 	return (
 		<>
-			<pre style={{ whiteSpace: 'pre-wrap' }}>
-				<code>{JSON.stringify(props, null, 2)}</code>
-			</pre>
+			<h1 className={s.heading}>{heading}</h1>
+			<OperationSections
+				headerSlot={
+					<div className={s.methodAndPath}>
+						<Badge className={s.method} type="outlined" text={type} />
+						<p className={s.path}>{path.truncated}</p>
+					</div>
+				}
+				examplesSlot={
+					<OperationExamples heading={slug} code={urlPathForCodeBlock} />
+				}
+				detailsSlot={
+					<OperationDetails
+						requestData={requestData}
+						responseData={responseData}
+					/>
+				}
+			/>
 		</>
 	)
 }

--- a/src/views/open-api-docs-view-v2/components/operation-content/server.ts
+++ b/src/views/open-api-docs-view-v2/components/operation-content/server.ts
@@ -3,21 +3,91 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+// Utils
+import { getOperationObjects } from '../../utils/get-operation-objects'
+import { getUrlPathCodeHtml } from '../../utils/get-url-path-code-html'
+import { truncateHcpOperationPath } from '../../utils/truncate-hcp-operation-path'
+import { getRequestData } from '../../utils/get-request-data'
+import { getResponseData } from '../../utils/get-response-data'
 // Types
 import type { OpenAPIV3 } from 'openapi-types'
 import type { OperationContentProps } from '.'
 
 /**
- * TODO: transform the schemaData into useful props
+ * Transform the schemaData into props for an individual operation
  */
 export default async function getOperationContentProps(
 	operationSlug: string,
 	schemaData: OpenAPIV3.Document
 ): Promise<OperationContentProps> {
-	return {
-		_placeholder: {
-			viewToImplement: `Operation view for ${operationSlug}`,
-			schemaSample: schemaData.info,
-		},
+	const operationObjects = getOperationObjects(schemaData)
+	const operation = operationObjects.find(
+		(operation) => operation.operationId === operationSlug
+	)
+	/**
+	 * The API's base URL is used to prefix the operation path,
+	 * so users can quickly copy the full path to the operation
+	 */
+	const apiBaseUrl = getApiBaseUrl(schemaData)
+	/**
+	 * Parse request and response details for this operation
+	 */
+	const parameters = 'parameters' in operation ? operation.parameters : []
+	const requestDataSlug = `${operationSlug}_request`
+	const requestData = {
+		heading: { text: 'Request', slug: requestDataSlug },
+		noGroupsMessage: 'No request data.',
+		groups: await getRequestData(
+			parameters,
+			operation.requestBody,
+			requestDataSlug
+		),
 	}
+	const responseDataSlug = `${operationSlug}_response`
+	const responseData = {
+		heading: { text: 'Response', slug: responseDataSlug },
+		noGroupsMessage: 'No response data.',
+		groups: await getResponseData(operation.responses, responseDataSlug),
+	}
+	/**
+	 * Return the operation content props
+	 */
+	return {
+		heading: operationSlug,
+		operationId: operationSlug,
+		tags: operation.tags,
+		slug: operationSlug,
+		type: operation.type,
+		path: {
+			full: operation.path,
+			truncated: truncateHcpOperationPath(operation.path),
+		},
+		requestData: requestData,
+		responseData: responseData,
+		urlPathForCodeBlock: getUrlPathCodeHtml(apiBaseUrl + operation.path),
+	}
+}
+
+/**
+ * Given some OpenAPI schemaData,
+ * Return a string representing the base URL for the API.
+ *
+ * The base URL is derived from the first server URL in the schemaData.
+ *
+ * @param schemaData
+ * @returns {string} The base URL for the API
+ */
+function getApiBaseUrl(schemaData: OpenAPIV3.Document): string {
+	let baseUrl = ''
+	if (schemaData.servers?.length > 0) {
+		const rawBaseUrl = schemaData.servers[0].url
+		/**
+		 * If we up-converted from an older OpenAPI version, then the spec would
+		 * have defined a `host` rather than explicit server URL, and the resulting
+		 * server URL will start with `//` rather than a valid protocol.
+		 * In this case we assume HTTPs, and update the baseUrl accordingly.
+		 */
+		baseUrl = rawBaseUrl.replace(/^\/\//, 'https://')
+	}
+	return baseUrl
 }

--- a/src/views/open-api-docs-view-v2/components/operation-content/style.module.css
+++ b/src/views/open-api-docs-view-v2/components/operation-content/style.module.css
@@ -1,0 +1,29 @@
+.heading {
+	composes: hds-typography-display-600 from global;
+
+	/* Ensure we jump to the very top of the page when linking to this item */
+	scroll-margin-top: calc(var(--total-scroll-offset) + 999vh);
+	font-weight: var(--token-typography-font-weight-bold);
+	color: var(--token-color-foreground-strong);
+	margin: 0 0 9px 0;
+}
+
+/* HEADER AREA */
+
+.methodAndPath {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+.method {
+	text-transform: uppercase;
+}
+
+.path {
+	composes: hds-typography-code-300 from global;
+	color: var(--token-color-foreground-primary);
+	overflow-wrap: break-word;
+	flex-shrink: 1;
+	min-width: 0;
+}

--- a/src/views/open-api-docs-view-v2/components/operation-details/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/operation-details/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Components
+import Badge from 'components/badge'
+// Local components
+import { ContentWithPermalink } from '../content-with-permalink'
+import { PropertyDetails } from '../property-details'
+// Types
+import type { PropertyDetailsProps } from '../property-details'
+// Styles
+import s from './operation-details.module.css'
+
+export interface PropertyDetailsGroup {
+	heading: {
+		text: string
+		slug: string
+		/**
+		 * If `theme` is provided, we render a badge with that theme.
+		 */
+		theme?: 'success' | 'neutral' | 'critical'
+	}
+	propertyDetails: PropertyDetailsProps[]
+}
+
+export interface PropertyDetailsSectionProps {
+	heading: {
+		text: string
+		slug: string
+	}
+	groups: PropertyDetailsGroup[]
+	noGroupsMessage: string
+}
+
+/**
+ * Render request and response data for an operation.
+ */
+export function OperationDetails({
+	requestData,
+	responseData,
+}: {
+	requestData: PropertyDetailsSectionProps
+	responseData: PropertyDetailsSectionProps
+}) {
+	return (
+		<div className={s.root}>
+			<PropertyDetailsSection
+				heading={requestData.heading}
+				groups={requestData.groups}
+				noGroupsMessage={requestData.noGroupsMessage}
+			/>
+			<PropertyDetailsSection
+				heading={responseData.heading}
+				groups={responseData.groups}
+				noGroupsMessage={responseData.noGroupsMessage}
+			/>
+		</div>
+	)
+}
+
+/**
+ * Render a section with many groups of property details.
+ *
+ * Used to show request and response details for operations
+ */
+function PropertyDetailsSection({
+	heading,
+	groups,
+	noGroupsMessage,
+}: PropertyDetailsSectionProps) {
+	return (
+		<div className={s.section}>
+			<ContentWithPermalink id={heading.slug} ariaLabel={heading.text}>
+				<h4 id={heading.slug} className={s.sectionHeading}>
+					{heading.text}
+				</h4>
+			</ContentWithPermalink>
+			{groups.length > 0 ? (
+				<div className={s.sectionGroups}>
+					{groups.map((group) => {
+						return (
+							<div className={s.group} key={group.heading.slug}>
+								<ContentWithPermalink
+									id={group.heading.slug}
+									ariaLabel={group.heading.text}
+								>
+									<h5 id={group.heading.slug} className={s.groupHeading}>
+										{group.heading.theme ? (
+											<Badge
+												type="outlined"
+												text={group.heading.text}
+												color={group.heading.theme}
+											/>
+										) : (
+											group.heading.text
+										)}
+									</h5>
+								</ContentWithPermalink>
+								<div className={s.groupProperties}>
+									{group.propertyDetails.map((property) => {
+										return <PropertyDetails key={property.name} {...property} />
+									})}
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			) : (
+				<div className={s.noGroupsMessage}>{noGroupsMessage}</div>
+			)}
+		</div>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/operation-details/operation-details.module.css
+++ b/src/views/open-api-docs-view-v2/components/operation-details/operation-details.module.css
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	display: flex;
+	flex-direction: column;
+	gap: 40px;
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.sectionHeading {
+	composes: g-offset-scroll-margin-top from global;
+	composes: hds-typography-display-300 from global;
+	font-weight: var(--token-typography-font-weight-bold);
+	color: var(--token-color-foreground-strong);
+}
+
+.sectionGroups {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.groupHeading {
+	composes: g-offset-scroll-margin-top from global;
+	composes: hds-typography-display-200 from global;
+	font-weight: var(--token-typography-font-weight-semibold);
+	color: var(--token-color-foreground-primary);
+}
+
+.groupProperties {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.noGroupsMessage {
+	composes: hds-typography-body-200 from global;
+	color: var(--token-color-foreground-faint);
+}

--- a/src/views/open-api-docs-view-v2/components/operation-examples/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/operation-examples/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// react-design-system-components
+import CodeBlock from '@hashicorp/react-design-system-components/src/components/code-block'
+
+/**
+ * Display the operation's full URL in an easy to copy code block,
+ * as a precursor to more fully built out example requests.
+ */
+export function OperationExamples({
+	heading,
+	code,
+}: {
+	heading: string
+	code: string
+}) {
+	return (
+		<CodeBlock
+			title={heading}
+			hasCopyButton
+			hasLineNumbers={false}
+			value={code}
+		/>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/operation-sections/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/operation-sections/index.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { ReactNode } from 'react'
+import s from './operation-sections.module.css'
+
+/**
+ * Lays out columns for the examples and details of an operation.
+ *
+ * On large viewports, the exampleSlot is sticky and scrolls alongside
+ * the detailsSlot. On smaller viewports, the examplesSlot stacks above
+ * the detailsSlot. On the smallest viewports, it may be hidden entirely.
+ *
+ * TODO: determine breakpoint at which to hide examplesSlot, and implement.
+ */
+export function OperationSections({
+	headerSlot,
+	examplesSlot,
+	detailsSlot,
+}: {
+	headerSlot: ReactNode
+	examplesSlot: ReactNode
+	detailsSlot: ReactNode
+}) {
+	return (
+		<div className={s.root}>
+			<div className={s.gridLayout}>
+				<div className={s.headerSlot}>{headerSlot}</div>
+				<div className={s.examplesStickyContainer}>
+					<div className={s.examplesSlot}>{examplesSlot}</div>
+				</div>
+				<div className={s.detailsSlot}>{detailsSlot}</div>
+			</div>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/operation-sections/operation-sections.module.css
+++ b/src/views/open-api-docs-view-v2/components/operation-sections/operation-sections.module.css
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.root {
+	/* stylelint-disable-next-line property-no-unknown */
+	container-type: inline-size;
+}
+
+.gridLayout {
+	display: grid;
+	gap: 24px;
+	grid-template-areas: 'header' 'details';
+	grid-template-columns: minmax(0, 1fr);
+
+	/* We show 'examples' in a one-column if the viewport size is large enough */
+	@media (min-width: 420px) {
+		grid-template-areas: 'header' 'examples' 'details';
+	}
+
+	/* Note: 744px = 360px per column, plus 24px grid gap.
+	   Calc & CSS vars are not supported in container queries. */
+
+	/* stylelint-disable-next-line at-rule-no-unknown */
+	@container (min-width: 744px) {
+		grid-template-areas: 'header examples' 'details examples';
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	}
+}
+
+.headerSlot {
+	grid-area: header;
+}
+
+.detailsSlot {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	grid-area: details;
+}
+
+.examplesStickyContainer {
+	display: none;
+
+	@media (min-width: 420px) {
+		display: block;
+		grid-area: examples;
+		height: 100%;
+		position: relative;
+	}
+}
+
+.examplesSlot {
+	--sticky-spacing: 24px;
+
+	position: sticky;
+	top: calc(var(--navigation-header-height) + var(--sticky-spacing));
+}

--- a/src/views/open-api-docs-view-v2/components/property-details/index.tsx
+++ b/src/views/open-api-docs-view-v2/components/property-details/index.tsx
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Third party
+import type { PropsWithChildren } from 'react'
+import classNames from 'classnames'
+// Components
+import { MdxInlineCode } from 'components/dev-dot-content/mdx-components'
+import Badge from 'components/badge'
+// Styles
+import s from './property-details.module.css'
+import { ContentWithPermalink } from '../content-with-permalink'
+
+/**
+ * Types are shared by the "base" and "nested" variations of
+ * the property details component.
+ */
+export interface PropertyDetailsProps {
+	name: string
+	slug: string
+	type: string
+	isRequired?: boolean
+	description?: string // Plain text or HTML
+	nestedProperties?: PropertyDetailsProps[]
+	depth?: number
+	isLastItem?: boolean
+}
+
+/**
+ * Render a top-level property, with optional nested properties.
+ *
+ * Future: will need to support "beta" badge for HCP Packer docs.
+ */
+export function PropertyDetails({
+	name,
+	slug,
+	type,
+	isRequired,
+	description,
+	nestedProperties,
+	depth = 0,
+}: PropertyDetailsProps) {
+	const hasNestedProperties = nestedProperties?.length > 0
+	return (
+		<div id={slug} className={s.baseRoot}>
+			<div className={s.baseMetaAndDescription}>
+				<ContentWithPermalink id={slug} ariaLabel={name}>
+					<div className={s.baseMeta}>
+						<MdxInlineCode>{name}</MdxInlineCode>
+						<span className={s.baseType}>{type}</span>
+						{isRequired ? <Badge text="Required" color="highlight" /> : null}
+					</div>
+				</ContentWithPermalink>
+			</div>
+			{description || hasNestedProperties ? (
+				<div>
+					{description ? (
+						<TreeContent
+							listItemStyle={!hasNestedProperties ? 'last' : null}
+							hideIndicator={!hasNestedProperties}
+						>
+							<div
+								className={classNames(s.baseDescription, {
+									[s.hasNestedProperties]: hasNestedProperties,
+								})}
+								dangerouslySetInnerHTML={{ __html: description }}
+							/>
+						</TreeContent>
+					) : null}
+					{hasNestedProperties ? (
+						<ListNestedProperties
+							nestedProperties={nestedProperties}
+							depth={depth}
+						/>
+					) : null}
+				</div>
+			) : null}
+		</div>
+	)
+}
+
+/**
+ * Render a list of nested properties within a base property.
+ */
+function ListNestedProperties({
+	nestedProperties,
+	depth,
+}: Pick<PropertyDetailsProps, 'nestedProperties' | 'depth'>) {
+	return (
+		<ul className={s.listNestedProperties}>
+			{nestedProperties.map((nestedProperty, idx) => {
+				const isLastItem = idx === nestedProperties.length - 1
+				return (
+					<li key={`${nestedProperty.name}_${depth}`}>
+						<PropertyDetailsNested
+							{...nestedProperty}
+							depth={depth + 1}
+							isLastItem={isLastItem}
+						/>
+					</li>
+				)
+			})}
+		</ul>
+	)
+}
+
+/**
+ * Renders details for a property nested within another property.
+ *
+ * Future: will need to support "beta" badge for HCP Packer docs.
+ */
+function PropertyDetailsNested({
+	name,
+	slug,
+	type,
+	isRequired,
+	description,
+	nestedProperties,
+	depth = 0,
+	isLastItem,
+}: PropertyDetailsProps) {
+	const hasNestedProperties = nestedProperties?.length > 0
+	return (
+		<div id={slug} className={s.nestedRoot}>
+			{/* Meta row */}
+			<TreeContent listItemStyle={isLastItem ? 'last' : 'middle'}>
+				<ContentWithPermalink id={slug} ariaLabel={name}>
+					<div className={s.nestedMeta}>
+						<div className={s.nestedNameAndType}>
+							<code className={s.nestedName}>{name}</code>
+							<span className={s.nestedType}>{type}</span>
+						</div>
+						{isRequired ? (
+							<Badge text="Required" color="highlight" size="small" />
+						) : null}
+					</div>
+				</ContentWithPermalink>
+			</TreeContent>
+			{/* Optional description and nested properties */}
+			{description || hasNestedProperties ? (
+				<TreeContent hideBorder={isLastItem}>
+					{description ? (
+						<TreeContent
+							listItemStyle={!hasNestedProperties ? 'last' : null}
+							hideIndicator={!hasNestedProperties}
+						>
+							<div
+								className={s.nestedDescription}
+								dangerouslySetInnerHTML={{ __html: description }}
+							/>
+						</TreeContent>
+					) : null}
+					{hasNestedProperties ? (
+						<ListNestedProperties
+							nestedProperties={nestedProperties}
+							depth={depth}
+						/>
+					) : null}
+				</TreeContent>
+			) : null}
+		</div>
+	)
+}
+
+/**
+ * Display `children` with structured tree styles, including tree markers.
+ *
+ * Accepts optional props that affect the appearance of the tree styles:
+ * - `hideBorder` - hide the tree marker, but retain spacing
+ * - `hideIndicator` - hide the tree marker, which shifts positioning,
+ *    and removes the consistent left padding.
+ * - `listItemStyle` - affects the tree marker style. By default,
+ *    the marker is a vertical line that extends to the bottom of the
+ * 	  container, creating the appearance of a continuous line for
+ * 		consecutive list items. The `middle` style adds a horizontal line,
+ *    which points to the children. The `last` style curves the vertical line
+ *    and ends it by pointing to the children.
+ */
+function TreeContent({
+	children,
+	listItemStyle,
+	hideBorder,
+	hideIndicator,
+}: PropsWithChildren<{
+	listItemStyle?: 'middle' | 'last'
+	hideBorder?: boolean
+	hideIndicator?: boolean
+}>) {
+	return (
+		<div
+			className={classNames(s.treeContent, {
+				[s.hideIndicator]: hideIndicator,
+			})}
+		>
+			{hideIndicator ? null : (
+				<div className={s.treeIndicatorContainer}>
+					<div
+						className={classNames(s.treeIndicator, {
+							[s.isLastItem]: listItemStyle === 'last',
+							[s.isMiddleItem]: listItemStyle === 'middle',
+							[s.hideBorder]: hideBorder,
+						})}
+					/>
+				</div>
+			)}
+			<div className={s.treeChildren}>{children}</div>
+		</div>
+	)
+}

--- a/src/views/open-api-docs-view-v2/components/property-details/property-details.module.css
+++ b/src/views/open-api-docs-view-v2/components/property-details/property-details.module.css
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+
+Common styles
+
+*/
+
+/* Split this out as it's a common pattern.
+   At some point, it might make sense to abstract it or add it
+	 at a global .css level. */
+.listResetStyles {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+}
+
+/* Description styles markdown content. Note we do not use MDX in this
+   case, so specific styles we want for markdown content will need
+	 to be added here. */
+.description {
+	color: var(--token-color-foreground-faint);
+	width: 100%;
+	overflow-wrap: break-word;
+
+	& p {
+		margin: 0;
+	}
+
+	& pre {
+		white-space: pre-wrap;
+	}
+}
+
+/*
+
+Base properties, at the top level
+
+*/
+
+.baseRoot {
+	composes: g-offset-scroll-margin-top from global;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	--tree-line-color: var(--token-color-border-primary);
+	--tree-line-width: 1px;
+}
+
+.baseMetaAndDescription {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.baseMeta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+}
+
+.baseType {
+	composes: hds-typography-code-200 from global;
+	color: var(--token-color-foreground-primary);
+}
+
+/* Style markdown rendered within the description */
+.baseDescription {
+	composes: hds-typography-body-200 from global;
+	composes: description;
+
+	&.hasNestedProperties {
+		padding-bottom: 4px;
+	}
+}
+
+/*
+
+List of nested properties
+
+*/
+
+.listNestedProperties {
+	composes: listResetStyles;
+}
+
+/*
+
+Nested properties
+
+*/
+
+.nestedRoot {
+	composes: g-offset-scroll-margin-top from global;
+}
+
+.nestedMetaAndDescription {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.nestedMeta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 0;
+}
+
+.nestedNameAndType {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+}
+
+.nestedName {
+	composes: hds-typography-code-100 from global;
+	background: var(--token-color-surface-strong);
+	border-radius: 5px;
+	color: var(--token-color-foreground-strong);
+	padding: 2px 4px 3px 4px;
+}
+
+.nestedType {
+	composes: hds-typography-code-100 from global;
+	color: var(--token-color-foreground-primary);
+}
+
+.nestedDescription {
+	composes: hds-typography-body-100 from global;
+	composes: description;
+	position: relative;
+	top: -4px;
+}
+
+/*
+
+Tree content styling
+
+*/
+
+.treeContent {
+	display: flex;
+	gap: 4px;
+	padding-left: 8px;
+
+	&.hideIndicator {
+		padding-left: 0;
+	}
+}
+
+.treeIndicatorContainer {
+	position: relative;
+	width: 8px;
+}
+
+.treeIndicator {
+	position: absolute;
+	top: 0;
+	height: 100%;
+	width: 100%;
+	border-width: var(--tree-line-width);
+	border-color: var(--tree-line-color);
+	border-left-style: solid;
+
+	&.hideBorder {
+		border-color: transparent;
+	}
+
+	/* Add horizontal line leading to from the "nesting line" to the item */
+	&.isMiddleItem::after {
+		position: absolute;
+		content: '';
+		top: 50%;
+		width: 100%;
+		border-bottom: var(--tree-line-width) solid var(--tree-line-color);
+	}
+
+	/* Modify the "nesting line" to curve towards the item" */
+	&.isLastItem {
+		height: 55%;
+		border-bottom-style: solid;
+		border-bottom-left-radius: 4px;
+	}
+}
+
+.treeChildren {
+	width: 0;
+	flex-grow: 1;
+}

--- a/src/views/open-api-docs-view-v2/schema-transforms/schema-transform-component.ts
+++ b/src/views/open-api-docs-view-v2/schema-transforms/schema-transform-component.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import type { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Modifies an incoming OpenAPI document, adjusting the provided reference
+ * definition schema according to the provided `modifyFn`.
+ */
+export function schemaTransformComponent(
+	schemaData: OpenAPIV3.Document,
+	componentId: string,
+	modifyFn: (reference: OpenAPIV3.SchemaObject) => OpenAPIV3.SchemaObject
+): OpenAPIV3.Document {
+	const referencedSchema = schemaData.components?.schemas[componentId]
+	if (!referencedSchema) {
+		console.warn(`Reference "${componentId}" not found in schema.`)
+		return schemaData
+	}
+	if ('$ref' in referencedSchema) {
+		console.warn(
+			`Target schema ${componentId} is itself a reference, this is unexpected.`
+		)
+		return schemaData
+	} else {
+		const modifiedReference = modifyFn(referencedSchema)
+		const modifiedSchemas = {
+			...schemaData.components.schemas,
+			[componentId]: modifiedReference,
+		}
+		return {
+			...schemaData,
+			components: { ...schemaData.components, schemas: modifiedSchemas },
+		}
+	}
+}

--- a/src/views/open-api-docs-view-v2/schema-transforms/shorten-protobuf-any-description.ts
+++ b/src/views/open-api-docs-view-v2/schema-transforms/shorten-protobuf-any-description.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import type { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Modifies an expected `protobufAny` OpenAPIV3 schema, replacing some
+ * descriptive text in the schema and its properties.
+ *
+ * This is done as we don't want to display the full descriptions of
+ * `protobufAny`, since they were too long in the context of the UI.
+ */
+export function shortenProtobufAnyDescription(
+	protobufAnySchema: OpenAPIV3.SchemaObject
+): OpenAPIV3.SchemaObject {
+	const clonedProtobufAny = { ...protobufAnySchema }
+	/**
+	 * Modify the description for the `protobufAny` schema
+	 * if it's over 400 characters.
+	 */
+	if ('description' in clonedProtobufAny) {
+		clonedProtobufAny.description = changeIfExceedsCharacterLimit(
+			clonedProtobufAny.description,
+			400,
+			'An arbitrary serialized message. Visit the [protobufAny documentation](https://protobuf.dev/reference/protobuf/google.protobuf/#any) for more information.'
+		)
+	}
+	/**
+	 * Modify the description for protobufAny's type property
+	 * if it's over 400 characters.
+	 */
+	if (
+		'properties' in clonedProtobufAny &&
+		typeof clonedProtobufAny.properties === 'object'
+	) {
+		const clonedProtobufAnyType = {
+			...clonedProtobufAny.properties['@type'],
+		}
+		if ('description' in clonedProtobufAnyType) {
+			clonedProtobufAnyType.description = changeIfExceedsCharacterLimit(
+				clonedProtobufAnyType.description,
+				400,
+				'A URL that describes the type of the serialized message.'
+			)
+			clonedProtobufAny.properties = {
+				...clonedProtobufAny.properties,
+				...{ ['@type']: clonedProtobufAnyType },
+			}
+		}
+	}
+	// Return the cloned and modified protobufAny schema
+	return clonedProtobufAny
+}
+
+/**
+ * Given an original string, a character length limit
+ * and an alternate string,
+ *
+ * If the original string exceeds the character length limit,
+ * return the alternate string.
+ * If the original string does not exceed the character length limit,
+ * return the original string.
+ */
+function changeIfExceedsCharacterLimit(
+	original: string,
+	characterLimit: number,
+	alternate: string
+): string {
+	return original.length > characterLimit ? alternate : original
+}

--- a/src/views/open-api-docs-view-v2/server.ts
+++ b/src/views/open-api-docs-view-v2/server.ts
@@ -22,6 +22,7 @@ import type {
 	SharedProps,
 	OpenApiDocsViewV2Config,
 } from 'views/open-api-docs-view-v2/types'
+import { OpenAPIV3 } from 'openapi-types'
 
 /**
  * Build static props for an OpenAPI docs view.
@@ -51,16 +52,18 @@ export async function getStaticProps({
 
 	/**
 	 * Fetch, parse, and validate the OpenAPI schema for this version.
+	 * Also apply any schema transforms.
 	 */
-	const rawSchemaData = await parseAndValidateOpenApiSchema(openApiJsonString)
-
-	/**
-	 * Apply any schema transforms.
-	 */
-	let schemaData = rawSchemaData
-	for (const schemaTransformFunction of schemaTransforms ?? []) {
-		schemaData = schemaTransformFunction(schemaData)
-	}
+	const schemaData = await parseAndValidateOpenApiSchema(
+		openApiJsonString,
+		(schema: OpenAPIV3.Document) => {
+			let transformedSchema = schema
+			for (const schemaTransformFunction of schemaTransforms ?? []) {
+				transformedSchema = schemaTransformFunction(transformedSchema)
+			}
+			return transformedSchema
+		}
+	)
 
 	/**
 	 * TODO: add breadcrumb bar. Or, could be done separately for each view,

--- a/src/views/open-api-docs-view-v2/utils/get-property-detail-props.ts
+++ b/src/views/open-api-docs-view-v2/utils/get-property-detail-props.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Third party
+import slugify from 'slugify'
+// Utilities
+import markdownToHtml from '@hashicorp/platform-markdown-utils/markdown-to-html'
+// Types
+import type { OpenAPIV3 } from 'openapi-types'
+import type { PropertyDetailsProps } from '../components/property-details'
+
+/**
+ * Given a parameter object,
+ * Return property detail props.
+ */
+export async function getPropertyDetailPropsFromParameter(
+	param: OpenAPIV3.ParameterObject,
+	parentSlug: string
+): Promise<PropertyDetailsProps> {
+	const slug = `${parentSlug}_${slugify(param.name)}`
+	const paramSchemaDetails = await getPropertyDetailsFromSchema(
+		param.schema,
+		slug
+	)
+	return {
+		name: param.name,
+		slug,
+		type: paramSchemaDetails.typeString,
+		// Note that we use the description from the parameter itself,
+		// rather than from the parameter's schema.
+		description: await markdownToHtml(param.description),
+		isRequired: param.required,
+		nestedProperties: paramSchemaDetails.nestedProperties,
+	}
+}
+
+/**
+ * Given a schema object,
+ * Return property detail props.
+ */
+export async function getPropertyDetailPropsFromSchemaObject(
+	key: string,
+	schema: OpenAPIV3.SchemaObject,
+	isRequired: boolean,
+	parentSlug: string
+): Promise<PropertyDetailsProps> {
+	const slug = `${parentSlug}_${slugify(key)}`
+	const schemaDetails = await getPropertyDetailsFromSchema(schema, slug, 0)
+	return {
+		name: key,
+		slug,
+		type: schemaDetails.typeString,
+		description: schemaDetails.description,
+		isRequired,
+		nestedProperties: schemaDetails.nestedProperties,
+	}
+}
+
+/**
+ * Given a schema object,
+ * Return a typeString summarizing the schema,
+ * descriptionHtml generated from the schema.description,
+ * and an array of nested properties with fully built props.
+ */
+async function getPropertyDetailsFromSchema(
+	schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+	parentSlug: string,
+	arrayDepth: number = 0
+): Promise<{
+	typeString: string
+	description?: string
+	nestedProperties?: PropertyDetailsProps[]
+}> {
+	/**
+	 * We don't expect reference objects (these should have been resolved already),
+	 * but if one pops up, we'll just return a string.
+	 */
+	if ('$ref' in schema) {
+		return { typeString: '$ref' }
+	}
+	/**
+	 * If we have an array type, we need to recurse into the items object.
+	 * We'll increase the arrayDepth, this will affect the type string we show.
+	 */
+	if (schema.type === 'array' && schema.items) {
+		return await getPropertyDetailsFromSchema(
+			schema.items,
+			parentSlug + '-array',
+			arrayDepth + 1
+		)
+	}
+	/**
+	 * For non-array types, we can build out our data.
+	 */
+	// Build a string that represents this type
+	const typeArraySuffix =
+		arrayDepth > 0 ? arrayFrom(arrayDepth, '[]').join('') : ''
+	const typeString = `${schema.type}${typeArraySuffix}`
+	// Build the description
+	const description = await markdownToHtml(schema.description)
+	// Build out nested properties, if present
+	const hasProperties = schema.type === 'object' && Boolean(schema.properties)
+	const nestedProperties: PropertyDetailsProps[] = []
+	if (hasProperties) {
+		// Note: the object-level schema specifies the required properties
+		const requiredProperties = schema.required || []
+		// Iterate over the properties, pushing them to the nested properties array,
+		// and recursing into the schema for each property as necessary.
+		for (const propertyKey of Object.keys(schema.properties)) {
+			const property = schema.properties[propertyKey]
+			const propertySlug = `${parentSlug}.${slugify(propertyKey)}`
+			const propertyDetails = await getPropertyDetailsFromSchema(
+				property,
+				propertySlug
+			)
+			nestedProperties.push({
+				name: propertyKey,
+				slug: propertySlug,
+				type: propertyDetails.typeString,
+				description: propertyDetails.description,
+				isRequired: requiredProperties.includes(propertyKey),
+				nestedProperties: propertyDetails.nestedProperties,
+			})
+		}
+	}
+	/**
+	 * Return the type string and nested properties
+	 */
+	return { typeString, description, nestedProperties }
+}
+
+/**
+ * Create an array of the given length, filled with the given value.
+ */
+function arrayFrom<T>(length: number, value: T): T[] {
+	const array = []
+	for (let i = 0; i < length; i++) {
+		array.push(value)
+	}
+	return array
+}

--- a/src/views/open-api-docs-view-v2/utils/get-request-data.ts
+++ b/src/views/open-api-docs-view-v2/utils/get-request-data.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Utils
+import {
+	getPropertyDetailPropsFromParameter,
+	getPropertyDetailPropsFromSchemaObject,
+} from './get-property-detail-props'
+// Types
+import type { PropertyDetailsGroup } from '../components/operation-details'
+import type { PropertyDetailsProps } from '../components/property-details'
+import type { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Given OpenAPI parameter objects,
+ * Return request data formatted for display.
+ */
+export async function getRequestData(
+	parameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[],
+	requestBody: OpenAPIV3.RequestBodyObject | OpenAPIV3.ReferenceObject,
+	slugPrefix: string
+): Promise<PropertyDetailsGroup[]> {
+	// Set up some slugs, we'll need these for headings and for unique prefixes
+	const pathParamsSlug = `${slugPrefix}_path-parameters`
+	const queryParamsSlug = `${slugPrefix}_query-parameters`
+	const bodyParamsSlug = `${slugPrefix}_body-parameters`
+	// Build arrays of path, query, and body parameters
+	const pathParameters: PropertyDetailsProps[] = []
+	const queryParameters: PropertyDetailsProps[] = []
+	if (Array.isArray(parameters)) {
+		for (const parameter of parameters) {
+			// Skip references
+			if ('$ref' in parameter) {
+				continue
+			}
+			// Skip parameters that are not "in" the request
+			if (!('in' in parameter)) {
+				continue
+			}
+			// Parse parameters by type
+			if (parameter.in === 'path') {
+				pathParameters.push(
+					await getPropertyDetailPropsFromParameter(parameter, pathParamsSlug)
+				)
+			} else if (parameter.in === 'query') {
+				queryParameters.push(
+					await getPropertyDetailPropsFromParameter(parameter, queryParamsSlug)
+				)
+			}
+		}
+	}
+	// Build body parameters from requestBody data, if present
+	const bodyParameters =
+		requestBody && !('$ref' in requestBody)
+			? await getBodyParameterProps(requestBody, bodyParamsSlug)
+			: []
+	// Build an array of request data, using any parameters present
+	const requestData: PropertyDetailsGroup[] = []
+	if (pathParameters.length > 0) {
+		requestData.push({
+			heading: { text: 'Path Parameters', slug: pathParamsSlug },
+			propertyDetails: pathParameters,
+		})
+	}
+	if (queryParameters.length > 0) {
+		requestData.push({
+			heading: { text: 'Query Parameters', slug: queryParamsSlug },
+			propertyDetails: queryParameters,
+		})
+	}
+	if (bodyParameters.length > 0) {
+		requestData.push({
+			heading: { text: 'Body Parameters', slug: bodyParamsSlug },
+			propertyDetails: bodyParameters,
+		})
+	}
+	// Return everything
+	return requestData
+}
+
+/**
+ * Given the parameter object from a body parameter,
+ * which we expect to be an object with a schema if it exists,
+ *
+ * Return property detail data.
+ */
+export async function getBodyParameterProps(
+	requestBody: OpenAPIV3.RequestBodyObject,
+	parentSlug: string
+): Promise<PropertyDetailsProps[]> {
+	const bodyProps = []
+
+	// OAS definitions may have body parameters with schemas for things other than
+	// 'application/json'. For example, 'application/octet-stream' for file upload
+	for (const [contentType, { schema }] of Object.entries(requestBody.content)) {
+		// If we don't find the expected schema, skip the object
+		if (!schema) {
+			continue
+		}
+
+		// We don't expect references, but for typing purposes we handle them.
+		if ('$ref' in schema) {
+			continue
+		}
+
+		/**
+		 * Note: we expect body schemas to always be objects at their root.
+		 * We flatten the body properties to avoid showing a redundant object.
+		 */
+
+		const requiredProperties = schema.required || []
+
+		// Non-JSON request messages elements will not have properties information,
+		// so we need to look for explicit type/format information instead
+		const hasProps = schema.properties
+
+		if (!hasProps) {
+			// Body parameters without properties typically do not have a name since
+			// they are things like data streams, so use the content type as the name
+			bodyProps.push({
+				name: contentType,
+				slug: parentSlug,
+				type: schema.type,
+				description: schema.format,
+				isRequired:
+					typeof schema.required != 'undefined' ? schema.required : 'false',
+				nestedProperties: [],
+			})
+		} else {
+			for (const [key, value] of Object.entries(schema.properties)) {
+				// Skip reference objects, we expect these to be de-referenced
+				// before this function is called
+				if ('$ref' in value) {
+					continue
+				}
+				// Skip read-only properties
+				if (value.readOnly) {
+					continue
+				}
+				const isRequired = requiredProperties.includes(key)
+				// Push props
+				bodyProps.push(
+					await getPropertyDetailPropsFromSchemaObject(
+						key,
+						value,
+						isRequired,
+						parentSlug
+					)
+				)
+			}
+		}
+	}
+	return bodyProps
+}

--- a/src/views/open-api-docs-view-v2/utils/get-response-data.ts
+++ b/src/views/open-api-docs-view-v2/utils/get-response-data.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Third party
+import { getReasonPhrase } from 'http-status-codes'
+
+// Utils
+import { getPropertyDetailPropsFromSchemaObject } from './get-property-detail-props'
+// Types
+import type { PropertyDetailsGroup } from '../components/operation-details'
+import type { PropertyDetailsProps } from '../components/property-details'
+import type { OpenAPIV3 } from 'openapi-types'
+
+/**
+ * Given OpenAPI responses data,
+ * Return response data formatted for display.
+ */
+export async function getResponseData(
+	responses: OpenAPIV3.ResponsesObject,
+	slugPrefix: string
+): Promise<PropertyDetailsGroup[]> {
+	// Set up an object to hold response data
+	const responseData: PropertyDetailsGroup[] = []
+	// Populate the responseData object using incoming responses
+	for (const responseCode of Object.keys(responses)) {
+		/**
+		 * OAS files may have multiple response definitions for each response code.
+		 * For example, an API that accepts JSON and XML requests will have two
+		 * definitions for a 200 response: a valid JSON response and a valid XML
+		 * response.
+		 **/
+
+		// Grab all the response messages for the current response code
+		const codeResponses = responses[responseCode]
+
+		// Skip instances where codeResponses is a $ref
+		if ('$ref' in codeResponses) {
+			continue
+		}
+
+		// Skip instances where codeResponse does not have content
+		if (!codeResponses.content) {
+			continue
+		}
+
+		// Process the parameters etc. for each of the response types (contentType)
+		// for the current response code (responseCode)
+		for (const [contentType, definition] of Object.entries(
+			codeResponses.content
+		)) {
+			/**
+			 * Skip the current object if:
+			 *   - The response object is not JSON (for now)
+			 *   - The response object definition is a reference
+			 *	 - The response object does not include a definition or schema
+			 *	 - The response schema is a reference
+			 **/
+			if (
+				contentType !== 'application/json' ||
+				contentType.includes('$ref') ||
+				!definition ||
+				!definition.schema ||
+				'$ref' in definition.schema
+			) {
+				continue
+			}
+
+			/**
+			 * Note: we expect response schemas to always be objects at their root.
+			 * We flatten the response properties to avoid showing a redundant object.
+			 */
+			if (definition.schema.properties) {
+				const responseSlug = `${slugPrefix}_${responseCode}`
+				const propertyDetails: PropertyDetailsProps[] = []
+				const requiredProperties = definition.schema.required || []
+
+				for (const propertyKey of Object.keys(definition.schema.properties)) {
+					const data = definition.schema.properties[propertyKey]
+					// If this schema is a reference, skip it
+					if ('$ref' in data) {
+						continue
+					}
+					const isRequired = requiredProperties.includes(propertyKey)
+					propertyDetails.push(
+						await getPropertyDetailPropsFromSchemaObject(
+							propertyKey,
+							data,
+							isRequired,
+							responseSlug
+						)
+					)
+				}
+
+				// Determine the heading text to show
+				const headingText =
+					responseCode === 'default'
+						? `Default Error Response`
+						: `${responseCode} -  ${getReasonPhrase(responseCode)}`
+				const headingTheme = responseCode.startsWith('2')
+					? 'success'
+					: 'critical'
+
+				responseData.push({
+					heading: {
+						text: headingText,
+						slug: responseSlug,
+						theme: headingTheme,
+					},
+					propertyDetails,
+				})
+			} // if: definition.schema.properties
+		} // for: contentType
+	} // for: responseCode
+	return responseData
+}

--- a/src/views/open-api-docs-view-v2/utils/get-url-path-code-html.ts
+++ b/src/views/open-api-docs-view-v2/utils/get-url-path-code-html.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/**
+ * Given a URL path,
+ * Return HTML that represents the URL path, with `{parameters}` syntax
+ * highlighted and with word breaks inserted before forward slashes
+ * to allow long URLs to wrap to multiple lines.
+ */
+export function getUrlPathCodeHtml(urlPath: string): string {
+	/**
+	 * Insert <wbr/> before forward slashes for more logical line breaks
+	 *
+	 * Note: we can't use zero-width spaces here as in other use cases,
+	 * as they show up when the code block contents are copied.
+	 */
+	const urlWithWordBreaks = urlPath.replace(/\//g, '/<wbr/>')
+	// Add syntax highlighting around any {parameters} in the path
+	const parameterRegex = /{([^}]+)}/g
+	const urlPathForCodeBlock = urlWithWordBreaks.replace(
+		parameterRegex,
+		'<span class="token regex">{$1}</span>'
+	)
+	return urlPathForCodeBlock
+}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

Implements operation page content for the split-operations Open API template.

## 🤷 Why

Our current OpenAPI docs view renders all operations on a single page. For some spec files, the page data can get heavy enough that it becomes very slow and even error-causing to try to handle it.

This PR implements the operation page content for a new version of the Open API docs template, which splits operations to separate pages.

## 🛠️ How

- Pulls in components from the existing OpenAPI view
- Implements `<OperationContent />` component to match upstream setup
    - Only significant difference is operation name is now used as `<h1 />` rather than `<h2 />`

## 📸 Design Screenshots

### HCP Vault Secrets

| Before | After |
| - | - |
| ![hcp-vault-secrets-before](https://github.com/user-attachments/assets/dab93c6c-44e7-4540-b59a-80c13f28cef2) | ![hcp-vault-secrets-after](https://github.com/user-attachments/assets/8aaf78de-be53-496c-a9a2-c14d8b21b572) |

### HCP Consul

| Before | After |
| - | - |
| ![hcp-consul-before](https://github.com/user-attachments/assets/7a8e7a30-3b26-4f2f-9f15-c7790b3e9154) | ![hcp-consul-after](https://github.com/user-attachments/assets/fc9ac3f1-5e43-4538-a0f5-92e2f085a01d) |

## 🧪 Testing

- [x] Visit the preview tool at [/open-api-docs-preview-v2]
- [x] Test out various specs, and compare to upstream
    - Example: compare an upload of the [HCP Consul Central][hcp-consul-central-spec] with the sidebar in the upstream [/hcp/api-docs/consul](https://developer.hashicorp.com/hcp/api-docs/consul)
    - Example: compare an upload of the [HCP Vault Secrets][hcp-vault-secrets-spec] with the sidebar in the upstream [/hcp/api-docs/vault-secrets](https://developer.hashicorp.com/hcp/api-docs/vault-secrets)

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/0/1208591364823440/f
[hcp-consul-central-spec]: https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-global-network-manager-service/preview/2023-10-10/hcp.swagger.json
[hcp-vault-secrets-spec]: https://github.com/hashicorp/hcp-specs/blob/main/specs/cloud-vault-secrets/stable/2023-06-13/hcp.swagger.json
[preview]: https://dev-portal-git-zsopen-api-v2-operation-content-hashicorp.vercel.app
[/open-api-docs-preview-v2]: https://dev-portal-git-zsopen-api-v2-operation-content-hashicorp.vercel.app/open-api-docs-preview-v2
