### PR TITLE
Remove extra vault tutorials link

### DIFF
--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -75,10 +75,6 @@
 		},
 		"divider",
 		{
-			"text": "Tutorials",
-			"url": "https://developer.hashicorp.com/vault/tutorials"
-		},
-		{
 			"text": "Docs",
 			"url": "/docs"
 		},

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -145,7 +145,7 @@
 			"os": "linux"
 		}
 	],
-	"basePaths": ["docs", "api-docs","downloads"],
+	"basePaths": ["docs", "api-docs","tutorials", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -75,6 +75,10 @@
 		},
 		"divider",
 		{
+			"text": "Tutorials",
+			"url": "https://developer.hashicorp.com/vault/tutorials"
+		},
+		{
 			"text": "Docs",
 			"url": "/docs"
 		},
@@ -141,7 +145,7 @@
 			"os": "linux"
 		}
 	],
-	"basePaths": ["docs", "api-docs","tutorials", "downloads"],
+	"basePaths": ["docs", "api-docs", "downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",

--- a/src/data/vault.json
+++ b/src/data/vault.json
@@ -145,7 +145,7 @@
 			"os": "linux"
 		}
 	],
-	"basePaths": ["docs", "api-docs", "downloads"],
+	"basePaths": ["docs", "api-docs","downloads"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",
@@ -161,11 +161,6 @@
 			"iconName": "api",
 			"name": "APIs",
 			"path": "api-docs"
-		},
-		{
-			"iconName": "guide",
-			"name": "Tutorials",
-			"path": "tutorials"
 		}
 	],
 	"integrationsConfig": {


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-remove-extra-vault-tutorials-link-hashicorp.vercel.app/vault) 🔎

## 🗒️ What

Removes the extra tutorials link for vault docs that was accidentally added in the PR: https://github.com/hashicorp/dev-portal/pull/2745.
