### PR TITLE
Switch professional to advanced on certs pages for renaming project

### DIFF
--- a/src/content/certifications/exam-faqs/terraform-associate-004.mdx
+++ b/src/content/certifications/exam-faqs/terraform-associate-004.mdx
@@ -92,10 +92,10 @@ Understand your recertification options. Start by finding the scenario that appl
 
 ### Scenario 1: You hold an unexpired Terraform Associate certification from the 004 version of the exam
 
-#### Option 1: Pass the Terraform Authoring and Operations Professional exam 
+#### Option 1: Pass the Terraform Authoring and Operations Advanced exam 
 
 - Extend your Associate credentials' expiration date 
-- Earn a new professional-level badge and certificate 
+- Earn a new advanced-level badge and certificate 
 
 #### Option 2: Pass the 004 version of the Terraform Associate exam starting 6 months before expiration 
 
@@ -103,10 +103,10 @@ Understand your recertification options. Start by finding the scenario that appl
 
 ### Scenario 2: You hold an unexpired Terraform Associate certification from the 002 or 003 version of the exam
 
-#### Option 1: Pass the Terraform Authoring and Operations Professional exam 
+#### Option 1: Pass the Terraform Authoring and Operations Advanced exam 
 
 - Extend your Associate credentials' expiration date 
-- Earn a new professional-level badge and certificate 
+- Earn a new advanced-level badge and certificate 
 
 #### Option 2: Pass the 004 version of the Terraform Associate exam starting 6 months before expiration 
 

--- a/src/content/certifications/exam-faqs/terraform-authoring-operations-professional.mdx
+++ b/src/content/certifications/exam-faqs/terraform-authoring-operations-professional.mdx
@@ -2,7 +2,7 @@
 
 ## Who should take this exam
 
-You should take the Terraform Authoring and Operations Professional exam if you have advanced production-level Terraform expertise in both configuration authoring and Terraform workflows. You will need to demonstrate your professional-level skills implementing and authoring Terraform modules, developing dynamic HCL configuration, and establishing scalable, collaborative workflows. 
+You should take the Terraform Authoring and Operations Advanced exam if you have advanced production-level Terraform expertise in both configuration authoring and Terraform workflows. You will need to demonstrate your advanced-level skills implementing and authoring Terraform modules, developing dynamic HCL configuration, and establishing scalable, collaborative workflows. 
 
 Prerequisites:
 
@@ -66,7 +66,7 @@ Prerequisites:
 
 ## Renewing your certification
 
-To renew your certification, you will need to take and pass the Terraform Authoring & Operations Professional exam again.
+To renew your certification, you will need to take and pass the Terraform Authoring & Operations Advanced exam again.
 
 ### Unexpired certification
 

--- a/src/content/certifications/exam-faqs/vault-associate-003.mdx
+++ b/src/content/certifications/exam-faqs/vault-associate-003.mdx
@@ -86,10 +86,10 @@ Understand your recertification options. Start by finding the scenario that appl
 
 ### Scenario 1: You hold an unexpired Vault Associate certification from the 003 version of the exam
 
-#### Option 1: Pass the Vault Operations Professional exam
+#### Option 1: Pass the Vault Operations Advanced exam
 
 - Extend your Associate credentials' expiration date 
-- Earn a new professional-level badge and certificate 
+- Earn a new advanced-level badge and certificate 
 
 #### Option 2: Pass the 003 version of the Vault Associate exam starting 6 months before expiration 
 
@@ -97,10 +97,10 @@ Understand your recertification options. Start by finding the scenario that appl
 
 ### Scenario 2: You hold an unexpired Vault Associate certification from the 002 version of the exam 
 
-#### Option 1: Pass the Vault Operations Professional exam
+#### Option 1: Pass the Vault Operations Advanced exam
 
 - Extend your Associate credentials' expiration date 
-- Earn a new professional-level badge and certificate 
+- Earn a new advanced-level badge and certificate 
 
 #### Option 2: Pass the 003 version of the Vault Associate exam starting 6 months before expiration 
 

--- a/src/content/certifications/exam-faqs/vault-operations-professional.mdx
+++ b/src/content/certifications/exam-faqs/vault-operations-professional.mdx
@@ -2,9 +2,7 @@
 
 ## Who should take this exam 
 
