### PR TITLE
Remove 'start' button from unordered collection

### DIFF
--- a/src/components/collection-progress-group/components/collection-progress-status-section/collection-progress-status-section.module.css
+++ b/src/components/collection-progress-group/components/collection-progress-status-section/collection-progress-status-section.module.css
@@ -10,6 +10,10 @@
 	display: flex;
 	gap: 8px;
 	width: 100%;
+
+	/* Height of the button link component */
+	padding-top: 5px;
+	padding-bottom: 5px;
 }
 
 .statusSectionWithBorder {

--- a/src/components/collection-progress-group/docs.mdx
+++ b/src/components/collection-progress-group/docs.mdx
@@ -4,7 +4,7 @@ componentName: 'CollectionProgressGroup'
 
 The `CollectionProgressGroup` component queries, parses, and displays collection progress information.
 
-It renders a `ButtonLink` to the "next tutorial" in the collection, as well as a `CollcetionProgressStatusSection`. The `CollectionProgressStatusSection` presents queried and parsed data. It can be used separately from `CollectionProgressGroup`.
+It renders a `ButtonLink` to the "next tutorial" in the collection, as well as a `CollectionProgressStatusSection`. The `CollectionProgressStatusSection` presents queried and parsed data. It can be used separately from `CollectionProgressGroup`.
 
 The examples below use `ButtonLink` and `CollectionProgressStatusSection`, which are the presentational components of `CollectionProgressGroup`.
 

--- a/src/components/collection-progress-group/index.tsx
+++ b/src/components/collection-progress-group/index.tsx
@@ -15,7 +15,7 @@ import s from './collection-progress-group.module.css'
  * Displays collection progress status and CTA.
  */
 function CollectionProgressGroup({ collection }: { collection: Collection }) {
-	const { id, slug, tutorials } = collection
+	const { id, slug, tutorials, ordered } = collection
 
 	/**
 	 * Get collection progress, which affects the
@@ -61,11 +61,13 @@ function CollectionProgressGroup({ collection }: { collection: Collection }) {
 
 	return (
 		<div className={s.root}>
-			<ButtonLink
-				aria-label={tutorialCta.ariaLabel}
-				href={tutorialCta.href}
-				text={tutorialCta.text}
-			/>
+			{ordered && (
+				<ButtonLink
+					aria-label={tutorialCta.ariaLabel}
+					href={tutorialCta.href}
+					text={tutorialCta.text}
+				/>
+			)}
 			<CollectionProgressStatusSection
 				completedTutorialCount={completedTutorialCount}
 				tutorialCount={tutorialCount}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1208777238149723/1208951572065294/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The start button puts the user in the first tutorial listed in the collection, which is relevant to ordered collections, so we want to keep it in all ordered collections. Unordered collections are arranged in rows of tutorials, to be completed in any order, so the start button is irrelevant since the user does not need to start with the first tutorial. We will remove it in all unordered collections.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

Removed "Start" button from unordered collection, updated style so `CollectionProgressStatusSection` doesn't look funky (it looks slightly more condensed).

Before:
![image](https://github.com/user-attachments/assets/886d38c7-b367-4173-9243-69ca63dff2bd)

After (no style change):
![image](https://github.com/user-attachments/assets/04a59dee-7a4b-4d8c-aab7-817932b31883)

After:
![image](https://github.com/user-attachments/assets/ec8ba2c9-1741-4c06-adaa-e9ca336eeaf3)
![image](https://github.com/user-attachments/assets/522f5812-1a9e-44d0-958d-1bdf5317c2b6)


## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
