### PR TITLE
feat: fetch redirects from udr for migrated repos

### DIFF
--- a/build-libs/__tests__/redirects.test.ts
+++ b/build-libs/__tests__/redirects.test.ts
@@ -263,6 +263,7 @@ describe('getRedirectsFromContentRepo', () => {
 			json: () => new Promise((resolve) => resolve(mockData)),
 			ok: true,
 		})
+		vi.stubEnv('HASHI_ENV', 'unified-docs-sandbox')
 
 		const redirects = await getRedirectsFromContentRepo(
 			'terraform-docs-common',
@@ -279,6 +280,8 @@ describe('getRedirectsFromContentRepo', () => {
 
 	it('returns empty array if there are not any redirects from UDR for a migrated repo', async () => {
 		global.fetch = vi.fn().mockResolvedValue({ ok: false })
+		vi.stubEnv('HASHI_ENV', 'unified-docs-sandbox')
+		const mockConsole = vi.spyOn(console, 'error').mockImplementation(() => {})
 
 		const redirects = await getRedirectsFromContentRepo(
 			'ptfe-releases',
@@ -291,6 +294,7 @@ describe('getRedirectsFromContentRepo', () => {
 		)
 
 		expect(redirects).toEqual([])
+		expect(mockConsole).toHaveBeenCalledOnce()
 	})
 })
 

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -64,6 +64,7 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	 * Return early if there are not any redirects found for that specific repo.
 	 */
 	if (
+		process.env.HASHI_ENV === 'unified-docs-sandbox' &&
 		config.flags?.unified_docs_migrated_repos?.find((repo) => repo === repoName)
 	) {
 		const getUDRRedirects = await fetch(
@@ -73,6 +74,9 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 			const udrRedirects = await getUDRRedirects.json()
 			return udrRedirects
 		}
+		console.error(
+			`Error fetching redirects from the unified docs repo for ${repoName}`
+		)
 		return []
 	}
 	/**


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-featudr-redirects-api-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1207899860738460/1208961563646273/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR adds support for fetching UDR redirects. It uses the app config to determine if a specific repo is migrated to UDR and if so, pulls the redirects from UDR instead of the product repo. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

To add support for UDR redirects in dev-portal

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
Existing functionality:
1. Go to [preview /terraform/cloud-docs/workspaces/creating](https://dev-portal-git-leah-featudr-redirects-api-hashicorp.vercel.app/terraform/cloud-docs/workspaces/creating)
2. Verify the link shown in the search bar is redirected to `/terraform/cloud-docs/workspaces/create`

New functionality: 
1. Run the command below and go to [local /terraform/cloud-docs/workspaces/creating](http://localhost:3000/terraform/cloud-docs/workspaces/creating)
```
HASHI_ENV="unified-docs-sandbox" npm start
```
2. Verify the link shown in the search bar is redirected to `/terraform/cloud-docs/workspaces/create`

