### PR TITLE
Add slack notifications for RUM errors

### DIFF
--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -2,3 +2,58 @@
 resource "instana_website_monitoring_config" "devdot" {
   name = var.website_name
 }
+
+resource "instana_alerting_channel" "slack" {
+  name = var.slack_channel_name
+  slack_app = {
+    app_id       = var.slack_app_id
+    team_id      = var.slack_team_id
+    team_name    = var.slack_team_name
+    channel_id   = var.slack_channel_id
+    channel_name = var.slack_channel_name
+  }
+}
+
+resource "instana_website_alert_config" "js_errors" {
+  name        = "${var.website_name} new RUM error detected"
+  description = "${var.website_name} new RUM error detected"
+  enabled     = true
+  triggering  = false
+  website_id  = instana_website_monitoring_config.devdot.id
+  granularity = var.granularity_minutes * 60000
+
+  alert_channel_ids = [
+    instana_alerting_channel.slack.id,
+  ]
+
+  rules = [
+    {
+      operator = ">="
+      rule = {
+        specific_js_error = {
+          metric_name = "errors"
+          aggregation = "SUM"
+          operator    = "NOT_EMPTY"
+        }
+      }
+      threshold = {
+        warning = {
+          static = {
+            value = var.warning_threshold
+          }
+        }
+        critical = {
+          static = {
+            value = var.critical_threshold
+          }
+        }
+      }
+    }
+  ]
+
+  time_threshold = {
+    violations_in_sequence = {
+      time_window = var.time_window_minutes * 60000
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,55 @@ variable "website_name" {
   type        = string
   default     = "developer.hashicorp.com"
 }
+
+variable "slack_app_id" {
+  description = "Slack App ID (starts with A) for the Instana notification bot."
+  type        = string
+  default     = "A08AEK9NX41"
+}
+
+variable "slack_channel_name" {
+  description = "The name of the slack channel to send alerts to"
+  type        = string
+  default     = "devdot-instana-digital-alerts"
+}
+
+variable "slack_channel_id" {
+  description = "Slack channel ID"
+  default     = "C0B9Y3JSL58"
+  type        = string
+}
+
+variable "slack_team_name" {
+  description = "The name of the slack team that contains the channel to send alerts to"
+  type        = string
+}
+
+variable "slack_team_id" {
+  description = "Slack team ID. You can find this by inspecting the URL of your Slack workspace (e.g. https://app.slack.com/client/<team ID>)"
+  type        = string
+}
+
+variable "granularity_minutes" {
+  description = "Evaluation granularity in minutes."
+  type        = number
+  default     = 5
+}
+
+variable "time_window_minutes" {
+  description = "Violation sequence time window in minutes."
+  type        = number
+  default     = 5
+}
+
+variable "warning_threshold" {
+  description = "Warning threshold for JS error count. Use 1 to mimic Datadog y > 0 behavior."
+  type        = number
+  default     = 1
+}
+
+variable "critical_threshold" {
+  description = "Critical threshold for JS error count."
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Add Instana based slack alerts for RUM errors (JS errors) on devdot

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- Comment out the `backend` stanza in `terraform.tf` to force the terraform to run using local state
- Run the terraform against test-hcp(you may have to grab [an API token](https://test-hcp.instana.io/#/config/securityAndAccess/accessControl/apiTokens?timeline.to=1782414253000&timeline.fm=1782414253000&timeline.ar=false&timeline.ws=1004653000) for test-hcp if you haven't already
- You may have to add an `import` block to your terraform code to import the existing website resource into the terraform code otherwise it will cause a naming conflict. You could also just delete or rename the existing website resource if you like.
- Run devdot locally as normal
- Throw a bunch of errors in the console
- You should see a smart alert fire
