### PR TITLE
Reduce Instana noise from browser extensions and password managers

### DIFF
--- a/src/lib/instana/index.tsx
+++ b/src/lib/instana/index.tsx
@@ -17,7 +17,8 @@ ineum('meta','env','${ENV}');
 ${COMMIT_SHA ? `ineum('meta','version','${COMMIT_SHA}');` : ''}
 ineum('trackSessions');
 ineum('autoPageDetection', true);
-ineum('ignoreErrorMessages', [/extension/i, /node_modules/i]);`
+ineum('ignoreErrorMessages', [/extension/i, /node_modules/i, /object not found matching id/i]);
+ineum('ignoreUrls', [/^chrome-extension:\\/\\//i, /^moz-extension:\\/\\//i]);`
 
 function InstanaHeadTag() {
 	return (


### PR DESCRIPTION
## What

Filters two categories of known-noisy errors from Instana EUM reporting:

1. **Browser extension errors** — adds `ignoreUrls` to drop any error whose stack trace originates from a `chrome-extension://` or `moz-extension://` URL (Chrome/Edge/Brave/Firefox extensions injecting scripts into the page).
2. **Password manager errors** — adds `Object Not Found Matching Id` to `ignoreErrorMessages` to suppress errors generated by password managers (1Password, LastPass, Dashlane, etc.) probing the DOM for form fields.

## Why

These errors are not caused by application code and cannot be fixed by us. They pollute Instana dashboards and alert thresholds, making it harder to identify real issues.

## Changes

`src/lib/instana/index.tsx`
- Added `ineum('ignoreUrls', [/^chrome-extension:\/\//i, /^moz-extension:\/\//i])`
- Added `/object not found matching id/i` to the existing `ignoreErrorMessages` array

## Notes

These filters apply client-side going forward — errors already recorded in Instana are unaffected.