### PR TITLE
Make UDR the source for terraform-docs-common and ptfe-releases

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -44,7 +44,9 @@
 			"terraform-plugin-sdk",
 			"terraform-plugin-testing",
 			"terraform-docs-agents",
-			"terraform-cdk"
+			"terraform-cdk",
+			"terraform-docs-common",
+			"ptfe-releases",
 		]
 	}
 }


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Update the dev portal config to make UDR the source for terraform-docs-common and terraform-entperirse (formerly ptfe-releases) docs.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
The (new) URL slug for `/content/ptfe-releases` is _actually_ `/content/terraform-enterprise`, but presumably (due to the work done in https://github.com/hashicorp/web-unified-docs/pull/419) `/content/ptfe-releases` is perfectly fine to use here (with a view to updating dev portal down the road to instead make requests to `/content/terraform-enterprise` instead?