### PR TITLE
Return all versions without filtering

### DIFF
--- a/src/views/docs-view/utils/__tests__/get-valid-versions.test.ts
+++ b/src/views/docs-view/utils/__tests__/get-valid-versions.test.ts
@@ -3,30 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { describe, it, expect, vi, type MockedFunction } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { getValidVersions } from '../get-valid-versions'
-import type { VersionSelectItem } from '../../loaders/remote-content'
 
 // Mock fetch
 global.fetch = vi.fn() as typeof fetch
 
 describe('getValidVersions', () => {
-	const versions: VersionSelectItem[] = [
-		{
-			version: '1.0.0',
-			label: 'v1.0.0',
-			name: 'v1.0.0',
-			isLatest: false,
-			releaseStage: 'stable',
-		},
-		{
-			version: '2.0.0',
-			label: 'v2.0.0',
-			name: 'v2.0.0',
-			isLatest: true,
-			releaseStage: 'stable',
-		},
-	]
 	const fullPath = 'doc#/path/to/document'
 	const productSlugForLoader = 'product-slug'
 
@@ -41,64 +24,5 @@ describe('getValidVersions', () => {
 				productSlugForLoader
 			)
 		).toEqual([])
-	})
-
-	it('should return filtered versions based on known versions from API', async () => {
-		const knownVersions = ['1.0.0']
-		;(fetch as MockedFunction<typeof fetch>).mockResolvedValueOnce({
-			ok: true,
-			status: 200,
-			json: async () => ({ versions: knownVersions }),
-		} as unknown as Response)
-
-		const result = await getValidVersions(
-			versions,
-			fullPath,
-			productSlugForLoader
-		)
-		expect(result).toEqual([
-			{
-				isLatest: false,
-				label: 'v1.0.0',
-				name: 'v1.0.0',
-				releaseStage: 'stable',
-				version: '1.0.0',
-			},
-		])
-	})
-
-	it('should return all versions if API call fails', async () => {
-		// Temporarily mock console.error
-		const originalConsoleError = console.error
-		console.error = vi.fn()
-
-		try {
-			;(fetch as MockedFunction<typeof fetch>).mockRejectedValueOnce(new Error('API error'))
-
-			const result = await getValidVersions(
-				versions,
-				fullPath,
-				productSlugForLoader
-			)
-			expect(result).toEqual(versions)
-		} finally {
-			// Restore console.error after the test
-			console.error = originalConsoleError
-		}
-	})
-
-	it('should log an error if API call fails', async () => {
-		const consoleErrorSpy = vi
-			.spyOn(console, 'error')
-			.mockImplementation(() => {})
-		;(fetch as MockedFunction<typeof fetch>).mockRejectedValueOnce(new Error('API error'))
-
-		await getValidVersions(versions, fullPath, productSlugForLoader)
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			`[docs-view/server] error fetching known versions for "${productSlugForLoader}" document "${fullPath}". Falling back to showing all versions.`,
-			expect.any(Error)
-		)
-
-		consoleErrorSpy.mockRestore()
 	})
 })

--- a/src/views/docs-view/utils/get-valid-versions.ts
+++ b/src/views/docs-view/utils/get-valid-versions.ts
@@ -2,13 +2,9 @@
  * Copyright (c) HashiCorp, Inc.
  * SPDX-License-Identifier: MPL-2.0
  */
-
-// Utils
-import { getContentApiBaseUrl } from 'lib/unified-docs-migration-utils'
 // Types
 import type { VersionSelectItem } from '../loaders/remote-content'
 
-const VERSIONS_ENDPOINT = '/api/content-versions'
 
 /**
  * Given a list of all possible versions, as well as a document path and
@@ -44,35 +40,9 @@ export async function getValidVersions(
 	productSlugForLoader: string
 ): Promise<VersionSelectItem[]> {
 	// If versions are falsy or empty, we can skip the API calls and return []
-	if (!versions || versions.length === 0) return []
-	/**
-	 * We are currently migrating away from our existing content API, to a new
-	 * content API backed by a unified documentation repository. If the provided
-	 * `productSlugForLoader` has been flagged as migrated to unified docs, then
-	 * we use the new unified docs API to fetch known versions.
-	 */
-	const contentApiBaseUrl = getContentApiBaseUrl(productSlugForLoader)
-	try {
-		// Build the URL to fetch known versions of this document
-		const validVersionsUrl = new URL(VERSIONS_ENDPOINT, contentApiBaseUrl)
-		validVersionsUrl.searchParams.set('product', productSlugForLoader)
-		validVersionsUrl.searchParams.set('fullPath', fullPath)
-		const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
-			? new Headers({
-					'x-vercel-protection-bypass':
-						process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
-			  })
-			: new Headers()
-		// Fetch known versions of this document
-		const response = await fetch(validVersionsUrl.toString(), { headers })
-		const { versions: knownVersions } = await response.json()
-		// Apply the filter, and return the valid versions
-		return versions.filter((option) => knownVersions.includes(option.version))
-	} catch (error) {
-		console.error(
-			`[docs-view/server] error fetching known versions for "${productSlugForLoader}" document "${fullPath}". Falling back to showing all versions.`,
-			error
-		)
+	if (!versions || versions.length === 0) {
+		return []
+	} else {
 		return versions
 	}
 }


### PR DESCRIPTION
Remove the version filtering logic for the time being and just return ALL versions. This will cause a TON of 404s and is only a temporary measure to get things going

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
1. Go to path on developer.hashicorp.com with versioned docs (i.e: `/vault/docs/deploy/aws/run`)
2. Observe that no documents below 1.19.x are available in the version picker dropdown
3. Go to the same path in the preview link
4. Observe that all versions are available, however any version below v1.19.x goes to a 404
