### PR TITLE
Replace cloud/networking collection

### DIFF
--- a/src/content/tutorials-landing.json
+++ b/src/content/tutorials-landing.json
@@ -181,7 +181,7 @@
 		"collectionSlugs": [
 			"well-architected-framework/com",
 			"consul/network-automation",
-			"cloud/networking"
+			"well-architected-framework/operational-excellence"
 		]
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR is related to https://github.com/hashicorp/tutorials/pull/2372

## 🤷 Why

To deprecate the `cloud/networking` tutorial collection, all references to it must be removed. 



## 📸 Design Screenshots

On the "[Tutorials](https://developer.hashicorp.com/tutorials)" landing page:

![image](https://github.com/user-attachments/assets/709682ef-9892-48db-98cf-134e30ae3b78)

