### PR TITLE
Fix invalid value for smart alert rule

### DIFF
--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -34,6 +34,7 @@ resource "instana_website_alert_config" "js_errors" {
           metric_name = "errors"
           aggregation = "SUM"
           operator    = "NOT_EMPTY"
+          value = "Any"
         }
       }
       threshold = {


### PR DESCRIPTION
The terraform provider allows you to omit the "value" option from the `specific_js_error` rule. However, this is technically invalid and breaks the GUI. The result of this is that validation errors appear in the GUI even though the terraform code seemingly works.

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Fix invalid value in Terraform code

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

The Instana terraform provider allows you to set values (or rather the `value` option) which causes breakages in the GUI. 

<img width="1359" height="1285" alt="image" src="https://github.com/user-attachments/assets/a1346291-b19a-4a59-b008-7496599b32cf" />

The fix would be to send a PR to the Instana terraform provider (which I might do shortly) but the fix (for our deployment) is to simply provide `value="Any"` which makes the GUI behave correctly again..

<img width="1803" height="1318" alt="image" src="https://github.com/user-attachments/assets/5585112f-01b3-4f67-9141-25cd197c8aa4" />

## 🧪 Testing

- Go to the instana sandbox, edit the RUM smart alert and observe that "Threshold" section of the GUI works correctly.
- Go to instana production, edit the RUM smart alert and observe that "Threshold" section of the GUI does not work correctly.

