### PR TITLE
Add beta to mcp server nav item

### DIFF
--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -163,7 +163,7 @@
 		},
 		{
 			"iconName": "docs",
-			"name": "Terraform MCP Server",
+			"name": "Terraform MCP Server <sup>BETA</sup>",
 			"path": "mcp-server",
 			"productSlugForLoader": "terraform-mcp-server"
 		}


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-atru-add-beta-badge-mcp-server-hashicorp.vercel.app/terraform) 🔎

## 🗒️ What

This PR adds a beta badge in the main Terraform sidebar navigation for the MCP server docs.

## 🤷 Why

Because MCP server is still in beta.