### PR TITLE
no-array-index-key

### DIFF
--- a/src/components/author-primitives/packer/badges-header/index.tsx
+++ b/src/components/author-primitives/packer/badges-header/index.tsx
@@ -3,21 +3,17 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import s from './style.module.css'
 
-function BadgesHeader({
-	children,
-}: {
-	children: React.ReactChild[]
-}): React.ReactElement {
+function BadgesHeader({ children }: PropsWithChildren): React.ReactElement {
 	const childrenArray = React.Children.toArray(children)
 	return (
 		<div className={s.root}>
 			<div className={s.surroundSpaceCompensator}>
-				{childrenArray.map((badge, idx) => {
+				{childrenArray.map((badge) => {
 					return (
-						<div className={s.badgeSpacer} key={idx}>
+						<div className={s.badgeSpacer} key={badge.toString()}>
 							{badge}
 						</div>
 					)

--- a/src/components/outline-nav/components/outline-list-items/index.tsx
+++ b/src/components/outline-nav/components/outline-list-items/index.tsx
@@ -17,9 +17,9 @@ import type { OutlineLinkItem } from 'components/outline-nav/types'
 function OutlineListItems({ items }: { items: OutlineLinkItem[] }) {
 	return (
 		<>
-			{items.map((item: OutlineLinkItem, index: number) => {
+			{items.map((item: OutlineLinkItem) => {
 				return (
-					<li key={`${index}-${item.url}`}>
+					<li key={item.url}>
 						{'items' in item ? (
 							<OutlineLinkWithNesting {...item} />
 						) : (

--- a/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
+++ b/src/views/product-root-docs-path-landing/components/marketing-content/index.tsx
@@ -21,8 +21,9 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 
 	return (
 		<div className={s.root}>
-			{blocks.map((block, index) => {
+			{blocks.map((block, index: number) => {
 				if (block.type === 'paragraph') {
+					// eslint-disable-next-line react/no-array-index-key
 					return <LandingPageBlocks.ParagraphBlock {...block} key={index} />
 				}
 
@@ -32,7 +33,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 							id={block.headingId}
 							level={block.headingLevel}
 							text={block.title}
-							key={index}
+							key={block.title}
 						/>
 					)
 				}
@@ -42,7 +43,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 						<LandingPageBlocks.IconCardGridBlock
 							cards={block.cards}
 							productSlug={currentProduct.slug}
-							key={index}
+							key={block.type + currentProduct.slug}
 						/>
 					)
 				}
@@ -55,7 +56,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 							headingLevel={block.headingLevel}
 							headingId={block.headingId}
 							title={block.title}
-							key={index}
+							key={block.headingId}
 						/>
 					)
 				}
@@ -67,7 +68,7 @@ const ProductRootDocsPathLandingMarketingContent = ({ blocks }) => {
 							ctas={[block.callToAction]}
 							heading={GETTING_STARTED_CARD_HEADING}
 							headingSlug={GETTING_STARTED_CARD_HEADING_SLUG}
-							key={index}
+							key={block.type + GETTING_STARTED_CARD_HEADING_SLUG}
 						/>
 					)
 				}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/0/home/1207213190767773/1209487818970503) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR resolves linting issues related to the `no-array-index-key` linting rule.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Slow but gradual chipping away of eslint errors in an effort to get linting working again in dev portal

## 💭 Anything else?
1. I would like to call out [this change](https://github.com/hashicorp/dev-portal/compare/rm/fix-linting...rm/no-array-index-key?expand=1#diff-0ee33eb12315f956f8e988aa744ca328320dc8e0b87700ef92db4185b3030006R9) where component typing was updated to use `PropsWithChildren` instead of manually typing `{ children: React.ReactChild[] }` - it wasn't  _directly_ in scope but it was showing as a react warning in my IDE and it seemed like a quick and easy fix at the time...
2. I'd also like to draw attention to [this file](https://github.com/hashicorp/dev-portal/pull/2714/files#diff-4a662c6db256155738bc8b6e0b6ab86cfb90e6b05511f17a6af09c7dbf351d97) and the changes in it. I tried to use various values (other than `index`) for the key, but in one case I had to just disable the lint rule for that line and in a couple of other places, I had to combine the fields in scope to get a (hopefully unique) value. Would love to hear if there's a better way of doing this.