### PR TITLE
Override sub deps to axios 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15496,14 +15496,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/axios/node_modules/form-data": {
@@ -34680,9 +34680,13 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -240,7 +240,8 @@
 		"tmp": "^0.2.4",
 		"trim": "^0.0.3",
 		"trim-newlines": "^3.0.1",
-		"prismjs": "^1.30.0"
+		"prismjs": "^1.30.0",
+		"axios": "^1.15.0"
 	},
 	"nextBundleAnalysis": {
 		"budget": null,


### PR DESCRIPTION
## 🗒️ What

Override any axios sub dependencies to  >= 1.15.0. It seems like `posthog-node` was the only dependency using axios.

## 🤷 Why

Current active CVE for axios <= 1.13.0.

## 🧪 Testing

1. Test to make sure posthog analytics, feature flags, etc still work.
