### PR TITLE
Fix: Retain current selected version in Version Dropdown

### DIFF
--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -93,7 +93,7 @@ describe('DocsVersionSwitcher', () => {
 
 		// assert that only n-1 versions are shown in the dropdown
 		const links = queryAllByRole('link')
-		expect(links).toHaveLength(3)
+		expect(links).toHaveLength(4)
 
 		// assert that the currently selected version is not shown in the dropdown
 		const dropdown = queryByRole('list')
@@ -113,7 +113,7 @@ describe('DocsVersionSwitcher', () => {
 		)
 
 		const links = queryAllByRole('link')
-		expect(links).toHaveLength(3)
+		expect(links).toHaveLength(4)
 
 		// link to latest
 		expect(links[1]).not.toHaveAttribute('rel')

--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -5,7 +5,7 @@
 
 import { type ReactNode } from 'react'
 import { VersionSelectItem } from 'views/docs-view/loaders/remote-content'
-import { render, within } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { CurrentProductProvider } from 'contexts'
 import DocsVersionSwitcher from '.'
 import { setProjectForAriaLabel } from '.'
@@ -79,27 +79,22 @@ describe('DocsVersionSwitcher', () => {
 	})
 
 	it.each([
-		['/waypoint/docs', 'v0.9.x (latest)'],
-		['/waypoint/docs/v0.8.x', 'v0.8.x'],
-	])('given path "%s", hides "%s" from the dropdown', (asPath, exclude) => {
+		['/waypoint/docs'],
+		['/waypoint/docs/v0.8.x'],
+	])('given path "%s", hides "%s" from the dropdown', (asPath) => {
 		mockUserRouter.mockImplementation(() => ({
 			asPath: asPath,
 		}))
 
-		const { queryAllByRole, queryByRole } = render(
+		const { queryAllByRole } = render(
 			<DocsVersionSwitcher options={options} />,
 			{ wrapper }
 		)
 
-		// assert that only n-1 versions are shown in the dropdown
+		// assert that only n versions are shown in the dropdown
 		const links = queryAllByRole('link')
 		expect(links).toHaveLength(4)
 
-		// assert that the currently selected version is not shown in the dropdown
-		const dropdown = queryByRole('list')
-		within(dropdown as HTMLUListElement).getAllByRole('link').forEach((link) => {
-			expect(link).not.toHaveTextContent(exclude)
-		})
 	})
 
 	it("passes `rel='nofollow'` to versioned links", () => {

--- a/src/components/docs-version-switcher/docs-version-switcher.test.tsx
+++ b/src/components/docs-version-switcher/docs-version-switcher.test.tsx
@@ -81,7 +81,7 @@ describe('DocsVersionSwitcher', () => {
 	it.each([
 		['/waypoint/docs'],
 		['/waypoint/docs/v0.8.x'],
-	])('given path "%s", hides "%s" from the dropdown', (asPath) => {
+	])('given path "%s", checks for all versions in the dropdown', (asPath) => {
 		mockUserRouter.mockImplementation(() => ({
 			asPath: asPath,
 		}))
@@ -91,7 +91,7 @@ describe('DocsVersionSwitcher', () => {
 			{ wrapper }
 		)
 
-		// assert that only n versions are shown in the dropdown
+		// assert that all n versions are shown in the dropdown
 		const links = queryAllByRole('link')
 		expect(links).toHaveLength(4)
 

--- a/src/components/dropdown-disclosure/components/list-item/list-item.module.css
+++ b/src/components/dropdown-disclosure/components/list-item/list-item.module.css
@@ -8,6 +8,15 @@
 	width: 100%;
 }
 
+/** 
+	Intended for the checkmark next to the current version in the version selector dropdown
+*/
+.link {
+	& span {
+		width: 100%;
+	}
+}
+
 .link,
 .button {
 	composes: g-focus-ring-from-box-shadow from global;

--- a/src/components/version-switcher/index.tsx
+++ b/src/components/version-switcher/index.tsx
@@ -10,7 +10,8 @@ import DropdownDisclosure, {
 import { VersionSwitcherProps, VersionSwitcherOption } from './types'
 import s from './version-switcher.module.css'
 import { Alert, Separator } from '@hashicorp/mds-react/components'
-import { IconFileX16 } from '@hashicorp/flight-icons/svg-react/file-x-16';
+import { IconFileX16 } from '@hashicorp/flight-icons/svg-react/file-x-16'
+import { IconCheck16 } from '@hashicorp/flight-icons/svg-react/check-16'
 
 const IS_DEV = process.env.NODE_ENV !== 'production'
 
@@ -28,7 +29,7 @@ function VersionSwitcher({ options, label }: VersionSwitcherProps) {
 
 	// Get the selected option, shown on the disclosure activator
 	const selectedOption = options.find(
-		(option: VersionSwitcherOption) => option.isSelected
+		(option: VersionSwitcherOption) => option.isSelected,
 	)
 
 	return (
@@ -42,25 +43,25 @@ function VersionSwitcher({ options, label }: VersionSwitcherProps) {
 			>
 				<DropdownDisclosureLabelItem>{label}</DropdownDisclosureLabelItem>
 				{options
-					// Hide currently selected version from dropdown list
-					.filter((option: VersionSwitcherOption) => !option.isSelected)
 					// Render an anchor item for each option
 					.map((option: VersionSwitcherOption, index: number) => {
 						return [
 							// If the next version is missing, then render a message to explain
-							(index < options.length - 1 && options[index].found && !options[index + 1].found) ? (
+							index < options.length - 1 &&
+							options[index].found &&
+							!options[index + 1].found ? (
 								<>
 									<DropdownDisclosureLabelItem>
-										<Separator spacing='0' />
+										<Separator spacing="0" />
 									</DropdownDisclosureLabelItem>
 									<DropdownDisclosureLabelItem>
 										<Alert
 											type="compact"
-											color='critical'
+											color="critical"
 											icon="info"
 											key="no-previous-versions"
 											description={`No versions of this document exist before ${options[index].label}. Click below to redirect to the version homepage.`}
-											role='alert'
+											role="alert"
 										/>
 									</DropdownDisclosureLabelItem>
 								</>
@@ -71,7 +72,12 @@ function VersionSwitcher({ options, label }: VersionSwitcherProps) {
 								rel={option.isLatest ? undefined : 'nofollow'}
 								icon={option.found ? null : <IconFileX16 />}
 							>
-								{option.label}
+								<div className={s.versionDropdownItem}>
+									{option.label}{' '}
+									{option.isSelected ? (
+										<IconCheck16 className={s.currentVersionCheckmark} />
+									) : null}
+								</div>
 							</DropdownDisclosureAnchorItem>,
 						]
 					})}

--- a/src/components/version-switcher/version-switcher.module.css
+++ b/src/components/version-switcher/version-switcher.module.css
@@ -25,6 +25,7 @@ https://app.asana.com/0/1202097197789424/1204412156894162/f
 		width: 100%;
 		justify-content: space-between;
 	}
+
 	/* Make dropdown list fill container */
 	& ul {
 		max-height: 234px;
@@ -40,9 +41,21 @@ https://app.asana.com/0/1202097197789424/1204412156894162/f
 		}
 		& a {
 			justify-content: initial;
-			&:active, &:focus {
+			&:active,
+			&:focus {
 				background: var(--mds-color-surface-action);
 			}
 		}
 	}
+}
+
+.versionDropdownItem {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.currentVersionCheckmark {
+	color: var(--mds-color-foreground-action-hover);
 }


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR proposes an update to the version dropdown selector found in various doc pages on dev.hashicorp.com. These changes make the selector not remove the current version and adds an additional current version checkmark. 

The details of this can be found in the [devdot backlog](https://ibm.monday.com/boards/18402251594/views/240427671/pulses/10910793414).

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->
The changes improve visual clarity and aid the user when navigating amongst differing versions.

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->
1. Looked for the pages where the version selector was being used to identify the specific component
2. Dug into the implementation of the version selector component to locate the current version state logic
3. Found corresponding CSS sheets and modified to ensure the least changes could be made to prevent any major breaking

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

**Previews found on the Nomad API page**
<img width="250" height="308" alt="image" src="https://github.com/user-attachments/assets/e8ba7931-97cf-41b4-b336-a171b6fe170f" />
<img width="253" height="304" alt="image" src="https://github.com/user-attachments/assets/874bb67c-bfbb-432c-8cff-a9d402b2343d" />

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Visit the [preview link](https://dev-portal-gdrs6gq5x-hashicorp.vercel.app/terraform/intro) and click on the version selector to see if the the current version is indicated
2. Click on a different version and see if the checkmark is moved appropriately

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->
>[!NOTE]
> Not sure if the dropdown intends to start at the currently selected version. For instance, if we select a version below the initial visible selections, the user would have to scroll down to find where they're at currently.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
