### PR TITLE
Route HCP Boundary docs to UDR top level product

### DIFF
--- a/src/data/boundary.json
+++ b/src/data/boundary.json
@@ -56,7 +56,7 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "api-docs", "downloads"],
+	"basePaths": ["docs", "api-docs", "downloads", "hcp-docs"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",
@@ -78,6 +78,12 @@
          "iconName": "docs",
          "name": "Domain model",
          "path": "docs/domain-model"
-      }
+      },
+		{
+			"iconName": "docs",
+			"name": "HCP Boundary",
+			"path": "hcp-docs",
+			"productSlugForLoader": "hcp-boundary"
+		}
 	]
 }

--- a/src/pages/boundary/hcp-docs/[...page].tsx
+++ b/src/pages/boundary/hcp-docs/[...page].tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import DocsView from 'views/docs-view'
+import { getRootDocsPathGenerationFunctions } from 'views/docs-view/utils/get-root-docs-path-generation-functions'
+
+const { getStaticPaths, getStaticProps } = getRootDocsPathGenerationFunctions(
+	'boundary',
+	'hcp-docs'
+)
+
+export { getStaticProps, getStaticPaths }
+export default DocsView


### PR DESCRIPTION
> [!NOTE]
> The Vercel deploy is currently failing for this PR. That's expected because there's no "hcp-boundary" product in production UDR to build content from. The UDR side of this is delivered by [this PR](https://github.com/hashicorp/web-unified-docs/pull/1902)


## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This is the devdot side of https://github.com/hashicorp/web-unified-docs/pull/1902/commit. Boundary HCP docs are (as-of this PR) sourced from the migrated `hcp-boundary` product, but `dev-portal` had no Boundary route metadata for `hcp-docs`. 

- add `hcp-docs` to Boundary `basePaths`
- add a Boundary `rootDocsPath` for `hcp-docs` with `productSlugForLoader: "hcp-boundary"`
- add docs page entrypoint for `/boundary/hcp-docs/[...page]`


## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Without this, `/boundary/hcp-docs/*` falls back to the legacy content API and returns 404s.


## 🧪 Testing

1. Clone https://github.com/hashicorp/web-unified-docs/pull/1902
1. Update `.env` to point to `http://localhost:8080` as follows:
    ```.env
    UNIFIED_DOCS_API="http://localhost:8080"
    UNIFIED_DOCS_PORT="8080"
    ```
1. Navigate to `http://localhost:3000/boundary/hcp-docs/audit-logging`
1. You should see
<img width="1485" height="1035" alt="image" src="https://github.com/user-attachments/assets/dc1c1649-03fd-4b35-970a-92556acbcaf3" />
