### PR TITLE
Redact DD API key in command output

### DIFF
--- a/scripts/__tests__/upload-source-maps.test.ts
+++ b/scripts/__tests__/upload-source-maps.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execSyncMock = vi.fn()
+
+vi.mock('child_process', () => ({
+	default: {
+		execSync: execSyncMock,
+	},
+	execSync: execSyncMock,
+}))
+
+const runUploader = async () => {
+	vi.resetModules()
+	await import('../upload-source-maps')
+}
+
+describe('upload-source-maps', () => {
+	const originalEnv = process.env
+
+	beforeEach(() => {
+		process.env = { ...originalEnv }
+		vi.spyOn(console, 'log').mockImplementation(() => undefined)
+		vi.spyOn(console, 'error').mockImplementation(() => undefined)
+	})
+
+	afterEach(() => {
+		process.env = originalEnv
+		vi.restoreAllMocks()
+	})
+
+	it("doesn't log the Datadog API key when upload fails", async () => {
+		const key = 'test-dd-api-key-123'
+
+		process.env.DD_API_KEY = key
+		process.env.VERCEL_ENV = 'preview'
+		process.env.VERCEL_GIT_COMMIT_SHA = 'commit-sha'
+		process.env.VERCEL_BRANCH_URL = 'branch.example.com'
+
+		execSyncMock
+			.mockImplementationOnce(() => {
+				throw new Error(
+					`Command failed: DATADOG_API_KEY=${key} npx @datadog/datadog-ci sourcemaps upload`
+				)
+			})
+			.mockImplementationOnce(() => Buffer.from(''))
+
+		await runUploader()
+
+		const errorOutput = vi
+			.mocked(console.error)
+			.mock.calls.flat()
+			.map((entry) => String(entry))
+			.join(' ')
+
+		const logOutput = vi
+			.mocked(console.log)
+			.mock.calls.flat()
+			.map((entry) => String(entry))
+			.join(' ')
+
+		expect(errorOutput).not.toContain(key)
+		expect(logOutput).not.toContain(key)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+})

--- a/scripts/upload-source-maps.ts
+++ b/scripts/upload-source-maps.ts
@@ -4,6 +4,14 @@
  */
 import { execSync } from 'child_process'
 
+const sensitiveKeys = [
+	process.env.DD_API_KEY,
+]
+
+const redactSensitiveKeys = (string: string) => {
+	return string.replace(new RegExp(sensitiveKeys.join('|'), 'g'), '[REDACTED]')
+}
+
 /**
  * Uploads source maps to Datadog and then deletes source maps to prevent bundle size increase and leaking of source code.
  */
@@ -36,7 +44,7 @@ const main = () => {
 
 		console.log('Source maps uploaded successfully')
 	} catch (error) {
-		console.error(error)
+		console.error(redactSensitiveKeys(String(error)))
 
 		console.log('Failed to upload sourcemaps')
 	}
@@ -45,7 +53,7 @@ const main = () => {
 	try {
 		execSync(`rm -f .next/static/**/*.js.map`)
 	} catch (error) {
-		console.error(error)
+		console.error(redactSensitiveKeys(String(error)))
 
 		console.log('Failed to delete sourcemaps')
 	}


### PR DESCRIPTION
## 🗒️ What

Automatically redact sensitive DD ingestion key in exceptions

## 🤷 Why

If sourcemap upload failed, the DD metrics ingestion key was leaked in the GH actions output

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

Add `throw new Error(errorOutput)` to the test code. Under normal circumstances this would contain the DataDog API key. However, it how redacts this value automatically.

<img width="1543" height="484" alt="image" src="https://github.com/user-attachments/assets/e046d3c0-4895-4ac8-b21f-61ef37695617" />
