### PR TITLE
Migrate HCP Vault Secrets to split OpenAPI view

### DIFF
--- a/src/pages/hcp/api-docs/vault-secrets/[[...page]].tsx
+++ b/src/pages/hcp/api-docs/vault-secrets/[[...page]].tsx
@@ -3,72 +3,85 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// Lib
-import { fetchCloudApiVersionData } from 'lib/api-docs/fetch-cloud-api-version-data'
 // View
-import OpenApiDocsView from 'views/open-api-docs-view'
+import OpenApiDocsViewV2 from 'views/open-api-docs-view-v2'
 import {
-	getStaticPaths,
-	getStaticProps as getOpenApiDocsStaticProps,
-} from 'views/open-api-docs-view/server'
+	generateStaticPaths,
+	generateStaticPropsVersioned,
+} from 'views/open-api-docs-view-v2/server'
+// Utils
+import { getOperationGroupKeyFromPath } from 'views/open-api-docs-view-v2/utils/get-operation-group-key-from-path'
+// Schema transforms
+import { schemaTransformShortenHcp } from 'views/open-api-docs-view-v2/schema-transforms/schema-transform-shorten-hcp'
+import { schemaTransformComponent } from 'views/open-api-docs-view-v2/schema-transforms/schema-transform-component'
+import { shortenProtobufAnyDescription } from 'views/open-api-docs-view-v2/schema-transforms/shorten-protobuf-any-description'
 // Types
-import type { GetStaticProps, GetStaticPropsContext } from 'next'
-import type { OpenAPIV3 } from 'openapi-types'
 import type {
-	OpenApiDocsParams,
-	OpenApiDocsViewProps,
-	OpenApiDocsPageConfig,
-} from 'views/open-api-docs-view/types'
-import {
-	schemaModShortenHcp,
-	schemaModComponent,
-	shortenProtobufAnyDescription,
-} from 'views/open-api-docs-view/utils/massage-schema-utils'
+	GetStaticPaths,
+	GetStaticProps,
+	GetStaticPropsContext,
+} from 'next'
+import type {
+	OpenApiDocsV2Params,
+	OpenApiDocsViewV2Props,
+	OpenApiDocsViewV2Config,
+} from 'views/open-api-docs-view-v2/types'
 
 /**
- * OpenApiDocsView server-side page configuration
+ * Configure this OpenAPI spec page, specifying the source,
+ * and additional configuration that doesn't fit in the schema itself.
  */
