### PR TITLE
fix: Tutorials Library Input Icon

### DIFF
--- a/src/views/tutorial-library/index.tsx
+++ b/src/views/tutorial-library/index.tsx
@@ -10,6 +10,7 @@ import {
 	UseSearchBoxProps,
 } from 'react-instantsearch'
 import { IconX16 } from '@hashicorp/flight-icons/svg-react/x-16'
+import { IconSearch16 } from '@hashicorp/flight-icons/svg-react/search-16'
 
 import FilterInput from 'components/filter-input'
 import Dialog from 'components/dialog'
@@ -70,6 +71,7 @@ export default function TutorialLibraryView({
 						setQuery(value)
 						refine(value)
 					}}
+					IconComponent={IconSearch16}
 				/>
 				<MobileFiltersButton onClick={() => setShowMobileFilters(true)} />
 				<Dialog


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Asana task](url) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR addresses the input icon being different in Tutorials Library compared to Integrations Library as described in this [Monday ticket](https://ibm.monday.com/boards/18402251594/views/240427671/pulses/11694397906).

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

1. Passed in the IconSearch16 component into FilterInput to properly render instead of the default icon

## 📸 Design Screenshots

<!--
Include a screenshot or two and a link to the designs you referenced with this code. These are both helpful context for reviewers to understand what designs you were looking at when you were putting this code together.
-->

Before
<img width="986" height="110" alt="image" src="https://github.com/user-attachments/assets/c4268b4d-216d-490c-bd4d-c72046721166" />

After
<img width="908" height="95" alt="image" src="https://github.com/user-attachments/assets/eb44072f-53bd-4f3b-8e21-cd5e30f773a0" />

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Open the [preview deployment link](https://dev-portal-git-fix-tutorial-library-filter-icon-hashicorp.vercel.app/tutorials/library) and make sure the icon on the filter input section matches with the [Integrations Library](https://dev-portal-git-fix-tutorial-library-filter-icon-hashicorp.vercel.app/vault/integrations) filter input.

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
