### PR TITLE
@typescript-eslint/no-explicit-any

### DIFF
--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -32,7 +32,7 @@ function removeClient(id: string): void {
 	}
 }
 
-function sendMessageToAllClients(obj: any): void {
+function sendMessageToAllClients(obj: $TSFixMe): void {
 	const jsonData = `data: ${JSON.stringify(obj)}\n\n`
 	for (const client of clients) {
 		client.res.write(jsonData)

--- a/src/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
+++ b/src/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 vi.mock('next/head', () => {
 	return {
 		__esModule: true,
-		default: ({ children }: React.PropsWithChildren<any>) => {
+		default: ({ children }: React.PropsWithChildren<$TSFixMe>) => {
 			return <div>{children}</div>
 		},
 	}

--- a/src/components/open-api-page/partials/collapsible/index.tsx
+++ b/src/components/open-api-page/partials/collapsible/index.tsx
@@ -77,7 +77,7 @@ function adjustHeight(
 	elem.addEventListener('transitionend', handleTransitionEnd, false)
 }
 
-type TransitionHandler = (this: HTMLDivElement, ev: TransitionEvent) => any
+type TransitionHandler = (this: HTMLDivElement, ev: TransitionEvent) => $TSFixMe
 const handleTransitionEnd: TransitionHandler = function (event) {
 	if (event.propertyName !== 'height') {
 		return

--- a/src/hooks/use-authentication/index.ts
+++ b/src/hooks/use-authentication/index.ts
@@ -44,7 +44,7 @@ interface UseAuthenticationResult {
 	signOut: (options?: SignOutParams) => ReturnType<typeof signOut>
 	signUp: typeof signUp
 	user: null | Session['user']
-	update: (data?: any) => Promise<Session | null>
+	update: (data?: $TSFixMe) => Promise<Session | null>
 }
 
 /**

--- a/src/layouts/sidebar-sidecar/types.ts
+++ b/src/layouts/sidebar-sidecar/types.ts
@@ -14,7 +14,7 @@ export interface SidebarSidecarLayoutProps {
 	githubFileUrl?: string
 	sidebarNavDataLevels: SidebarProps[]
 	/** @TODO determine the minimum set of props that all Sidebars should have */
-	AlternateSidebar?: (props: any) => ReactElement
+	AlternateSidebar?: (props: $TSFixMe) => ReactElement
 	versions?: VersionSelectItem[]
 	showScrollProgress?: boolean
 	mainWidth?: 'wide' | 'narrow'

--- a/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
+++ b/src/layouts/sidebar-sidecar/utils/prepare-nav-data-for-client.ts
@@ -130,7 +130,7 @@ async function prepareNavNodeForClient({
 	 *
 	 * ref: https://app.asana.com/0/1201010428539925/1201602267333015/f
 	 */
-	if ((node as any).hidden) {
+	if ((node as $TSFixMe).hidden) {
 		return null
 	}
 

--- a/src/lib/api-docs/fetch-cloud-api-version-data/build-query-string-suffix.ts
+++ b/src/lib/api-docs/fetch-cloud-api-version-data/build-query-string-suffix.ts
@@ -11,7 +11,7 @@
  * an empty string will be returned. Meaningful values are all values
  * other than `undefined` and `null`.
  */
-function buildQueryStringSuffix(params: Record<string, any>): string {
+function buildQueryStringSuffix(params: Record<string, $TSFixMe>): string {
 	const queryParams = new URLSearchParams()
 	for (const [key, value] of Object.entries(params)) {
 		if (value === undefined || value === null) {

--- a/src/lib/integrations-api-client/standard-client.ts
+++ b/src/lib/integrations-api-client/standard-client.ts
@@ -28,8 +28,8 @@ export async function request<ResponseObject>(
 	method: Method,
 	url: string,
 	opts?: {
-		body?: any
-		query?: any
+		body?: $TSFixMe
+		query?: $TSFixMe
 	}
 ): Promise<ApiResponse<ResponseObject>> {
 	const requestURL = new URL(

--- a/src/lib/next-mdx-remote/__tests__/next-mdx-remote.test.tsx
+++ b/src/lib/next-mdx-remote/__tests__/next-mdx-remote.test.tsx
@@ -152,7 +152,7 @@ async function renderStatic(
 		mdxOptions,
 		target,
 	}: {
-		components?: Record<string, React.ComponentType<any>>
+		components?: Record<string, React.ComponentType<$TSFixMe>>
 	} & SerializeOptions = {}
 ): Promise<string> {
 	const mdxSource = await serialize(mdx, { mdxOptions, target })

--- a/src/lib/next-mdx-remote/index.tsx
+++ b/src/lib/next-mdx-remote/index.tsx
@@ -35,7 +35,7 @@ type MDXRemoteProps = MDXRemoteSerializeResult & {
 	 *
 	 * For example: `{ ComponentName: Component }` will be accessible in the MDX as `<ComponentName/>`.
 	 */
-	components?: Record<string, React.ComponentType<any>>
+	components?: Record<string, React.ComponentType<$TSFixMe>>
 	/**
 	 * Determines whether or not the content should be hydrated asynchronously, or "lazily"
 	 */

--- a/src/lib/rehype-code-plugins.ts
+++ b/src/lib/rehype-code-plugins.ts
@@ -37,7 +37,7 @@ export const rehypeCodePlugins: Pluggable[] = [
 					span(node, _line: number, col: number) {
 						// prevent user-select on the start +/- in diff lines
 						if (this.options.lang === 'diff' && col === 0) {
-							const firstChild = node.children[0] as any
+							const firstChild = node.children[0] as $TSFixMe
 
 							if (['-', '+'].includes(firstChild?.value)) {
 								node.properties.style += '; user-select: none;'
@@ -101,8 +101,8 @@ export const rehypeCodePlugins: Pluggable[] = [
 			],
 		},
 		// unified's Pluggable type is difficult to satisfy, but we know this is
-		// the correct declaration for the plugin, so we assert it as any.
-	] as any,
+		// the correct declaration for the plugin, so we assert it as $TSFixMe.
+	] as $TSFixMe,
 ]
 
 /**

--- a/src/lib/remark-plugins/rehype-sanitize/__tests__/rehype-sanitize.test.ts
+++ b/src/lib/remark-plugins/rehype-sanitize/__tests__/rehype-sanitize.test.ts
@@ -140,7 +140,7 @@ describe('rehypeSanitize', () => {
 			paragraphNode,
 			'Paragraph node is expected to have a link element as a child.'
 		).toHaveProperty('children')
-		const linkNode = (paragraphNode as any).children[0]
+		const linkNode = (paragraphNode as $TSFixMe).children[0]
 		expect(
 			linkNode,
 			'Link node is expected to have properties.'

--- a/src/lib/remark-plugins/remark-image-dimensions/__tests__/index.test.tsx
+++ b/src/lib/remark-plugins/remark-image-dimensions/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('remarkPluginInjectImageDimensions', () => {
 			},
 		})
 		const { getByAltText } = render(
-			<MDXRemote {...mdxSource} components={{ img: Image as any }} />
+			<MDXRemote {...mdxSource} components={{ img: Image as $TSFixMe }} />
 		)
 		const img = getByAltText(alt)
 

--- a/src/lib/syntax-highlighting/index.ts
+++ b/src/lib/syntax-highlighting/index.ts
@@ -7,8 +7,8 @@ import { getHighlighter, bundledLanguages } from 'shiki'
 import { theme } from './theme'
 import sentinelGrammar from './languages/sentinel.tmGrammar.json'
 
-// Shiki's TypeScript types are broken, so we silence the error with `any`.
-const sentinel = { ...sentinelGrammar, name: 'sentinel' } as any
+// Shiki's TypeScript types are broken, so we silence the error with `$TSFixMe`.
+const sentinel = { ...sentinelGrammar, name: 'sentinel' } as $TSFixMe
 
 // !! Note: the syntax highlighting is done through the theme, which is a textmate grammar which define token scope. You can inspect textmate scope in VSCode executing the command `Developer: Inspect Editor Tokens and Scopes` !!
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -55,7 +55,7 @@ addGlobalLinkHandler((destinationUrl: string) => {
 export default function App({
 	Component,
 	pageProps: { session, ...pageProps },
-}: AppProps<{ session?: Session } & Record<string, any>>) {
+}: AppProps<{ session?: Session } & Record<string, $TSFixMe>>) {
 	useAnchorLinkAnalytics()
 	useEffect(() => makeDevAnalyticsLogger(), [])
 

--- a/src/pages/api/open-api-docs-preview-v2.ts
+++ b/src/pages/api/open-api-docs-preview-v2.ts
@@ -158,7 +158,7 @@ async function deleteOldFiles(directoryPath: string, maxAgeMs: number) {
  * unique file ID, then write to that file, and
  * Return the unique file ID
  */
-function writeDataToTmpFile(tmpDir: string, jsonData: any): string {
+function writeDataToTmpFile(tmpDir: string, jsonData: $TSFixMe): string {
 	const timestamp = Date.now()
 	const uniqueFileId = `ts${timestamp}_${randomUUID()}`
 	const newTempFile = getTempFilePath(tmpDir, uniqueFileId)
@@ -171,7 +171,7 @@ function writeDataToTmpFile(tmpDir: string, jsonData: any): string {
  * If successful, return [null, data], where `data` is the parsed JSON.
  * Otherwise, return [err, null], where `err` describes the failure.
  */
-function readJsonFile(filePath): [string, null] | [null, any] {
+function readJsonFile(filePath): [string, null] | [null, $TSFixMe] {
 	try {
 		const fileString = fs.readFileSync(filePath, 'utf8')
 		return [null, JSON.parse(fileString)]

--- a/src/pages/api/opt-out-feedback.ts
+++ b/src/pages/api/opt-out-feedback.ts
@@ -103,7 +103,7 @@ export default async function handler(
 	}
 
 	// Filter out any keys that aren't sanctioned
-	const filteredBody: any = {}
+	const filteredBody: $TSFixMe = {}
 	allowedKeys.forEach((key) => {
 		if (typeof request.body[key] !== 'undefined') {
 			filteredBody[key] = request.body[key]

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -90,7 +90,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
 				}
 			)
 		)
-	).filter(Boolean) as any[]
+	).filter(Boolean) as $TSFixMe[]
 
 	const revalidatePromises = []
 

--- a/src/views/collection-view/index.tsx
+++ b/src/views/collection-view/index.tsx
@@ -42,7 +42,7 @@ function CollectionView({
 			 * correct types. This will require chaning many files, so deferring for
 			 * a follow-up PR since this is functional for the time being.
 			 */
-			sidebarNavDataLevels={sidebarNavDataLevels as any}
+			sidebarNavDataLevels={sidebarNavDataLevels as $TSFixMe}
 		>
 			<CollectionMeta
 				collection={collection}

--- a/src/views/docs-view/loaders/__tests__/file-system.test.ts
+++ b/src/views/docs-view/loaders/__tests__/file-system.test.ts
@@ -19,7 +19,7 @@ let loader: FileSystemLoader
 import * as nextMdxRemote from 'lib/next-mdx-remote/serialize'
 vi.mock('lib/next-mdx-remote/serialize', async () => ({
 	__esModule: true,
-	...((await vi.importActual('lib/next-mdx-remote/serialize')) as any),
+	...((await vi.importActual('lib/next-mdx-remote/serialize')) as $TSFixMe),
 }))
 const serializeSpy = vi.spyOn(nextMdxRemote, 'serialize').mockReturnValue(
 	Promise.resolve({

--- a/src/views/docs-view/loaders/__tests__/remote-content.test.ts
+++ b/src/views/docs-view/loaders/__tests__/remote-content.test.ts
@@ -20,7 +20,7 @@ let scope: nock.Scope
 import * as nextMdxRemote from 'lib/next-mdx-remote/serialize'
 vi.mock('lib/next-mdx-remote/serialize', async () => ({
 	__esModule: true,
-	...((await vi.importActual('lib/next-mdx-remote/serialize')) as any),
+	...((await vi.importActual('lib/next-mdx-remote/serialize')) as $TSFixMe),
 }))
 const serializeSpy = vi.spyOn(nextMdxRemote, 'serialize').mockReturnValue(
 	Promise.resolve({
@@ -453,8 +453,8 @@ describe('RemoteContentLoader', () => {
 		})
 
 		// Verify that the function completed successfully
-		expect((props.navData[0] as any).path).not.toBeDefined()
-		expect((props.navData[0] as any).title).toEqual('Item with no path')
+		expect((props.navData[0] as $TSFixMe).path).not.toBeDefined()
+		expect((props.navData[0] as $TSFixMe).title).toEqual('Item with no path')
 	})
 })
 

--- a/src/views/docs-view/loaders/content-api/index.ts
+++ b/src/views/docs-view/loaders/content-api/index.ts
@@ -15,7 +15,7 @@ export async function fetchNavData(
 	product: string, //: string, // waypoint
 	basePath: string, //: string, // commands | docs | plugins
 	version: string //: string // v0.5.x
-): Promise<any> {
+) {
 	const contentApiBaseUrl = getContentApiBaseUrl(product)
 	const fullPath = `nav-data/${version}/${basePath}`
 	const url = `${contentApiBaseUrl}/api/content/${product}/${fullPath}`
@@ -33,7 +33,7 @@ export async function fetchNavData(
 export async function fetchDocument(
 	product: string,
 	fullPath: string
-): Promise<any> {
+) {
 	const contentApiBaseUrl = getContentApiBaseUrl(product)
 	const url = `${contentApiBaseUrl}/api/content/${product}/${fullPath}`
 	const response = await fetch(url)

--- a/src/views/docs-view/loaders/file-system.ts
+++ b/src/views/docs-view/loaders/file-system.ts
@@ -78,7 +78,7 @@ export default class FileSystemLoader implements DataLoader {
 		// We support passing in a function to remarkPlugins, which gets the parameters of the current page
 		if (typeof this.opts.remarkPlugins === 'function') {
 			remarkPlugins = this.opts.remarkPlugins(
-				paramsNoVersion as any,
+				paramsNoVersion as $TSFixMe,
 				versionFromPath
 			)
 			if (!Array.isArray(remarkPlugins)) {

--- a/src/views/docs-view/loaders/index.ts
+++ b/src/views/docs-view/loaders/index.ts
@@ -137,8 +137,8 @@ export interface GenerateStaticPropsContext {
 	params: Record<string, string[]> // {} | { page: ["destroy"] }
 	product: { name: string; slug: string }
 	mainBranch?: string // = 'main',
-	remarkPlugins?: any[]
-	scope?: any // optional, I think?
+	remarkPlugins?: $TSFixMe[]
+	scope?: $TSFixMe // optional, I think?
 	paramId?: string
 	basePath: string // 'docs'
 	githubFileUrl?: (path: string) => string

--- a/src/views/docs-view/types.ts
+++ b/src/views/docs-view/types.ts
@@ -14,7 +14,7 @@ export interface DocsViewProps {
 	/**
 	 * Frontmatter parsed from the MDX document
 	 */
-	metadata?: Record<string, any>
+	metadata?: Record<string, $TSFixMe>
 
 	/**
 	 * Represents the return value of a call to `serialize()`. The properties

--- a/src/views/docs-view/utils/__tests__/get-valid-versions.test.ts
+++ b/src/views/docs-view/utils/__tests__/get-valid-versions.test.ts
@@ -35,13 +35,13 @@ describe('getValidVersions', () => {
 			[]
 		)
 		expect(
-			await getValidVersions(undefined as any, fullPath, productSlugForLoader)
+			await getValidVersions(undefined as $TSFixMe, fullPath, productSlugForLoader)
 		).toEqual([])
 	})
 
 	it('should return filtered versions based on known versions from API', async () => {
 		const knownVersions = ['1.0.0']
-		;(fetch as any).mockResolvedValueOnce({
+		;(fetch as $TSFixMe).mockResolvedValueOnce({
 			json: async () => ({ versions: knownVersions }),
 		})
 
@@ -67,7 +67,7 @@ describe('getValidVersions', () => {
 		console.error = vi.fn()
 
 		try {
-			;(fetch as any).mockRejectedValueOnce(new Error('API error'))
+			;(fetch as $TSFixMe).mockRejectedValueOnce(new Error('API error'))
 
 			const result = await getValidVersions(
 				versions,
@@ -85,7 +85,7 @@ describe('getValidVersions', () => {
 		const consoleErrorSpy = vi
 			.spyOn(console, 'error')
 			.mockImplementation(() => {})
-		;(fetch as any).mockRejectedValueOnce(new Error('API error'))
+		;(fetch as $TSFixMe).mockRejectedValueOnce(new Error('API error'))
 
 		await getValidVersions(versions, fullPath, productSlugForLoader)
 		expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/src/views/product-tutorials-view/index.tsx
+++ b/src/views/product-tutorials-view/index.tsx
@@ -80,7 +80,7 @@ function ProductTutorialsView({
 			 * correct types. This will require chaning many files, so deferring for
 			 * a follow-up PR since this is functional for the time being.
 			 */
-			sidebarNavDataLevels={sidebarNavDataLevels as any}
+			sidebarNavDataLevels={sidebarNavDataLevels as $TSFixMe}
 		>
 			<PageHeading />
 			<ProductViewContent blocks={blocks} />

--- a/src/views/tutorial-view/index.tsx
+++ b/src/views/tutorial-view/index.tsx
@@ -250,7 +250,7 @@ function TutorialView({
 						 * the correct types. This will require chaning many files, so
 						 * deferring for a follow-up PR since this is functional for the time being.
 						 */
-						sidebarNavDataLevels={sidebarNavDataLevels as any}
+						sidebarNavDataLevels={sidebarNavDataLevels as $TSFixMe}
 						showScrollProgress={true}
 						AlternateSidebar={TutorialsSidebar}
 						sidecarTopSlot={


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/home/1207213190767773/1209487818970503) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR resolves the `@typescript-eslint/no-explicit-any` eslint error only relative to the base assembly branch (`rm/fix-linting`)

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Slow but gradual chipping away of eslint errors in an effort to get linting working again in dev portal

## 💭 Anything else?

Apologies to @LeahMarieBush for introducing a ton more `$TSFixMe` instances, but it seemed like the best way to resolve this eslint error within the scope of the ticket without doing _a ton_ of refactoring. If there's a better way to resolve some/all of this I'm happy to hear it though.