### PR TITLE
Switch to TFC varset for instana

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -18,6 +18,8 @@ terraform {
 }
 
 provider "instana" {
-  api_token = var.instana_production_endpoint_token
-  endpoint  = var.instana_production_endpoint
+# Provider api token and endpoint come from varsets in HCP:
+# INSTANA_API_TOKEN
+# INSTANA_ENDPOINT
+# INSTANA_TLS_SKIP_VERIFY
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,1 +1,6 @@
 website_name = "developer.hashicorp.com"
+
+# Provider api token and endpoint come from varsets in HCP:
+# INSTANA_API_TOKEN
+# INSTANA_ENDPOINT
+# INSTANA_TLS_SKIP_VERIFY

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,16 +1,3 @@
-variable "instana_production_endpoint_token" {
-  description = "Instana API token. If null, provider can read INSTANA_API_TOKEN env var."
-  type        = string
-  sensitive   = true
-  default     = null
-}
-
-variable "instana_production_endpoint" {
-  description = "Instana tenant endpoint, e.g. tenant-org.instana.io. If null, provider can read INSTANA_ENDPOINT env var."
-  type        = string
-  default     = null
-}
-
 variable "website_name" {
   description = "Website monitoring config name to create in Instana."
   type        = string


### PR DESCRIPTION
Instead of keeping the values in state for this project, we can instead use org-wide varsets to point to production (or testing) instana instances

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Since the original PR (#3007) was closed, the iops team were kind enough to provide us with a terraform cloud varset we can use between projects and workspaces. 

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

This will make it easier to add Instana/terraform to other apps (like UDR) going forward and keep all the credentials consistent.

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->
- Kick off a new terraform run (or look at the run output attached to this PR)
- If the run passes, it worked