### PR TITLE
[WIP] Re-attempt sentinel migration

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -52,7 +52,8 @@
 			"vault",
 			"ptfe-releases",
 			"well-architected-framework",
-			"terraform-enterprise"
+			"terraform-enterprise",
+			"sentinel"
 		]
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -25,7 +25,8 @@
 			"vault",
 			"ptfe-releases",
 			"well-architected-framework",
-			"terraform-enterprise"
+			"terraform-enterprise",
+			"sentinel"
 		]
 	}
 }

--- a/config/unified-docs-sandbox.json
+++ b/config/unified-docs-sandbox.json
@@ -24,7 +24,8 @@
 			"terraform-docs-common",
 			"terraform",
 			"vault",
-			"well-architected-framework"
+			"well-architected-framework",
+			"sentinel"
 		]
 	}
 }

--- a/src/data/sentinel.json
+++ b/src/data/sentinel.json
@@ -44,7 +44,6 @@
 	"basePaths": ["docs", "downloads"],
 	"rootDocsPaths": [
 		{
-			"basePathForLoader": "sentinel",
 			"iconName": "docs",
 			"name": "Documentation",
 			"path": "docs"

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -110,7 +110,8 @@ interface RootDocsPath {
 	/**
 	 * Optional basePath for our content API. For "sentinel", this differs
 	 * from the basePath used on the client, as sentinel content is served
-	 * on docs.hashicorp.com/sentinel.
+	 * on docs.hashicorp.com/sentinel. Now that "sentinel" is served from
+	 * UDR, this is only used for "well-artchitected-framework"
 	 */
 	basePathForLoader?: string
 


### PR DESCRIPTION
The initial failed migration may have been due to outdated binaries in UDR. Re-attempting the migration (which will fail initially) so that we can then re-create the initial failure and debug.