### PR TITLE
feat: add support for n.x.x versions

### DIFF
--- a/src/constants/version-path.ts
+++ b/src/constants/version-path.ts
@@ -13,3 +13,6 @@ export const NO_V_VERSION_IN_PATH_REGEX = /\d+\.\d+\.(\d+|\w+)/i
 export const TFE_VERSION_IN_PATH_REGEXP = /v[0-9]{6}-\d+/i
 
 export const SHORT_VERSION_REGEX = /v\d+\.(\d+|\w+)/i
+
+/** This REGEX is used to parse a product version with the format vN.x.x where N is a number */
+export const DOUBLE_X_VERSION_REGEX = /v\d+\.(\w+)\.(\w+)/i

--- a/src/lib/__tests__/get-target-path.test.ts
+++ b/src/lib/__tests__/get-target-path.test.ts
@@ -96,6 +96,16 @@ describe('getTargetPath', () => {
 		expect(target).toEqual('/vault/docs/v2.x/secrets/kv')
 	})
 
+	it('should handle double-x versions', () => {
+		const input = {
+			basePath: 'vault/docs',
+			asPath: '/vault/docs/secrets/kv',
+			version: 'v2.x.x',
+		}
+		const target = getTargetPath(input)
+		expect(target).toEqual('/vault/docs/v2.x.x/secrets/kv')
+	})
+
 	describe('with 3-segment basePath (terraform/plugin/framework)', () => {
 		it('should return a target path while on "latest"', () => {
 			const input = {

--- a/src/lib/__tests__/get-version-from-path.test.ts
+++ b/src/lib/__tests__/get-version-from-path.test.ts
@@ -36,6 +36,13 @@ describe('getVersionFromPath', () => {
 			const version = getVersionFromPath(path)
 			expect(version).toEqual('v2.x')
 		}
+
+		{
+			const path = 'https://developer.hashicorp.com/vault/docs/v2.x.x/k8s/connect'
+
+			const version = getVersionFromPath(path)
+			expect(version).toEqual('v2.x.x')
+		}
 	})
 
 	it('should return `undefined` if no version is present', () => {

--- a/src/lib/__tests__/remove-version-from-path.test.ts
+++ b/src/lib/__tests__/remove-version-from-path.test.ts
@@ -44,6 +44,15 @@ describe('removeVersionFromPath', () => {
 				'https://developer.hashicorp.com/vault/docs/platform'
 			)
 		}
+
+		{
+			const path = 'https://developer.hashicorp.com/vault/docs/v2.x.x/platform'
+
+			const cleanedPath = removeVersionFromPath(path)
+			expect(cleanedPath).toEqual(
+				'https://developer.hashicorp.com/vault/docs/platform'
+			)
+		}
 	})
 
 	it('should return the original path if no version is present', () => {

--- a/src/lib/get-target-path.ts
+++ b/src/lib/get-target-path.ts
@@ -7,7 +7,8 @@ import {
 	TFE_VERSION_IN_PATH_REGEXP,
 	VERSION_IN_PATH_REGEX,
 	NO_V_VERSION_IN_PATH_REGEX,
-	SHORT_VERSION_REGEX
+	SHORT_VERSION_REGEX,
+	DOUBLE_X_VERSION_REGEX,
 } from 'constants/version-path'
 
 const LEADING_TRAILING_SLASHES_REGEXP = /^\/+|\/+$/g
@@ -55,6 +56,7 @@ export function getTargetPath({
 		const tfeMatch = el.match(TFE_VERSION_IN_PATH_REGEXP)
 		const versionMatch = el.match(VERSION_IN_PATH_REGEX)
 		const noVMatch = el.match(NO_V_VERSION_IN_PATH_REGEX)
+		const doubleXMatch = el.match(DOUBLE_X_VERSION_REGEX)
 		const shortMatch = el.match(SHORT_VERSION_REGEX)
 		
 		// A version segment must match the entire segment, not just part of it
@@ -62,6 +64,7 @@ export function getTargetPath({
 			(tfeMatch && el === tfeMatch[0]) ||
 			(versionMatch && el === versionMatch[0]) ||
 			(noVMatch && el === noVMatch[0]) ||
+			(doubleXMatch && el === doubleXMatch[0]) ||
 			(shortMatch && el === shortMatch[0])
 		)
 	})
@@ -78,6 +81,7 @@ export function getTargetPath({
 			.replace(TFE_VERSION_IN_PATH_REGEXP, '')
 			.replace(VERSION_IN_PATH_REGEX, '')
 			.replace(NO_V_VERSION_IN_PATH_REGEX, '')
+			.replace(DOUBLE_X_VERSION_REGEX, '')
 			.replace(SHORT_VERSION_REGEX, '')
 			.replace(LEADING_TRAILING_SLASHES_REGEXP, ''))
 

--- a/src/lib/get-version-from-path.ts
+++ b/src/lib/get-version-from-path.ts
@@ -7,7 +7,8 @@ import {
 	VERSION_IN_PATH_REGEX,
 	TFE_VERSION_IN_PATH_REGEXP,
 	NO_V_VERSION_IN_PATH_REGEX,
-	SHORT_VERSION_REGEX
+	SHORT_VERSION_REGEX,
+	DOUBLE_X_VERSION_REGEX
 } from 'constants/version-path'
 
 /**
@@ -32,6 +33,9 @@ export function getVersionFromPath(path: string): string | undefined {
 			return true
 		}
 		if ((i === 2 || i === 3 || i === 4) && NO_V_VERSION_IN_PATH_REGEX.test(el)) {
+			return true
+		}
+		if ((i === 2 || i === 3 || i === 4) && DOUBLE_X_VERSION_REGEX.test(el)) {
 			return true
 		}
 		if ((i === 2 || i === 3 || i === 4) && SHORT_VERSION_REGEX.test(el)) {

--- a/src/lib/remove-version-from-path.ts
+++ b/src/lib/remove-version-from-path.ts
@@ -7,7 +7,8 @@ import {
 	VERSION_IN_PATH_REGEX,
 	TFE_VERSION_IN_PATH_REGEXP,
 	NO_V_VERSION_IN_PATH_REGEX,
-	SHORT_VERSION_REGEX
+	SHORT_VERSION_REGEX,
+	DOUBLE_X_VERSION_REGEX
 } from 'constants/version-path'
 
 /**
@@ -22,6 +23,7 @@ export function removeVersionFromPath(path: string): string {
 			VERSION_IN_PATH_REGEX.test(el) ||
 			TFE_VERSION_IN_PATH_REGEXP.test(el) ||
 			NO_V_VERSION_IN_PATH_REGEX.test(el) ||
+			DOUBLE_X_VERSION_REGEX.test(el) ||
 			SHORT_VERSION_REGEX.test(el)
 		)
 	})

--- a/src/views/docs-view/loaders/utils/strip-version-from-path.ts
+++ b/src/views/docs-view/loaders/utils/strip-version-from-path.ts
@@ -7,6 +7,7 @@ const REGEX = /^v[0-9]+\.[0-9]+\.(x|[0-9]+)$/i
 const TFE_REGEX = /^v[0-9]{6}-[0-9]+$/i
 const NO_V_REGEX = /^[0-9]+\.[0-9]+\.(x|[0-9]+)$/i
 const SHORT_VERSION_REGEX = /^v[0-9]+\.(x|[0-9]+)$/i
+const DOUBLE_X_VERSION_REGEX = /^v[0-9]+\.x\.x$/i
 
 /**
  * Given an array of strings, returns a tuple of
@@ -18,7 +19,14 @@ const SHORT_VERSION_REGEX = /^v[0-9]+\.(x|[0-9]+)$/i
 export const stripVersionFromPathParams = (
 	pathParams: string[] = []
 ): [string, string[]] => {
-	const index = pathParams.findIndex((e) => REGEX.test(e) || TFE_REGEX.test(e) || NO_V_REGEX.test(e) || SHORT_VERSION_REGEX.test(e))
+	const index = pathParams.findIndex(
+		(e) =>
+			REGEX.test(e) ||
+			TFE_REGEX.test(e) ||
+			NO_V_REGEX.test(e) ||
+			DOUBLE_X_VERSION_REGEX.test(e) ||
+			SHORT_VERSION_REGEX.test(e)
+	)
 	let version = 'latest'
 	let params = [...pathParams]
 


### PR DESCRIPTION
### Description

[Monday task](https://ibm.monday.com/boards/18402251594/pulses/11656658405)

This PR adds support for double 'x' versions in dev-portal. There is a partner PR that will be merged around the same time as this one for UDR [here](https://github.com/hashicorp/web-unified-docs/pull/2131). 

The main changes in this PR are as follows: 
- Adds double 'x' version regex in all the spots that the normal version regex is used
- Adds tests for the double 'x' version

### Testing

This PR needs to be tested with the changes for UDR. Without those changes, the ones in this PR will not work. You will need to locally run UDR and dev-portal to see these changes reflected. 

First, do the steps in UDR:
UDR: 
1. Checkout `leah/feat/n.x.x-version-support`
2. Go to vault and create a few new versions. You can do this by copying the latest version folder and pasting it and then changing the name. For testing the sorting, use a variety of version names (ex. v2.x.x, v3.x.x, v4.x.x (rc), v5.x.x (beta))
3. Run `npm run prebuild`
4. After that finishes, run `npm run dev`

Then do the steps in dev-portal:
Dev-portal: 
1. Checkout `leah/feat/n.x.x-version-support`
2. In the .env file, change the `UNIFIED_DOCS_API` to `http://localhost:8080`
3. Run `npm start`
4. Go to `http://localhost:3000` and click through the vault docs. Verify the new double 'x' versions are sorted properly with the existing versions and look as expected