### PR TITLE
Add agent key to vercel using terraform

### DIFF
--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,5 +1,12 @@
 locals {
   environment = {
+    INSTANA_AGENT_KEY = {
+      value          = var.instana_agent_key
+      sensitive      = true
+      comment        = "Agent key used to submit build metrics to Instana"
+      client_visible = false
+      targets        = ["production", "preview"]
+    }
     INSTANA_WEBSITE_MONITORING_KEY = {
       value          = instana_website_monitoring_config.devdot.id
       sensitive      = false


### PR DESCRIPTION
The instana agent key was added to vercel env manually

<img width="523" height="123" alt="image" src="https://github.com/user-attachments/assets/356cb864-a307-4c47-b5fc-f50bab30814a" />


When the env var was renamed in #3077 - this was accidentally missed and not renamed(or recreated) as it should have been.
