### PR TITLE
Remove Consul 003 registration link pre-retirement MERGE JULY 14 A.M. 

### DIFF
--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -40,8 +40,7 @@
 			"versionTested": "Consul 1.15",
 			"description": "Prove your foundational Consul knowledge and skills in an hour-long multiple-choice exam. The Consul Associate exam will be retired on July 15, 2026. More details below.",
 			"links": {
-				"prepare": "/consul/tutorials/certification-003",
-				"register": "/certifications/signin"
+				"prepare": "/consul/tutorials/certification-003"
 			},
 			"faqSlug": "consul-associate-003"
 		}


### PR DESCRIPTION

- [Preview link](https://dev-portal-git-CERTS-447-hashicorp.vercel.app/certifications/security-automation) 🔎
- [Jira task](https://hashicorp.atlassian.net/browse/CERTS-447) 🎟️

## 🗒️ What

Consul Associate 003 is not accepting registrations after July 14th. The exam will still be listed on the website until July 15

