### PR TITLE
update: fedora repository installation script

### DIFF
--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -122,7 +122,7 @@
 			"label": "Fedora",
 			"commands": [
 				"sudo dnf install -y dnf-plugins-core",
-				"sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
+				"sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo",
 				"sudo dnf -y install vault"
 			],
 			"os": "linux"

--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -75,7 +75,7 @@ export const generateDefaultPackageManagers = (
 			label: 'Fedora',
 			commands: [
 				`sudo dnf install -y dnf-plugins-core`,
-				`sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo`,
+				`sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo`,
 				`sudo dnf -y install ${productSlug}`,
 			],
 			os: 'linux',
@@ -136,7 +136,7 @@ export function generateEnterprisePackageManagers(
 			label: 'Fedora',
 			commands: [
 				`sudo dnf install -y dnf-plugins-core`,
-				`sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo`,
+				`sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo`,
 				`sudo dnf -y install ${productSlug}-enterprise`,
 			],
 			os: 'linux',


### PR DESCRIPTION
Fixes an issue with the Fedora installation [as the adding repository command changed slightly in Fedora 41.](https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/#_for_fedora_41_or_later_dnf_5)

resolves #2651