### PR TITLE
Don't check download url for vault

### DIFF
--- a/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
+++ b/src/views/docs-view/utils/__tests__/rewrite-docs-url.test.ts
@@ -13,9 +13,9 @@ import nomadProductData from 'data/nomad.json'
 
 describe('rewriteDocsUrl', () => {
 	describe('/downloads links', () => {
-		// there is no downloads link for hcp
+		// there is no downloads link for hcp, waypoint, or vault
 		const productsToTest = productSlugs.filter(
-			(slug) => slug !== 'hcp' && slug !== 'waypoint'
+			(slug) => slug !== 'hcp' && slug !== 'waypoint' && slug !== 'vault'
 		)
 
 		test.each(productsToTest)(


### PR DESCRIPTION
## 🔗 Relevant links

## 🗒️ What

Remove the `'/downloads` check for Vault docs.

## 🤷 Why

The Vault docs don't have a downloads folder.

## 🛠️ How

Add `vault` to the exclusion list for the "rewriteDocsUrl" -> "/downloads links" test