### PR TITLE
fix: update github script version for failing TSCCR check on dev-portal-internal

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -34,7 +34,7 @@ jobs:
           github_token: ${{ secrets.PAT_HASHIBOT_WEB_DEV_PORTAL_INTERNAL_SYNC }}
 
       - name: Ship pull request
-        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ secrets.PAT_HASHIBOT_WEB_DEV_PORTAL_INTERNAL_SYNC }}
           result-encoding: string


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/1208691590278290/1208699942108403/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This PR updates the version for `actions/github-script` to the latest trusted version. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
The [TSCCR verify check](https://github.com/hashicorp/dev-portal-internal/actions/runs/11745455774/job/32722917783) on dev-portal-internal is failing because the version of `actions/github-script` in `repo-sync` is untrusted. They recommend upgrading to `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea` instead of `actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0`
