### PR TITLE
Nits: Vault version & URLs

### DIFF
--- a/src/content/certifications/exam-faqs/terraform-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-003.mdx
@@ -69,7 +69,7 @@
 
 ## Requirements for Attending an Exam
 
-Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/en-us/sections/26234702018573) for taking HashiCorp certification exams.
+Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/26234761626125-Exam-appointment-rules-and-requirements) for taking HashiCorp certification exams.
 
 ## Renewing Your Certification
 

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -74,7 +74,7 @@ _* API was added to objective 5g and communicated to test-takers March 4 2025._
 
 ## Requirements for Attending an Exam
 
-Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/en-us/sections/26234702018573) for taking HashiCorp certification exams.
+Review the [rules and policies](https://hashicorp-certifications.zendesk.com/hc/en-us/articles/26234761626125-Exam-appointment-rules-and-requirements) for taking HashiCorp certification exams.
 
 ## Renewing Your Certification
 

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -25,7 +25,7 @@
 			"title": "Vault Operations Professional",
 			"examTier": "pro",
 			"productSlug": "vault",
-			"versionTested": "Vault 1.13.0 and higher",
+			"versionTested": "Vault 1.16",
 			"description": "The Vault Operations Professional certification is a lab-based exam for Cloud Engineers focused on deploying, configuring, managing, and monitoring HashiCorp Vault. You are well-qualified to take this exam if you hold the Vault Associate Certification (or equivalent knowledge), have experience operating Vault in production, and can evaluate Vault Enterprise functionality and use cases.",
 			"links": {
 				"prepare": "/vault/tutorials/ops-pro-cert",


### PR DESCRIPTION
I fixed the exam version, as somehow this was incorrect

- [Preview link](https://dev-portal-git-BE_nites-hashicorp.vercel.app/certifications/security-automation) 🔎
