### PR TITLE
Terraform housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ public/.extracted/
 sitemap-0.xml
 sitemap.xml
 robots.txt
-.terraform*
+.terraform
 terraform.tfvars

--- a/.terraformignore
+++ b/.terraformignore
@@ -1,0 +1,4 @@
+**
+!*.tf
+!*.tf.json
+!.terraform.lock.hcl


### PR DESCRIPTION
Add a terraform ignore file to prevent terraform uploading the entire project to HCP (rather than just terraform/). This helps speed up plan times quite a bit.

Also unignores `.terraformignore` so that we can commit it
