### PR TITLE
fix: update actions/cache version to fix errors

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -32,7 +32,7 @@ jobs:
         uses: bahmutov/npm-install@237ded403e6012a48281f4572eab0c8eafe55b3f # v1.10.1
 
       - name: Restore next build
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: restore-build-cache
         env:
           cache-name: cache-next-build


### PR DESCRIPTION
## 🗒️ What

This PR updates the actions/cache version to fix errors on [bundle analysis builds](https://github.com/hashicorp/dev-portal/actions/runs/13634967691). I used the version web uses for their bundle analysis action to keep them in sync. More details about this [here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

## 🤷 Why

Bundle analysis actions are failing.

## 🧪 Testing

Verify the bundle analysis action works on this PR.
