### PR TITLE
Update video embed to also track video plays

### DIFF
--- a/src/components/video-embed/index.tsx
+++ b/src/components/video-embed/index.tsx
@@ -15,7 +15,7 @@ import {
 	useMilestones,
 } from './helpers'
 import s from './video-embed.module.css'
-import { trackVideoStart } from 'lib/posthog-events'
+import { trackVideoStart, trackVideoPlay } from 'lib/posthog-events'
 
 /**
  * MAX_PLAYBACK_SPEED is based on max speeds for YouTube & Wistia.
@@ -152,7 +152,10 @@ function VideoEmbed({
 						setPosition(playedSeconds)
 					}}
 					onEnded={setEnded}
-					onPlay={setPlaying}
+					onPlay={() => {
+						setPlaying()
+						trackVideoPlay(url)
+					}}
 					onPause={setStopped}
 					className={s.reactPlayer}
 					width="100%"

--- a/src/lib/posthog-events.ts
+++ b/src/lib/posthog-events.ts
@@ -23,3 +23,26 @@ export function trackVideoStart(url: string): void {
 		})
 	}
 }
+
+/**
+ * Enables PostHog video play tracking
+ * This is different from the video start event because it is triggered
+ * when the user actually plays the video (start and after play after pause).
+ */
+export function trackVideoPlay(url: string): void {
+	if (!window?.posthog) return
+
+	let video_host = ""
+	if (url.includes('wistia')) {
+		video_host = 'wistia'
+	} else if (url.includes('youtube')) {
+		video_host = 'youtube'
+	} 
+
+	if (video_host) {
+		window.posthog.capture('video_play', {
+			video_host,
+			url,
+		})
+	}
+}


### PR DESCRIPTION
## 🔗 Relevant links

The current implementation only tracks video starts rather than video plays (starts and when users restart the video after clicking pause). The historic way we've tracked video plays before the video embed was whenever users clicked the CSS selector that mapped to the wisita/youtube embed. This update makes it closer to the original implementation.

We still want to keep `video_start` as a metric. This newer `video_play` metric will let us reconcile with our historical data.

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to any page with a video in the deploy preview ([example](https://dev-portal-git-video-embed-ph-track-plays-hashicorp.vercel.app/terraform/tutorials/aws-get-started/infrastructure-as-code)). For event tracking to work, you must have adblocker disabled... also Arc disables tracking by default. Please use Safari or Chrome.
2. Start the video. Pause the video. Click the video again.
3. You should see two events for `video_play` in PostHog ([event details](https://eu.posthog.com/project/29987/data-management/events/0196efdd-2a0c-7631-b917-3c4e6330c57c))
  <img width="1188" alt="image" src="https://github.com/user-attachments/assets/ad5fabbc-de40-4286-a9b0-b5d8e0a2a596" />


## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
