### PR TITLE
Update link url in UDR it if wraps an img and both share a url

### DIFF
--- a/src/lib/remark-plugins/remark-rewrite-assets.ts
+++ b/src/lib/remark-plugins/remark-rewrite-assets.ts
@@ -4,7 +4,7 @@
  */
 
 import * as path from 'path'
-import { visit } from 'unist-util-visit'
+import { visitParents } from 'unist-util-visit-parents'
 
 import type { Plugin } from 'unified'
 import type { Image } from 'mdast'
@@ -29,7 +29,7 @@ export function remarkRewriteAssets(args: {
 	return function plugin() {
 		return function transform(tree) {
 			// @ts-expect-error Types Should be correct here
-			visit<Image>(tree, 'image', (node) => {
+			visitParents<Image>(tree, 'image', (node, ancestors: Array.<Parent>) => {
 				let url
 				const originalUrl = node.url
 
@@ -61,6 +61,14 @@ export function remarkRewriteAssets(args: {
 
 If this is a net-new asset, you'll need to commit and push it to GitHub.\n`
 				)
+
+				// if the image is wrapped in a link, and shares the same url as the original image, then update the link's url to the new asset url
+				if (isInUDR) {
+					const parent = ancestors[ancestors.length - 1]
+					if (parent && parent.type === 'link' && parent.url === originalUrl) {
+						parent.url = url.toString()
+					}
+				}
 			})
 		}
 	}

--- a/src/lib/remark-plugins/remark-rewrite-assets.ts
+++ b/src/lib/remark-plugins/remark-rewrite-assets.ts
@@ -29,7 +29,7 @@ export function remarkRewriteAssets(args: {
 	return function plugin() {
 		return function transform(tree) {
 			// @ts-expect-error Types Should be correct here
-			visitParents<Image>(tree, 'image', (node, ancestors: Array.<Parent>) => {
+			visitParents<Image>(tree, 'image', (node, ancestors: Array<Parent>) => {
 				let url
 				const originalUrl = node.url
 


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-rn-update-img-wrapped-in-links-in-udr-hashicorp.vercel.app/) 🔎

## 🗒️ What

[We currently have a case where an image wrapped in a link to that image](https://hashicorp.slack.com/archives/C09K1N960/p1750692279277449), so folks can easily see a bigger version of that image is not updating to the newest image URL. This is because we are now serving images through an API.

This PR adds a special case to our rewrite image remark plugin to handle that case.

## 🧪 Testing

- [ ] On the page [terraform/cloud-docs/architectural-details/security-model#authorization-model](https://dev-portal-git-rn-update-img-wrapped-in-links-in-udr-hashicorp.vercel.app/terraform/cloud-docs/architectural-details/security-model#authorization-model) click on "**click on diagram for larger view**", and the image should load up in a new tab.
