### PR TITLE
Update Ubuntu install instructions to match packing guide upates

### DIFF
--- a/src/views/product-downloads-view/helpers.ts
+++ b/src/views/product-downloads-view/helpers.ts
@@ -13,15 +13,12 @@ import semverParse from 'semver/functions/parse'
 import semverPrerelease from 'semver/functions/prerelease'
 import semverRSort from 'semver/functions/rsort'
 import semverValid from 'semver/functions/valid'
-import { ProductData} from 'types/products'
+import { ProductData } from 'types/products'
 import {
 	getInlineCollections,
 	getInlineTutorials,
 } from 'views/product-tutorials-view/helpers/get-inline-content'
-import {
-	PackageManager,
-	SortedReleases,
-} from './types'
+import { PackageManager, SortedReleases } from './types'
 import capitalize from '@hashicorp/platform-util/text/capitalize'
 
 const PLATFORM_MAP = {
@@ -48,7 +45,7 @@ export const generateDefaultPackageManagers = (
 			label: 'Ubuntu/Debian',
 			commands: [
 				`wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg`,
-				`echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list`,
+				`echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list`,
 				`sudo apt update && sudo apt install ${productSlug}`,
 			],
 			os: 'linux',


### PR DESCRIPTION
## 🔗 Relevant links

- [Official packaging guide](https://www.hashicorp.com/en/official-packaging-guide?product_intent=terraform)
- https://github.com/hashicorp/terraform/issues/37057 

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

The packaging guide was recently updated to update the logic determining which Ubuntu codename to include. This update brings the install pages in line with the packaging guide.

## 🤷 Why

The current instructions work for Ubuntu, however they do not work for Ubuntu variants such as Mint. The updated command looks up the base Ubuntu codename, rather than the variant codename.