### PR TITLE
Remove "HCP Button" from Consul

### DIFF
--- a/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/__tests__/get-nav-items.test.ts
@@ -154,6 +154,19 @@ const testHCPData = {
 	],
 } as ProductData
 
+const testConsulData = {
+	slug: 'consul',
+	name: 'Consul',
+	rootDocsPaths: [
+		{
+			iconName: 'docs',
+			name: 'Documentation',
+			path: 'docs',
+			shortName: 'Docs',
+		},
+	],
+} as ProductData
+
 describe('getLeftSideNavItems', () => {
 	it('for most products, returns the standard set of items', () => {
 		expect(getLeftSideNavItems(testNomadData)).toMatchInlineSnapshot(`
@@ -311,5 +324,8 @@ describe('getRightSideNavItems', () => {
 			  },
 			]
 		`)
+	})
+	it('for Consul, does not return a Try HCP Consul item', () => {
+		expect(getRightSideNavItems(testConsulData)).toMatchInlineSnapshot(`[]`)
 	})
 })

--- a/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
+++ b/src/components/navigation-header/components/product-page-content/utils/get-nav-items.ts
@@ -12,7 +12,6 @@ import SANDBOX_CONFIG from 'content/sandbox/sandbox.json'
 
 const TRY_CLOUD_ITEM_PRODUCT_SLUGS = [
 	'boundary',
-	'consul',
 	'hcp',
 	'packer',
 	'terraform',


### PR DESCRIPTION
HCP Consul was EOL last November, so we don't want the "Try HCP Consul"
button in the navbar anymore
