### PR TITLE
feat: add single source of truth for internal products support

### DIFF
--- a/src/views/docs-view/loaders/__tests__/remote-content.test.ts
+++ b/src/views/docs-view/loaders/__tests__/remote-content.test.ts
@@ -461,6 +461,76 @@ describe('RemoteContentLoader', () => {
 		expect((props.navData[0] as { path?: string; title?: string }).path).not.toBeDefined()
 		expect((props.navData[0] as { path?: string; title?: string }).title).toEqual('Item with no path')
 	})
+
+	test('uses import path from nav node when navNode has import property', async () => {
+		const navDataWithImport = {
+			meta: { status_code: 200, status_text: 'OK' },
+			result: {
+				navData: [
+					{ title: 'Build', path: 'build', import: 'commands/build/index.mdx' },
+				],
+			},
+		}
+
+		scope
+			.get('/api/content/waypoint/version-metadata')
+			.query({ partial: 'true' })
+			.reply(200, versionMetadata_200)
+		scope
+			.get('/api/content/waypoint/nav-data/latest/commands')
+			.reply(200, navDataWithImport)
+		// Only register the import-derived path. If the default path is used instead,
+		// nock will throw because disableNetConnect is active.
+		scope
+			.get('/api/content/waypoint/doc/latest/commands/build/index.mdx')
+			.reply(200, document_200)
+
+		const loaderNoVersionRef = new RemoteContentLoader({
+			basePath: 'commands',
+			product: 'waypoint',
+		})
+
+		const props = await loaderNoVersionRef.loadStaticProps({
+			params: { page: ['build'] },
+		})
+
+		expect(props).toBeDefined()
+		expect(props.frontMatter).toEqual(document_200.result.metadata)
+	})
+
+	test('falls back to default fullPath when nav node is not found', async () => {
+		const navDataNoMatch = {
+			meta: { status_code: 200, status_text: 'OK' },
+			result: {
+				navData: [{ title: 'Other', path: 'other' }],
+			},
+		}
+
+		scope
+			.get('/api/content/waypoint/version-metadata')
+			.query({ partial: 'true' })
+			.reply(200, versionMetadata_200)
+		scope
+			.get('/api/content/waypoint/nav-data/latest/commands')
+			.reply(200, navDataNoMatch)
+		// Only register the default path. If an import path is erroneously used,
+		// nock will throw.
+		scope
+			.get('/api/content/waypoint/doc/latest/commands/build')
+			.reply(200, document_200)
+
+		const loaderNoVersionRef = new RemoteContentLoader({
+			basePath: 'commands',
+			product: 'waypoint',
+		})
+
+		const props = await loaderNoVersionRef.loadStaticProps({
+			params: { page: ['build'] },
+		})
+
+		expect(props).toBeDefined()
+		expect(props.frontMatter).toEqual(document_200.result.metadata)
+	})
 })
 
 describe('mapVersionList', () => {

--- a/src/views/docs-view/loaders/remote-content.ts
+++ b/src/views/docs-view/loaders/remote-content.ts
@@ -14,7 +14,8 @@ import {
 } from './content-api'
 import {
 	stripVersionFromPathParams,
-	getPathsFromNavData
+	getPathsFromNavData,
+	getNodeFromPath,
 } from './utils'
 import renderPageMdx from '../render-page-mdx'
 import { DEFAULT_PARAM_ID, REMARK_ARRAY_ERROR } from '../consts'
@@ -207,9 +208,7 @@ export default class RemoteContentLoader implements DataLoader {
 
 		if (this.opts.enabledVersionedDocs) {
 			versionToFetch =
-				versionFromPath === 'latest'
-					? latestVersion
-					: versionFromPath
+				versionFromPath === 'latest' ? latestVersion : versionFromPath
 		}
 
 		/**
@@ -221,23 +220,44 @@ export default class RemoteContentLoader implements DataLoader {
 		 * We want the latter URL to 404, so we do NOT want to automatically
 		 * resolve trailing `/index` from provided URL path parts.
 		 */
-		const fullPath = [
+		let fullPath = [
 			'doc',
 			versionToFetch,
 			this.opts.basePath,
 			...paramsNoVersion,
 		].join('/')
 
-		const documentPromise = fetchDocument(this.opts.product, fullPath)
 		const navDataPromise = fetchNavData(
 			this.opts.product,
 			this.opts.navDataPrefix!,
 			versionToFetch
 		)
 
-		const [{ result: document, docHeaders }, navData] = await Promise.all([
+		const [navData] = await Promise.all([navDataPromise])
+
+		// This case handles docs using an internal only product as the single
+		// source of truth. For these products, they will include an `import` field 
+		// in their nav-data which specifies the path to the content file to load 
+		// for a given page. If this field is present, we should use it instead 
+		// of attempting to resolve the content file path ourselves based on the URL.
+		const pathToCheck =
+			versionToFetch !== 'latest'
+				? [versionToFetch, ...paramsNoVersion].join('/')
+				: paramsNoVersion.join('/')
+
+		try {
+			const navNode = getNodeFromPath(pathToCheck, navData.navData, '')
+
+			if (navNode.import) {
+				fullPath = ['doc', versionToFetch, navNode.import].join('/')
+			}
+		} catch {
+			// if there is not a node, continue with the rest of the original flow
+		}
+
+		const documentPromise = fetchDocument(this.opts.product, fullPath)
+		const [{ result: document, docHeaders }] = await Promise.all([
 			documentPromise,
-			navDataPromise,
 		])
 
 		// For non-latest versions


### PR DESCRIPTION
### Description

This PR adds support for internal products and single source of truth. This means that products can now be listed as internal only and be imported by other products as the single source of truth. For more info about this process and how it works, please read [the documentation on this process](https://github.com/hashicorp/web-unified-docs/pull/2528/changes#diff-5f9d8bd7bc2109afba213572f08894bad6181c3f5d6971fa0c034053e009f877). This PR adds this functionality for dev-portal which includes checking if a nav-node has import data and if it does, uses that data to pull the correct content. There is also a [UDR PR](https://github.com/hashicorp/web-unified-docs/pull/2528) that accompanies this PR for the changes required on that side in order for this functionality to work.

### Testing

Since this PR requires changes on UDR, it must be tested locally:

UDR: 
1. Checkout branch: `git checkout leah/feat/single-source-of-truth`
2. Run `npm run prebuild`
3. After that finishes, run `npm run dev`

Dev portal:
1. Checkout branch: `git checkout leah/feat/single-source-of-truth`
2. Change `UNIFIED_DOCS_API` in `.env` to `"http://localhost:8080"`
3. Run `npm start`

After both of these are up and running, check the following test cases:
- http://localhost:3000/vault/docs - verify you see test product and test-product-2 content in the sidebar and that clicking on all these links works. Also checkout the partial import test page which is under the about vault dropdown. Verify that the version for test product and test product 2 matches the versions in version-config.json
- http://localhost:3000/vault/docs/v1.21.x - verify you only see test product content. Test that all these links work the same as the above test
- http://localhost:3000/well-architected-framework - Verify you can see test product content the same as the above tests
