### PR TITLE
Fix: Non-heading anchors land below anchor text

### DIFF
--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -33,10 +33,6 @@
 /* Print Styles */
 @import './print.css';
 
-:root {
-	--mdx-content-max-width: 75ch;
-}
-
 /*
  * About this selector:
  * `.g-subnav ~ *` finds all elements after the navigation.
@@ -229,14 +225,26 @@ and negative margin.
 * "Reconcile" task: https://app.asana.com/0/1201987349274776/1202052090505082/f
 ***
 */
+
 :root {
+	--mdx-content-max-width: 75ch;
 	--permalink-scroll-offset: 24px;
 	--total-scroll-offset: calc(
-		var(--navigation-header-height) + var(--permalink-scroll-offset)
+		calc(var(--navigation-header-height) * 2) + var(--permalink-scroll-offset)
 	);
 	--ce-color: purple;
 }
 
+/* 
+	The issue with the scrolling has to do with this scroll-margin-top, which controls how far the links redirect
+	When we calculate --total-scroll-offset, we do so without accounting for the extra subnav height (64px) -> Header hidden behind subnav
+	So, the change is done to --total-scroll-offset above where we just double --navigation-header-height given the nav & subnav are the save height
+	We can safely do this because the sidecar disappears after a certain min width (1280px) is reached - src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
+	and this width is well above the tablet/mobile views.
+
+	Note: A better fix would be to incorporate the dynamicness of the nav height into --total-scroll-offset and there is the existence of --sticky-bars-height 
+	found in src/layouts/base-layout/base-layout.module.css that we can maybe incorporate. But we'd need to import the file and that gets messy to refactor.
+*/
 .g-offset-scroll-margin-top {
 	scroll-margin-top: var(--total-scroll-offset);
 

--- a/src/pages/style.css
+++ b/src/pages/style.css
@@ -238,7 +238,7 @@ and negative margin.
 /* 
 	The issue with the scrolling has to do with this scroll-margin-top, which controls how far the links redirect
 	When we calculate --total-scroll-offset, we do so without accounting for the extra subnav height (64px) -> Header hidden behind subnav
-	So, the change is done to --total-scroll-offset above where we just double --navigation-header-height given the nav & subnav are the save height
+	So, the change is done to --total-scroll-offset above where we just double --navigation-header-height given the nav & subnav are the same height
 	We can safely do this because the sidecar disappears after a certain min width (1280px) is reached - src/layouts/sidebar-sidecar/sidebar-sidecar-layout.module.css
 	and this width is well above the tablet/mobile views.
 


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR updates the jumps handled by the sidecar found on the right side of the screen for desktop users. Prior to the changes, the jump would make it so that the header is hidden behind the subnav. This fix should make it so that the jump displays the header properly.

More details can be found in this [devdot-backlog ticket](https://ibm.monday.com/boards/18402251594/pulses/10910814809).

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

1. My initial thought was that the subnav is hiding the header and that the jump must be excluding the height of that subnav (this was correct).
2. I dug into the pages to find out how the sidecar is being implemented (in layouts) and proceeded to look into the component (sidebar-sidecar) itself. I wanted to see how the sidecar was handling jumps and this pretty much led nowhere as it didn't contain any logic for it besides the link ref. 
3. I asked Bob to locate the issue given these files and it proceeded to throw me into the global styles and base layout, which was definitely odd.
4. From there, I manually adjusted the supposed problematic variable in order to come to the proposed fix.

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

**Pre-fix sidecar jump**
<img width="1728" height="721" alt="image" src="https://github.com/user-attachments/assets/ae746f58-d621-4ba3-abad-22f1fe72cc4f" />

**Post-fix sidecar jump**
<img width="3456" height="1454" alt="image" src="https://github.com/user-attachments/assets/70e29432-debc-4dc9-9739-55ebefad91b1" />

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Open the [preview](https://dev-portal-git-fix-non-heading-anchors-text-hashicorp.vercel.app/terraform) and click upon any of the headers found on the right side of the page.
5. Click onto documentation or any other section on the left and do the same as step 1.
6. Note if any jumps seem out of place or does not show up as expected.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
