### PR TITLE
swap latestVersionRef to demo content fix

### DIFF
--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -166,6 +166,7 @@ export function getStaticGenerationFunctions<
 		basePath: basePathForLoader,
 		enabledVersionedDocs: true,
 		navDataPrefix,
+		latestVersionRef: 'delete-me-permalink-test',
 	}
 
 	// Defining a getter here so that we can pass in remarkPlugins on a per-request basis to collect headings

--- a/src/views/docs-view/server.ts
+++ b/src/views/docs-view/server.ts
@@ -166,7 +166,13 @@ export function getStaticGenerationFunctions<
 		basePath: basePathForLoader,
 		enabledVersionedDocs: true,
 		navDataPrefix,
-		latestVersionRef: 'delete-me-permalink-test',
+	}
+
+	/**
+	 * This is a temporary shim to demo upstream content changes.
+	 */
+	if (productSlugForLoader === 'vault') {
+		loaderOptions.latestVersionRef = 'delete-me-permalink-test'
 	}
 
 	// Defining a getter here so that we can pass in remarkPlugins on a per-request basis to collect headings


### PR DESCRIPTION
> [!WARNING]
> DO NOT MERGE. This PR is meant as a tool to validate the content changes made in:
> - https://github.com/hashicorp/vault/pull/28996

## 🔗 Relevant links

- [Preview link][preview] 🔎

## 🗒️ What

Validates content changes made in https://github.com/hashicorp/vault/pull/28996 by forcing `/vault/docs` to load from a custom "version" of content uploaded from the `zs.patch-permalink-issues` branch of `hashicorp/vault`.

## 📸 Design Screenshots

| Before | After |
| - | - |
| ![swap-before](https://github.com/user-attachments/assets/a5bbf0da-f95a-4823-a3b5-06468a1ec7d4) | ![swap-after](https://github.com/user-attachments/assets/0a45a125-7fbf-4047-9385-5b134f0fcafc) |

## 🧪 Testing

- [ ] Visit the [preview], specifically [/vault/docs/commands]
    - The page should render successfully
    - Permalink items should function as expected

## 💭 Anything else?

Not at the moment

[preview]: https://dev-portal-git-zsdemo-vault-content-fix-hashicorp.vercel.app/
[/vault/docs/commands]: https://dev-portal-git-zsdemo-vault-content-fix-hashicorp.vercel.app/vault/docs/commands
