### PR TITLE
fix: address app crashing if no title in search results

### DIFF
--- a/src/components/command-bar/commands/search/unified-search/components/unified-hit/helpers/get-unified-hit-props.ts
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hit/helpers/get-unified-hit-props.ts
@@ -29,10 +29,10 @@ export function getUnifiedHitProps(hit: Hit): UnifiedHitProps {
 	// Title and description
 	const titleHtml = (
 		hit._highlightResult.page_title as HitAttributeHighlightResult
-	).value
+	)?.value
 	const descriptionHtml = (
 		hit._highlightResult.description as HitAttributeHighlightResult
-	).value
+	)?.value
 
 	// Default product
 	const productSlug = parseDefaultProductSlug(hit)

--- a/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
+++ b/src/components/command-bar/commands/search/unified-search/components/unified-hits-container/index.tsx
@@ -32,7 +32,6 @@ export function UnifiedHitsContainer({
 	tabsData: UnifiedSearchTabContent[]
 	suggestedPages: SuggestedPageProps[]
 }) {
-
 	return (
 		<div className={s.tabsWrapper}>
 			<Tabs showAnchorLine={false} variant="compact">
@@ -60,11 +59,17 @@ export function UnifiedHitsContainer({
 									</div>
 									<div className={s.commandBarListWrapper}>
 										<CommandBarList ariaLabelledBy={resultsLabelId}>
-											{hits.map((hit: Hit) => (
-												<li key={hit.objectID}>
-													<UnifiedHit {...getUnifiedHitProps(hit)} />
-												</li>
-											))}
+											{hits.map((hit: Hit) => {
+												const unifiedHitProps = getUnifiedHitProps(hit)
+												if (unifiedHitProps.titleHtml === undefined) {
+													return
+												}
+												return (
+													<li key={hit.objectID}>
+														<UnifiedHit {...unifiedHitProps} />
+													</li>
+												)
+											})}
 										</CommandBarList>
 										{/* TODO: add suggested pages */}
 									</div>


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-leah-fixapp-crash-if-no-title-hashicorp.vercel.app/) 🔎
- [Monday task](https://ibm.monday.com/boards/18402251594/pulses/11241971567) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR fixes a bug where a user would type a specific string into the search bar and the app would crash. The underlying issue was the one of the results did not have `page_title` in the frontmatter so it did not get added to the algolia record. When we try to access this value, the app crashes. This PR fixes that by adding an optional check on the value and then removing the result if there is no title. 

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Go to [preview](https://dev-portal-git-leah-fixapp-crash-if-no-title-hashicorp.vercel.app/)
2. Search for any of the broken phrases (test y, test m, vault moni, nomad monitoring) and verify that the page does not break

## 💭 Anything else?

There is an accompanying PR on UDR that fixes the files without page_title here: https://github.com/hashicorp/web-unified-docs/pull/2986. Since this PR removes any results from search that don't have a title, the UDR PR adds titles for all docs that did not have it so we are not excluding any results.
