### PR TITLE
Patch fix: documentation tab in search modal broken

### DIFF
--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -147,13 +147,13 @@ function SearchResults({
 						)
 					}
 				)}
-				<Index indexName={__config.dev_dot.algolia.udrIndexName} indexId="docs">
+				{/* <Index indexName={__config.dev_dot.algolia.udrIndexName} indexId="docs">
 					<Configure
 						query={currentInputValue}
 						filters={getAlgoliaFilters(currentProductSlug, 'docs')}
 					/>
 					<HitsReporter setHits={(hits) => setHitData('docs', hits)} />
-				</Index>
+				</Index> */}
 			</InstantSearch>
 			{/* UnifiedHitsContainer renders search results in a tabbed interface. */}
 			<UnifiedHitsContainer

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -147,7 +147,7 @@ function SearchResults({
 						)
 					}
 				)}
-				{/* <Index indexName={__config.dev_dot.algolia.udrIndexName} indexId="docs">
+				{/* TODO: uncomment this when hits from the prod_UDR index can be merged with *_DEVODOT_omni docs records <Index indexName={__config.dev_dot.algolia.udrIndexName} indexId="docs">
 					<Configure
 						query={currentInputValue}
 						filters={getAlgoliaFilters(currentProductSlug, 'docs')}


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task](https://app.asana.com/1/90955849329269/project/1202801212949828/task/1209672612329409?focus=true)

## 🗒️ What

- Comment out udr docs index as it is overriding docs records from  the `*_DEVOT_omni` index

## 🤷 Why

- The records w/ `type: 'docs'` from `*_DEVOT_omni`  are being overridden by the udr index. The implementation of federated search is incorrect. The hits from prod_UDR need to be merged with hits `*_DEVOT_omni`

- As an interim solution, the JSON file generated from `npm run prebuild` has been added to the `prod_DEVDOV_omni` index.
