### PR TITLE
Remove old import blocks

### DIFF
--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -60,12 +60,6 @@ resource "instana_website_alert_config" "js_errors" {
   }
 }
 
-# @todo Remove after apply - don't actually need to, but this will be a no-op
-# so we should probably clean it up
-import {
-  id = "BkwLjIyeSQasx5EBFRAc3g"
-  to = instana_application_config.devdot
-}
 resource "instana_application_config" "devdot" {
   label          = "web-devdot - ${var.github_repository}"
   boundary_scope = "INBOUND"
@@ -87,12 +81,6 @@ locals {
   }
 }
 
-# @todo Remove after apply - don't actually need to, but this will be a no-op
-# so we should probably clean it up
-import {
-  id = "GHOlFdRaQzef02Ixy0nhcg"
-  to = instana_application_alert_config.repo_sync_failed_alert
-}
 resource "instana_application_alert_config" "repo_sync_failed_alert" {
   name            = "${var.github_repository} repo-sync failed"
   tag_filter      = "endpoint.name@dest EQUALS 'repo-sync-failed'"
@@ -125,12 +113,6 @@ resource "instana_application_alert_config" "repo_sync_failed_alert" {
   boundary_scope = "INBOUND"
 }
 
-# @todo Remove after apply - don't actually need to, but this will be a no-op
-# so we should probably clean it up
-import {
-  id = "tYXabw6kT46BR8VG3h5vWw"
-  to = instana_application_alert_config.not_found_alert
-}
 resource "instana_application_alert_config" "not_found_alert" {
   name            = "high docs content-not-found errors"
   tag_filter      = "endpoint.name@dest EQUALS 'content-not-found'"
@@ -163,12 +145,6 @@ resource "instana_application_alert_config" "not_found_alert" {
   boundary_scope = "INBOUND"
 }
 
-# @todo Remove after apply - don't actually need to, but this will be a no-op
-# so we should probably clean it up
-import {
-  id = "Ny24CKFwSBO2Kg4btaONHg"
-  to = instana_custom_dashboard.devdot_dashboard
-}
 # Custom dashboard for devdot metrics
 resource "instana_custom_dashboard" "devdot_dashboard" {
   access_rule = [


### PR DESCRIPTION
## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->
Removes old terraform import blocks to clean up the code

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
The import blocks only existed to bring existing resources under Terraform management. Now that this has been done, those import blocks are basically a no-op. There's no harm keeping them, but they clutter up the config, so it's best to just get rid of them

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

- Open the terraform plan and make sure no changes are indicated (there should be no changes planned)