### PR TITLE
Fix: Remove collection

### DIFF
--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -180,8 +180,7 @@
 	"crossProductSection": {
 		"collectionSlugs": [
 			"well-architected-framework/com",
-			"consul/network-automation",
-			"cloud/networking"
+			"consul/network-automation"
 		]
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links
- [Preview link](https://dev-portal-git-nels-remove-collection-hashicorp.vercel.app/tutorials) 🔎

## 🗒️ What
The `cloud/networking` tutorial collection is being removed in [this PR](https://github.com/hashicorp/tutorials/pull/2372) but the collection is referenced on the /tutorials landing page. This results in broken builds in the tutorials PR. This PR removes the reference.
