### PR TITLE
feat: support tab text experiment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
 				"openapi-types": "^12.1.3",
 				"p-map": "^4.0.0",
 				"pkg-dir": "^5.0.0",
-				"posthog-js": "^1.194.6",
+				"posthog-js": "^1.249.1",
 				"probe-image-size": "^7.2.3",
 				"promise-polyfill": "^8.2.1",
 				"query-string": "^7.1.1",
@@ -42983,14 +42983,26 @@
 			}
 		},
 		"node_modules/posthog-js": {
-			"version": "1.194.6",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.194.6.tgz",
-			"integrity": "sha512-5g5n7FjWLha/QWVTeWeMErGff21v4/V3wYCZ2z8vAbHaCyHkaDBEbuM756jMFBQMsq3HJcDX9mlxi2HhAHxq2A==",
+			"version": "1.249.1",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.249.1.tgz",
+			"integrity": "sha512-gRqoD7umCMBQwP27gFArQWSJ5WXmrmNi+kcH8Yu2CmRX3twSYkTSVBzDhXtSW6NGqyLXbkS+vH4JW5xZJPK5uw==",
 			"dependencies": {
 				"core-js": "^3.38.1",
 				"fflate": "^0.4.8",
 				"preact": "^10.19.3",
-				"web-vitals": "^4.2.0"
+				"web-vitals": "^4.2.4"
+			},
+			"peerDependencies": {
+				"@rrweb/types": "2.0.0-alpha.17",
+				"rrweb-snapshot": "2.0.0-alpha.17"
+			},
+			"peerDependenciesMeta": {
+				"@rrweb/types": {
+					"optional": true
+				},
+				"rrweb-snapshot": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 		"openapi-types": "^12.1.3",
 		"p-map": "^4.0.0",
 		"pkg-dir": "^5.0.0",
-		"posthog-js": "^1.194.6",
+		"posthog-js": "^1.249.1",
 		"probe-image-size": "^7.2.3",
 		"promise-polyfill": "^8.2.1",
 		"query-string": "^7.1.1",

--- a/src/components/command-bar/commands/search/unified-search/components/no-results-message/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/no-results-message/index.tsx
@@ -4,11 +4,14 @@
  */
 
 import { ReactElement } from 'react'
+// Experiment: support-tab-text START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: support-tab-text END
 import Badge from 'components/badge'
 import Text from 'components/text'
 import { useCommandBar } from 'components/command-bar'
 import s from './no-results-message.module.css'
-import type { SearchContentTypes } from '../../types'
+import { SearchContentTypes } from '../../types'
 
 interface NoResultsMessageProps {
 	tabsWithResults: {
@@ -28,6 +31,11 @@ function NoResultsMessage({
 	currentTabHeading,
 }: NoResultsMessageProps) {
 	const { currentInputValue } = useCommandBar()
+	// Experiment: support-tab-text START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'support-tab-text'
+	)
+	// Experiment: support-tab-text END
 
 	return (
 		<div className={s.root}>
@@ -40,12 +48,19 @@ function NoResultsMessage({
 					Check the{' '}
 					{tabsWithResults.map((otherTab, idx) => {
 						const isLastItem = idx === tabsWithResults.length - 1
+						// Experiment: support-tab-text START
+						const badgeHeading =
+							featureFlagKey === 'variant' &&
+							otherTab.type === SearchContentTypes.KNOWLEDGEBASE
+								? 'Knowledge Base'
+								: otherTab.heading
+						// Experiment: support-tab-text END
 						return (
 							<span key={otherTab.type}>
 								<Badge
 									className={s.otherTabBadge}
 									icon={otherTab.icon}
-									text={otherTab.heading}
+									text={badgeHeading}
 									type="outlined"
 									size="small"
 								/>

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
@@ -7,6 +7,9 @@
 import Tabs, { Tab } from 'components/tabs'
 import { CommandBarDivider } from 'components/command-bar/components'
 import { CommandBarList } from 'components/command-bar/components'
+// Experiment: support-tab-text START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: support-tab-text END
 // Unified search
 import TabHeadingWithCount from '../tab-heading-with-count'
 import NoResultsMessage from '../no-results-message'
@@ -32,18 +35,32 @@ export function UnifiedHitsContainer({
 	tabsData: UnifiedSearchTabContent[]
 	suggestedPages: SuggestedPageProps[]
 }) {
+	// Experiment: support-tab-text START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'support-tab-text'
+	)
+	// Experiment: support-tab-text END
+
 	return (
 		<div className={s.tabsWrapper}>
 			<Tabs showAnchorLine={false} variant="compact">
 				{tabsData.map((tabData: UnifiedSearchTabContent) => {
 					const { type, heading, icon, hits, hitCount, otherTabData } = tabData
 					const resultsLabelId = `${type}-search-results-label`
+
+					// Experiment: support-tab-text START
+					const tabHeading =
+						featureFlagKey === 'variant' &&
+						type === SearchContentTypes.KNOWLEDGEBASE
+							? 'Knowledge Base'
+							: heading
+					// Experiment: support-tab-text END
 					return (
 						<Tab
-							heading={heading}
+							heading={tabHeading}
 							headingSlot={
 								<TabHeadingWithCount
-									heading={heading}
+									heading={tabHeading}
 									count={
 										type === SearchContentTypes.GLOBAL ? undefined : hitCount
 									}
@@ -71,7 +88,7 @@ export function UnifiedHitsContainer({
 							) : (
 								<div className={s.noResultsWrapper}>
 									<NoResultsMessage
-										currentTabHeading={heading}
+										currentTabHeading={tabHeading}
 										tabsWithResults={otherTabData}
 									/>
 									<CommandBarDivider className={s.divider} />

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
@@ -9,6 +9,7 @@ import { CommandBarDivider } from 'components/command-bar/components'
 import { CommandBarList } from 'components/command-bar/components'
 // Experiment: support-tab-text START
 import { useFeatureFlagVariantKey } from 'posthog-js/react'
+import posthog from 'posthog-js'
 // Experiment: support-tab-text END
 // Unified search
 import TabHeadingWithCount from '../tab-heading-with-count'
@@ -39,11 +40,23 @@ export function UnifiedHitsContainer({
 	const featureFlagKey = useFeatureFlagVariantKey(
 		'support-tab-text'
 	)
+
+	const handleChange = (newActiveIndex: number) => {
+		// The index of the "Support" tab is 4, so we want to send an event to posthog
+		// when the users clicks this tab
+		if(newActiveIndex === 4) {
+			// Send event to posthog
+			posthog.capture('experiment_activated', {
+				id: 'support-tab-text',
+				flagKey: featureFlagKey,
+			})
+		}
+	}
 	// Experiment: support-tab-text END
 
 	return (
 		<div className={s.tabsWrapper}>
-			<Tabs showAnchorLine={false} variant="compact">
+			<Tabs showAnchorLine={false} variant="compact" onChange={handleChange}>
 				{tabsData.map((tabData: UnifiedSearchTabContent) => {
 					const { type, heading, icon, hits, hitCount, otherTabData } = tabData
 					const resultsLabelId = `${type}-search-results-label`


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](https://app.asana.com/1/90955849329269/project/1210146125607813/task/1210201394680100?focus=true) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR adds an experiment for the support tab text. Currently, the text is 'Support' for the last tab in the search modal. In this experiment, we are testing if the text 'Knowledge Base' leads to higher clicks for this tab.

I also had to update the `posthog-js` package in this PR because the package we were using previously had a bug where if you tried flipping the flags on the posthog toolbar, it would not work and an error would pop up.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->
Control
<img width="839" alt="Screenshot 2025-06-04 at 11 52 09 AM" src="https://github.com/user-attachments/assets/a1b5753c-aae8-40a3-98f8-a011bd6c3b4d" />


Variant 
<img width="845" alt="Screenshot 2025-06-04 at 11 52 17 AM" src="https://github.com/user-attachments/assets/3136d492-97da-4d1f-805d-228849bd2763" />
## 🧪 Testing

1. Go to [posthog](https://eu.posthog.com/project/29988/toolbar)
2. Click launch on the link that is `https://dev-portal-git-leah-featsupport-tab-experiment-hashicorp.vercel.app/
`
3. Open the search modal from that link and type something
4. Verify that you are seeing either the control (Support) or variant (Knowledge Base) text on the last tab
5. In the posthog toolbar, select the feature flag button and turn on the `support-tab-text` flag
6. Click on both the variant and control and verify the correct text is showing for each
7. Go to [posthog activity](https://eu.posthog.com/project/29988/activity/explore)
8. Verify you are seeing the `experiment_activated` event (may need to refresh a few times)
<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