-You should take the Vault Operations Professional exam if you are a Cloud Engineer with advanced, production-level Vault operations expertise. You will need to demonstrate your ability to deploy, configure, manage, and monitor HashiCorp Vault, and you must also be able to evaluate Vault Enterprise functionality and use cases. 
-
-Prerequisites:
+You should take the Vault Operations Advanced exam if you are a Cloud Engineer with advanced, production-level Vault operations expertise. You will need to demonstrate your ability to deploy, configure, manage, and monitor HashiCorp Vault, and you must also be able to evaluate Vault Enterprise functionality and use cases.
 
 - Vault Associate certification (strongly recommend, or equivalent experience required) 
 - Linux skills such as list and edit files via command terminal 
@@ -70,7 +68,7 @@ Prerequisites:
 
 ## Renewing your certification
 
-To renew your certification, you will need to pass the Vault Operations Professional exam again.
+To renew your certification, you will need to pass the Vault Operations Advanced exam again.
 
 ### Unexpired certification
 

--- a/src/content/certifications/programs/infrastructure-automation.json
+++ b/src/content/certifications/programs/infrastructure-automation.json
@@ -2,11 +2,11 @@
 	"title": "Infrastructure Automation",
 	"summary": {
 		"heading": "Infrastructure<br />Automation Certifications",
-		"description": "We offer Terraform certifications at two levels to help you showcase your infrastructure automation expertise. Earn the Terraform Associate certification to validate your foundational Terraform knowledge and skills. Demonstrate your advanced Terraform production experience with the Terraform Authoring and Operations Professional certification."
+		"description": "We offer Terraform certifications at two levels to help you showcase your infrastructure automation expertise. Earn the Terraform Associate certification to validate your foundational Terraform knowledge and skills. Demonstrate your advanced Terraform production experience with the Terraform Authoring and Operations Advanced certification."
 	},
 	"hero": {
 		"heading": "Infrastructure<br />Automation Certifications",
-		"description": "We offer Terraform certifications at two levels to help you showcase your infrastructure automation expertise. Earn the Terraform Associate certification to validate your foundational Terraform knowledge and skills. Demonstrate your advanced Terraform production experience with the Terraform Authoring and Operations Professional certification."
+		"description": "We offer Terraform certifications at two levels to help you showcase your infrastructure automation expertise. Earn the Terraform Associate certification to validate your foundational Terraform knowledge and skills. Demonstrate your advanced Terraform production experience with the Terraform Authoring and Operations Advanced certification."
 	},
 	"exams": [
 		{
@@ -22,7 +22,7 @@
 			"faqSlug": "terraform-associate-004"
 		},
 		{
-			"title": "Terraform Authoring and Operations Professional",
+			"title": "Terraform Authoring and Operations Advanced",
 			"examTier": "pro",
 			"productSlug": "terraform",
 			"versionTested": "Terraform 1.6",

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -2,11 +2,11 @@
 	"title": "Security Automation",
 	"summary": {
 		"heading": "Security<br />Automation Certifications",
-		"description": "Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Professional exam."
+		"description": "Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Advanced exam."
 	},
 	"hero": {
 		"heading": "Security<br />Automation Certifications",
-		"description": " Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Professional exam."
+		"description": " Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Advanced exam."
 	},
 	"exams": [
 		{
@@ -22,7 +22,7 @@
 			"faqSlug": "vault-associate-003"
 		},
 		{
-			"title": "Vault Operations Professional",
+			"title": "Vault Operations Advanced",
 			"examTier": "pro",
 			"productSlug": "vault",
 			"versionTested": "Vault 1.16",

--- a/src/content/certifications/programs/security-automation.json
+++ b/src/content/certifications/programs/security-automation.json
@@ -6,7 +6,7 @@
 	},
 	"hero": {
 		"heading": "Security<br />Automation Certifications",
-		"description": " Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Advanced exam."
+		"description": "Verify your security and networking automation expertise with our Vault certifications. Earn an associate-level certification to validate your foundational Vault knowledge and skills. You can also demonstrate your advanced Vault operational experience when you pass the Vault Operations Advanced exam."
 	},
 	"exams": [
 		{


### PR DESCRIPTION
## 🔗 Relevant links

- [Preview link](https://dev-portal-git-CERTS-377-rename-hashicorp.vercel.app/certifications 🔎
- [Jira task](https://hashicorp.atlassian.net/browse/CERTS-396) 🎟️

## 🗒️ What

This PR changes the exam names and all refs to the exam names changing from professional to advanced on the /certifications home page. This PR will not change the slugs, as that will happen when we roll out the new website design. 
This PR should accurately reflect all lab-based exams having Advanced as their level, and any references to Professional exams should be gone.

## 🤷 Why

<!--
Describe why the changes proposed are needed. Some examples: new feature requested, refactor to make things easier later, styling tweaks requested by design, etc.
-->

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

## 💭 Anything else?
