### PR TITLE
fix: initialize posthog in correct env

### DIFF
--- a/src/components/posthog/posthog-provider.tsx
+++ b/src/components/posthog/posthog-provider.tsx
@@ -18,7 +18,7 @@ export function ConditionalPostHogProvider({
 		if (categoryPerformanceConsent) {
 			// This initialization code came from the PostHog documentation
 			// https://posthog.com/docs/libraries/next-js#router-specific-instructions
-			posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+			posthog.init(process.env.POSTHOG_PROJECT_API_KEY, {
 				api_host:
 					process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
 				// Enable debug mode in development


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR initializes posthog using the correct api key for whatever environment it is in. Previously it was always using the prod key for initialization.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

We should be using the correct keys for the correct environments. This env variable has a check in the [next config file](https://github.com/hashicorp/dev-portal/blob/0156798af89c4a7b9ba2529eced0362b39562bbf/next.config.js#L86) that sets it for the environment

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to [preview](https://dev-portal-git-leah-fixposthog-init-env-hashicorp.vercel.app/terraform/tutorials/aws-get-started/infrastructure-as-code)
2. Click play and pause on the video a few times
3. Verify the events are showing up in the [dev posthog project](https://eu.posthog.com/project/29988/activity/explore)
