### PR TITLE
chore: Remove udr index component

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -9,8 +9,7 @@
 			"description": "Explore {product} product documentation, tutorials, and examples."
 		},
 		"algolia": {
-			"unifiedIndexName": "prod_DEVDOT_omni",
-			"udrIndexName": "prod_UDR"
+			"unifiedIndexName": "prod_DEVDOT_omni"
 		},
 		"analytics": {
 			"included_domains": "developer.hashi-mktg.com developer.hashicorp.com"

--- a/config/unified-docs-sandbox.json
+++ b/config/unified-docs-sandbox.json
@@ -4,11 +4,7 @@
 		"max_static_paths": 1
 	},
 	"dev_dot": {
-		"max_static_paths": 1,
-		"algolia": {
-			"unifiedIndexName": "prod_DEVDOT_omni",
-			"udrIndexName": "prod_UDR"
-		}
+		"max_static_paths": 1
 	},
 	"learn": {
 		"max_static_paths": 1

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -147,13 +147,6 @@ function SearchResults({
 						)
 					}
 				)}
-				{/* TODO: uncomment this when hits from the prod_UDR index can be merged with *_DEVODOT_omni docs records <Index indexName={__config.dev_dot.algolia.udrIndexName} indexId="docs">
-					<Configure
-						query={currentInputValue}
-						filters={getAlgoliaFilters(currentProductSlug, 'docs')}
-					/>
-					<HitsReporter setHits={(hits) => setHitData('docs', hits)} />
-				</Index> */}
 			</InstantSearch>
 			{/* UnifiedHitsContainer renders search results in a tabbed interface. */}
 			<UnifiedHitsContainer


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task](https://app.asana.com/0/1205788188868789/1209705281993242/f)
- [related UDR PR](https://github.com/hashicorp/web-unified-docs/pull/192)

## 🗒️ What

Clean up task:
- Removing udr index component as udr docs are now pushed to the appropriate devdot omni index
- Removing udr index from Algolia property in config files

## 🤷 Why

- this implementation was overriding the docs from the omni index; it's now no longer needed as udr records are not under a udr index, they are pushed to the omni index

## 🧪 Testing
n/a, removing commented out code
