### PR TITLE
Load mdx images from UDR

### DIFF
--- a/.env
+++ b/.env
@@ -44,6 +44,7 @@ MKTG_CONTENT_DOCS_API="https://content.hashicorp.com"
 # possible. This environment variable is being set up with the intent of being
 # used to test and to later enable this type of migration.
 UNIFIED_DOCS_API="https://web-presence-experimental-docs.vercel.app"
+HASHI_ENV=unified-docs-sandbox
 
 #
 # DOCS STATIC PATHS FROM ANALYTICS API

--- a/.env
+++ b/.env
@@ -44,7 +44,6 @@ MKTG_CONTENT_DOCS_API="https://content.hashicorp.com"
 # possible. This environment variable is being set up with the intent of being
 # used to test and to later enable this type of migration.
 UNIFIED_DOCS_API="https://web-presence-experimental-docs.vercel.app"
-HASHI_ENV=unified-docs-sandbox
 
 #
 # DOCS STATIC PATHS FROM ANALYTICS API

--- a/src/lib/remark-plugins/remark-rewrite-assets.ts
+++ b/src/lib/remark-plugins/remark-rewrite-assets.ts
@@ -17,20 +17,34 @@ export function remarkRewriteAssets(args: {
 	product: string
 	version: string
 	getAssetPathParts?: (nodeUrl: string) => string[]
+	isInUDR?: boolean
 }): Plugin {
-	const { product, version, getAssetPathParts = (nodeUrl) => [nodeUrl] } = args
+	const {
+		product,
+		version,
+		getAssetPathParts = (nodeUrl) => [nodeUrl],
+		isInUDR = false,
+	} = args
 
 	return function plugin() {
 		return function transform(tree) {
 			// @ts-expect-error Types Should be correct here
 			visit<Image>(tree, 'image', (node) => {
+				let url
 				const originalUrl = node.url
-				const asset = path.posix.join(...getAssetPathParts(originalUrl))
 
-				const url = new URL(`${process.env.MKTG_CONTENT_DOCS_API}/api/assets`)
-				url.searchParams.append('asset', asset)
-				url.searchParams.append('version', version)
-				url.searchParams.append('product', product)
+				if (isInUDR) {
+					url = new URL(
+						`${process.env.UNIFIED_DOCS_API}/api/assets/${product}/${version}${node.url}`
+					)
+				} else {
+					const asset = path.posix.join(...getAssetPathParts(originalUrl))
+
+					const url = new URL(`${process.env.MKTG_CONTENT_DOCS_API}/api/assets`)
+					url.searchParams.append('asset', asset)
+					url.searchParams.append('version', version)
+					url.searchParams.append('product', product)
+				}
 
 				node.url = url.toString()
 				logOnce(

--- a/src/views/docs-view/loaders/__tests__/file-system.test.ts
+++ b/src/views/docs-view/loaders/__tests__/file-system.test.ts
@@ -133,6 +133,7 @@ describe('FileSystemLoader', () => {
 		await l.loadStaticProps({ params: {} })
 
 		expect(mockMdxContentHook).toHaveBeenCalledWith(expect.any(String), {
+			product: 'waypoint',
 			version: 'latest',
 		})
 		// assert that `serialize` is called with the result of the hook

--- a/src/views/docs-view/loaders/__tests__/remote-content.test.ts
+++ b/src/views/docs-view/loaders/__tests__/remote-content.test.ts
@@ -273,6 +273,7 @@ describe('RemoteContentLoader', () => {
 		})
 
 		expect(mockMdxContentHook).toHaveBeenCalledWith(expect.any(String), {
+			product: 'waypoint',
 			version: 'v0.4.x',
 		})
 		// assert that `serialize` is called with the result of the hook

--- a/src/views/docs-view/loaders/file-system.ts
+++ b/src/views/docs-view/loaders/file-system.ts
@@ -94,7 +94,11 @@ export default class FileSystemLoader implements DataLoader {
 				mdxContentHook: this.opts.mdxContentHook,
 				remarkPlugins,
 				rehypePlugins: this.opts.rehypePlugins,
-				scope: { version: versionFromPath, ...this.opts.scope },
+				scope: {
+					product: this.opts.product,
+					version: versionFromPath,
+					...this.opts.scope,
+				},
 			})
 		// Build the currentPath from page parameters
 		const currentPath =

--- a/src/views/docs-view/loaders/remote-content.ts
+++ b/src/views/docs-view/loaders/remote-content.ts
@@ -190,7 +190,11 @@ export default class RemoteContentLoader implements DataLoader {
 				mdxContentHook: this.opts.mdxContentHook,
 				remarkPlugins,
 				rehypePlugins: this.opts.rehypePlugins,
-				scope: { version: versionFromPath, ...this.opts.scope },
+				scope: {
+					product: this.opts.product,
+					version: versionFromPath,
+					...this.opts.scope,
+				},
 			})
 
 		const versionMetadataList: VersionMetadataItem[] =

--- a/src/views/docs-view/render-page-mdx.ts
+++ b/src/views/docs-view/render-page-mdx.ts
@@ -37,7 +37,7 @@ async function renderPageMdx(
 			(product) => product === scope.product
 		)
 	) {
-		console.log('finalRemarkPlugins 1', { finalRemarkPlugins })
+		console.log('rubenTest - inject remarkRewriteAssets for UDR')
 		finalRemarkPlugins.push(
 			remarkRewriteAssets({
 				product: scope.product as string,
@@ -47,8 +47,6 @@ async function renderPageMdx(
 			})
 		)
 	}
-
-	console.log('finalRemarkPlugins 2', { finalRemarkPlugins })
 
 	return await trace
 		.getTracer('docs-view')

--- a/src/views/docs-view/render-page-mdx.ts
+++ b/src/views/docs-view/render-page-mdx.ts
@@ -50,6 +50,7 @@ async function renderPageMdx(
 
 	console.log({
 		HASHI_ENV: process.env.HASHI_ENV,
+		MKTG_CONTENT_DOCS_API: process.env.MKTG_CONTENT_DOCS_API,
 		unified_docs_migrated_repos: __config.flags?.unified_docs_migrated_repos,
 	})
 

--- a/src/views/docs-view/render-page-mdx.ts
+++ b/src/views/docs-view/render-page-mdx.ts
@@ -37,7 +37,6 @@ async function renderPageMdx(
 			(product) => product === scope.product
 		)
 	) {
-		console.log('rubenTest - inject remarkRewriteAssets for UDR')
 		finalRemarkPlugins.push(
 			remarkRewriteAssets({
 				product: scope.product as string,
@@ -47,12 +46,6 @@ async function renderPageMdx(
 			})
 		)
 	}
-
-	console.log({
-		HASHI_ENV: process.env.HASHI_ENV,
-		MKTG_CONTENT_DOCS_API: process.env.MKTG_CONTENT_DOCS_API,
-		unified_docs_migrated_repos: __config.flags?.unified_docs_migrated_repos,
-	})
 
 	return await trace
 		.getTracer('docs-view')

--- a/src/views/docs-view/render-page-mdx.ts
+++ b/src/views/docs-view/render-page-mdx.ts
@@ -48,6 +48,11 @@ async function renderPageMdx(
 		)
 	}
 
+	console.log({
+		HASHI_ENV: process.env.HASHI_ENV,
+		unified_docs_migrated_repos: __config.flags?.unified_docs_migrated_repos,
+	})
+
 	return await trace
 		.getTracer('docs-view')
 		.startActiveSpan('renderPageMdx', async (span) => {

--- a/src/views/docs-view/utils/get-deploy-preview-loader.ts
+++ b/src/views/docs-view/utils/get-deploy-preview-loader.ts
@@ -83,9 +83,6 @@ export function getDeployPreviewLoader({
 					(product) => product === currentRootDocsPath.productSlugForLoader
 				)
 			) {
-				console.log(
-					'rubenTest - normal remarkRewriteAssets for terraform|ptfe-releases'
-				)
 				remarkTerraformPlugins.push(
 					remarkRewriteAssets({
 						product: currentRootDocsPath.productSlugForLoader,

--- a/src/views/docs-view/utils/get-deploy-preview-loader.ts
+++ b/src/views/docs-view/utils/get-deploy-preview-loader.ts
@@ -83,6 +83,9 @@ export function getDeployPreviewLoader({
 					(product) => product === currentRootDocsPath.productSlugForLoader
 				)
 			) {
+				console.log(
+					'rubenTest - normal remarkRewriteAssets for terraform|ptfe-releases'
+				)
 				remarkTerraformPlugins.push(
 					remarkRewriteAssets({
 						product: currentRootDocsPath.productSlugForLoader,

--- a/src/views/docs-view/utils/get-deploy-preview-loader.ts
+++ b/src/views/docs-view/utils/get-deploy-preview-loader.ts
@@ -78,6 +78,9 @@ export function getDeployPreviewLoader({
 			if (
 				currentRootDocsPath.productSlugForLoader?.match(
 					/^(terraform|ptfe-releases)/i
+				) &&
+				!__config.flags?.unified_docs_migrated_repos?.find(
+					(product) => product === currentRootDocsPath.productSlugForLoader
 				)
 			) {
 				remarkTerraformPlugins.push(


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-load-mdx-imgs-from-udr-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/0/1207899860738460/1207910088307871) 🎟️

## 🗒️ What

This PR modifies MDX image loading to load from the UDR asset API. It does this by updating and injecting the `remark-rewrite-assets.ts` remark plugin to rewrite the MDX img URLs when an product is in `config.flags.unified_docs_migrated_repos`. Which currently only the `HASHI_ENV=unified-docs-sandbox` has those flags set.

Before this [only use case of remark-rewrite-assets remark plugin](https://github.com/hashicorp/dev-portal/pull/2684/files#diff-fba91fc20d9e03dac5cd7a8a0b953d1a58f0c1c245e55b5ef004bf67f5f961ccR78) was in rewriting the MDX imgs of URLS for any `terraform` and `ptfe-releases` products. (e.g. `terraform-plugins-*` would match) So an added guard has been placed on that to make sure that `remark-rewrite-assets` does not run twice in those situations.


## 🧪 Testing

This branch has [special env vars injected into it](https://vercel.com/hashicorp/dev-portal/settings/environment-variables) so that it loads content from UDR. So it can be tested by visiting the following links:


- [ ] [A UDR product loads images from the UDR asset API](https://dev-portal-git-load-mdx-imgs-from-udr-hashicorp.vercel.app/terraform/intro/core-workflow)
    1. Make sure images are loading through the UDR asset API, e.g. https://web-presence-experimental-docs.vercel.app/api/assets/terraform/latest/img/docs/manually-pasted-plan-output.png

- [ ] [A NON UDR product loads images from the normal asset API](https://dev-portal-git-load-mdx-imgs-from-udr-hashicorp.vercel.app/nomad/docs/concepts/architecture)
    1. Make sure images are loading through the normal asset API, e.g. `/_next/image?url=https%3A%2F%2Fcontent.hashicorp.com%2Fapi%2Fassets%3Fproduct%3Dnomad%26version%3Drefs%252Fheads%252Fstable-website%26asset%3Dwebsite%252Fpublic%252Fimg%252Fnomad-architecture-region.png%26width%3D1920%26height%3D852&w=3840&q=75&dpl=dpl_8W7uyq4JfqA3fDjL1z9LF9hFo1FA`
