### PR TITLE
fix isActive bug in OpenAPI docs view v2

### DIFF
--- a/src/views/open-api-docs-view-v2/server.ts
+++ b/src/views/open-api-docs-view-v2/server.ts
@@ -234,6 +234,9 @@ export async function generateStaticProps({
 			notFound: true,
 		}
 	}
+	const targetOperationSlug = targetOperation
+		? slugifyOperationId(targetOperation.operationId)
+		: null
 
 	/**
 	 * Build links for the sidebar.
@@ -260,7 +263,7 @@ export async function generateStaticProps({
 			return {
 				text: wordBreakCamelCase(operationId),
 				href: operationUrl,
-				isActive: operationSlug === operationId,
+				isActive: operationSlug === targetOperationSlug,
 			}
 		}),
 	}))


### PR DESCRIPTION
- [Preview link][preview] 🔎

## 🗒️ What

This PR fixes a bug in OpenAPI docs view where active operation pages are not marked as active.

## 🧪 Testing

You can use the [preview], or visit these upstream PRs to confirm that the issue is fixed:
- https://github.com/hashicorp/dev-portal/pull/2631
- https://github.com/hashicorp/dev-portal/pull/2624

[preview]: https://dev-portal-git-zsfix-openapi-isactive-bug-hashicorp.vercel.app/