### PR TITLE
Et/ptfe removal and renaming to terraform enterprise

### DIFF
--- a/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
+++ b/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
@@ -17,7 +17,11 @@ describe('getLatestContentShaForProduct', () => {
 				expect(typeof latestSha).toBe('string')
 			})
 		}
-		if (['hcp-docs', 'sentinel', 'ptfe-releases', 'hvd-docs'].includes(repo)) {
+		if (
+			['hcp-docs', 'sentinel', 'terraform-enterprise', 'hvd-docs'].includes(
+				repo
+			)
+		) {
 			console.log(`Skipping test for private repo "${repo}"`)
 		} else {
 			it(`fetches the latest SHA for the "${repo}" repo, then validates the SHA by fetching redirects`, async () => {

--- a/build-libs/__tests__/redirects.test.ts
+++ b/build-libs/__tests__/redirects.test.ts
@@ -258,7 +258,7 @@ describe('getRedirectsFromContentRepo', () => {
 			'terraform-docs-common',
 			'test',
 			{
-				'flags.unified_docs_migrated_repos': ['terraform-docs-common']
+				'flags.unified_docs_migrated_repos': ['terraform-docs-common'],
 			}
 		)
 
@@ -270,10 +270,10 @@ describe('getRedirectsFromContentRepo', () => {
 		const mockConsole = vi.spyOn(console, 'error').mockImplementation(() => {})
 
 		const redirects = await getRedirectsFromContentRepo(
-			'ptfe-releases',
+			'terraform-enterprise',
 			'test',
 			{
-				'flags.unified_docs_migrated_repos': ['ptfe-releases']
+				'flags.unified_docs_migrated_repos': ['terraform-enterprise'],
 			}
 		)
 

--- a/build-libs/get-latest-content-sha-for-product.js
+++ b/build-libs/get-latest-content-sha-for-product.js
@@ -24,7 +24,8 @@ const KNOWN_LATEST_REF_ENDPOINTS = {
 	'terraform-docs-common':
 		'/api/content/terraform-docs-common/nav-data/latest/docs',
 	'hcp-docs': '/api/content/hcp-docs/nav-data/latest/docs',
-	'ptfe-releases': '/api/content/ptfe-releases/nav-data/latest/enterprise',
+	'terraform-enterprise':
+		'/api/content/terraform-enterprise/nav-data/latest/enterprise',
 	sentinel: '/api/content/sentinel/nav-data/latest/sentinel',
 }
 

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -64,12 +64,13 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	 * Load redirects from the unified docs repo if it's in the list of migrated repos.
 	 * Return early if there are not any redirects found for that specific repo.
 	 */
-	if (
-		config['flags.unified_docs_migrated_repos'].includes(repoName)
-	) {
-		const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN ? new Headers({
-			'x-vercel-protection-bypass': process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
-		}) : new Headers()
+	if (config['flags.unified_docs_migrated_repos'].includes(repoName)) {
+		const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
+			? new Headers({
+					'x-vercel-protection-bypass':
+						process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
+			  })
+			: new Headers()
 
 		const getUDRRedirects = await fetch(
 			`${process.env.UNIFIED_DOCS_API}/api/content/${repoName}/redirects`,
@@ -85,12 +86,15 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 		return []
 	}
 
-	const privateRepos = ['hcp-docs', 'ptfe-releases', 'sentinel', 'hvd-docs']
+	const privateRepos = ['hcp-docs', 'sentinel', 'hvd-docs']
 	/**
 	 * The UDR docker image does not have access to the github token necessary to
 	 * fetch redirects from private repos so we return an empty array for those redirects
 	 */
-	if (process.env.HASHI_ENV === 'unified-docs-sandbox' && privateRepos.includes(repoName)) {
+	if (
+		process.env.HASHI_ENV === 'unified-docs-sandbox' &&
+		privateRepos.includes(repoName)
+	) {
 		return []
 	}
 
@@ -144,7 +148,6 @@ const PRODUCT_REDIRECT_ENTRIES = [
 	{ repo: 'consul', path: 'website/redirects.js' },
 	{ repo: 'terraform-docs-common', path: 'website/redirects.js' },
 	{ repo: 'hcp-docs', path: '/redirects.js' }, // private repo
-	{ repo: 'ptfe-releases', path: 'website/redirects.js' }, // private repo
 	{ repo: 'sentinel', path: 'website/redirects.js' }, // private repo
 	{ repo: 'hvd-docs', path: '/redirects.js' }, // private repo
 ]
@@ -316,8 +319,6 @@ function filterInvalidRedirects(redirects, repoSlug) {
 		/** @deprecated - terraform-website is now archived and redirects have been moved to `terraform-docs-common` */
 		'terraform-website': 'terraform',
 		'terraform-docs-common': 'terraform',
-		// Note: `ptfe-releases` docs are rendered under `terraform/enterprise` URLs
-		'ptfe-releases': 'terraform/enterprise',
 		'cloud.hashicorp.com': 'hcp',
 		'hcp-docs': 'hcp',
 		'hvd-docs': 'validated-designs',

--- a/config/base.json
+++ b/config/base.json
@@ -48,7 +48,7 @@
 			"terraform",
 			"terraform-docs-common",
 			"vault",
-			"ptfe-releases"
+			"terraform-enterprise"
 		]
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -21,7 +21,7 @@
 			"terraform",
 			"terraform-docs-common",
 			"vault",
-			"ptfe-releases"
+			"terraform-enterprise"
 		]
 	}
 }

--- a/config/unified-docs-sandbox.json
+++ b/config/unified-docs-sandbox.json
@@ -18,7 +18,7 @@
 			"terraform-plugin-testing",
 			"terraform-docs-agents",
 			"terraform-cdk",
-			"ptfe-releases",
+			"terraform-enterprise",
 			"terraform-docs-common",
 			"terraform",
 			"vault"

--- a/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
@@ -9,16 +9,27 @@
  *  - navDataPrefix: the filename prefix for nav data JSON files
  */
 const getMdxAndNavDataDirectoriesForRepo = (repo: string) => {
+	// Legacy product slug mapping
+	const normalizedRepo =
+		repo === 'ptfe-releases' ? 'terraform-enterprise' : repo
+
 	// The default values that most repos use
 	let mdxPrefix = 'website/content'
 	let navDataPrefix = 'website/data'
 
 	// HCP and Terraform docs content repos use slightly different values
 	// Note: cloud.hashicorp.com is being renamed to hcp-docs
-	if (repo === 'cloud.hashicorp.com' || repo === 'hcp-docs') {
+	if (
+		normalizedRepo === 'cloud.hashicorp.com' ||
+		normalizedRepo === 'hcp-docs'
+	) {
 		mdxPrefix = 'content'
 		navDataPrefix = 'data'
-	} else if (repo.startsWith('terraform') || repo.startsWith('ptfe-releases')) {
+	} else if (normalizedRepo === 'terraform-enterprise') {
+		// Terraform Enterprise (ptfe-releases) content now lives in web-unified-docs
+		mdxPrefix = 'content'
+		navDataPrefix = 'data'
+	} else if (repo.startsWith('terraform')) {
 		mdxPrefix = 'website/docs'
 	}
 

--- a/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-mdx-and-nav-data-directories-for-repo.ts
@@ -21,12 +21,9 @@ const getMdxAndNavDataDirectoriesForRepo = (repo: string) => {
 	// Note: cloud.hashicorp.com is being renamed to hcp-docs
 	if (
 		normalizedRepo === 'cloud.hashicorp.com' ||
-		normalizedRepo === 'hcp-docs'
+		normalizedRepo === 'hcp-docs' ||
+		normalizedRepo === 'terraform-enterprise'
 	) {
-		mdxPrefix = 'content'
-		navDataPrefix = 'data'
-	} else if (normalizedRepo === 'terraform-enterprise') {
-		// Terraform Enterprise (ptfe-releases) content now lives in web-unified-docs
 		mdxPrefix = 'content'
 		navDataPrefix = 'data'
 	} else if (repo.startsWith('terraform')) {

--- a/scripts/docs-content-link-rewrites/helpers/get-mdx-links-to-rewrite.ts
+++ b/scripts/docs-content-link-rewrites/helpers/get-mdx-links-to-rewrite.ts
@@ -56,9 +56,8 @@ const getMdxLinksToRewrite = async ({
 		 * property indicates that the content is regularly copied over from the
 		 * source, and thus should not be modified.
 		 *
-		 * Example file in the `ptfe-releases` repository:
-		 * https://github.com/hashicorp/ptfe-releases/blob/ba4dc2af20cc9d0f46247c919be8b2ed90d1e6f8/website/docs/enterprise/registry/index.mdx?plain=1#L6
-		 */
+		 * Example file in the `terraform-enterprise` repository (formerly ptfe-releases):
+		 * https://github.com/hashicorp/web-unified-docs/blob/main/content/terraform-enterprise/...		 */
 		const { data: frontmatter } = matter(fileContent)
 		const isSourcedFromDifferentRepo =
 			typeof frontmatter?.source === 'string' && frontmatter.source !== repo

--- a/scripts/list-open-prs-with-docs-changes.ts
+++ b/scripts/list-open-prs-with-docs-changes.ts
@@ -12,16 +12,27 @@ import { Octokit } from '@octokit/rest'
  *  - navDataPrefix: the filename prefix for nav data JSON files
  */
 const getRelevantFileNamePrefixes = (repo: string) => {
+	// Legacy product slug mapping
+	const normalizedRepo =
+		repo === 'ptfe-releases' ? 'terraform-enterprise' : repo
+
 	// The default values that most repos use
 	let mdxPrefix = 'website/content'
 	let navDataPrefix = 'website/data'
 
 	// HCP and Terraform docs content repos use slightly different values
 	// Note: cloud.hashicorp.com is being renamed to hcp-docs
-	if (repo === 'cloud.hashicorp.com' || repo === 'hcp-docs') {
+	if (
+		normalizedRepo === 'cloud.hashicorp.com' ||
+		normalizedRepo === 'hcp-docs'
+	) {
 		mdxPrefix = 'content'
 		navDataPrefix = 'content'
-	} else if (repo.startsWith('terraform') || repo.startsWith('ptfe-releases')) {
+	} else if (normalizedRepo === 'terraform-enterprise') {
+		// Terraform Enterprise (ptfe-releases) content now lives in web-unified-docs
+		mdxPrefix = 'content'
+		navDataPrefix = 'content'
+	} else if (normalizedRepo.startsWith('terraform')) {
 		mdxPrefix = 'website/docs'
 	}
 

--- a/scripts/list-open-prs-with-docs-changes.ts
+++ b/scripts/list-open-prs-with-docs-changes.ts
@@ -24,12 +24,9 @@ const getRelevantFileNamePrefixes = (repo: string) => {
 	// Note: cloud.hashicorp.com is being renamed to hcp-docs
 	if (
 		normalizedRepo === 'cloud.hashicorp.com' ||
-		normalizedRepo === 'hcp-docs'
+		normalizedRepo === 'hcp-docs' ||
+		normalizedRepo === 'terraform-enterprise'
 	) {
-		mdxPrefix = 'content'
-		navDataPrefix = 'content'
-	} else if (normalizedRepo === 'terraform-enterprise') {
-		// Terraform Enterprise (ptfe-releases) content now lives in web-unified-docs
 		mdxPrefix = 'content'
 		navDataPrefix = 'content'
 	} else if (normalizedRepo.startsWith('terraform')) {

--- a/src/__tests__/e2e/product-docs-menu-links.spec.ts
+++ b/src/__tests__/e2e/product-docs-menu-links.spec.ts
@@ -15,11 +15,11 @@ test('product "Documentation" menu renders correct links', async ({
 }) => {
 	await page.goto(`${baseURL}/terraform`)
 
-	const navActivator = page.locator('header button', {
-		has: page.locator('text=Documentation'),
-	})
+	const navActivator = page
+		.locator('header')
+		.getByRole('button', { name: 'Documentation' })
 
-	await navActivator.hover()
+	await navActivator.hover({ force: true })
 
 	const dropdownId = await navActivator.getAttribute('aria-controls')
 

--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -148,7 +148,7 @@ const cases = [
 			iconName: 'org',
 			name: 'Terraform Enterprise',
 			path: 'enterprise',
-			productSlugForLoader: 'ptfe-releases',
+			productSlugForLoader: 'terraform-enterprise',
 		},
 		currentProduct: {
 			slug: 'terraform',

--- a/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
@@ -109,7 +109,7 @@ describe('getNavItems', () => {
 					iconName: 'enterprise',
 					name: 'Terraform Enterprise',
 					path: 'enterprise',
-					productSlugForLoader: 'ptfe-releases',
+					productSlugForLoader: 'terraform-enterprise',
 				},
 				{
 					iconName: 'docs',

--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -87,7 +87,7 @@
 			"iconName": "org",
 			"name": "Terraform Enterprise",
 			"path": "enterprise",
-			"productSlugForLoader": "ptfe-releases"
+			"productSlugForLoader": "terraform-enterprise"
 		},
 		{
 			"iconName": "docs",

--- a/src/lib/docs-content-link-rewrites/__tests__/normalize-remote-loader-slug.test.ts
+++ b/src/lib/docs-content-link-rewrites/__tests__/normalize-remote-loader-slug.test.ts
@@ -7,7 +7,7 @@ import { normalizeRemoteLoaderSlug } from '../normalize-remote-loader-slug'
 
 const REMOTE_LOADER_SLUGS_TO_PRODUCT_SLUGS = {
 	'hcp-docs': 'hcp',
-	'ptfe-releases': 'terraform',
+	'terraform-enterprise': 'terraform',
 	'terraform-cdk': 'terraform',
 	'terraform-docs-agents': 'terraform',
 	'terraform-docs-common': 'terraform',

--- a/src/pages/api/revalidate.test.ts
+++ b/src/pages/api/revalidate.test.ts
@@ -12,8 +12,8 @@ describe('resolveProduct', () => {
 		expect(result).toBe('terraform')
 	})
 
-	it('should return "terraform" for "ptfe-releases"', () => {
-		const productRepoName = 'ptfe-releases'
+	it('should return "terraform" for "terraform-enterprise" (ptfe-releases)', () => {
+		const productRepoName = 'terraform-enterprise'
 		const result = resolveProduct(productRepoName)
 		expect(result).toBe('terraform')
 	})

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -17,7 +17,7 @@ import { ProductSlug } from 'types/products'
  */
 export function resolveProduct(product: string): ProductSlug {
 	// Handle TF's sub-projects
-	if (product.startsWith('terraform-') || product === 'ptfe-releases') {
+	if (product.startsWith('terraform-') || product === 'terraform-enterprise') {
 		return 'terraform'
 	} else if (product === 'hcp-docs') {
 		return 'hcp'

--- a/src/views/docs-view/loaders/remote-content.ts
+++ b/src/views/docs-view/loaders/remote-content.ts
@@ -281,11 +281,9 @@ export default class RemoteContentLoader implements DataLoader {
 			 * Note: If we need more granularity here, we could change this to be
 			 * part of `rootDocsPath` configuration in `src/data/<product>.json`.
 			 */
-			const isPrivateContentRepo = [
-				'hcp-docs',
-				'sentinel',
-				'ptfe-releases',
-			].includes(this.opts.product)
+			const isPrivateContentRepo = ['hcp-docs', 'sentinel'].includes(
+				this.opts.product
+			)
 
 			if (isLatest && !isPrivateContentRepo) {
 				// GitHub only allows you to modify a file if you are on a branch, not a commit

--- a/src/views/docs-view/utils/__tests__/fetch-valid-versions.test.ts
+++ b/src/views/docs-view/utils/__tests__/fetch-valid-versions.test.ts
@@ -102,7 +102,7 @@ describe('fetchValidVersions', () => {
 		const pathParts = ['v202409-2', 'releases', '2024', 'v202409-1']
 		const versionPathPart = 'v202409-2'
 		const basePathForLoader = 'enterprise'
-		const productSlugForLoader = 'ptfe-releases'
+		const productSlugForLoader = 'terraform-enterprise'
 		const releaseNotesVersions: VersionSelectItem[] = [
 			{
 				name: 'latest',

--- a/src/views/docs-view/utils/get-deploy-preview-loader.ts
+++ b/src/views/docs-view/utils/get-deploy-preview-loader.ts
@@ -77,7 +77,7 @@ export function getDeployPreviewLoader({
 			const remarkTerraformPlugins = []
 			if (
 				currentRootDocsPath.productSlugForLoader?.match(
-					/^(terraform|ptfe-releases)/i
+					/^(terraform|terraform-enterprise)/i
 				) &&
 				!__config.flags?.unified_docs_migrated_repos?.find(
 					(product) => product === currentRootDocsPath.productSlugForLoader
@@ -108,7 +108,7 @@ export function getDeployPreviewLoader({
 			}
 			if (
 				currentRootDocsPath.productSlugForLoader?.match(
-					/(terraform-docs-common|ptfe-releases)/i
+					/(terraform-docs-common|terraform-enterprise)/i
 				)
 			) {
 				remarkTerraformPlugins.push([remarkTfeContentExclusion, { version }])


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What


- Replaced all `ptfe-releases` references with `terraform-enterprise` across configuration, API endpoints, and build logic
- Removed legacy `ptfe-releases` from private repository arrays and redirect mappings
- Updated script logic to handle unified docs structure for terraform-enterprise content
- Fixed test locators and update all test files to use correct product slugs
- Removed obsolete redirect configurations for unused `ptfe-releases` repository


## 🤷 Why

API requests in Vercel logs were showing 404 errors where the system tried to fetch content using the old `ptfe-releases` product slug, but the content actually lives under `terraform-enterprise` in the `web-unified-docs` repository. This mismatch was causing widespread content loading failures for Terraform Enterprise documentation.


## 🛠️ How

**Configuration Updates:**
- Updated config files (`base.json`, `development.json`, `unified-docs-sandbox.json`) to reference `terraform-enterprise`
- Modified product data in `src/data/terraform.json` to use correct `productSlugForLoader`

**API & Build Logic:**
- Removed `ptfe-releases` from private repository arrays since content moved to public `web-unified-docs`
- Updated API content paths in `build-libs/get-latest-content-sha-for-product.js`
- Removed legacy redirect mappings and private repo configurations
- Fixed revalidation API logic to handle `terraform-enterprise` instead of `ptfe-releases`

**Script Logic:**
- Added legacy mapping (`ptfe-releases` → `terraform-enterprise`) in content processing scripts
- Updated directory prefixes to handle unified docs structure (`content/` instead of `website/docs/`)
- Maintained backward compatibility during transition period

**Testing:**
- Updated all test files to use `terraform-enterprise` product slug
- Fixed E2E test locator conflicts for documentation menu
- Updated test expectations to match new unified docs structure


## 📸  Screenshots

<img width="1416" height="866" alt="Screenshot 2025-08-04 at 10 59 04 AM" src="https://github.com/user-attachments/assets/f69c2110-6cc6-4173-98af-9f953382ac7d" />
<img width="1198" height="884" alt="Screenshot 2025-08-04 at 10 59 14 AM" src="https://github.com/user-attachments/assets/15dda2c1-c483-4a2e-a731-0ffab6c29865" />
<img width="1063" height="864" alt="Screenshot 2025-08-04 at 10 59 21 AM" src="https://github.com/user-attachments/assets/fa04bbc5-f8d2-42a5-aee4-e6ea25352427" />
<img width="867" height="871" alt="Screenshot 2025-08-04 at 10 59 49 AM" src="https://github.com/user-attachments/assets/bde88b63-ed75-4d0e-8347-93c92e58fc89" />
<img width="691" height="903" alt="Screenshot 2025-08-04 at 11 00 10 AM" src="https://github.com/user-attachments/assets/cc2c6718-c0da-4f98-bc15-746ffdf86b25" />
<img width="1465" height="927" alt="Screenshot 2025-08-04 at 11 00 57 AM" src="https://github.com/user-attachments/assets/0071da26-c890-47f1-8e94-f97b7eda3836" />


## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?

## **PR Template Fill-out:**

```markdown
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-fix-product-slug-mapping-replace-ptfe-releases-with-terraform-enterprise-hashicorp.vercel.app/) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

- Replace all `ptfe-releases` references with `terraform-enterprise` across configuration, API endpoints, and build logic
- Remove legacy `ptfe-releases` from private repository arrays and redirect mappings
- Update script logic to handle unified docs structure for terraform-enterprise content
- Fix test locators and update all test files to use correct product slugs
- Remove obsolete redirect configurations for unused `ptfe-releases` repository

## 🤷 Why

API requests in Vercel logs were showing 404 errors where the system tried to fetch content using the old `ptfe-releases` product slug, but the content actually lives under `terraform-enterprise` in the `web-unified-docs` repository. This mismatch was causing widespread content loading failures for Terraform Enterprise documentation.

Example error:
```
API Error: No content found for /api/content/ptfe-releases/doc/v202502-1/enterprise/requirements/hardware
Checked for content at: content/terraform-enterprise/v202502-1/docs/enterprise/requirements/hardware.mdx
```

## 🛠️ How

**Configuration Updates:**
- Updated config files (`base.json`, `development.json`, `unified-docs-sandbox.json`) to reference `terraform-enterprise`
- Modified product data in `src/data/terraform.json` to use correct `productSlugForLoader`

**API & Build Logic:**
- Removed `ptfe-releases` from private repository arrays since content moved to public `web-unified-docs`
- Updated API content paths in `build-libs/get-latest-content-sha-for-product.js`
- Removed legacy redirect mappings and private repo configurations
- Fixed revalidation API logic to handle `terraform-enterprise` instead of `ptfe-releases`

**Script Logic:**
- Added legacy mapping (`ptfe-releases` → `terraform-enterprise`) in content processing scripts
- Updated directory prefixes to handle unified docs structure (`content/` instead of `website/docs/`)
- Maintained backward compatibility during transition period

**Testing:**
- Updated all test files to use `terraform-enterprise` product slug
- Fixed E2E test locator conflicts for documentation menu
- Updated test expectations to match new unified docs structure

## 📸 Design Screenshots

No design changes - this is a backend/configuration fix for content routing.

## 🧪 Testing

**Before testing, ensure dev server is running on port 3000:**
```bash
npm run dev
```

**API Endpoints:**
- [ ] Verify terraform-enterprise content loads: `http://localhost:3000/terraform/enterprise`

**Content Loading:**
- [ ] Navigate to `/terraform/enterprise` and verify content displays
- [ ] Check that version switcher works for terraform-enterprise docs
- [ ] Confirm no console errors about missing `ptfe-releases` content

**Legacy Compatibility:**
- [ ] Verify old `ptfe-releases` endpoints return 404 (as expected)
- [ ] Test that revalidation API works with `terraform-enterprise` product slug

**E2E Tests:**
- [ ] Run `npm run test:e2e` to verify all tests pass
- [ ] Confirm documentation menu test no longer times out

## 💭 Anything else?

This PR eliminates all references to the deprecated `ptfe-releases` repository name. 

Note: After this PR merges, will monitor Vercel logs to confirm the 404 errors for `ptfe-releases` content are resolved.

