### PR TITLE
Add `validated-patterns` content

### DIFF
--- a/scripts/content-repo-preview/builders/developer.ts
+++ b/scripts/content-repo-preview/builders/developer.ts
@@ -30,9 +30,13 @@ export function DeveloperPreviewBuilder(product) {
 			/**
 			 * Remove specific page files to speed up preview builds:
 			 * - /src/pages/well-architected-framework
+			 * - /src/pages/validated-patterns
 			 */
 			const pagesDir = path.join(cwd, 'src', 'pages')
-			const pagesDirsToRemove = ['well-architected-framework']
+			const pagesDirsToRemove = [
+				'well-architected-framework',
+				'validated-patterns',
+			]
 
 			/**
 			 * Remove validated designs paths from docs previews

--- a/scripts/generate-tutorial-variant-map.ts
+++ b/scripts/generate-tutorial-variant-map.ts
@@ -64,7 +64,10 @@ async function getVariantRewrites() {
 			const [product, collectionFilename] = collection.slug.split('/')
 			let path = `/${product}/tutorials/${collectionFilename}/${tutorialFilename}`
 
-			if (product === 'well-architected-framework') {
+			if (
+				product === 'well-architected-framework' ||
+				product === 'validated-patterns'
+			) {
 				path = `/${product}/${collectionFilename}/${tutorialFilename}`
 			}
 

--- a/src/components/branded-card/index.tsx
+++ b/src/components/branded-card/index.tsx
@@ -21,7 +21,7 @@ import patternWaypoint from './img/waypoint.png'
 import s from './branded-card.module.css'
 
 const PATTERN_IMG_MAP: Record<
-	Exclude<ProductSlug, 'well-architected-framework'>,
+	Exclude<ProductSlug, 'well-architected-framework' | 'validated-patterns'>,
 	StaticImageData
 > = {
 	boundary: patternBoundary,

--- a/src/components/command-bar/commands/search/helpers/generate-suggested-pages.tsx
+++ b/src/components/command-bar/commands/search/helpers/generate-suggested-pages.tsx
@@ -87,7 +87,10 @@ const generateBasicSuggestedPages = (productSlug: ProductSlug) => {
  * link to the Tutorials Library.
  */
 const EXTRA_PAGES: Record<
-	Exclude<ProductSlug, 'sentinel' | 'well-architected-framework'>,
+	Exclude<
+		ProductSlug,
+		'sentinel' | 'well-architected-framework' | 'validated-patterns'
+	>,
 	SuggestedPageProps[]
 > = {
 	boundary: [

--- a/src/components/sidebar/helpers/add-nav-item-meta-data.ts
+++ b/src/components/sidebar/helpers/add-nav-item-meta-data.ts
@@ -83,7 +83,6 @@ export const addNavItemMetaData = (
 			 * This should be in place until all nav data content (including past
 			 * versions) no longer contains `<sup>` tags in `title`s.
 			 */
-			console.log('item', item)
 			if (item.hasOwnProperty('title')) {
 				const itemWithTitle = item as
 					| EnrichedSubmenuNavItem

--- a/src/components/sidebar/helpers/add-nav-item-meta-data.ts
+++ b/src/components/sidebar/helpers/add-nav-item-meta-data.ts
@@ -83,6 +83,7 @@ export const addNavItemMetaData = (
 			 * This should be in place until all nav data content (including past
 			 * versions) no longer contains `<sup>` tags in `title`s.
 			 */
+			console.log('item', item)
 			if (item.hasOwnProperty('title')) {
 				const itemWithTitle = item as
 					| EnrichedSubmenuNavItem

--- a/src/components/sidebar/helpers/generate-resources-nav-items.ts
+++ b/src/components/sidebar/helpers/generate-resources-nav-items.ts
@@ -30,7 +30,10 @@ const DEFAULT_GITHUB_LINK = 'https://github.com/hashicorp'
 const DEFAULT_SUPPORT_LINK = 'https://www.hashicorp.com/customer-success'
 
 const COMMUNITY_LINKS_BY_PRODUCT: {
-	[key in Exclude<ProductSlug, 'well-architected-framework'>]: string
+	[key in Exclude<
+		ProductSlug,
+		'well-architected-framework' | 'validated-patterns'
+	>]: string
 } = {
 	boundary: 'https://discuss.hashicorp.com/c/boundary/50',
 	consul: 'https://discuss.hashicorp.com/c/consul/29',
@@ -47,7 +50,7 @@ const COMMUNITY_LINKS_BY_PRODUCT: {
 const GITHUB_LINKS_BY_PRODUCT_SLUG: {
 	[key in Exclude<
 		ProductSlug,
-		'waypoint' | 'well-architected-framework'
+		'waypoint' | 'well-architected-framework' | 'validated-patterns'
 	>]: string
 } = {
 	boundary: 'https://github.com/hashicorp/boundary',

--- a/src/components/try-hcp-callout/content.ts
+++ b/src/components/try-hcp-callout/content.ts
@@ -19,7 +19,10 @@ export function hasHcpCalloutContent(s: string): s is ProductSlugWithContent {
 }
 
 export const tryHcpCalloutContent: Record<
-	Exclude<ProductSlugWithContent, 'well-architected-framework'>,
+	Exclude<
+		ProductSlugWithContent,
+		'well-architected-framework' | 'validated-patterns'
+	>,
 	HcpCalloutContent
 > = {
 	terraform: {

--- a/src/content/validated-patterns/index.json
+++ b/src/content/validated-patterns/index.json
@@ -2,11 +2,11 @@
 	"sidebarCategories": [],
 	"landingPage": {
 		"hero": {
-			"heading": "Validated Patterns",
+			"heading": "Validated Patterns"
 		},
 		"overview": {
 			"heading": "What are Validated Patterns?",
-			"body": "HashiCorp Validated Patterns provide prescriptive guidance on integrating HashiCorp and partner technologies.",
+			"body": "HashiCorp Validated Patterns provide prescriptive guidance on integrating HashiCorp and partner technologies."
 		}
 	}
 }

--- a/src/content/validated-patterns/index.json
+++ b/src/content/validated-patterns/index.json
@@ -1,0 +1,17 @@
+{
+	"sidebarCategories": [],
+	"landingPage": {
+		"hero": {
+			"heading": "Validated Patterns",
+			"image": "/img/well-architected-framework/landing-hero-graphic.png"
+		},
+		"overview": {
+			"heading": "What are Validated Patterns?",
+			"body": "HashiCorp Validated Patterns provide prescriptive guidance on integrating HashiCorp and partner technologies.",
+			"image": {
+				"light": "https://www.datocms-assets.com/2885/1679095265-devdot-waf_lm.png",
+				"dark": "https://www.datocms-assets.com/2885/1679087810-devdot-waf_dm.png"
+			}
+		}
+	}
+}

--- a/src/content/validated-patterns/index.json
+++ b/src/content/validated-patterns/index.json
@@ -3,15 +3,10 @@
 	"landingPage": {
 		"hero": {
 			"heading": "Validated Patterns",
-			"image": "/img/well-architected-framework/landing-hero-graphic.png"
 		},
 		"overview": {
 			"heading": "What are Validated Patterns?",
 			"body": "HashiCorp Validated Patterns provide prescriptive guidance on integrating HashiCorp and partner technologies.",
-			"image": {
-				"light": "https://www.datocms-assets.com/2885/1679095265-devdot-waf_lm.png",
-				"dark": "https://www.datocms-assets.com/2885/1679087810-devdot-waf_dm.png"
-			}
 		}
 	}
 }

--- a/src/data/validated-patterns.json
+++ b/src/data/validated-patterns.json
@@ -1,0 +1,4 @@
+{
+	"slug": "validated-patterns",
+	"name": "Validated Patterns"
+}

--- a/src/lib/learn-client/api/page/index.ts
+++ b/src/lib/learn-client/api/page/index.ts
@@ -31,7 +31,7 @@ export type PageSlugOption =
 	| ProductOption
 	| ThemeOption.cloud
 	| 'well-architected-framework'
-
+	| 'validated-patterns'
 export async function getPage(
 	slug: PageSlugOption
 ): Promise<ClientProductPage> {

--- a/src/lib/learn-client/schemas.ts
+++ b/src/lib/learn-client/schemas.ts
@@ -88,7 +88,8 @@ export const ProductPageSchema = Joi.object({
 		.valid(
 			...Object.values(ProductOption),
 			ThemeOption.cloud,
-			'well-architected-framework'
+			'well-architected-framework',
+			'validated-patterns'
 		)
 		.required(),
 	pageData: Joi.object({

--- a/src/lib/learn-client/types.ts
+++ b/src/lib/learn-client/types.ts
@@ -231,6 +231,7 @@ export enum ProductOption {
 
 export enum SectionOption {
 	'well-architected-framework' = 'well-architected-framework',
+	'validated-patterns' = 'validated-patterns',
 }
 
 export enum EditionOption {

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -78,7 +78,10 @@ import {
  * could use to simplify our setup... It feels a bit convoluted right now.
  */
 const productSlugsToNames: {
-	[slug in Exclude<ProductSlug, 'well-architected-framework'>]: ProductName
+	[slug in Exclude<
+		ProductSlug,
+		'well-architected-framework' | 'validated-patterns'
+	>]: ProductName
 } = {
 	hcp: 'HashiCorp Cloud Platform',
 	terraform: 'Terraform',
@@ -96,7 +99,10 @@ const productSlugsToNames: {
  * A map of product slugs to their "dot io" site hostname.
  */
 const productSlugsToHostNames: {
-	[slug in Exclude<ProductSlug, 'well-architected-framework'>]: string
+	[slug in Exclude<
+		ProductSlug,
+		'well-architected-framework' | 'validated-patterns'
+	>]: string
 } = {
 	boundary: 'boundaryproject.io',
 	consul: 'consul.io',

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/get-is-external-learn-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/get-is-external-learn-link.test.ts
@@ -49,6 +49,7 @@ describe('getIsExternalLearnLink', () => {
 			['/vault', true],
 			['/waypoint', true],
 			['/well-architected-framework', true],
+			['/validated-patterns', true],
 			['/cloud', true],
 		])
 	})
@@ -70,6 +71,7 @@ describe('getIsExternalLearnLink', () => {
 			['/collections/vault/collection-slug', true],
 			['/collections/waypoint/collection-slug', true],
 			['/collections/well-architected-framework/collection-slug', true],
+			['/collections/validated-patterns/collection-slug', true],
 			['/collections/cloud/collection-slug', true],
 		])
 	})
@@ -91,6 +93,7 @@ describe('getIsExternalLearnLink', () => {
 			['/tutorials/vault/tutorial-slug', true],
 			['/tutorials/waypoint/tutorial-slug', true],
 			['/tutorials/well-architected-framework/tutorial-slug', true],
+			['/tutorials/validated-patterns/tutorial-slug', true],
 			['/tutorials/cloud/tutorial-slug', true],
 		]
 
@@ -114,6 +117,8 @@ describe('getIsExternalLearnLink', () => {
 			['/waypoint/tutorials/collection-slug/tutorial-slug', false],
 			['/well-architected-framework/collection-slug', false],
 			['/well-architected-framework/collection-slug/tutorial-slug', false],
+			['/validated-patterns/collection-slug', false],
+			['/validated-patterns/collection-slug/tutorial-slug', false],
 
 			['/hcp/tutorials/collection-slug', false],
 			['/hcp/tutorials/collection-slug/tutorial-slug', false],

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-collection-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-collection-link.test.ts
@@ -55,6 +55,10 @@ describe('rewriteExternalCollectionLink', () => {
 				'/collections/well-architected-framework/com',
 				'/well-architected-framework/com',
 			],
+			[
+				'/collections/validated-patterns/PLACEHOLDER',
+				'/validated-patterns/PLACEHOLDER',
+			],
 			['/collections/cloud/networking', '/hcp/tutorials/networking'],
 			['/collections/hcp/networking', '/hcp/tutorials/networking'],
 		])
@@ -77,6 +81,10 @@ describe('rewriteExternalCollectionLink', () => {
 			[
 				'/collections/well-architected-framework/com?paramA=valueA',
 				'/well-architected-framework/com?paramA=valueA',
+			],
+			[
+				'/collections/validated-patterns/PLACEHOLDER?paramA=valueA',
+				'/validated-patterns/PLACEHOLDER?paramA=valueA',
 			],
 			[
 				'/collections/cloud/networking?paramA=valueA',
@@ -108,6 +116,10 @@ describe('rewriteExternalCollectionLink', () => {
 				'/well-architected-framework/com#test-hash',
 			],
 			[
+				'/collections/validated-patterns/PLACEHOLDER#test-hash',
+				'/validated-patterns/PLACEHOLDER#test-hash',
+			],
+			[
 				'/collections/cloud/networking#test-hash',
 				'/hcp/tutorials/networking#test-hash',
 			],
@@ -135,6 +147,10 @@ describe('rewriteExternalCollectionLink', () => {
 			[
 				'/collections/well-architected-framework/com?paramA=valueA#test-hash',
 				'/well-architected-framework/com?paramA=valueA#test-hash',
+			],
+			[
+				'/collections/validated-patterns/PLACEHOLDER?paramA=valueA#test-hash',
+				'/validated-patterns/PLACEHOLDER?paramA=valueA#test-hash',
 			],
 			[
 				'/collections/cloud/networking?paramA=valueA#test-hash',

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-collection-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-collection-link.test.ts
@@ -55,10 +55,7 @@ describe('rewriteExternalCollectionLink', () => {
 				'/collections/well-architected-framework/com',
 				'/well-architected-framework/com',
 			],
-			[
-				'/collections/validated-patterns/PLACEHOLDER',
-				'/validated-patterns/PLACEHOLDER',
-			],
+			['/collections/validated-patterns/nomad', '/validated-patterns/nomad'],
 			['/collections/cloud/networking', '/hcp/tutorials/networking'],
 			['/collections/hcp/networking', '/hcp/tutorials/networking'],
 		])
@@ -83,8 +80,8 @@ describe('rewriteExternalCollectionLink', () => {
 				'/well-architected-framework/com?paramA=valueA',
 			],
 			[
-				'/collections/validated-patterns/PLACEHOLDER?paramA=valueA',
-				'/validated-patterns/PLACEHOLDER?paramA=valueA',
+				'/collections/validated-patterns/nomad?paramA=valueA',
+				'/validated-patterns/nomad?paramA=valueA',
 			],
 			[
 				'/collections/cloud/networking?paramA=valueA',
@@ -116,8 +113,8 @@ describe('rewriteExternalCollectionLink', () => {
 				'/well-architected-framework/com#test-hash',
 			],
 			[
-				'/collections/validated-patterns/PLACEHOLDER#test-hash',
-				'/validated-patterns/PLACEHOLDER#test-hash',
+				'/collections/validated-patterns/nomad#test-hash',
+				'/validated-patterns/nomad#test-hash',
 			],
 			[
 				'/collections/cloud/networking#test-hash',
@@ -149,8 +146,8 @@ describe('rewriteExternalCollectionLink', () => {
 				'/well-architected-framework/com?paramA=valueA#test-hash',
 			],
 			[
-				'/collections/validated-patterns/PLACEHOLDER?paramA=valueA#test-hash',
-				'/validated-patterns/PLACEHOLDER?paramA=valueA#test-hash',
+				'/collections/validated-patterns/nomad?paramA=valueA#test-hash',
+				'/validated-patterns/nomad?paramA=valueA#test-hash',
 			],
 			[
 				'/collections/cloud/networking?paramA=valueA#test-hash',

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-tutorial-link.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-external-tutorial-link.test.ts
@@ -12,6 +12,7 @@ const MOCK_TUTORIAL_MAP = {
 	'cloud/amazon-peering-hcp': '/hcp/tutorials/networking/amazon-peering-hcp',
 	'well-architected-framework/tutorial':
 		'/well-architected-framework/collection/tutorial',
+	'validated-patterns/tutorial': '/validated-patterns/collection/tutorial',
 }
 
 const testEachCase = (cases: string[][]) => {
@@ -56,6 +57,10 @@ describe('rewriteExternalTutorialLink', () => {
 			[
 				'/tutorials/well-architected-framework/tutorial',
 				MOCK_TUTORIAL_MAP['well-architected-framework/tutorial'],
+			],
+			[
+				'/tutorials/validated-patterns/tutorial',
+				MOCK_TUTORIAL_MAP['validated-patterns/tutorial'],
 			],
 			['/tutorials/not-a-beta-product/tutorial', undefined],
 			['/tutorials/vault/tutorial-does-not-exist', undefined],

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -6,6 +6,7 @@
 import remark from 'remark'
 import { rewriteTutorialLinksPlugin } from 'lib/remark-plugins/rewrite-tutorial-links'
 import { productSlugs, productSlugsToHostNames } from 'lib/products'
+import path from 'path'
 
 // HELPERS ------------------------------------------------------
 
@@ -66,7 +67,9 @@ const TEST_MD_LINKS = {
 	productDocsLinkUseCases:
 		'[link to vault use cases](https://www.vaultproject.io/use-cases)',
 	wafTutorialLink:
-		'[waf link](/tutorials/well-architected-framework/cloud-operating-model)',
+		'[link to waf](/tutorials/well-architected-framework/cloud-operating-model)',
+	validatedPatternsTutorialLink:
+		'[link to validated patterns](/tutorials/validated-patterns/PLACEHOLDER)',
 }
 
 /**
@@ -83,6 +86,7 @@ const MOCK_TUTORIALS_MAP = {
 	'waypoint/get-started': '/waypoint/tutorials/get-started-docker/get-started',
 	'well-architected-framework/cloud-operating-model':
 		'/well-architected-framework/com/cloud-operating-model',
+	'validated-patterns/PLACEHOLDER': '/validated-patterns/PLACEHOLDER',
 	'cloud/get-started-vault': '/vault/tutorials/cloud/get-started-vault',
 }
 
@@ -328,5 +332,14 @@ describe('rewriteTutorialLinks remark plugin', () => {
 		expect(newPath).toBe(
 			'/well-architected-framework/com/cloud-operating-model'
 		)
+	})
+
+	test('Validated patterns tutorial link should be rewritten properly', async () => {
+		const contents = await remark()
+			.use(rewriteTutorialLinksPlugin, { tutorialMap: MOCK_TUTORIALS_MAP })
+			.process(TEST_MD_LINKS.validatedPatternsTutorialLink)
+
+		const newPath = isolatePathFromMarkdown(String(contents))
+		expect(newPath).toBe('/validated-patterns/PLACEHOLDER')
 	})
 })

--- a/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
+++ b/src/lib/remark-plugins/rewrite-tutorial-links/__tests__/rewrite-tutorial-links.test.ts
@@ -69,7 +69,7 @@ const TEST_MD_LINKS = {
 	wafTutorialLink:
 		'[link to waf](/tutorials/well-architected-framework/cloud-operating-model)',
 	validatedPatternsTutorialLink:
-		'[link to validated patterns](/tutorials/validated-patterns/PLACEHOLDER)',
+		'[link to validated patterns](/tutorials/validated-patterns/workload-modernization-with-traefik)',
 }
 
 /**
@@ -86,7 +86,8 @@ const MOCK_TUTORIALS_MAP = {
 	'waypoint/get-started': '/waypoint/tutorials/get-started-docker/get-started',
 	'well-architected-framework/cloud-operating-model':
 		'/well-architected-framework/com/cloud-operating-model',
-	'validated-patterns/PLACEHOLDER': '/validated-patterns/PLACEHOLDER',
+	'validated-patterns/workload-modernization-with-traefik':
+		'/validated-patterns/nomad/workload-modernization-with-traefik',
 	'cloud/get-started-vault': '/vault/tutorials/cloud/get-started-vault',
 }
 
@@ -340,6 +341,8 @@ describe('rewriteTutorialLinks remark plugin', () => {
 			.process(TEST_MD_LINKS.validatedPatternsTutorialLink)
 
 		const newPath = isolatePathFromMarkdown(String(contents))
-		expect(newPath).toBe('/validated-patterns/PLACEHOLDER')
+		expect(newPath).toBe(
+			'/validated-patterns/nomad/workload-modernization-with-traefik'
+		)
 	})
 })

--- a/src/pages/validated-patterns/[...tutorialSlug]/index.tsx
+++ b/src/pages/validated-patterns/[...tutorialSlug]/index.tsx
@@ -21,6 +21,7 @@ export async function getStaticProps({
 }: GetStaticPropsContext<{ tutorialSlug: [string, string] }>): Promise<
 	{ props: ValidatedPatternsTutorialViewProps } | { notFound: boolean }
 > {
+	return { notFound: true }
 	const props = await getValidatedPatternsTutorialViewProps(params.tutorialSlug)
 
 	// If the tutorial doesn't exist, hit the 404

--- a/src/pages/validated-patterns/[...tutorialSlug]/index.tsx
+++ b/src/pages/validated-patterns/[...tutorialSlug]/index.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { getCollectionsBySection } from 'lib/learn-client/api/collection'
+import {
+	Collection as ApiCollection,
+	TutorialLite as ApiTutorialLite,
+} from 'lib/learn-client/types'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import ValidatedPatternsTutorialView from 'views/validated-patterns/tutorial-view'
+import { getValidatedPatternsTutorialViewProps } from 'views/validated-patterns/tutorial-view/server'
+import validatedPatternsData from 'data/validated-patterns.json'
+import { ValidatedPatternsTutorialViewProps } from 'views/validated-patterns/types'
+import { GetStaticPropsContext } from 'next'
+import { getStaticPathsFromAnalytics } from 'lib/get-static-paths-from-analytics'
+
+export async function getStaticProps({
+	params,
+}: GetStaticPropsContext<{ tutorialSlug: [string, string] }>): Promise<
+	{ props: ValidatedPatternsTutorialViewProps } | { notFound: boolean }
+> {
+	const props = await getValidatedPatternsTutorialViewProps(params.tutorialSlug)
+
+	// If the tutorial doesn't exist, hit the 404
+	if (!props) {
+		return { notFound: true }
+	}
+	return props
+}
+
+export async function getStaticPaths() {
+	const allCollections = await getCollectionsBySection(validatedPatternsData.slug)
+	let paths = []
+	allCollections.forEach((c: ApiCollection) => {
+		const collectionSlug = splitProductFromFilename(c.slug)
+		c.tutorials.forEach(({ slug }: { slug: ApiTutorialLite['slug'] }) =>
+			paths.push({
+				params: {
+					tutorialSlug: [collectionSlug, splitProductFromFilename(slug)],
+				},
+			})
+		)
+	})
+
+	// For hashicorp/tutorials PR previews, skip the call to determine paths
+	// from analytics, and statically build all paths.
+	if (process.env.HASHI_ENV === 'tutorials-preview') {
+		return {
+			paths: paths,
+			fallback: false,
+		}
+	}
+
+	try {
+		paths = await getStaticPathsFromAnalytics({
+			param: 'tutorialSlug',
+			limit: __config.learn.max_static_paths ?? 0,
+			pathPrefix: `/validated-patterns`,
+			validPaths: paths,
+		})
+	} catch {
+		// In the case of an error, fallback to using the base list of generated paths to ensure we do _some_ form of static generation
+		paths = paths.slice(0, __config.learn.max_static_paths ?? 0)
+	}
+
+	return { paths, fallback: 'blocking' }
+}
+
+export default ValidatedPatternsTutorialView

--- a/src/pages/validated-patterns/[collectionSlug].tsx
+++ b/src/pages/validated-patterns/[collectionSlug].tsx
@@ -16,9 +16,10 @@ import validatedPatternsData from 'data/validated-patterns.json'
 
 export async function getStaticProps({
 	params,
-}: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
-	props: ValidatedPatternsCollectionViewProps
-}> {
+}: GetStaticPropsContext<{ collectionSlug: string }>): Promise<
+	{ props: ValidatedPatternsCollectionViewProps } | { notFound: boolean }
+> {
+	return { notFound: true }
 	const allValidatedPatternsCollections = await getCollectionsBySection(
 		validatedPatternsData.slug
 	)

--- a/src/pages/validated-patterns/[collectionSlug].tsx
+++ b/src/pages/validated-patterns/[collectionSlug].tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { GetStaticPropsContext } from 'next'
+import { getCollectionsBySection } from 'lib/learn-client/api/collection'
+import { Collection as ApiCollection } from 'lib/learn-client/types'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import { buildCategorizedValidatedPatternsSidebar } from 'views/validated-patterns/utils/generate-sidebar-items'
+import ValidatedPatternsCollectionView from 'views/validated-patterns/collection-view'
+import { ValidatedPatternsCollectionViewProps } from 'views/validated-patterns/types'
+import validatedPatternsContent from 'content/validated-patterns/index.json'
+import validatedPatternsData from 'data/validated-patterns.json'
+
+export async function getStaticProps({
+	params,
+}: GetStaticPropsContext<{ collectionSlug: string }>): Promise<{
+	props: ValidatedPatternsCollectionViewProps
+}> {
+	const allValidatedPatternsCollections = await getCollectionsBySection(
+		validatedPatternsData.slug
+	)
+	const currentCollection = allValidatedPatternsCollections.find(
+		(collection: ApiCollection) =>
+			collection.slug ===
+			`${validatedPatternsData.slug}/${params.collectionSlug}`
+	)
+	const sidebarSections = buildCategorizedValidatedPatternsSidebar(
+		allValidatedPatternsCollections,
+		validatedPatternsContent.sidebarCategories,
+		currentCollection.slug
+	)
+	const breadcrumbLinks = [
+		{ title: 'Developer', url: '/' },
+		{
+			title: validatedPatternsData.name,
+			url: `/${validatedPatternsData.slug}`,
+		},
+		{
+			title: currentCollection.name,
+			url: `/${currentCollection.slug}`,
+			isCurrentPage: true,
+		},
+	]
+
+	return {
+		props: stripUndefinedProperties({
+			metadata: {
+				title: currentCollection.name,
+				validatedPatternsName: validatedPatternsData.name,
+				validatedPatternsSlug: validatedPatternsData.slug,
+			},
+			collection: currentCollection,
+			layoutProps: {
+				sidebarSections,
+				breadcrumbLinks,
+			},
+		}),
+	}
+}
+
+export async function getStaticPaths() {
+	const allCollections = await getCollectionsBySection(
+		validatedPatternsData.slug
+	)
+	const paths = allCollections.map((c: ApiCollection) => ({
+		params: { collectionSlug: splitProductFromFilename(c.slug) },
+	}))
+
+	return {
+		paths: paths.slice(0, __config.learn.max_static_paths ?? 0),
+		fallback: 'blocking',
+	}
+}
+
+export default ValidatedPatternsCollectionView

--- a/src/pages/validated-patterns/index.tsx
+++ b/src/pages/validated-patterns/index.tsx
@@ -16,9 +16,10 @@ import getProcessedPageData from 'views/product-tutorials-view/helpers/page-data
 import { TableOfContentsHeading } from 'components/table-of-contents'
 import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items-from-headings'
 
-export async function getStaticProps(): Promise<{
-	props: ValidatedPatternsLandingProps
-}> {
+export async function getStaticProps(): Promise<
+	{ props: ValidatedPatternsLandingProps } | { notFound: boolean }
+> {
+	return { notFound: true }
 	const { pageData, headings: pageHeadings } = await getProcessedPageData(
 		validatedPatternsData.slug as PageSlugOption,
 		{ showOverviewHeading: false }

--- a/src/pages/validated-patterns/index.tsx
+++ b/src/pages/validated-patterns/index.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import slugify from 'slugify'
+import { getCollectionsBySection } from 'lib/learn-client/api/collection'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { PageSlugOption } from 'lib/learn-client/api/page'
+import ValidatedPatternsLandingView from 'views/validated-patterns'
+import { buildCategorizedValidatedPatternsSidebar } from 'views/validated-patterns/utils/generate-sidebar-items'
+import { ValidatedPatternsLandingProps } from 'views/validated-patterns/types'
+import rawValidatedPatternsContent from 'content/validated-patterns/index.json'
+import validatedPatternsData from 'data/validated-patterns.json'
+import getProcessedPageData from 'views/product-tutorials-view/helpers/page-data'
+import { TableOfContentsHeading } from 'components/table-of-contents'
+import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items-from-headings'
+
+export async function getStaticProps(): Promise<{
+	props: ValidatedPatternsLandingProps
+}> {
+	const { pageData, headings: pageHeadings } = await getProcessedPageData(
+		validatedPatternsData.slug as PageSlugOption,
+		{ showOverviewHeading: false }
+	)
+	const validatedPatternsCollections = await getCollectionsBySection(
+		validatedPatternsData.slug
+	)
+
+	/**
+	 * Build and add the slug for the overview heading
+	 */
+	const validatedPatternsContent = {
+		...rawValidatedPatternsContent,
+		landingPage: {
+			...rawValidatedPatternsContent.landingPage,
+			overview: {
+				...rawValidatedPatternsContent.landingPage.overview,
+				headingSlug: slugify(
+					rawValidatedPatternsContent.landingPage.overview.heading,
+					{
+						lower: true,
+					}
+				),
+			},
+		},
+	}
+
+	const headings: TableOfContentsHeading[] = [
+		{
+			title: validatedPatternsContent.landingPage.overview.heading,
+			level: 2,
+			slug: validatedPatternsContent.landingPage.overview.headingSlug,
+		},
+		...pageHeadings,
+	]
+	const breadcrumbLinks = [
+		{ title: 'Developer', url: '/' },
+		{
+			title: validatedPatternsData.name,
+			url: `/${validatedPatternsData.slug}`,
+			isCurrentPage: true,
+		},
+	]
+
+	return {
+		props: stripUndefinedProperties({
+			metadata: {
+				title: validatedPatternsData.name,
+				name: validatedPatternsData.name,
+				slug: validatedPatternsData.slug,
+			},
+			data: {
+				pageData,
+				validatedPatternsContent: validatedPatternsContent.landingPage,
+			},
+			outlineItems: outlineItemsFromHeadings(headings),
+			layoutProps: {
+				breadcrumbLinks,
+				sidebarSections: buildCategorizedValidatedPatternsSidebar(
+					validatedPatternsCollections,
+					validatedPatternsContent.sidebarCategories
+				),
+			},
+		}),
+	}
+}
+
+export default ValidatedPatternsLandingView

--- a/src/views/collection-view/helpers/get-slug.ts
+++ b/src/views/collection-view/helpers/get-slug.ts
@@ -23,7 +23,10 @@ export function getTutorialSlug(
 	const tutorialFilename = splitProductFromFilename(tutorialDbSlug)
 
 	// @TODO genericize this to use 'topic' or 'section' instead of 'product'
-	if (rawProductSlug === 'well-architected-framework') {
+	if (
+		rawProductSlug === 'well-architected-framework' ||
+		rawProductSlug === 'validated-patterns'
+	) {
 		return `/${collectionDbSlug}/${tutorialFilename}`
 	}
 
@@ -36,7 +39,10 @@ export function getCollectionSlug(collectionDbSlug: string): string {
 	const [rawProductSlug, collectionFilename] = collectionDbSlug.split('/')
 
 	// @TODO genericize this to use 'topic' or 'section' instead of 'product'
-	if (rawProductSlug === 'well-architected-framework') {
+	if (
+		rawProductSlug === 'well-architected-framework' ||
+		rawProductSlug === 'validated-patterns'
+	) {
 		return `/${collectionDbSlug}`
 	}
 

--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -44,6 +44,10 @@ describe('rewriteDocsUrl', () => {
 				expected:
 					'/well-architected-framework/operational-excellence/operational-excellence-workspaces-projects',
 			},
+			{
+				input: '/validated-patterns/COLLECTION-SLUG/PLACEHOLDER',
+				expected: '/validated-patterns/COLLECTION-SLUG/PLACEHOLDER',
+			},
 			// special case for non devdot 'waf' link
 			{
 				input: 'https://aws.amazon.com/architecture/well-architected/',

--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -45,8 +45,9 @@ describe('rewriteDocsUrl', () => {
 					'/well-architected-framework/operational-excellence/operational-excellence-workspaces-projects',
 			},
 			{
-				input: '/validated-patterns/COLLECTION-SLUG/PLACEHOLDER',
-				expected: '/validated-patterns/COLLECTION-SLUG/PLACEHOLDER',
+				input: '/validated-patterns/nomad/workload-modernization-with-traefik',
+				expected:
+					'/validated-patterns/nomad/workload-modernization-with-traefik',
 			},
 			// special case for non devdot 'waf' link
 			{

--- a/src/views/docs-view/utils/get-docs-mdx-components.ts
+++ b/src/views/docs-view/utils/get-docs-mdx-components.ts
@@ -48,7 +48,7 @@ const HCPCallout = dynamic(
 )
 
 const productsToPrimitives: Record<
-	Exclude<ProductSlug, 'well-architected-framework'>,
+	Exclude<ProductSlug, 'well-architected-framework' | 'validated-patterns'>,
 	Record<string, ComponentType>
 > = {
 	boundary: null,

--- a/src/views/docs-view/utils/product-url-adjusters.ts
+++ b/src/views/docs-view/utils/product-url-adjusters.ts
@@ -127,9 +127,11 @@ export function rewriteDocsUrl(
 	)
 	const isProductPath = new RegExp(`^/(${productSlugs.join('|')})`)
 	const isTutorialsPath = new RegExp(
-		`^/(${[...productSlugs, SectionOption['well-architected-framework']].join(
-			'|'
-		)}(/tutorials)?)`
+		`^/(${[
+			...productSlugs,
+			SectionOption['well-architected-framework'],
+			SectionOption['validated-patterns'],
+		].join('|')}(/tutorials)?)`
 	)
 
 	if (isCurrentProductDocsUrl) {

--- a/src/views/product-landing/components/hero-heading-visual/index.tsx
+++ b/src/views/product-landing/components/hero-heading-visual/index.tsx
@@ -68,9 +68,11 @@ function HeroHeadingVisual({
 			}
 		>
 			<h1 className={s.heading}>{heading}</h1>
-			<div className={s.image}>
-				<img src={image} alt="" />
-			</div>
+			{image && (
+				<div className={s.image}>
+					<img src={image} alt="" />
+				</div>
+			)}
 		</div>
 	)
 }

--- a/src/views/product-landing/components/hero-heading-visual/types.ts
+++ b/src/views/product-landing/components/hero-heading-visual/types.ts
@@ -7,6 +7,6 @@ import { ProductSlug } from 'types/products'
 
 export interface HeroHeadingVisualProps {
 	heading: string
-	image: string
+	image?: string
 	productSlug?: ProductSlug
 }

--- a/src/views/tutorial-view/components/next-previous/helpers.ts
+++ b/src/views/tutorial-view/components/next-previous/helpers.ts
@@ -66,6 +66,10 @@ export function getNextPrevious({
 		finalLink = '/well-architected-framework'
 	}
 
+	if (currentCollectionSection === 'validated-patterns') {
+		finalLink = '/validated-patterns'
+	}
+
 	const tutorial = {
 		previous: previousTutorial,
 		next: nextTutorial,

--- a/src/views/validated-patterns/collection-view/index.tsx
+++ b/src/views/validated-patterns/collection-view/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { TutorialLite as ClientTutorialLite } from 'lib/learn-client/types'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import getReadableTime from 'components/tutorial-meta/components/badges/helpers'
+import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
+import { SidebarProps } from 'components/sidebar'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import CollectionMeta from 'views/collection-view/components/collection-meta'
+import CollectionTutorialList from 'views/collection-view/components/collection-tutorial-list'
+import { ValidatedPatternsCollectionViewProps } from '../types'
+import { generateValidatedPatternsCollectionSidebar } from '../utils/generate-collection-sidebar'
+
+export default function ValidatedPatternsCollectionView({
+	collection,
+	layoutProps,
+	metadata,
+}: ValidatedPatternsCollectionViewProps) {
+	const { name, id, description, tutorials, ordered, slug } = collection
+	const { sidebarSections, breadcrumbLinks } = layoutProps
+
+	return (
+		<SidebarSidecarLayout
+			breadcrumbLinks={breadcrumbLinks}
+			sidebarNavDataLevels={[
+				generateTopLevelSidebarNavData(
+					metadata.validatedPatternsName
+				) as SidebarProps,
+				generateValidatedPatternsCollectionSidebar(
+					{
+						name: metadata.validatedPatternsName,
+						slug: metadata.validatedPatternsSlug,
+					},
+					sidebarSections
+				),
+			]}
+		>
+			<CollectionMeta
+				collection={collection}
+				heading={{ text: name, id }}
+				description={description}
+			/>
+			<CollectionTutorialList
+				isOrdered={ordered}
+				tutorials={tutorials.map((t: ClientTutorialLite) => ({
+					id: t.id,
+					collectionId: id,
+					description: t.description,
+					duration: getReadableTime(t.readTime),
+					hasInteractiveLab: Boolean(t.handsOnLab),
+					hasVideo: Boolean(t.video),
+					heading: t.name,
+					url: `/${slug}/${splitProductFromFilename(t.slug)}`,
+					productsUsed: t.productsUsed.map((p) => p.product.slug),
+				}))}
+			/>
+		</SidebarSidecarLayout>
+	)
+}

--- a/src/views/validated-patterns/index.tsx
+++ b/src/views/validated-patterns/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import slugify from 'slugify'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
+import { OutlineNavWithActive } from 'components/outline-nav/components'
+import ProductViewContent from 'views/product-tutorials-view/components/product-view-content'
+import HeroHeadingVisual from 'views/product-landing/components/hero-heading-visual'
+import { SidebarProps } from 'components/sidebar'
+import OverviewCta from 'views/product-landing/components/overview-cta'
+import { ValidatedPatternsLandingProps } from './types'
+import s from './validated-patterns-landing.module.css'
+import { generateValidatedPatternsCollectionSidebar } from './utils/generate-collection-sidebar'
+
+export default function ValidatedPatternsLandingView(
+	props: ValidatedPatternsLandingProps
+) {
+	const { data, outlineItems, layoutProps, metadata } = props
+	const { blocks } = data.pageData
+	const { hero, overview } = data.validatedPatternsContent
+
+	return (
+		<SidebarSidecarLayout
+			sidecarSlot={<OutlineNavWithActive items={outlineItems.slice()} />}
+			breadcrumbLinks={layoutProps.breadcrumbLinks}
+			sidebarNavDataLevels={[
+				generateTopLevelSidebarNavData(metadata.name) as SidebarProps,
+				generateValidatedPatternsCollectionSidebar(
+					metadata,
+					layoutProps.sidebarSections
+				),
+			]}
+		>
+			<div className={s.hero}>
+				<HeroHeadingVisual {...hero} />
+			</div>
+			<div className={s.overview}>
+				<OverviewCta
+					{...overview}
+					headingSlug={slugify(overview.heading, { lower: true })}
+				/>
+			</div>
+			<ProductViewContent blocks={blocks} />
+		</SidebarSidecarLayout>
+	)
+}

--- a/src/views/validated-patterns/tutorial-view/index.tsx
+++ b/src/views/validated-patterns/tutorial-view/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Head from 'next/head'
+import { Fragment } from 'react'
+import InstruqtProvider from 'contexts/instruqt-lab'
+import TutorialMeta from 'components/tutorial-meta'
+import VideoEmbed from 'components/video-embed'
+import getVideoUrl from 'views/tutorial-view/utils/get-video-url'
+import DevDotContent from 'components/dev-dot-content'
+import { OutlineNavWithActive } from 'components/outline-nav/components'
+import MDX_COMPONENTS from 'views/tutorial-view/utils/mdx-components'
+import { FeaturedInCollections } from 'views/tutorial-view/components'
+import VariantProvider from 'views/tutorial-view/utils/variants/context'
+import { VariantDropdownDisclosure } from 'views/tutorial-view/components'
+import SidebarSidecarLayout from 'layouts/sidebar-sidecar'
+import { NextPrevious } from 'views/tutorial-view/components'
+import { generateCanonicalUrl } from 'views/tutorial-view/utils'
+import s from 'views/tutorial-view/tutorial-view.module.css'
+import { ValidatedPatternsTutorialViewProps } from '../types'
+
+export default function ValidatedPatternsTutorialView({
+	tutorial,
+	layoutProps,
+	outlineItems,
+	pageHeading,
+}: ValidatedPatternsTutorialViewProps) {
+	const {
+		id,
+		slug,
+		readTime,
+		edition,
+		productsUsed,
+		video,
+		handsOnLab,
+		content,
+		collectionCtx,
+		nextPreviousData,
+		variant,
+	} = tutorial
+	const hasVideo = Boolean(video)
+	const isInteractive = Boolean(handsOnLab)
+	const featuredInWithoutCurrent = collectionCtx.featuredIn?.filter(
+		(c) => c.id !== collectionCtx.current.id
+	)
+	const InteractiveLabWrapper = isInteractive ? InstruqtProvider : Fragment
+	const canonicalCollectionSlug = tutorial.collectionCtx.default.slug
+	const canonicalUrl = generateCanonicalUrl(canonicalCollectionSlug, slug)
+
+	return (
+		<>
+			<Head>
+				<link rel="canonical" href={canonicalUrl.toString()} key="canonical" />
+			</Head>
+			<InteractiveLabWrapper
+				key={slug}
+				{...(isInteractive && { labId: handsOnLab.id })}
+			>
+				<VariantProvider variant={variant}>
+					<SidebarSidecarLayout
+						sidecarSlot={<OutlineNavWithActive items={outlineItems.slice()} />}
+						breadcrumbLinks={layoutProps.breadcrumbLinks}
+						sidebarNavDataLevels={layoutProps.navLevels}
+						mainWidth="narrow"
+						sidecarTopSlot={
+							variant ? (
+								<VariantDropdownDisclosure variant={variant} isFullWidth />
+							) : null
+						}
+					>
+						<TutorialMeta
+							heading={pageHeading}
+							meta={{
+								readTime,
+								edition,
+								productsUsed,
+								isInteractive,
+								hasVideo,
+							}}
+							tutorialId={id}
+						/>
+						{video?.id && !video.videoInline && (
+							<VideoEmbed
+								url={getVideoUrl({
+									videoId: video.id,
+									videoHost: video.videoHost,
+								})}
+							/>
+						)}
+						<DevDotContent
+							mdxRemoteProps={{ ...content, components: MDX_COMPONENTS }}
+						/>
+						<NextPrevious {...nextPreviousData} />
+						<FeaturedInCollections
+							className={s.featuredInCollections}
+							collections={featuredInWithoutCurrent}
+						/>
+					</SidebarSidecarLayout>
+				</VariantProvider>
+			</InteractiveLabWrapper>
+		</>
+	)
+}

--- a/src/views/validated-patterns/tutorial-view/server.ts
+++ b/src/views/validated-patterns/tutorial-view/server.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { serializeContent } from 'views/tutorial-view/utils/serialize-content'
+import { getTutorial } from 'lib/learn-client/api/tutorial'
+import { getCollectionsBySection } from 'lib/learn-client/api/collection'
+import { stripUndefinedProperties } from 'lib/strip-undefined-props'
+import { splitProductFromFilename } from 'views/tutorial-view/utils'
+import { getCollectionContext } from 'views/tutorial-view/utils/get-collection-context'
+import validatedPatternsData from 'data/validated-patterns.json'
+import validatedPatternsContent from 'content/validated-patterns/index.json'
+import { buildCategorizedValidatedPatternsSidebar } from 'views/validated-patterns/utils/generate-sidebar-items'
+import {
+	Collection as ClientCollection,
+	TutorialLite as ClientTutorialLite,
+} from 'lib/learn-client/types'
+import { generateTopLevelSidebarNavData } from 'components/sidebar/helpers'
+import { MenuItem, SidebarProps } from 'components/sidebar'
+import { EnrichedNavItem } from 'components/sidebar/types'
+import { generateValidatedPatternsCollectionSidebar } from 'views/validated-patterns/utils/generate-collection-sidebar'
+import { getNextPrevious } from 'views/tutorial-view/components'
+import outlineItemsFromHeadings from 'components/outline-nav/utils/outline-items-from-headings'
+import { getTutorialViewVariantData } from 'views/tutorial-view/utils/variants'
+import { ValidatedPatternsTutorialViewProps } from '../types'
+
+export async function getValidatedPatternsTutorialViewProps(
+	fullSlug: [string, string] | [string, string, string] // Third option is a variant
+): Promise<{ props: ValidatedPatternsTutorialViewProps }> {
+	// Remove the variant from the slug
+	const tutorialSlug = fullSlug.slice(0, 2) as [string, string]
+	const [collectionFilename, tutorialFilename] = tutorialSlug
+	const currentPath = `/${validatedPatternsData.slug}/${tutorialSlug.join('/')}`
+
+	// get all the validated-patterns collections to generate the collection level sidebar
+	const allValidatedPatternsCollections = await getCollectionsBySection(
+		validatedPatternsData.slug
+	)
+	const currentCollection = allValidatedPatternsCollections.find(
+		(collection: ClientCollection) =>
+			collection.slug === `${validatedPatternsData.slug}/${collectionFilename}`
+	)
+	const currentTutorialReference = currentCollection?.tutorials.find(
+		(t: ClientTutorialLite) =>
+			tutorialFilename === splitProductFromFilename(t.slug)
+	)
+
+	// The tutorial doesn't exist in collection - return 404
+	if (!currentCollection || !currentTutorialReference) {
+		return null
+	}
+
+	// Need to get tutorial data with full mdx content
+	const fullTutorialData = await getTutorial(currentTutorialReference.slug)
+
+	// Double guard if tutorial doesn't exist after call - return 404
+	if (fullTutorialData === null) {
+		return null
+	}
+
+	const variantSlug = fullSlug[2]
+	const variant = getTutorialViewVariantData(
+		variantSlug,
+		fullTutorialData.variant
+	)
+
+	const { content: serializedContent, headings } = await serializeContent(
+		fullTutorialData
+	)
+	const collectionContext = getCollectionContext(
+		currentCollection,
+		fullTutorialData.collectionCtx
+	)
+	const tutorialNavLevelMenuItems = collectionContext.current.tutorials.map(
+		(t: ClientTutorialLite) => {
+			const fullTutorialPath = `/${
+				collectionContext.current.slug
+			}/${splitProductFromFilename(t.slug)}`
+
+			return {
+				title: t.name,
+				id: t.id,
+				fullPath: fullTutorialPath,
+				isActive: currentPath === fullTutorialPath,
+			}
+		}
+	)
+	const categorizedValidatedPatternsCollectionSidebarItems =
+		buildCategorizedValidatedPatternsSidebar(
+			allValidatedPatternsCollections,
+			validatedPatternsContent.sidebarCategories,
+			collectionContext.current.slug
+		)
+	const lastTutorialIndex = collectionContext.current.tutorials.length - 1
+	const isLastTutorial =
+		collectionContext.current.tutorials[lastTutorialIndex].id ===
+		fullTutorialData.id
+	let nextCollection
+
+	if (isLastTutorial) {
+		const filteredSidebarItems =
+			categorizedValidatedPatternsCollectionSidebarItems.filter(
+				(item: MenuItem) => !item.divider && !item.heading
+			)
+		const currentIndex = filteredSidebarItems.findIndex(
+			(item: MenuItem) => item.fullPath === `/${currentCollection.slug}`
+		)
+		const nextSidebarItem: MenuItem = filteredSidebarItems[currentIndex + 1]
+		nextCollection = allValidatedPatternsCollections.find(
+			(c) => nextSidebarItem?.id === c.id
+		)
+	}
+
+	/**
+	 * Generate page heading and outline nav items from headings
+	 */
+	const pageHeading = {
+		slug: headings[0].slug,
+		text: headings[0].title,
+	}
+	const outlineItems = outlineItemsFromHeadings(headings)
+
+	return {
+		props: stripUndefinedProperties<ValidatedPatternsTutorialViewProps>({
+			metadata: {
+				title: fullTutorialData.name,
+			},
+			tutorial: {
+				...fullTutorialData,
+				content: serializedContent,
+				collectionCtx: collectionContext,
+				nextPreviousData: getNextPrevious({
+					currentCollection: collectionContext.current,
+					currentTutorialSlug: fullTutorialData.slug,
+					nextCollectionInSidebar: nextCollection,
+					formatting: {
+						getCollectionSlug: (collectionSlug: string) => `/${collectionSlug}`,
+						getTutorialSlug: (tutorialSlug: string, collectionSlug: string) =>
+							`/${collectionSlug}/${splitProductFromFilename(tutorialSlug)}`,
+					},
+				}),
+				variant,
+			},
+			pageHeading,
+			outlineItems,
+			layoutProps: {
+				breadcrumbLinks: [
+					{ title: 'Developer', url: '/' },
+					{
+						title: validatedPatternsData.name,
+						url: `/${validatedPatternsData.slug}`,
+					},
+					{
+						title: collectionContext.current.name,
+						url: `/${collectionContext.current.slug}`,
+					},
+					{
+						title: fullTutorialData.name,
+						url: `/${collectionContext.current.slug}/${splitProductFromFilename(
+							fullTutorialData.slug
+						)}`,
+						isCurrentPage: true,
+					},
+				],
+				navLevels: [
+					generateTopLevelSidebarNavData(
+						validatedPatternsData.name
+					) as SidebarProps,
+					generateValidatedPatternsCollectionSidebar(
+						validatedPatternsData,
+						categorizedValidatedPatternsCollectionSidebarItems
+					),
+					{
+						title: validatedPatternsData.name,
+						visuallyHideTitle: true,
+						showFilterInput: false,
+						levelButtonProps: {
+							levelUpButtonText: collectionContext.current.shortName,
+							levelDownButtonText: fullTutorialData.name,
+						},
+						backToLinkProps: {
+							text: collectionContext.current.shortName,
+							href: `/${collectionContext.current.slug}`,
+						},
+						/**
+						 * TODO: fix up Enriched item interfaces here.
+						 *
+						 * Currently, EnrichedLinkNavItem requires both `path` and `href`,
+						 * since it extends both the RawInternalLinkNavItem and the
+						 * RawExternalLinkNavItem interfaces.
+						 */
+						menuItems:
+							tutorialNavLevelMenuItems as $TSFixMe as EnrichedNavItem[],
+					},
+				],
+			},
+		}),
+	}
+}

--- a/src/views/validated-patterns/types.ts
+++ b/src/views/validated-patterns/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Collection as ApiCollection } from 'lib/learn-client/types'
+import { EnrichedNavItem } from 'components/sidebar/types'
+import { NextPreviousProps } from 'views/tutorial-view/components'
+import { SidebarProps } from 'components/sidebar/types'
+import { SidebarSidecarLayoutProps } from 'layouts/sidebar-sidecar'
+import { HeroHeadingVisualProps } from 'views/product-landing/components/hero-heading-visual/types'
+import { OverviewCtaProps } from 'views/product-landing/components/overview-cta/types'
+import { ProductViewBlock } from 'views/product-tutorials-view/components/product-view-content'
+import { TutorialData } from 'views/tutorial-view'
+import { OutlineLinkItem } from 'components/outline-nav/types'
+import { TutorialViewProps } from 'views/tutorial-view'
+import { HeadMetadataProps } from 'components/head-metadata/types'
+
+export interface ValidatedPatternsLandingProps {
+	metadata: HeadMetadataProps & {
+		name: string
+		slug: string
+	}
+	outlineItems: OutlineLinkItem[]
+	data: {
+		pageData: {
+			blocks: ProductViewBlock[]
+		}
+		validatedPatternsContent: {
+			hero: HeroHeadingVisualProps
+			overview: OverviewCtaProps
+		}
+	}
+	layoutProps: {
+		breadcrumbLinks: SidebarSidecarLayoutProps['breadcrumbLinks']
+		sidebarSections: EnrichedNavItem[]
+	}
+}
+
+export interface ValidatedPatternsCollectionViewProps {
+	metadata: {
+		validatedPatternsName: string
+		validatedPatternsSlug: string
+	}
+	collection: ApiCollection
+	layoutProps: {
+		breadcrumbLinks: SidebarSidecarLayoutProps['breadcrumbLinks']
+		sidebarSections: EnrichedNavItem[]
+	}
+}
+
+export interface ValidatedPatternsTutorialViewProps {
+	metadata: HeadMetadataProps
+	tutorial: TutorialData & {
+		nextPreviousData: NextPreviousProps
+		variant?: TutorialViewProps['metadata']['variant']
+	}
+	pageHeading: {
+		slug: string
+		text: string
+	}
+	outlineItems: OutlineLinkItem[]
+	layoutProps: {
+		breadcrumbLinks: SidebarSidecarLayoutProps['breadcrumbLinks']
+		navLevels: SidebarProps[]
+	}
+}

--- a/src/views/validated-patterns/utils/generate-collection-sidebar.ts
+++ b/src/views/validated-patterns/utils/generate-collection-sidebar.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { EnrichedNavItem, SidebarProps } from 'components/sidebar/types'
+import addBrandedOverviewSidebarItem from 'lib/docs/add-branded-overview-sidebar-item'
+
+export function generateValidatedPatternsCollectionSidebar(
+	validatedPatternsData: { name: string; slug: string },
+	sidebarSections: EnrichedNavItem[]
+): SidebarProps {
+	return {
+		title: validatedPatternsData.name,
+		levelButtonProps: {
+			levelUpButtonText: `Main Menu`,
+			levelDownButtonText: 'Previous',
+		},
+		/* We always visually hide the title, as we've added in a
+			"highlight" item that would make showing the title redundant. */
+		visuallyHideTitle: true,
+		menuItems: addBrandedOverviewSidebarItem(sidebarSections, {
+			title: validatedPatternsData.name,
+			fullPath: `/${validatedPatternsData.slug}`,
+			theme: 'hcp',
+		}) as $TSFixMe,
+		showFilterInput: false,
+	}
+}

--- a/src/views/validated-patterns/utils/generate-sidebar-items.ts
+++ b/src/views/validated-patterns/utils/generate-sidebar-items.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { MenuItem } from 'components/sidebar'
+import { EnrichedNavItem } from 'components/sidebar/types'
+import { Collection as ApiCollection } from 'lib/learn-client/types'
+import { sortAlphabetically } from 'lib/sort-alphabetically'
+
+interface SidebarCategory {
+	name: string
+	collections: string[]
+}
+
+/**
+ * The sidebar consists first of a list of uncategorized collections, sorted
+ * alphabetically. Then follows with the categorized collections defined
+ * in the `sidebarCategories` data above.
+ */
+export function buildCategorizedValidatedPatternsSidebar(
+	collections: ApiCollection[],
+	sidebarCategories: SidebarCategory[],
+	currentSlug?: string
+): EnrichedNavItem[] {
+	/**
+	 * Create a map of all the collections. As they are added to
+	 * categorized sections, they will be deleted from this map.
+	 * This ensures all collections will render in the sidebar even
+	 * if they don't have a category
+	 *  */
+	const uncategorizedItems = new Map(
+		collections
+			.sort(sortAlphabetically('name'))
+			.map((collection: ApiCollection) => [
+				collection.slug,
+				{
+					title: collection.name,
+					fullPath: `/${collection.slug}`,
+					isActive: collection.slug === currentSlug,
+					id: collection.id,
+				},
+			])
+	)
+	const categorizedItems = []
+
+	// build a sidebar section per category
+	sidebarCategories.forEach((category: SidebarCategory) => {
+		const sectionHeading = [{ divider: true }, { heading: category.name }]
+		const sectionItems: MenuItem[] = category.collections
+			.map((collectionSlug: string) => {
+				// find the categorized collection based on its slug
+				const collection = collections.find(
+					(collection: ApiCollection) => collection.slug === collectionSlug
+				)
+				if (!collection) {
+					return
+				}
+
+				// remove item from 'uncategorized'list
+				uncategorizedItems.delete(collectionSlug)
+				return {
+					title: collection.name,
+					isActive: collection.slug === currentSlug,
+					fullPath: `/${collection.slug}`,
+					id: collection.id,
+				}
+			})
+			.sort(sortAlphabetically('title'))
+
+		categorizedItems.push(...sectionHeading, ...sectionItems)
+	})
+
+	return [...Array.from(uncategorizedItems.values()), ...categorizedItems]
+}

--- a/src/views/validated-patterns/validated-patterns-landing.module.css
+++ b/src/views/validated-patterns/validated-patterns-landing.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+.hero {
+	margin-bottom: 38px;
+}
+.overview {
+	margin-bottom: 48px;
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/1208777238149723/1208951572065292/f) 🎟️

## 🗒️ What

This PR temporarily creates an empty `validated-patterns` landing page so we can preview the changes in the `tutorials` repo.

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

I used well-architected-framework as a template for validated-patterns. We'll add `validated-patterns` to the product dropdown when the content is ready in `tutorials`.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
