### PR TITLE
Add 404 error slack notifications

### DIFF
--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -20,33 +20,44 @@ locals {
     instana_alerting_channel.slack.id,
   ])
 
-  status_code_alerts = {
-    not_found_errors = {
-      label       = "404"
-      metric_name = "httpxxx"
-      operator    = "EQUALS"
-      value       = "404"
-    }
-    server_errors = {
-      label       = "5xx"
-      metric_name = "httpxxx"
-      operator    = "STARTS_WITH"
-      value       = "5"
-    },
-  }
+  # Filter out any request where the extension ends with one of these values
+  static_asset_extensions = [
+    ".css",
+    ".js",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".ico",
+  ]
 
-  granularity_milliseconds = var.granularity_minutes * 60000
-  time_window_milliseconds = var.time_window_minutes * 60000
+  browser_exclusion_clauses = [
+    "beacon.browser.name@na NOT_CONTAIN 'bot'",
+    "beacon.browser.name@na NOT_EQUAL 'Slurp'",
+    "beacon.browser.name@na NOT_EQUAL 'DuckDuckGo-Favicons-Bot'",
+  ]
+
+  # Generate a tag filter expression to exclude static assets and selected bots.
+  static_asset_tag_filter = "(${join(
+    " AND ",
+    concat(
+      [
+        for ext in local.static_asset_extensions :
+        "beacon.http.url@na NOT_ENDS_WITH '${ext}'"
+      ],
+      local.browser_exclusion_clauses
+    )
+  )})"
 }
 
 resource "instana_website_alert_config" "status_codes_alerts" {
-  for_each    = local.status_code_alerts
-  name        = "${var.website_name} ${each.value.label} status code detected"
-  description = "${var.website_name} ${each.value.label} status code detected"
+  name        = "[Alert] High Volume of 404 Errors - ${instana_website_monitoring_config.devdot.name}"
+  description = "High volume of 404 responses detected for ${instana_website_monitoring_config.devdot.name}"
   enabled     = true
   triggering  = false
   website_id  = local.website_monitoring_id
-  granularity = local.granularity_milliseconds
+  granularity = var.not_found_granularity_minutes * 60000
 
   alert_channel_ids = local.alert_channel_ids
 
@@ -56,30 +67,33 @@ resource "instana_website_alert_config" "status_codes_alerts" {
       rule = {
         status_code = {
           aggregation = "SUM"
-          metric_name = each.value.metric_name
-          operator    = each.value.operator
-          value       = each.value.value
+          metric_name = "httpxxx"
+          operator    = "EQUALS"
+          value       = "404"
         },
       }
       threshold = {
         warning = {
           static = {
-            value = var.warning_threshold
+            value = var.not_found_warning_threshold
           }
         }
         critical = {
           static = {
-            value = var.critical_threshold
+            value = var.not_found_critical_threshold
           }
         }
       }
     }
   ]
 
+  # Exclude static asset URLs using a generated filter expression.
+  tag_filter = local.static_asset_tag_filter
+
   time_threshold = {
     violations_in_period = {
       violations  = 1
-      time_window = local.time_window_milliseconds
+      time_window = var.not_found_time_window_minutes * 60000
     }
   }
 }

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -2,3 +2,64 @@
 resource "instana_website_monitoring_config" "devdot" {
   name = var.website_name
 }
