### PR TITLE
tfctl: register beta CLI docs product

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -19,6 +19,7 @@
 		"unified_docs_migrated_repos": [
 			"terraform-mcp-server",
 			"terraform-migrate",
+			"tfctl",
 			"terraform-plugin-framework",
 			"terraform-plugin-log",
 			"terraform-plugin-mux",

--- a/src/data/terraform.json
+++ b/src/data/terraform.json
@@ -165,6 +165,12 @@
 			"name": "Terraform MCP Server",
 			"path": "mcp-server",
 			"productSlugForLoader": "terraform-mcp-server"
+		},
+		{
+			"iconName": "terminal-screen",
+			"name": "tfctl",
+			"path": "tfctl",
+			"productSlugForLoader": "tfctl"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Registers the **beta** `tfctl` CLI docs (served from `hashicorp/web-unified-docs`) so they render under `/terraform/tfctl/...`.

This is a content handoff for the tfctl docs port (Education: IPE-1459). Opening as **draft** for docs-team review.

### Changes
- `config/production.json` — add `"tfctl"` to `unified_docs_migrated_repos`.
- `src/data/terraform.json` — add `tfctl` `rootDocsPaths` entry (`productSlugForLoader: tfctl`).

### Companion PR
- Content + `productConfig.mjs`: hashicorp/web-unified-docs#2659

🤖 Generated with [opencode](https://opencode.ai)