### PR TITLE
Skip .next dir when running vitest

### DIFF
--- a/src/views/docs-view/loaders/__tests__/remote-content.test.ts
+++ b/src/views/docs-view/loaders/__tests__/remote-content.test.ts
@@ -42,7 +42,11 @@ describe('RemoteContentLoader', () => {
 
 		nock.disableNetConnect()
 
-		scope = nock(process.env.MKTG_CONTENT_DOCS_API)
+		scope = nock(
+			new RegExp(
+				`${process.env.MKTG_CONTENT_DOCS_API}|${process.env.UNIFIED_DOCS_API}`
+			)
+		)
 	})
 
 	afterAll(() => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,7 +7,12 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'jsdom',
-		exclude: [...configDefaults.exclude, 'src/__tests__/e2e', 'src/.extracted'],
+		exclude: [
+			...configDefaults.exclude,
+			'.next',
+			'src/__tests__/e2e',
+			'src/.extracted',
+		],
 		setupFiles: ['dotenv/config', '.test/setup-vitest.js'],
 	},
 })


### PR DESCRIPTION
## 🗒️ What

1. We were running vitest on compiled code in the .next directory, which was causing tests to fail. We can safety skip the compiled test code.

## 🧪 Testing

1. Checkout `main`
1. Run `npm run test:ci`
1. Notice the error
1. Checkout this branch: `rn/skip-dotnext-in-vitest`
1. Run `npm run test:ci`
1. The error in 3 should be gone