+
+resource "instana_alerting_channel" "slack" {
+  name = var.slack_channel_name
+  slack_app = {
+    app_id       = var.slack_app_id
+    team_id      = var.slack_team_id
+    team_name    = var.slack_team_name
+    channel_id   = var.slack_channel_id
+    channel_name = var.slack_channel_name
+  }
+}
+
+locals {
+  website_monitoring_id = instana_website_monitoring_config.devdot.id
+  alert_channel_ids = [
+    instana_alerting_channel.slack.id,
+  ]
+}
+
+resource "instana_website_alert_config" "js_errors" {
+  name        = "${var.website_name} JS error detected"
+  description = "${var.website_name} JS error detected"
+  enabled     = true
+  triggering  = false
+  website_id  = local.website_monitoring_id
+  granularity = var.granularity_minutes * 60000
+
+  alert_channel_ids = toset(local.alert_channel_ids)
+
+  rules = [
+    {
+      operator = ">"
+      rule = {
+        specific_js_error = {
+          metric_name = "errors"
+          aggregation = "SUM"
+          operator    = "GREATER_THAN"
+          value       = null
+        }
+      }
+      threshold = {
+        warning = {
+          static = {
+            value = var.warning_threshold
+          }
+        }
+        critical = {
+          static = {
+            value = var.critical_threshold
+          }
+        }
+      }
+    }
+  ]
+
+  time_threshold = {
+    violations_in_sequence = {
+      time_window = var.time_window_minutes * 60000
+    }
+  }
+}

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -16,10 +16,9 @@ resource "instana_alerting_channel" "slack" {
 
 locals {
   website_monitoring_id = instana_website_monitoring_config.devdot.id
-  alert_channel_ids = toset([
+  alert_channel_ids = [
     instana_alerting_channel.slack.id,
-  ])
-
+  ]
   tag_filter_clauses = [
     # Exclude common asset types from alert
     "beacon.resourceType@na NOT_EQUAL 'stylesheet'",

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -16,31 +16,50 @@ resource "instana_alerting_channel" "slack" {
 
 locals {
   website_monitoring_id = instana_website_monitoring_config.devdot.id
-  alert_channel_ids = [
+  alert_channel_ids = toset([
     instana_alerting_channel.slack.id,
-  ]
+  ])
+
+  status_code_alerts = {
+    not_found_errors = {
+      label       = "404"
+      metric_name = "httpxxx"
+      operator    = "EQUALS"
+      value       = "404"
+    }
+    server_errors = {
+      label       = "5xx"
+      metric_name = "httpxxx"
+      operator    = "STARTS_WITH"
+      value       = "5"
+    },
+  }
+
+  granularity_milliseconds = var.granularity_minutes * 60000
+  time_window_milliseconds = var.time_window_minutes * 60000
 }
 
-resource "instana_website_alert_config" "js_errors" {
-  name        = "${var.website_name} JS error detected"
-  description = "${var.website_name} JS error detected"
+resource "instana_website_alert_config" "status_codes_alerts" {
+  for_each    = local.status_code_alerts
+  name        = "${var.website_name} ${each.value.label} status code detected"
+  description = "${var.website_name} ${each.value.label} status code detected"
   enabled     = true
   triggering  = false
   website_id  = local.website_monitoring_id
-  granularity = var.granularity_minutes * 60000
+  granularity = local.granularity_milliseconds
 
-  alert_channel_ids = toset(local.alert_channel_ids)
+  alert_channel_ids = local.alert_channel_ids
 
   rules = [
     {
-      operator = ">"
+      operator = ">="
       rule = {
-        specific_js_error = {
-          metric_name = "errors"
+        status_code = {
           aggregation = "SUM"
-          operator    = "GREATER_THAN"
-          value       = null
-        }
+          metric_name = each.value.metric_name
+          operator    = each.value.operator
+          value       = each.value.value
+        },
       }
       threshold = {
         warning = {
@@ -58,8 +77,9 @@ resource "instana_website_alert_config" "js_errors" {
   ]
 
   time_threshold = {
-    violations_in_sequence = {
-      time_window = var.time_window_minutes * 60000
+    violations_in_period = {
+      violations  = 1
+      time_window = local.time_window_milliseconds
     }
   }
 }

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -20,35 +20,19 @@ locals {
     instana_alerting_channel.slack.id,
   ])
 
-  # Filter out any request where the extension ends with one of these values
-  static_asset_extensions = [
-    ".css",
-    ".js",
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".svg",
-    ".ico",
-  ]
+  tag_filter_clauses = [
+    # Exclude common asset types from alert
+    "beacon.resourceType@na NOT_EQUAL 'stylesheet'",
+    "beacon.resourceType@na NOT_EQUAL 'script'",
+    "beacon.resourceType@na NOT_EQUAL 'image'",
 
-  browser_exclusion_clauses = [
+    # Exclude common bots/crawlers from alert
     "beacon.browser.name@na NOT_CONTAIN 'bot'",
     "beacon.browser.name@na NOT_EQUAL 'Slurp'",
     "beacon.browser.name@na NOT_EQUAL 'DuckDuckGo-Favicons-Bot'",
   ]
 
-  # Generate a tag filter expression to exclude static assets and selected bots.
-  static_asset_tag_filter = "(${join(
-    " AND ",
-    concat(
-      [
-        for ext in local.static_asset_extensions :
-        "beacon.http.url@na NOT_ENDS_WITH '${ext}'"
-      ],
-      local.browser_exclusion_clauses
-    )
-  )})"
+  static_asset_tag_filter = "(${join(" AND ", local.tag_filter_clauses)})"
 }
 
 resource "instana_website_alert_config" "status_codes_alerts" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,18 +7,15 @@ variable "website_name" {
 variable "slack_app_id" {
   description = "Slack App ID (starts with A) for the Instana notification bot."
   type        = string
-  default     = "A08AEK9NX41"
 }
 
 variable "slack_channel_name" {
-  description = "The name of the slack channel to send alerts to"
+  description = "The name of the Slack channel to send alerts to."
   type        = string
-  default     = "devdot-instana-digital-alerts"
 }
 
 variable "slack_channel_id" {
-  description = "Slack channel ID"
-  default     = "C0B9Y3JSL58"
+  description = "Slack channel ID."
   type        = string
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,26 +32,26 @@ variable "slack_team_id" {
   type        = string
 }
 
-variable "granularity_minutes" {
-  description = "Evaluation granularity in minutes."
+variable "not_found_granularity_minutes" {
+  description = "Evaluation granularity in minutes for 404 alerts."
   type        = number
   default     = 5
 }
 
-variable "time_window_minutes" {
-  description = "Violation sequence time window in minutes."
+variable "not_found_time_window_minutes" {
+  description = "Violation sequence time window in minutes for 404 alerts. Instana's violations_in_period threshold type caps this at 60 minutes; use a value that is a multiple of not_found_granularity_minutes."
   type        = number
-  default     = 5
+  default     = 60
 }
 
-variable "warning_threshold" {
-  description = "Warning threshold for JS error count. Use 1 to mimic Datadog y > 0 behavior."
+variable "not_found_warning_threshold" {
+  description = "Warning threshold for 404 alerts. Default is scaled for a 60-minute window (8000 / 4 from the original 4h Datadog window)."
   type        = number
-  default     = 1
+  default     = 2000
 }
 
-variable "critical_threshold" {
-  description = "Critical threshold for JS error count."
+variable "not_found_critical_threshold" {
+  description = "Critical threshold for 404 alerts. Default is scaled for a 60-minute window (12000 / 4 from the original 4h Datadog window)."
   type        = number
-  default     = 2
+  default     = 3000
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,55 @@ variable "website_name" {
   type        = string
   default     = "developer.hashicorp.com"
 }
+
+variable "slack_app_id" {
+  description = "Slack App ID (starts with A) for the Instana notification bot."
+  type        = string
+  default     = "A08AEK9NX41"
+}
+
+variable "slack_channel_name" {
+  description = "The name of the slack channel to send alerts to"
+  type        = string
+  default     = "devdot-instana-digital-alerts"
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel ID"
+  default     = "C0B9Y3JSL58"
+  type        = string
+}
+
+variable "slack_team_name" {
+  description = "The name of the slack team that contains the channel to send alerts to"
+  type        = string
+}
+
+variable "slack_team_id" {
+  description = "Slack team ID. You can find this by inspecting the URL of your Slack workspace (e.g. https://app.slack.com/client/<team ID>)"
+  type        = string
+}
+
+variable "granularity_minutes" {
+  description = "Evaluation granularity in minutes."
+  type        = number
+  default     = 5
+}
+
+variable "time_window_minutes" {
+  description = "Violation sequence time window in minutes."
+  type        = number
+  default     = 5
+}
+
+variable "warning_threshold" {
+  description = "Warning threshold for JS error count. Use 1 to mimic Datadog y > 0 behavior."
+  type        = number
+  default     = 1
+}
+
+variable "critical_threshold" {
+  description = "Critical threshold for JS error count."
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Add slack notifications for 404 errors detected by Instana.


## 🧪 Testing

- Grab the website key from [here](https://test-hcp.instana.io/#/websiteMonitoring/website;websiteId=d-CdMGjjTKSIMaufhBqFlg/configuration/options) and add it to your `.env` as `NEXT_PUBLIC_INSTANA_WEBSITE_MONITORING_KEY`
- Start dev portal locally in production mode (`npm run build; npm run serve`)
- Navigate to the preview link
- Generate a bunch of 404 errors by navigating to nonexistent pages 
- A slack notification should show up in [the designated slack channel](https://ibm-hashicorp.slack.com/archives/C0B9Y3JSL58/p1781725262146999)
<img width="1017" height="327" alt="image" src="https://github.com/user-attachments/assets/bbb8af59-4659-48af-8cea-26c02ed5976c" />

- There should be a a 1:1 match for 404 errors detected by Datadog to 404 errors detected by Instana
- You can also compare [the instana Smart Alert config](https://test-hcp.instana.io/#/websiteMonitoring/website;websiteId=d-CdMGjjTKSIMaufhBqFlg/alerts;alertOrderBy=dateUpdated;alertOrderDirection=DESC;page=1;query;pageSize=10;alertId=9K9cD7kASrWk9IdqRqcj5A;alertCreated=1781726400225/details) with [the Datadog alert config](https://app.datadoghq.com/monitors/181005916?fromUser=false&start=1781796009489&end=1781799609489)