### PR TITLE
feat: product dropdown promo placement experiment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@hashicorp/platform-util": "^0.2.0",
 				"@hashicorp/react-alert-banner": "^7.1.0",
 				"@hashicorp/react-button": "^6.3.1",
-				"@hashicorp/react-components": "^1.1.10",
+				"@hashicorp/react-components": "^1.1.11",
 				"@hashicorp/react-content": "^8.3.0",
 				"@hashicorp/react-design-system-components": "0.0.0-nightly.0a567ac",
 				"@hashicorp/react-design-system-tokens": "0.0.0-nightly.3d21315",
@@ -6081,24 +6081,20 @@
 			}
 		},
 		"node_modules/@hashicorp/react-components": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/@hashicorp/react-components/-/react-components-1.1.10.tgz",
-			"integrity": "sha512-YGbYSBNyLvXgq5A1gxbG3+sgSrOHbo4c2TSgOmqoMkB/4eQaxDZjlK6aFD32yGrqQSGmNoSdoFs16Uoxcen+GQ==",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/@hashicorp/react-components/-/react-components-1.1.11.tgz",
+			"integrity": "sha512-JyfEdNGjDoCX/K2/U8pl7FEgXCRHm69dSZ4tvAVu2oGPRnedC1na3Qaer03i/irboK3SQktJvi6KrXDq1r62xQ==",
 			"dependencies": {
-				"@hashicorp/flight-icons": "^3.5.0",
+				"@hashicorp/flight-icons": "^3.7.0",
 				"@hashicorp/platform-product-meta": "^0.1.1",
 				"@hashicorp/platform-util": "^0.2.0",
-				"@hashicorp/react-design-system-components": "*",
 				"@hashicorp/web-mktg-logos": "*",
 				"@radix-ui/react-navigation-menu": "^1.2.0",
 				"@radix-ui/react-visually-hidden": "^1.1.0",
-				"@vercel/analytics": "^1.3.1",
 				"@vercel/fetch": "^7.0.0",
 				"@vercel/stega": "^0.1.2",
 				"classnames": "^2.3.2",
-				"js-cookie": "^3.0.5",
-				"moize": "^6.1.3",
-				"react-hook-form": "^7.43.5"
+				"posthog-js": "^1.195.0"
 			}
 		},
 		"node_modules/@hashicorp/react-components/node_modules/@vercel/fetch": {
@@ -6115,14 +6111,6 @@
 			"peerDependencies": {
 				"@types/node-fetch": "^2.6.1",
 				"node-fetch": "^2.6.7"
-			}
-		},
-		"node_modules/@hashicorp/react-components/node_modules/js-cookie": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@hashicorp/react-content": {
@@ -17108,26 +17096,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@vercel/analytics": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
-			"integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
-			"dependencies": {
-				"server-only": "^0.0.1"
-			},
-			"peerDependencies": {
-				"next": ">= 13",
-				"react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"next": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@vercel/fetch": {
 			"version": "6.2.0",
@@ -47583,11 +47551,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/server-only": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-			"integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
 		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
 		"@hashicorp/platform-util": "^0.2.0",
 		"@hashicorp/react-alert-banner": "^7.1.0",
 		"@hashicorp/react-button": "^6.3.1",
-		"@hashicorp/react-components": "^1.1.10",
+		"@hashicorp/react-components": "^1.1.11",
 		"@hashicorp/react-content": "^8.3.0",
 		"@hashicorp/react-design-system-components": "0.0.0-nightly.0a567ac",
 		"@hashicorp/react-design-system-tokens": "0.0.0-nightly.3d21315",

--- a/src/components/mobile-menu-levels-generic/index.tsx
+++ b/src/components/mobile-menu-levels-generic/index.tsx
@@ -9,6 +9,10 @@ import MobileMenuContainer, {
 } from 'components/mobile-menu-container'
 import ProductPanel from '@hashicorp/react-components/src/components/nav-panel/product-panel'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
+// Hooks
+// Experiment: product-dropdown-promo-placement START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: product-dropdown-promo-placement END
 // Data
 import { mobileNavigationData, navPromo, sidePanelContent } from 'lib/products'
 // Styles
@@ -26,6 +30,11 @@ import s from './mobile-menu-levels-generic.module.css'
  * in turn determines visibility of the root `motion.div` of that component.
  */
 function MobileMenuLevelsGeneric() {
+	// Experiment: product-dropdown-promo-placement START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'product-dropdown-promo-placement'
+	)
+	// Experiment: product-dropdown-promo-placement END
 	return (
 		<MobileMenuContainer className={s.mobileMenuContainer}>
 			<MobileAuthenticationControls className={s.mobileMenuAuthContainer} />
@@ -35,6 +44,7 @@ function MobileMenuLevelsGeneric() {
 					productCategories={mobileNavigationData}
 					promo={navPromo}
 					sidePanel={sidePanelContent}
+					isPromoOnTop={featureFlagKey === 'variant'}
 				/>
 			</NavigationMenu.Root>
 		</MobileMenuContainer>

--- a/src/components/navigation-header/components/dropdown-menu/index.tsx
+++ b/src/components/navigation-header/components/dropdown-menu/index.tsx
@@ -7,6 +7,9 @@
 import { Fragment, KeyboardEvent, ReactElement, useRef, useState } from 'react'
 import { useId } from '@react-aria/utils'
 import classNames from 'classnames'
+// Experiment: product-dropdown-promo-placement START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: product-dropdown-promo-placement END
 
 // HashiCorp imports
 import { IconChevronDown16 } from '@hashicorp/flight-icons/svg-react/chevron-down-16'
@@ -57,6 +60,11 @@ const NavigationHeaderDropdownMenu = ({
 	const [isOpen, setIsOpen] = useState(false)
 	const menuId = `navigation-header-menu-${uniqueId}`
 	const hasLeadingIcon = !!leadingIcon
+	// Experiment: product-dropdown-promo-placement START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'product-dropdown-promo-placement'
+	)
+	// Experiment: product-dropdown-promo-placement END
 
 	// Handles closing the menu if there is a click outside of it and it is open.
 	useOnClickOutside([menuRef], () => setIsOpen(false), isOpen)
@@ -221,6 +229,7 @@ const NavigationHeaderDropdownMenu = ({
 						productCategories={productPanelData.navigationData}
 						promo={productPanelData.navPromo}
 						sidePanel={productPanelData.sidePanelContent}
+						isPromoOnTop={featureFlagKey === 'variant'}
 					/>
 				) : (
 					<div className={s.dropdownContainerInner}>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -8,6 +8,9 @@ import { useMemo, useState } from 'react'
 import classNames from 'classnames'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
 import ProductPanel from '@hashicorp/react-components/src/components/nav-panel/product-panel'
+// Experiment: product-dropdown-promo-placement START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: product-dropdown-promo-placement END
 
 // Global imports
 import { SIDEBAR_LABEL_ID, SIDEBAR_NAV_ELEMENT_ID } from 'constants/element-ids'
@@ -59,6 +62,11 @@ const Sidebar = ({
 		[currentPath, menuItems]
 	)
 	const isProductPanel = shouldRenderMobileControls && title === 'Main Menu'
+	// Experiment: product-dropdown-promo-placement START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'product-dropdown-promo-placement'
+	)
+	// Experiment: product-dropdown-promo-placement END
 
 	let backToElement
 	if (shouldRenderMobileControls && levelButtonProps) {
@@ -144,6 +152,7 @@ const Sidebar = ({
 						productCategories={mobileNavigationData}
 						promo={navPromo}
 						sidePanel={sidePanelContent}
+						isPromoOnTop={featureFlagKey === 'variant'}
 					/>
 				</NavigationMenu.Root>
 				{showResourcesList && (

--- a/src/pages/tutorials/library.tsx
+++ b/src/pages/tutorials/library.tsx
@@ -9,6 +9,9 @@ import { history } from 'instantsearch.js/es/lib/routers'
 import { useRouter } from 'next/router'
 import ProductPanel from '@hashicorp/react-components/src/components/nav-panel/product-panel'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
+// Experiment: product-dropdown-promo-placement START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: product-dropdown-promo-placement END
 
 import SidebarSidecarLayout, {
 	SidebarSidecarLayoutProps,
@@ -52,6 +55,11 @@ interface TutorialsLibraryPageProps {
 }
 
 function TutorialLibrarySidebar() {
+	// Experiment: product-dropdown-promo-placement START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'product-dropdown-promo-placement'
+	)
+	// Experiment: product-dropdown-promo-placement END
 	return (
 		// TODO: we should consider using Sidebar here to make the markup consistent across pages. We aren't for now due to duplicate "Resources" headings and Tutorial Library being a semi-special case.
 		<>
@@ -65,6 +73,7 @@ function TutorialLibrarySidebar() {
 							productCategories={productPanelMobileNavigationData}
 							promo={productPanelNavPromo}
 							sidePanel={productPanelSidePanelContent}
+							isPromoOnTop={featureFlagKey === 'variant'}
 						/>
 					</NavigationMenu.Root>
 				</SidebarNavList>

--- a/src/views/profile/sidebar/index.tsx
+++ b/src/views/profile/sidebar/index.tsx
@@ -15,6 +15,9 @@ import { useRouter } from 'next/router'
 import ProductPanel from '@hashicorp/react-components/src/components/nav-panel/product-panel'
 import { mobileNavigationData, navPromo, sidePanelContent } from 'lib/products'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
+// Experiment: product-dropdown-promo-placement START
+import { useFeatureFlagVariantKey } from 'posthog-js/react'
+// Experiment: product-dropdown-promo-placement END
 
 /**
  * shared left side bar for /profile pages
@@ -26,6 +29,12 @@ export function ProfileSidebar() {
 	const isActive = (path: string) => {
 		return asPath === path
 	}
+
+	// Experiment: product-dropdown-promo-placement START
+	const featureFlagKey = useFeatureFlagVariantKey(
+		'product-dropdown-promo-placement'
+	)
+	// Experiment: product-dropdown-promo-placement END
 
 	return (
 		<>
@@ -69,6 +78,7 @@ export function ProfileSidebar() {
 					productCategories={mobileNavigationData}
 					promo={navPromo}
 					sidePanel={sidePanelContent}
+					isPromoOnTop={featureFlagKey === 'variant'}
 				/>
 			</NavigationMenu.Root>
 		</>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-featproduct-dropdown-experiment-hashicorp.vercel.app/) 🔎
- [Asana task](https://app.asana.com/1/90955849329269/project/1206815131022336/task/1210201394680102?focus=true) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR adds an experiment to move the promo placement in the product dropdown. Currently, the promo is underneath under the products in the dropdown (control) but this experiment will be moving it to the top of the dropdown for half of users (variant). I am using the autocapture event where the element text is 'All HCP Products' to track the primary metric in this experiment

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

We want to see if changing the position of this element will lead to higher clicks.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

### Control
| Desktop | Mobile |
| --- | --- |
| <img width="1109" alt="Screenshot 2025-06-19 at 2 35 33 PM" src="https://github.com/user-attachments/assets/14d225f0-536b-4adc-a8ca-77fb51cd8bca" /> | <img width="492" alt="Screenshot 2025-06-19 at 2 35 53 PM" src="https://github.com/user-attachments/assets/7b21ec64-205b-46e0-bb25-9a364d6e2359" /> |


### Variant

| Desktop | Mobile |
| --- | --- |
| <img width="1103" alt="Screenshot 2025-06-19 at 2 35 11 PM" src="https://github.com/user-attachments/assets/c9fd462d-3c76-4437-b856-4fa066d7c11a" /> | <img width="473" alt="Screenshot 2025-06-19 at 2 35 22 PM" src="https://github.com/user-attachments/assets/0fce3c1a-1979-44a2-96d3-9400cca2fdbb" /> |

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to [posthog](https://eu.posthog.com/project/29988/toolbar)
2. Click launch on the link that is `https://dev-portal-git-leah-featproduct-dropdown-experiment-hashicorp.vercel.app/`
3. Open the toolbar on the bottom and turn on the product-dropdown-promo-placement feature flag and set it to control
4. Open the product dropdown from the top menu and verify the promo is on the bottom
5. Switch to mobile and verify that the promo is on the bottom
6. Open the toolbar and switch to the variant
7. Verify the promo is on the top for both desktop and mobile

## 💭 Anything else?

Before merge I will set up the experiment in prod so the feature flag is ready once we merge this