### PR TITLE
Enable Vercel automation bypass for e2e tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,7 @@ jobs:
         run: npm run test:e2e
         env:
           E2E_BASE_URL: ${{ github.event.deployment_status.target_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: always()
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,10 @@ const config: PlaywrightTestConfig = {
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
+
+		extraHTTPHeaders: {
+			'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '',
+		}
 	},
 
 	/* Configure projects for major browsers (https://playwright.dev/docs/test-advanced#projects) */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,7 @@ const config: PlaywrightTestConfig = {
 		trace: 'on-first-retry',
 
 		extraHTTPHeaders: {
-			'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '',
+			'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET ?? '',
 		}
 	},
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/0/home/1207213190767773/1209537883815012) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Enable vercel authentication bypass for e2e tests.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Vercel deployment protection is currently disabled for previews because enabling it causes e2e tests to fail. The fix for this is to enable automation bypass which allows an additional token (obtained via env var) to be passed in the header allowing programmatic access to preview deployments

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

Some additional work to be done when this is merged:

In order to avoid breakages to new deployments (while this is in review) the Vercel/GitHub side of things hasn't been turned on yet. When this PR is merged, there is some additional work to be done to set this up:

1. Go into Vercel and [enable deployment protection for dev-portal](https://vercel.com/hashicorp/dev-portal/settings/deployment-protection) and select "Only pre-production deployments" from the dropdown
2. Copy the `VERCEL_AUTOMATION_BYPASS_SECRET` value and paste it into [GitHub settings](https://github.com/hashicorp/dev-portal/settings/secrets/actions)