### PR TITLE
Remove badge from Terraform MCP Server entry

### DIFF
--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -164,11 +164,7 @@
 			"iconName": "docs",
 			"name": "Terraform MCP Server",
 			"path": "mcp-server",
-			"productSlugForLoader": "terraform-mcp-server",
-			"badge": {
-				"text": "BETA",
-				"color": "highlight"
-			}
+			"productSlugForLoader": "terraform-mcp-server"
 		}
 	]
 }


### PR DESCRIPTION
This PR removes the beta badge for Terraform MCP server. The GA is scheduled for June 8. 