-const PAGE_CONFIG: OpenApiDocsPageConfig = {
-	productSlug: 'hcp',
-	serviceProductSlug: 'vault',
+const PAGE_CONFIG: OpenApiDocsViewV2Config = {
+	backToLink: {
+		href: '/hcp',
+		text: 'HashiCorp Cloud Platform',
+	},
 	basePath: '/hcp/api-docs/vault-secrets',
-	githubSourceDirectory: {
+	breadcrumbLinksPrefix: [
+		{
+			title: 'Developer',
+			url: '/',
+		},
+		{
+			title: 'HashiCorp Cloud Platform',
+			url: '/hcp',
+		},
+	],
+	schemaSource: {
 		owner: 'hashicorp',
 		repo: 'hcp-specs',
 		path: 'specs/cloud-vault-secrets',
 		ref: 'main',
 	},
-	groupOperationsByPath: true,
+	productContext: 'hcp',
+	theme: 'vault',
+	getOperationGroupKey: getOperationGroupKeyFromPath,
 	statusIndicatorConfig: {
 		pageUrl: 'https://status.hashicorp.com',
 		endpointUrl:
 			'https://status.hashicorp.com/api/v2/components/hk67zg2j2rkd.json',
 	},
-	navResourceItems: [
+	resourceLinks: [
 		{
-			title: 'Tutorial Library',
+			text: 'Tutorial Library',
 			href: '/tutorials/library?product=vault&edition=hcp',
 		},
 		{
-			title: 'Certifications',
+			text: 'Certifications',
 			href: '/certifications/security-automation',
 		},
 		{
-			title: 'Community',
+			text: 'Community',
 			href: 'https://discuss.hashicorp.com/',
 		},
 		{
-			title: 'Support',
+			text: 'Support',
 			href: 'https://www.hashicorp.com/customer-success',
 		},
 	],
-
-	/**
-	 * Massage the schema data a little bit
-	 */
-	massageSchemaForClient: (schemaData: OpenAPIV3.Document) => {
+	schemaTransforms: [
 		//  Replace "HashiCorp Cloud Platform" with "HCP" in the title
-		const withShortTitle = schemaModShortenHcp(schemaData)
+		schemaTransformShortenHcp,
 		/**
 		 * Shorten the description of the protobufAny schema
 		 *
@@ -82,41 +95,34 @@ const PAGE_CONFIG: OpenApiDocsPageConfig = {
 		 * Related task:
 		 * https://app.asana.com/0/1207339219333499/1207339701271604/f
 		 */
-		const withShortProtobufDocs = schemaModComponent(
-			withShortTitle,
-			'protobufAny',
-			shortenProtobufAnyDescription
-		)
-		// Return the schema data with modifications
-		return withShortProtobufDocs
-	},
+		(schema) => {
+			return schemaTransformComponent(
+				schema,
+				'protobufAny',
+				shortenProtobufAnyDescription
+			)
+		},
+	],
 }
 
 /**
- * Get static paths, using `versionData` fetched from GitHub.
+ * Get static paths, using the configured `schemaSource`.
  */
-export { getStaticPaths }
-
-/**
- * Get static props, using `versionData` fetched from GitHub.
- *
- * We need all version data for the version selector,
- * and of course we need specific data for the current version.
- */
-export const getStaticProps: GetStaticProps<
-	OpenApiDocsViewProps,
-	OpenApiDocsParams
-> = async ({ params }: GetStaticPropsContext<OpenApiDocsParams>) => {
-	// Fetch all version data, based on remote `stable` & `preview` subfolders
-	const versionData = await fetchCloudApiVersionData(
-		PAGE_CONFIG.githubSourceDirectory
-	)
-	// Generate static props based on page configuration, params, and versionData
-	return await getOpenApiDocsStaticProps({
-		...PAGE_CONFIG,
-		context: { params },
-		versionData,
+export const getStaticPaths: GetStaticPaths<OpenApiDocsV2Params> = async () => {
+	return await generateStaticPaths({
+		schemaSource: PAGE_CONFIG.schemaSource,
+		schemaTransforms: PAGE_CONFIG.schemaTransforms,
 	})
 }
 
-export default OpenApiDocsView
+/**
+ * Get static paths, using the configured `schemaSource`.
+ */
+export const getStaticProps: GetStaticProps<
+	OpenApiDocsViewV2Props,
+	OpenApiDocsV2Params
+> = async ({ params }: GetStaticPropsContext<OpenApiDocsV2Params>) => {
+	return await generateStaticPropsVersioned(PAGE_CONFIG, params?.page)
+}
+
+export default OpenApiDocsViewV2


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link][preview] 🔎
- [Asana task][task] 🎟️

## 🗒️ What

This PR migrates `/hcp/api-docs/vault-secrets` to the new split-operations OpenAPI view.

## 🤷 Why

Our current OpenAPI docs view renders all operations on a single page. For some spec files, the page data can get heavy enough that it becomes very slow and even error-causing to try to handle it.

## 🛠️ How

Uses very similar configuration to upstream, but passes it to the new OpenAPI view.

## 📸 Design Screenshots

Overview content

| Before | After |
| - | - |
| ![overview-before](https://github.com/user-attachments/assets/7cc02444-e401-4141-853f-b5075544d96a) | ![overview-after](https://github.com/user-attachments/assets/f4c57d2b-b0da-441e-a7ea-f2d223cc520f) |

Operation content

| Before | After |
| - | - |
| ![operation-before](https://github.com/user-attachments/assets/d662b3f1-6187-43d0-bb73-07a4e54dff77) | ![operation-after](https://github.com/user-attachments/assets/1389e1d4-0422-4f90-90b4-36887520f1e1) |

## 🧪 Testing

- [ ] Visit the [preview], specifically [/hcp/api-docs/vault-secrets]
    - It should provide an equivalent experience, with all the same content, as the [upstream /hcp/api-docs/vault-secrets].

## 💭 Anything else?

Not at the moment!

[task]: https://app.asana.com/0/1207339219333499/1208630306714664/f
[preview]: https://dev-portal-git-zsmigrate-openapi-hcp-vault-secrets-hashicorp.vercel.app
[/hcp/api-docs/vault-secrets]: https://dev-portal-git-zsmigrate-openapi-hcp-vault-secrets-hashicorp.vercel.app/hcp/api-docs/vault-secrets
[upstream /hcp/api-docs/vault-secrets]: https://developer.hashicorp.com/hcp/api-docs/vault-secrets