### PR TITLE
Hide version picker if page has no previous versions

### DIFF
--- a/src/components/docs-version-switcher/index.tsx
+++ b/src/components/docs-version-switcher/index.tsx
@@ -87,6 +87,10 @@ const DocsVersionSwitcher = ({
 		currentProduct
 	)
 
+	if (options.length === 1) {
+		return null
+	}
+
 	/**
 	 * Encode docs concerns into the `options` to pass to `VersionSwitcher`.
 	 */


### PR DESCRIPTION
## 🗒️ What

If no previous version exists then we should hide the version picker. Otherwise it is a poor user experience and gives the user the idea that this document existed in previous versions, when it did not.

The document **might** of existed in a previous path, and got renamed/moved in a new version but our current API/data structure has no concept of that.

## 🚧 Testing
1. [Vault document that **has NO** previous versions](https://dev-portal-git-rn-hide-version-picker-on-singl-c7df6d-hashicorp.vercel.app/vault/docs/about-vault/what-is-vault)
    1. It might of gotten renamed, but see above.
1. [Vault document that **has** previous version](https://dev-portal-git-rn-hide-version-picker-on-singl-c7df6d-hashicorp.vercel.app/vault/docs/get-started/developer-qs)
