### PR TITLE
Add explicit key to avoid runtime error

### DIFF
--- a/src/content/vault/docs-landing.json
+++ b/src/content/vault/docs-landing.json
@@ -7,6 +7,7 @@
 		},
 		{
 			"type": "icon-card-grid",
+			"key": "vault-options",
 			"cards": [
 				{
 					"iconName": "vault-color",
@@ -67,6 +68,7 @@
 		},
 		{
 			"type": "icon-card-grid",
+			"key": "work-with-vault",
 			"cards": [
 				{
 					"iconName": "wrench",


### PR DESCRIPTION
Building locally generated runtime errors for the Vault docs page about two instances of the `icon-card-grid` having the same key. I've assigned explicit keys to resolve the runtime error