### PR TITLE
fix: redirects for hvd-docs causing make to fail in UDR

### DIFF
--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -84,6 +84,15 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 		)
 		return []
 	}
+
+	/**
+	 * The UDR docker image does not have access to the github token necessary to
+	 * fetch redirects from the hvd-docs repo so we return an empty array
+	 */
+	if (process.env.HASHI_ENV === 'unified-docs-sandbox' && repoName === 'hvd-docs') {
+		return []
+	}
+
 	/**
 	 * Load redirects from the target repo (or return early for non-target repos).
 	 */


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Asana task](https://app.asana.com/1/90955849329269/project/1206815131022336/task/1210451336821731?focus=true) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR updates the redirects in dev-portal so that the UDR docker image does not request redirects for hvd-docs.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

UDR currently has a bug where the `make` command is failing for the dev-portal image. This is because UDR does not have access to the token necessary to pull the redirects for the hvd-docs repo since it is a private repo. 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Pull down this branch
2. Create a docker image: `docker build -t test-dev-portal-build . `    
3. Add that image to UDR in docker-compose.yaml on line 6
4. Run UDR using `make`
5. Verify that dev-portal builds successfully
