### PR TITLE
Adjust env var settings

### DIFF
--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -2,9 +2,10 @@ locals {
   environment = {
     INSTANA_WEBSITE_MONITORING_KEY = {
       value          = instana_website_monitoring_config.devdot.id
-      sensitive      = true
+      sensitive      = false
       comment        = "Instana RUM/EUM beacon key for devdot."
       client_visible = true
+      targets = ["production", "preview", "development"]
     }
   }
 }


### PR DESCRIPTION
This env var was previously marked as sensitive by accident. It's actually not a sensitive value since it's exposed to the client. Additionally, it was also previously exposed to all environments, but in #3010 we accidentally narrowed the scope ONLY to production.

This isn't a huge breaking change, but we probably do want to re-open this env var to all environments again to replicate the behavior we had with Datadog RUM.