### PR TITLE
Update boundary OpenAPI ref

### DIFF
--- a/src/pages/boundary/api-docs/[[...page]].tsx
+++ b/src/pages/boundary/api-docs/[[...page]].tsx
@@ -45,7 +45,7 @@ function getVersionData(): ApiDocsVersionData[] {
 				owner: 'hashicorp',
 				repo: 'boundary',
 				path: 'internal/gen/controller.swagger.json',
-				ref: 'stable-website',
+				ref: 'main',
 		  }
 	return [
 		{


### PR DESCRIPTION
## 🗒️ What

We were using the old 'stable-website' ref when loading the OpenAPI spec for Boundary, which means it has not been updated for 7 months, this PR updates it to 'main'.

## 🧪 Testing

1. Make sure that the [Boundary OpenAPI pages load, poke around at a few of them.](https://dev-portal-git-rn-update-boundary-open-api-spec-ref-hashicorp.vercel.app/boundary/api-docs)

## PCI review checklist

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.
