### PR TITLE
Nomad: Remove link to archived tutorial so tutorials PR will build

### DIFF
--- a/src/content/nomad/product-landing.json
+++ b/src/content/nomad/product-landing.json
@@ -35,7 +35,6 @@
 		{
 			"type": "tutorial_cards",
 			"tutorialSlugs": [
-				"nomad/multiregion-deployments",
 				"nomad/schedule-edge-services",
 				"nomad/external-application-load-balancing"
 			]
@@ -138,9 +137,9 @@
 			"type": "linked_cards",
 			"cards": [
 				{
-					"heading": "Operating Nomad Clusters",
+					"heading": "Build Nomad Clusters",
 					"body": "Learn the features operators need to build and maintain Nomad clusters.",
-					"url": "nomad/tutorials/manage-clusters"
+					"url": "nomad/docs/deploy/clusters"
 				},
 				{
 					"heading": "Upgrade a Cluster",
@@ -161,7 +160,7 @@
 				{
 					"heading": "Task Drivers",
 					"body": "Task drivers are used by Nomad clients to execute a task and provide resource isolation. Extending task drivers allows Nomad the flexibility to support a broad set of workloads.",
-					"url": "nomad/plugins/drivers"
+					"url": "nomad/docs/deploy/task-driver"
 				},
 				{
 					"heading": "External Tools",


### PR DESCRIPTION
## 🔗 Relevant links

Jira: [CE-872]

https://dev-portal-git-ce872nomadtutorials-hashicorp.vercel.app/nomad

## 🗒️ What

product-landing.json: 
- remove `nomad/multiregion-deployments` link. That tutorial that has been archived. 
- Update link to task drivers content
- Change "Operating Nomad Clusters" to "Build Nomad Clusters" and change link to point to docs.

## 🤷 Why

This is required for my tutorials PR to build. https://github.com/hashicorp/tutorials/pull/2607

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->


[CE-872]: https://hashicorp.atlassian.net/browse/CE-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