### PR TITLE
Set terraform-docs-agents to load from UDR

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -42,7 +42,8 @@
 			"terraform-plugin-log",
 			"terraform-plugin-mux",
 			"terraform-plugin-sdk",
-			"terraform-plugin-testing"
+			"terraform-plugin-testing",
+			"terraform-docs-agents"
 		]
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -15,7 +15,8 @@
 			"terraform-plugin-log",
 			"terraform-plugin-mux",
 			"terraform-plugin-sdk",
-			"terraform-plugin-testing"
+			"terraform-plugin-testing",
+			"terraform-docs-agents"
 		]
 	}
 }

--- a/config/unified-docs-sandbox.json
+++ b/config/unified-docs-sandbox.json
@@ -15,7 +15,8 @@
 			"terraform-plugin-log",
 			"terraform-plugin-mux",
 			"terraform-plugin-sdk",
-			"terraform-plugin-testing"
+			"terraform-plugin-testing",
+			"terraform-docs-agents"
 		]
 	}
 }


### PR DESCRIPTION
## 🔗 Relevant links

- [Asana task](url) 🎟️

## 🗒️ What

Enabled loading terraform-docs-agents in dev-portal from UDR.

**Important:**
UDR needs to ship terraform-docs-agents support in main before this PR can be tested/goes out.