### PR TITLE
Add terraform-enterprise to redirect array

### DIFF
--- a/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
+++ b/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
@@ -6,13 +6,17 @@
 import getLatestContentShaForProduct from '../get-latest-content-sha-for-product'
 import fetchGithubFile from '@build-libs/fetch-github-file'
 import { PRODUCT_REDIRECT_ENTRIES } from '@build-libs/redirects'
+import { loadHashiConfigForEnvironment } from '../../config'
 
 describe('getLatestContentShaForProduct', () => {
-	PRODUCT_REDIRECT_ENTRIES.forEach(({ repo, path }) => {
-		if (repo === 'hvd-docs') {
-			console.log(`Skipping test for repo "${repo}"`)
-		} else {
-			it(`fetches the latest SHA for the "${repo}" repo`, async () => {
+	const config = loadHashiConfigForEnvironment()
+	PRODUCT_REDIRECT_ENTRIES
+		.filter(({ repo }) => !config['flags.unified_docs_migrated_repos'].includes(repo)) // skip repos we don't have access to
+		.forEach(({ repo, path }) => {
+			if (repo === 'hvd-docs') {
+				console.log(`Skipping test for repo "${repo}"`)
+			} else {
+				it(`fetches the latest SHA for the "${repo}" repo`, async () => {
 				const latestSha = await getLatestContentShaForProduct(repo)
 				expect(typeof latestSha).toBe('string')
 			})

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -148,6 +148,7 @@ const PRODUCT_REDIRECT_ENTRIES = [
 	{ repo: 'consul', path: 'website/redirects.js' },
 	{ repo: 'terraform-docs-common', path: 'website/redirects.js' },
 	{ repo: 'terraform-enterprise', path: 'website/redirects.js' },
+	{ repo: 'well-architected-framework', path: 'website/redirects.js' },
 	{ repo: 'hcp-docs', path: '/redirects.js' }, // private repo
 	{ repo: 'sentinel', path: 'website/redirects.js' }, // private repo
 	{ repo: 'hvd-docs', path: '/redirects.js' }, // private repo

--- a/build-libs/redirects.js
+++ b/build-libs/redirects.js
@@ -147,6 +147,7 @@ const PRODUCT_REDIRECT_ENTRIES = [
 	{ repo: 'packer', path: 'website/redirects.js' },
 	{ repo: 'consul', path: 'website/redirects.js' },
 	{ repo: 'terraform-docs-common', path: 'website/redirects.js' },
+	{ repo: 'terraform-enterprise', path: 'website/redirects.js' },
 	{ repo: 'hcp-docs', path: '/redirects.js' }, // private repo
 	{ repo: 'sentinel', path: 'website/redirects.js' }, // private repo
 	{ repo: 'hvd-docs', path: '/redirects.js' }, // private repo


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-rm-fix-terraform-enterprise-redirects-hashicorp.vercel.app/) 🔎


## 🗒️ What

Adds products (mostly `terraform-*` but others too like WAF to the `PRODUCT_REDIRECT_ENTRIES` array to fix redirects in devdot.

<!--
Briefly list out the changes proposed in this PR.
-->

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Redirects are currently not working due to devdot not requesting the array of redirects from UDR

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

If I `curl` the redirects endpoint for terraform enterprise(filtering for the source path we're interested in), like so:

```bash
curl 'https://web-unified-docs-hashicorp.vercel.app/api/content/terraform-enterprise/redirects' | jq '.[] | select(.source | contains("terraform/enterprise/system-overview/capacity"))'
```

I get this:

```json
{
  "source": "/terraform/enterprise/system-overview/capacity",
  "destination": "/terraform/enterprise/replicated/architecture/system-overview/capacity",
  "permanent": true
}
```

So, UDR is returning the redirect, but dev-portal is ignoring it. Okay, let's dig deeper, let's see if that redirect is actually making it to the redirect() function in `next.config.js`....

Adding this in next.config.js:

```js
const redirects = Object.entries(simpleRedirects['*'])
	.map(([source, { destination }]) => ({ source, destination, permanent: true }))
	.concat(complexRedirects)
	.filter(({ source }) => source.includes('terraform/enterprise'))
console.log({ redirects })
```

Returns
```js
{
  redirects: [
    {
      source: '/terraform/enterprise/vcs/bitbucket-server',
      destination: '/terraform/enterprise/vcs/bitbucket-data-center',
      permanent: true
    }
  ]
}
```

I between complex and simple redirects I'd expect to see it in there somewhere. If I add that redirect object in manually in the `redirects()` function, it works.

Tracing the source of the data all the way back up led to `build-libs/redirects.js` which contained the array updated in this PR. Some more judicious logging out revealed that devdot simply wasn't requesting the redirects for terraform-enterprise(and presumably other products too)

## 🧪 Testing

- [ ] Go to https://dev-portal-git-rm-fix-terraform-enterprise-redirects-hashicorp.vercel.app/terraform/enterprise/system-overview/capacity
- [ ] You should be redirected to https://dev-portal-git-rm-fix-terraform-enterprise-redirects-hashicorp.vercel.app/terraform/enterprise/replicated/architecture/system-overview/capacity
- [ ] Go to https://dev-portal-git-rm-fix-terraform-enterprise-redirects-hashicorp.vercel.app/well-architected-framework/operational-excellence
- [ ] You should be redirected to https://dev-portal-git-rm-fix-terraform-enterprise-redirects-hashicorp.vercel.app/well-architected-framework/what-is
