### PR TITLE
Add hcp docs to Vagrant product

### DIFF
--- a/src/data/vagrant.json
+++ b/src/data/vagrant.json
@@ -47,7 +47,7 @@
 			"type": "inbound"
 		}
 	],
-	"basePaths": ["docs", "intro", "vagrant-cloud", "vmware", "downloads"],
+	"basePaths": ["docs", "intro", "vagrant-cloud", "vmware", "downloads", "hcp-docs"],
 	"rootDocsPaths": [
 		{
 			"iconName": "docs",
@@ -64,6 +64,12 @@
 			"iconName": "cloud",
 			"name": "Vagrant Cloud",
 			"path": "vagrant-cloud"
+		},
+		{
+			"iconName": "docs",
+			"name": "HCP Vagrant",
+			"path": "hcp-docs",
+			"productSlugForLoader": "hcp-vagrant"
 		}
 	]
 }

--- a/src/pages/vagrant/hcp-docs/[[...page]].tsx
+++ b/src/pages/vagrant/hcp-docs/[[...page]].tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import DocsView from 'views/docs-view'
+import { getRootDocsPathGenerationFunctions } from 'views/docs-view/utils/get-root-docs-path-generation-functions'
+
+const { getStaticPaths, getStaticProps } = getRootDocsPathGenerationFunctions(
+	'vagrant',
+	'hcp-docs'
+)
+
+export { getStaticProps, getStaticPaths }
+export default DocsView


### PR DESCRIPTION
Modeled after https://github.com/hashicorp/dev-portal/pull/2966

> [!NOTE]
> The Vercel deploy is currently failing for this PR. That's expected because there's no "hcp-vagrant" product in production UDR to build content from. The UDR side of this is delivered by [this PR](https://github.com/hashicorp/web-unified-docs/pull/2764)


## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
This is the devdot side of https://github.com/hashicorp/web-unified-docs/pull/2764/commit. 

- add `hcp-docs` to Vagrant `basePaths`
- add a Boundary `rootDocsPath` for `hcp-docs` with `productSlugForLoader: "hcp-vagrant"`
- add docs page entrypoint for `/vagrant/hcp-docs/[[...page]]`


## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Without this, `/vagrant/hcp-docs/*` falls back to the legacy content API and returns 404s.


## 🧪 Testing

1. Clone https://github.com/hashicorp/web-unified-docs/pull/2764
1. Update `.env` to point to `http://localhost:8080` as follows:
    ```.env
    UNIFIED_DOCS_API="http://localhost:8080"
    UNIFIED_DOCS_PORT="8080"
    ```