### PR TITLE
@typescript-eslint/no-require-imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,11 +66,6 @@ module.exports = [
 			
 			// Not necessary in Next.js (https://spectrum.chat/next-js/general/react-must-be-in-scope-when-using-jsx~6193ef62-4d5e-4681-8f51-8c7bf6b9d56d)
             'react/react-in-jsx-scope': 'off',
-		},
-	},
-	{
-		files: ['**/*.js?(x)'],
-		rules: {
 			// For instances where we aren't using esmodules or TypeScript and therefore can't use import
 			'@typescript-eslint/no-require-imports': 'off'
 		},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,7 +65,7 @@ module.exports = [
 			'@typescript-eslint/explicit-function-return-type': 'off',
 			
 			// Not necessary in Next.js (https://spectrum.chat/next-js/general/react-must-be-in-scope-when-using-jsx~6193ef62-4d5e-4681-8f51-8c7bf6b9d56d)
-            'react/react-in-jsx-scope': 'off',
+			'react/react-in-jsx-scope': 'off',
 			// For instances where we aren't using esmodules or TypeScript and therefore can't use import
 			'@typescript-eslint/no-require-imports': 'off'
 		},
@@ -73,9 +73,9 @@ module.exports = [
 	{
 		files: ['**/*.ts?(x)'],
 		rules: {
-            'react/prop-types': 'off',
-            'react/no-array-index-key': 'warn',
-            'react/no-unknown-property': ['error', { ignore: ['class'] }]
+			'react/prop-types': 'off',
+			'react/no-array-index-key': 'warn',
+			'react/no-unknown-property': ['error', { ignore: ['class'] }]
 		},
 	},
 ]


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/home/1207213190767773/1209487818970503) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR updates the eslint config file to allow the usage of inline `require` (thus resolving 13 linting issues). Under closer inspection of this (and of www) it seems as though (in the case of the latter) inline `require()` is used in various places. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Slow but gradual chipping away of eslint errors in an effort to get linting working again in dev portal

## 💭 Anything else?
The significant commit can be found here: https://github.com/hashicorp/dev-portal/commit/7a9724b30a815f8b251065b48fcfeefd268aea27. 