### PR TITLE
feat: fetch paths from UDR all-docs-paths

### DIFF
--- a/src/lib/__tests__/docs-content-fields.test.ts
+++ b/src/lib/__tests__/docs-content-fields.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { allDocsFields } from '../sitemap/docs-content-fields'
 
-// vi.mock('../sitemap/helpers', () => ({
-// 	makeSitemapField: vi.fn((args) => args),
-// }))
-
 describe('allDocsFields', () => {
 	beforeEach(() => {
 		vi.resetAllMocks()

--- a/src/lib/__tests__/docs-content-fields.test.ts
+++ b/src/lib/__tests__/docs-content-fields.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest'
+import { allDocsFields } from '../sitemap/docs-content-fields'
+
+// vi.mock('../sitemap/helpers', () => ({
+// 	makeSitemapField: vi.fn((args) => args),
+// }))
+
+describe('allDocsFields', () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+	})
+
+	it('should fetch and return all docs fields from content API when unified-docs-sandbox is not set', async () => {
+		process.env.HASHI_ENV = 'production'
+		process.env.MKTG_CONTENT_DOCS_API = 'https://content-api.example.com'
+		const mockContentAPIDocsResult = [
+			{ path: 'doc1', created_at: '2025-01-07T18:44:51.431Z' },
+			{ path: 'doc2', created_at: '2025-01-07T18:44:51.431Z' },
+		]
+		global.fetch = vi.fn().mockResolvedValue({
+			json: vi.fn().mockResolvedValue({ result: mockContentAPIDocsResult }),
+		})
+
+		const result = await allDocsFields()
+
+		expect(fetch).toHaveBeenCalledWith(
+			'https://content-api.example.com/api/all-docs-paths'
+		)
+		expect(result).toEqual(
+			mockContentAPIDocsResult.map((page) => ({
+				loc: `https://developer.hashicorp.com/${page.path}`,
+				lastmod: page.created_at,
+				priority: 1,
+				changefreq: 'daily',
+			}))
+		)
+	})
+
+	it('should fetch and return all docs fields from both content API and UDR when unified-docs-sandbox is set', async () => {
+		process.env.HASHI_ENV = 'unified-docs-sandbox'
+		process.env.MKTG_CONTENT_DOCS_API = 'https://content-api.example.com'
+		process.env.UNIFIED_DOCS_API = 'https://udr-api.example.com'
+		__config.flags = {
+			enable_datadog: false,
+			enable_io_beta_cta: false,
+			enable_hvd_on_preview_branch: false,
+			unified_docs_migrated_repos: ['repo1', 'repo2'],
+		}
+		const mockContentAPIDocsResult = [
+			{ path: 'doc1', created_at: '2025-01-07T18:44:51.431Z' },
+			{ path: 'doc2', created_at: '2025-01-07T18:44:51.431Z' },
+		]
+		const mockUDRDocsResult = [
+			{ path: 'udr-doc1', created_at: '2025-01-07T18:44:51.431Z' },
+			{ path: 'udr-doc2', created_at: '2023-01-04' },
+		]
+		global.fetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				json: vi.fn().mockResolvedValue({ result: mockContentAPIDocsResult }),
+			})
+			.mockResolvedValueOnce({
+				json: vi.fn().mockResolvedValue({ result: mockUDRDocsResult }),
+			})
+
+		const result = await allDocsFields()
+
+		expect(fetch).toHaveBeenCalledWith(
+			'https://content-api.example.com/api/all-docs-paths?filterOut=repo1&filterOut=repo2'
+		)
+		expect(fetch).toHaveBeenCalledWith(
+			'https://udr-api.example.com/api/all-docs-paths?products=repo1&products=repo2'
+		)
+		expect(result).toEqual(
+			[...mockContentAPIDocsResult, ...mockUDRDocsResult].map((page) => ({
+				loc: `https://developer.hashicorp.com/${page.path}`,
+				lastmod: page.created_at,
+				priority: 1,
+				changefreq: 'daily',
+			}))
+		)
+	})
+})

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -6,14 +6,45 @@
 import { makeSitemapField } from './helpers'
 
 export async function allDocsFields() {
-	const getDocsPaths = await fetch(
+	const getContentAPIDocsPaths = await fetch(
 		`${process.env.MKTG_CONTENT_DOCS_API}/api/all-docs-paths`
 	)
-	const { result: docsResult } = await getDocsPaths.json()
-	return docsResult.map((page: { path: string; created_at: string }) =>
-		makeSitemapField({
-			slug: `${page.path}`,
-			lastmodDate: page.created_at,
-		})
+	const { result: contentAPIDocsResult } = await getContentAPIDocsPaths.json()
+
+	// If there are docs that have been migrated to the unified docs repo, get the paths for those docs
+	// and merge them with the paths for the docs that haven't been migrated from the content API
+	if (__config.flags?.unified_docs_migrated_repos.length > 0) {
+		const getUDRDocsPaths = await fetch(
+			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths`
+		)
+		const { result: udrDocsResult } = await getUDRDocsPaths.json()
+
+		// Filter the result from the content API to take out the duplicate paths between
+		// the content API and UDR
+		const filteredContentAPIDocsResult = contentAPIDocsResult.filter(
+			(item: { path: string; created_at: string }) => {
+				return !udrDocsResult.find(
+					(URDItem: { path: string; created_at: string }) => {
+						return URDItem.path === item.path
+					}
+				)
+			}
+		)
+
+		const allDocsData = [...filteredContentAPIDocsResult, ...udrDocsResult]
+		return allDocsData.map((page: { path: string; created_at: string }) =>
+			makeSitemapField({
+				slug: `${page.path}`,
+				lastmodDate: page.created_at,
+			})
+		)
+	}
+
+	return contentAPIDocsResult.map(
+		(page: { path: string; created_at: string }) =>
+			makeSitemapField({
+				slug: `${page.path}`,
+				lastmodDate: page.created_at,
+			})
 	)
 }

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -17,8 +17,14 @@ export async function allDocsFields() {
 		process.env.HASHI_ENV === 'unified-docs-sandbox' &&
 		__config.flags?.unified_docs_migrated_repos.length > 0
 	) {
+		const productsFilter = __config.flags.unified_docs_migrated_repos.map(
+			(repo) => {
+				return `products=${repo}`
+			}
+		)
+		const productsFilterString = productsFilter.join('&')
 		const getUDRDocsPaths = await fetch(
-			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths`
+			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths?${productsFilterString}`
 		)
 		const { result: udrDocsResult } = await getUDRDocsPaths.json()
 

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -6,41 +6,33 @@
 import { makeSitemapField } from './helpers'
 
 export async function allDocsFields() {
-	const getContentAPIDocsPaths = await fetch(
-		`${process.env.MKTG_CONTENT_DOCS_API}/api/all-docs-paths`
-	)
-	const { result: contentAPIDocsResult } = await getContentAPIDocsPaths.json()
-
 	// If there are docs that have been migrated to the unified docs repo, get the paths for those docs
 	// and merge them with the paths for the docs that haven't been migrated from the content API
 	if (
 		process.env.HASHI_ENV === 'unified-docs-sandbox' &&
 		__config.flags?.unified_docs_migrated_repos.length > 0
 	) {
-		const productsFilter = __config.flags.unified_docs_migrated_repos.map(
+		const contentAPIFilter = __config.flags.unified_docs_migrated_repos.map(
 			(repo) => {
-				return `products=${repo}`
+				return `filterOut=${repo}`
 			}
 		)
-		const productsFilterString = productsFilter.join('&')
+		const contentAPIFilterString = contentAPIFilter.join('&')
+		const getContentAPIDocsPaths = await fetch(
+			`${process.env.MKTG_CONTENT_DOCS_API}/api/all-docs-paths?${contentAPIFilterString}`
+		)
+		const { result: contentAPIDocsResult } = await getContentAPIDocsPaths.json()
+
+		const UDRFilter = __config.flags.unified_docs_migrated_repos.map((repo) => {
+			return `products=${repo}`
+		})
+		const UDRFilterString = UDRFilter.join('&')
 		const getUDRDocsPaths = await fetch(
-			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths?${productsFilterString}`
+			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths?${UDRFilterString}`
 		)
 		const { result: udrDocsResult } = await getUDRDocsPaths.json()
 
-		// Filter the result from the content API to take out the duplicate paths between
-		// the content API and UDR
-		const filteredContentAPIDocsResult = contentAPIDocsResult.filter(
-			(item: { path: string; created_at: string }) => {
-				return !udrDocsResult.find(
-					(URDItem: { path: string; created_at: string }) => {
-						return URDItem.path === item.path
-					}
-				)
-			}
-		)
-
-		const allDocsData = [...filteredContentAPIDocsResult, ...udrDocsResult]
+		const allDocsData = [...contentAPIDocsResult, ...udrDocsResult]
 		return allDocsData.map((page: { path: string; created_at: string }) =>
 			makeSitemapField({
 				slug: `${page.path}`,
@@ -48,6 +40,11 @@ export async function allDocsFields() {
 			})
 		)
 	}
+
+	const getContentAPIDocsPaths = await fetch(
+		`${process.env.MKTG_CONTENT_DOCS_API}/api/all-docs-paths`
+	)
+	const { result: contentAPIDocsResult } = await getContentAPIDocsPaths.json()
 
 	return contentAPIDocsResult.map(
 		(page: { path: string; created_at: string }) =>

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -13,7 +13,10 @@ export async function allDocsFields() {
 
 	// If there are docs that have been migrated to the unified docs repo, get the paths for those docs
 	// and merge them with the paths for the docs that haven't been migrated from the content API
-	if (__config.flags?.unified_docs_migrated_repos.length > 0) {
+	if (
+		process.env.HASHI_ENV === 'unified-docs-sandbox' &&
+		__config.flags?.unified_docs_migrated_repos.length > 0
+	) {
 		const getUDRDocsPaths = await fetch(
 			`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths`
 		)


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-featudr-all-docs-paths-hashicorp.vercel.app/server-sitemap.xml) 🔎
- [Asana task](https://app.asana.com/0/1206815131022336/1208939388171199/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This PR fetches the paths from the UDR `api/all-docs-paths` for generating the sitemap. It only does fetches these if there are migrated content repos in the config. After fetching the paths, it filters the paths from the content API that are duplicates and then merges both results together.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to [Preview link](https://dev-portal-git-leah-featudr-all-docs-paths-hashicorp.vercel.app/server-sitemap.xml)
2. Verify that there is not an entry for `https://developer.hashicorp.com/terraform` in the sitemap (Run command f with `https://developer.hashicorp.com/terraform<`)
3. Pull down this branch and run the command below. Verify that `https://developer.hashicorp.com/terraform` is in the sitemap. The UDR will return this as a path but the content API does not which is why it will only be included with the UDR results.
```
HASHI_ENV=unified-docs-sandbox npm start       
```
