### PR TITLE
feat: use omni algolia index for zendesk articles

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -9,8 +9,7 @@
 			"description": "Explore {product} product documentation, tutorials, and examples."
 		},
 		"algolia": {
-			"unifiedIndexName": "prod_DEVDOT_omni",
-			"zendeskIndexName": "prod_ZENDESK"
+			"unifiedIndexName": "prod_DEVDOT_omni"
 		},
 		"analytics": {
 			"included_domains": "developer.hashi-mktg.com developer.hashicorp.com"

--- a/config/preview.json
+++ b/config/preview.json
@@ -5,8 +5,7 @@
 	},
 	"dev_dot": {
 		"algolia": {
-			"unifiedIndexName": "staging_DEVDOT_omni",
-			"zendeskIndexName": "dev_ZENDESK"
+			"unifiedIndexName": "staging_DEVDOT_omni"
 		}
 	},
 	"flags": {

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -30,7 +30,6 @@ import { type UnifiedSearchResults, SearchContentTypes } from '../../types'
 import s from './dialog-body.module.css'
 
 const ALGOLIA_INDEX_NAME = __config.dev_dot.algolia.unifiedIndexName
-const ZENDESK_ALGOLIA_INDEX_NAME = __config.dev_dot.algolia.zendeskIndexName
 
 // Initialize the algolia search client
 const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID
@@ -135,38 +134,24 @@ function SearchResults({
 			{/* <InstantSearch /> updates algoliaData, and renders nothing.
 			    Maybe helpful to think of this as "the part that fetches results". */}
 			<InstantSearch indexName={ALGOLIA_INDEX_NAME} searchClient={searchClient}>
-				{[
-					SearchContentTypes.GLOBAL,
-					SearchContentTypes.DOCS,
-					SearchContentTypes.INTEGRATION,
-					SearchContentTypes.TUTORIAL,
-				].map(
+				{Object.values(SearchContentTypes).map(
 					(
-						type: Exclude<SearchContentTypes, SearchContentTypes.KNOWLEDGEBASE>
+						type: SearchContentTypes
 					) => {
 						const filters = getAlgoliaFilters(currentProductSlug, type)
 						return (
 							<Index key={type} indexName={ALGOLIA_INDEX_NAME} indexId={type}>
-								<Configure query={currentInputValue} filters={filters} />
+								<Configure 
+									query={currentInputValue} 
+									filters={filters} 
+									attributesToSnippet={type === SearchContentTypes.KNOWLEDGEBASE && ['description:25']} 
+									attributesToHighlight={type === SearchContentTypes.KNOWLEDGEBASE ? ['page_title', 'description:25'] : ['*']} 
+								/>
 								<HitsReporter setHits={(hits) => setHitData(type, hits)} />
 							</Index>
 						)
 					}
 				)}
-
-				<Index indexName={ZENDESK_ALGOLIA_INDEX_NAME} indexId={SearchContentTypes.KNOWLEDGEBASE}>
-					<Configure
-						query={currentInputValue}
-						attributesToSnippet={['description:25']}
-						attributesToHighlight={['page_title', 'description:25']}
-						filters={getAlgoliaFilters(currentProductSlug, SearchContentTypes.KNOWLEDGEBASE)}
-					/>
-					<HitsReporter
-						setHits={(hits) =>
-							setHitData(SearchContentTypes.KNOWLEDGEBASE, hits)
-						}
-					/>
-				</Index>
 			</InstantSearch>
 			{/* UnifiedHitsContainer renders search results in a tabbed interface. */}
 			<UnifiedHitsContainer

--- a/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/dialog-body/index.tsx
@@ -144,8 +144,8 @@ function SearchResults({
 								<Configure 
 									query={currentInputValue} 
 									filters={filters} 
-									attributesToSnippet={type === SearchContentTypes.KNOWLEDGEBASE && ['description:25']} 
-									attributesToHighlight={type === SearchContentTypes.KNOWLEDGEBASE ? ['page_title', 'description:25'] : ['*']} 
+									attributesToSnippet={['description:25']} 
+									attributesToHighlight={['page_title', 'description:250']} 
 								/>
 								<HitsReporter setHits={(hits) => setHitData(type, hits)} />
 							</Index>

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/helpers/gather-search-tabs-content.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/helpers/gather-search-tabs-content.tsx
@@ -85,21 +85,7 @@ export function gatherSearchTabsData(
 	const tabsData = validContentTypes.map((type: SearchContentTypes) => {
 		const { heading, icon } = tabContentByType[type]
 		const rawHits = unifiedSearchResults[type].hits
-
-		// If type is global, also add knowledgebase hits since they are not included in the global hits
-		// in the <InstantSearch> component because the knowledgebase hits come from a different index.
-		// Also, don't add knowledgebase hits if there are already 20 or more hits for global.
-		if (type === SearchContentTypes.GLOBAL && rawHits.length < 20) {
-			const knowledgeBaseHitsAlreadyAdded = rawHits.find((hit) => hit.type === SearchContentTypes.KNOWLEDGEBASE)
-			if (!knowledgeBaseHitsAlreadyAdded) {
-				const knowledgebaseHits = unifiedSearchResults.knowledgebase.hits.slice(
-					0,
-					20 - rawHits.length
-				)
-				rawHits.push(...knowledgebaseHits)
-			}
-		}
-
+		
 		/**
 		 * If the resultType is `global`, we want to include all results...
 		 * **Except** we need to filter out `integrations` for products that don't


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

This PR update the zendesk algolia configuration to use the omni algolia index instead of the zendesk one. This will make the zendesk results returned in the 'All' tab without special configuration. The reason the separate index was used at first was so data in the dev and prod index could be tested without impacting the production site global results.

Since the algolia staging_DEVDOT_omni index settings were adjusted as part of this PR (and the prod ones will be adjusted after this merges as well), the search results across all tabs will be ordered differently from what they are on prod. They now are ordered based off the following criteria in order: page_title, description, headings. Now in the global search, results from different sections may be intermingled instead of all the results from one tab and then the next tab and so on.

## 🧪 Testing

1. Go to [preview link](https://dev-portal-git-leah-featzendesk-one-index-hashicorp.vercel.app/)
2. Open the search
3. Verify it behaves the same way it does in prod

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->