### PR TITLE
feat: add hvd-docs redirects functionality

### DIFF
--- a/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
+++ b/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
@@ -9,12 +9,15 @@ import { PRODUCT_REDIRECT_ENTRIES } from '@build-libs/redirects'
 
 describe('getLatestContentShaForProduct', () => {
 	PRODUCT_REDIRECT_ENTRIES.forEach(({ repo, path }) => {
-		it(`fetches the latest SHA for the "${repo}" repo`, async () => {
-			const latestSha = await getLatestContentShaForProduct(repo)
-			expect(typeof latestSha).toBe('string')
-		})
-
-		if (['hcp-docs', 'sentinel', 'ptfe-releases'].includes(repo)) {
+		if (repo === 'hvd-docs') {
+			console.log(`Skipping test for repo "${repo}"`)
+		} else {
+			it(`fetches the latest SHA for the "${repo}" repo`, async () => {
+				const latestSha = await getLatestContentShaForProduct(repo)
+				expect(typeof latestSha).toBe('string')
+			})
+		}
+		if (['hcp-docs', 'sentinel', 'ptfe-releases', 'hvd-docs'].includes(repo)) {
 			console.log(`Skipping test for private repo "${repo}"`)
 		} else {
 			it(`fetches the latest SHA for the "${repo}" repo, then validates the SHA by fetching redirects`, async () => {

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -86,7 +86,11 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	let redirectsFileString
 	if (isDeveloperBuild) {
 		// For `hashicorp/dev-portal` builds, load redirects remotely
-		const latestContentSha = await getLatestContentShaForProduct(repoName)
+		// hvd-docs is not hosted on the content API, so we need to use main as the latest sha
+		const latestContentSha =
+			repoName === 'hvd-docs'
+				? 'daf97dfd494470e27acf2b74a95919ac748a54f6'
+				: await getLatestContentShaForProduct(repoName)
 		redirectsFileString = await fetchGithubFile({
 			owner: 'hashicorp',
 			repo: repoName,
@@ -126,6 +130,7 @@ const PRODUCT_REDIRECT_ENTRIES = [
 	{ repo: 'hcp-docs', path: '/redirects.js' },
 	{ repo: 'ptfe-releases', path: 'website/redirects.js' },
 	{ repo: 'sentinel', path: 'website/redirects.js' },
+	{ repo: 'hvd-docs', path: '/redirects.js' },
 ]
 
 async function buildProductRedirects() {
@@ -299,6 +304,7 @@ function filterInvalidRedirects(redirects, repoSlug) {
 		'ptfe-releases': 'terraform/enterprise',
 		'cloud.hashicorp.com': 'hcp',
 		'hcp-docs': 'hcp',
+		'hvd-docs': 'validated-designs',
 	}
 	const productSlug = productSlugsByRepo[repoSlug] ?? repoSlug
 

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -89,7 +89,7 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 		// hvd-docs is not hosted on the content API, so we need to use main as the latest sha
 		const latestContentSha =
 			repoName === 'hvd-docs'
-				? 'daf97dfd494470e27acf2b74a95919ac748a54f6'
+				? 'main'
 				: await getLatestContentShaForProduct(repoName)
 		redirectsFileString = await fetchGithubFile({
 			owner: 'hashicorp',

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,13 @@
 			"@components/*": ["components/*"]
 		},
 		"types": ["vitest/globals", "@testing-library/jest-dom"],
-		"strictNullChecks": false
+		"strictNullChecks": false,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		]
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
 	"exclude": ["node_modules", "scripts/migrate-io/templates"]
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-feathvd-redirects-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1206815131022336/1208690625725474/f) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This PR adds redirects functionality for hvd-docs. It works the same way as other product redirects in dev-portal.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

There is not currently redirect support for hvd-docs. That team has requested the functionality (see [Slack thread](https://hashicorp.slack.com/archives/C5FSPUGDS/p1730463708879159))

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
1. Go to [/validated-designs/boundary-operating-guides-adoption](https://dev-portal-git-leah-feathvd-redirects-hashicorp.vercel.app/validated-designs/boundary-operating-guides-adoption)
2. Verify that it is not going to that page and instead redirects to the `/validated-designs` homepage

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

The PR has a sha value for the hvd-docs repo that is just for testing. The sha links to a commit that I created on the hvd-docs repo to add an example redirect for testing (See [this commit](https://github.com/hashicorp/hvd-docs/commit/daf97dfd494470e27acf2b74a95919ac748a54f6)) After PR has been tested by a reviewer, I will change that back to 'main' before merging. See PR comment for more info.
