### PR TITLE
Add alert grace period

### DIFF
--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -15,12 +15,12 @@ resource "instana_alerting_channel" "slack" {
 }
 
 resource "instana_website_alert_config" "js_errors" {
-  name        = "${var.website_name} new RUM error detected"
-  description = "${var.website_name} new RUM error detected"
-  enabled     = true
-  triggering  = false
-  website_id  = instana_website_monitoring_config.devdot.id
-  granularity = var.granularity_minutes * 60000
+  name         = "${var.website_name} new RUM error detected"
+  description  = "${var.website_name} new RUM error detected"
+  enabled      = true
+  triggering   = false
+  website_id   = instana_website_monitoring_config.devdot.id
+  granularity  = var.granularity_minutes * 60000
   grace_period = var.rum_alert_grace_period_minutes * 60000
 
   alert_channel_ids = [
@@ -35,7 +35,7 @@ resource "instana_website_alert_config" "js_errors" {
           metric_name = "errors"
           aggregation = "SUM"
           operator    = "NOT_EMPTY"
-          value = "Any"
+          value       = "Any"
         }
       }
       threshold = {

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -21,6 +21,7 @@ resource "instana_website_alert_config" "js_errors" {
   triggering  = false
   website_id  = instana_website_monitoring_config.devdot.id
   granularity = var.granularity_minutes * 60000
+  grace_period = var.rum_alert_grace_period_minutes * 60000
 
   alert_channel_ids = [
     instana_alerting_channel.slack.id,

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     instana = {
       source  = "instana/instana"
-      version = ">= 7.0.0"
+      version = ">= 7.3.1"
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,12 @@ variable "granularity_minutes" {
   default     = 5
 }
 
+variable "rum_alert_grace_period_minutes" {
+  description = "Cooldown/grace period specified in minutes"
+  type        = number
+  default     = 5
+}
+
 variable "time_window_minutes" {
   description = "Violation sequence time window in minutes."
   type        = number


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

Updates the smart alert configuration to enable configuration of the cooldown/grace period of alerts. In order words, the amount of time before the metric is considered breached again. This helps prevent noise and alert fatigue so that (hopefully) only *new* issues trigger alerts. 

The default value is 5 minutes which is the same as the default value, but I prefer having a value explicitly set rather than just relying on default values to hopefully make it a bit more obvious how things are configured...

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

Ideally this would've been covered by #3021 but the Instana provider did not support the configuration of this value at the time. In version 7.3.1 of the provider this is now supported (hence the provider version bump).

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- Sign into HCP
- Read the plan output
- A value of 5 minutes (which is also the default) should now be explicitly set for the grace period.
