### PR TITLE
feat: Refactored UDR + MKTG CONTENT DOCS API into single utility function

### DIFF
--- a/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
+++ b/build-libs/__tests__/get-latest-content-sha-for-product.test.ts
@@ -11,35 +11,37 @@ import { loadHashiConfigForEnvironment } from '../../config'
 describe.skip('getLatestContentShaForProduct', async () => {
 	const config = await loadHashiConfigForEnvironment()
 
-	PRODUCT_REDIRECT_ENTRIES
-		.filter(({ repo }) => !config['flags.unified_docs_migrated_repos'].includes(repo)) // skip repos we don't have access to
+	PRODUCT_REDIRECT_ENTRIES.filter(
+		({ repo }) =>
+			!(config['flags.unified_docs_migrated_repos'] as string[]).includes(repo),
+	) // skip repos we don't have access to
 		.forEach(({ repo, path }) => {
 			if (repo === 'hvd-docs') {
 				console.log(`Skipping test for repo "${repo}"`)
 			} else {
 				it(`fetches the latest SHA for the "${repo}" repo`, async () => {
-				const latestSha = await getLatestContentShaForProduct(repo)
-				expect(typeof latestSha).toBe('string')
-			})
-		}
-		if (
-			['hcp-docs', 'sentinel', 'terraform-enterprise', 'hvd-docs'].includes(
-				repo
-			)
-		) {
-			console.log(`Skipping test for private repo "${repo}"`)
-		} else {
-			it(`fetches the latest SHA for the "${repo}" repo, then validates the SHA by fetching redirects`, async () => {
-				const latestSha = await getLatestContentShaForProduct(repo)
-				expect(typeof latestSha).toBe('string')
-				const redirectsFileString = await fetchGithubFile({
-					owner: 'hashicorp',
-					repo: repo,
-					path: path,
-					ref: latestSha,
+					const latestSha = await getLatestContentShaForProduct(repo)
+					expect(typeof latestSha).toBe('string')
 				})
-				expect(typeof redirectsFileString).toBe('string')
-			})
-		}
-	})
+			}
+			if (
+				['hcp-docs', 'sentinel', 'terraform-enterprise', 'hvd-docs'].includes(
+					repo,
+				)
+			) {
+				console.log(`Skipping test for private repo "${repo}"`)
+			} else {
+				it(`fetches the latest SHA for the "${repo}" repo, then validates the SHA by fetching redirects`, async () => {
+					const latestSha = await getLatestContentShaForProduct(repo)
+					expect(typeof latestSha).toBe('string')
+					const redirectsFileString = await fetchGithubFile({
+						owner: 'hashicorp',
+						repo: repo,
+						path: path,
+						ref: latestSha,
+					})
+					expect(typeof redirectsFileString).toBe('string')
+				})
+			}
+		})
 })

--- a/build-libs/__tests__/redirects.test.ts
+++ b/build-libs/__tests__/redirects.test.ts
@@ -251,8 +251,9 @@ describe('getRedirectsFromContentRepo', () => {
 			},
 		]
 		global.fetch = vi.fn().mockResolvedValue({
-			json: () => new Promise((resolve) => resolve(mockData)),
+			status: 200,
 			ok: true,
+			json: () => new Promise((resolve) => resolve(mockData)),
 		})
 
 		const redirects = await getRedirectsFromContentRepo(

--- a/build-libs/redirects.ts
+++ b/build-libs/redirects.ts
@@ -3,27 +3,24 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-//@ts-check
+import fs from 'fs'
+import path from 'path'
 
-const fs = require('fs')
-const path = require('path')
+import { isDeployPreview } from '../src/lib/env-checks'
+import { ContentClient } from '../src/lib/content-client/content-client'
+import fetchGithubFile from './fetch-github-file'
+import getLatestContentShaForProduct from './get-latest-content-sha-for-product'
+import { getTutorialRedirects } from './tutorial-redirects'
+import { getDocsDotHashiCorpRedirects } from './docs-dot-hashicorp-redirects'
+import { packerPluginRedirects } from './integration-packer-redirects'
+import { loadHashiConfigForEnvironment } from '../config'
 
-const { isDeployPreview } = require('../src/lib/env-checks')
-const fetchGithubFile = require('./fetch-github-file')
-const getLatestContentShaForProduct = require('./get-latest-content-sha-for-product')
-const { getTutorialRedirects } = require('./tutorial-redirects')
-const {
-	getDocsDotHashiCorpRedirects,
-} = require('./docs-dot-hashicorp-redirects')
-const { packerPluginRedirects } = require('./integration-packer-redirects')
-const { loadHashiConfigForEnvironment } = require('../config')
+import 'isomorphic-unfetch'
 
-require('isomorphic-unfetch')
-
-/** @typedef { import("next/dist/lib/load-custom-routes").Redirect } Redirect  */
+import type { Redirect } from 'next/dist/lib/load-custom-routes'
 
 // copied from src/constants/hostname-map.ts so it's usable at build-time in the next config
-const HOSTNAME_MAP = {
+const HOSTNAME_MAP: Record<string, string> = {
 	'docs.hashicorp.com': 'sentinel',
 	'test-st.hashi-mktg.com': 'sentinel',
 }
@@ -53,7 +50,11 @@ const HOSTNAME_MAP = {
  * @param {string} redirectsPath Path within the repo to the redirects file.
  * @returns {Promise<Redirect[]>}
  */
-async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
+async function getRedirectsFromContentRepo(
+	repoName: string,
+	redirectsPath: string,
+	config: Record<string, unknown>,
+): Promise<Redirect[]> {
 	/**
 	 * Note: These constants are declared for clarity in build context intent.
 	 */
@@ -64,18 +65,15 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	 * Load redirects from the unified docs repo if it's in the list of migrated repos.
 	 * Return early if there are not any redirects found for that specific repo.
 	 */
-	if (config['flags.unified_docs_migrated_repos'].includes(repoName)) {
-		const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
-			? new Headers({
-					'x-vercel-protection-bypass':
-						process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
-				})
-			: new Headers()
-
-		const getUDRRedirects = await fetch(
-			`${process.env.UNIFIED_DOCS_API}/api/content/${repoName}/redirects`,
-			{ headers },
+	if (
+		(config['flags.unified_docs_migrated_repos'] as string[]).includes(repoName)
+	) {
+		const getUDRRedirects = await ContentClient(
+			`api/content/${repoName}/redirects`,
+			true,
+			false,
 		)
+
 		if (getUDRRedirects.ok) {
 			const udrRedirects = await getUDRRedirects.json()
 			return udrRedirects
@@ -101,8 +99,7 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	/**
 	 * Load redirects from the target repo (or return early for non-target repos).
 	 */
-	/** @type {string} */
-	let redirectsFileString
+	let redirectsFileString: string
 	if (isDeveloperBuild || process.env.HASHI_ENV === 'unified-docs-sandbox') {
 		// For `hashicorp/dev-portal` builds, load redirects remotely
 		// hvd-docs is not hosted on the content API, so we need to use main as the latest sha
@@ -128,18 +125,16 @@ async function getRedirectsFromContentRepo(repoName, redirectsPath, config) {
 	/**
 	 * Evaluate the redirects file string, filter invalid redirects.
 	 */
-	/** @type {Redirect[]} */
-	const parsedRedirects = eval(redirectsFileString) ?? []
+	const parsedRedirects: Redirect[] = eval(redirectsFileString) ?? []
 	const validRedirects = filterInvalidRedirects(parsedRedirects, repoName)
 	return validRedirects
 }
 
 /**
- * @type {{ repo: string, path: string}[]} An array of redirect
- * entries. Each entry specifies a repo and the path within that repo to the
- * redirects file.
+ * An array of redirect entries. Each entry specifies a repo and the path
+ * within that repo to the redirects file.
  */
-const PRODUCT_REDIRECT_ENTRIES = [
+const PRODUCT_REDIRECT_ENTRIES: { repo: string; path: string }[] = [
 	{ repo: 'boundary', path: 'website/redirects.js' },
 	{ repo: 'nomad', path: 'website/redirects.js' },
 	{ repo: 'vault', path: 'website/redirects.js' },
@@ -275,15 +270,15 @@ async function buildDevPortalRedirects() {
  * which exceeded Vercel's limits for built-in redirects handling.
  * For further details see: https://vercel.com/guides/how-can-i-increase-the-limit-of-redirects-or-use-dynamic-redirects-on-vercel
  *
- * @param {Redirect[]} redirects
+ * @param redirects
  * @returns {{ simpleRedirects: Redirect[], complexRedirects: Redirect[] }}
  */
-function splitRedirectsByType(redirects) {
-	/** @type {Redirect[]} */
-	const simpleRedirects = []
-
-	/** @type {Redirect[]} */
-	const complexRedirects = []
+function splitRedirectsByType(redirects: Redirect[]): {
+	simpleRedirects: Redirect[]
+	complexRedirects: Redirect[]
+} {
+	const simpleRedirects: Redirect[] = []
+	const complexRedirects: Redirect[] = []
 
 	redirects.forEach((redirect) => {
 		const isGlobRedirect = ['(', ')', '{', '}', ':', '*', '+', '?'].some(
@@ -310,15 +305,18 @@ function splitRedirectsByType(redirects) {
  *
  * Invalid redirects will be filtered out and ignored.
  *
- * @param {Redirect[]} redirects
- * @param {string} repoSlug
+ * @param redirects
+ * @param repoSlug
  * @returns {Redirect[]}
  */
-function filterInvalidRedirects(redirects, repoSlug) {
+function filterInvalidRedirects(
+	redirects: Redirect[],
+	repoSlug: string,
+): Redirect[] {
 	/**
 	 * Normalize the repoSlug into a productSlug.
 	 */
-	const productSlugsByRepo = {
+	const productSlugsByRepo: Record<string, string> = {
 		/** @deprecated - terraform-website is now archived and redirects have been moved to `terraform-docs-common` */
 		'terraform-website': 'terraform',
 		'terraform-docs-common': 'terraform',
@@ -328,8 +326,7 @@ function filterInvalidRedirects(redirects, repoSlug) {
 	}
 	const productSlug = productSlugsByRepo[repoSlug] ?? repoSlug
 
-	/** @type {Redirect[]} */
-	const invalidRedirects = []
+	const invalidRedirects: Redirect[] = []
 
 	/**
 	 * Filter out any redirects not prefixed with the `product` slug.
@@ -370,10 +367,10 @@ function filterInvalidRedirects(redirects, repoSlug) {
  * without text between them. This normalizes patterns like `(regex):name`
  * (unnamed capture immediately followed by named param) to `:name(regex[^/]+)`.
  *
- * @param {string} source
+ * @param source
  * @returns {string}
  */
-function normalizeRedirectSource(source) {
+function normalizeRedirectSource(source: string): string {
 	// Match an unnamed capture group followed immediately by a named parameter,
 	// e.g. `((?!get$)):slug` → `:slug((?!get$)[^/]+)`
 	return source.replace(
@@ -385,13 +382,17 @@ function normalizeRedirectSource(source) {
 /**
  * Groups simple redirects into an object keyed by the product slug they apply
  * to (as determined by the `host` property).
- * @param {Redirect[]} redirects
  */
-function groupSimpleRedirects(redirects) {
-	/** @type {Record<string, Record<string, { destination: string, permanent?: boolean }>>} */
-	const groupedRedirects = {}
+function groupSimpleRedirects(
+	redirects: Redirect[],
+): Record<string, Record<string, { destination: string; permanent?: boolean }>> {
+	const groupedRedirects: Record<
+		string,
+		Record<string, { destination: string; permanent?: boolean }>
+	> = {}
+
 	redirects.forEach((redirect) => {
-		let product
+		let product: string | undefined
 		if (redirect.has && redirect.has.length > 0) {
 			if (redirect.has[0].type === 'host') {
 				const hasHostValue = redirect.has[0].value
@@ -473,7 +474,7 @@ async function redirectsConfig() {
 	}
 }
 
-module.exports = {
+export {
 	PRODUCT_REDIRECT_ENTRIES,
 	redirectsConfig,
 	splitRedirectsByType,

--- a/config/__tests__/index.test.ts
+++ b/config/__tests__/index.test.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const path = require('path')
-const { loadHashiConfigForEnvironment } = require('../index')
+import path from 'path'
 
 const fixtureDir = path.join(__dirname, '__fixtures__', 'config-loading')
 
@@ -18,6 +17,8 @@ describe('loadHashiConfigByEnvironment', () => {
 	})
 
 	test('loads configuration and handles extending', async () => {
+		vi.resetModules()
+		const { loadHashiConfigForEnvironment } = await import('../index')
 		vi.spyOn(process, 'cwd').mockReturnValue(fixtureDir)
 		expect(await loadHashiConfigForEnvironment()).toMatchInlineSnapshot(`
 			{

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const fs = require('fs')
-const path = require('path')
-const flat = require('flat')
+import fs from 'fs'
+import path from 'path'
+import flat from 'flat'
+import { ContentClient } from '../src/lib/content-client/content-client'
 
 // Cache the final config to avoid re-reading files multiple times
-let finalConfig;
+let finalConfig: Record<string, unknown>
 
 /**
  * Load an environment config for the current environment, which is controlled by
@@ -24,15 +25,15 @@ async function loadHashiConfigForEnvironment() {
 /**
  * Load an environment config from a specific path.
  */
-async function getHashiConfig(configPath) {
+async function getHashiConfig(configPath: string) {
 	if (finalConfig) {
 		return finalConfig
 	}
 
 	try {
 		const baseConfigPath = path.join(process.cwd(), 'config', `base.json`)
-		const baseConfig = JSON.parse(fs.readFileSync(baseConfigPath))
-		const envConfig = JSON.parse(fs.readFileSync(configPath))
+		const baseConfig = JSON.parse(fs.readFileSync(baseConfigPath, 'utf-8'))
+		const envConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
 
 		// Load the extended config, if no extends property is defined use the base config
 		let extendsConfig = baseConfig
@@ -41,12 +42,12 @@ async function getHashiConfig(configPath) {
 			const extendsConfigPath = path.join(
 				process.cwd(),
 				'config',
-				`${envConfig.extends}.json`
+				`${envConfig.extends}.json`,
 			)
 			extendsConfig = await getHashiConfig(extendsConfigPath)
 		}
 
-		if (process.env.VERCEL !== 'production') {
+		if (process.env.VERCEL_ENV !== 'production') {
 			// Fetch additional config from UNIFIED_DOCS_API if available
 			if (process.env.UNIFIED_DOCS_API) {
 				try {
@@ -55,10 +56,14 @@ async function getHashiConfig(configPath) {
 
 					let udrProducts = Object.values({
 						...extendsConfig.flags?.unified_docs_migrated_repos,
-						...envConfig.flags?.unified_docs_migrated_repos
+						...envConfig.flags?.unified_docs_migrated_repos,
 					})
 
-					const response = await fetch(`${process.env.UNIFIED_DOCS_API}/api/supported-products`)
+					const response = await ContentClient(
+						'api/supported-products',
+						false,
+						false,
+					)
 					udrProducts = (await response.json()).result
 
 					// clear out any existing values and replace with fetched products
@@ -66,19 +71,25 @@ async function getHashiConfig(configPath) {
 					extendsConfig.flags.unified_docs_migrated_repos = []
 					envConfig.flags.unified_docs_migrated_repos = udrProducts
 				} catch (err) {
-					console.warn(`⛔️ Failed to fetch from "${process.env.UNIFIED_DOCS_API}/api/supported-products":`, err.message)
-					console.warn('⛔️ Defaulting to "config/production.json" list of UDR products')
+					console.warn(
+						`⛔️ Failed to fetch from "${process.env.UNIFIED_DOCS_API}/api/supported-products":`,
+						(err as Error).message,
+					)
+					console.warn(
+						'⛔️ Defaulting to "config/production.json" list of UDR products',
+					)
 
 					const prodConfigPath = path.join(
 						process.cwd(),
 						'config',
-						'production.json'
+						'production.json',
 					)
-					const prodConfig = JSON.parse(fs.readFileSync(prodConfigPath))
+					const prodConfig = JSON.parse(fs.readFileSync(prodConfigPath, 'utf-8'))
 
 					envConfig.flags.unified_docs_migrated_repos = []
 					extendsConfig.flags.unified_docs_migrated_repos = []
-					envConfig.flags.unified_docs_migrated_repos = prodConfig.flags.unified_docs_migrated_repos
+					envConfig.flags.unified_docs_migrated_repos =
+						prodConfig.flags.unified_docs_migrated_repos
 				}
 			}
 		}
@@ -90,7 +101,7 @@ async function getHashiConfig(configPath) {
 		})
 
 		// Because we are "flattening" the object, a simple spread should be sufficient here
-		finalConfig = { ...extendsFlattened, ...envFlattened }
+		finalConfig = { ...extendsFlattened, ...envFlattened } as Record<string, unknown>
 
 		if (process.env.DEBUG_CONFIG) {
 			console.log('[DEBUG_CONFIG]', finalConfig)
@@ -102,4 +113,4 @@ async function getHashiConfig(configPath) {
 	}
 }
 
-module.exports = { loadHashiConfigForEnvironment }
+export { loadHashiConfigForEnvironment }

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,19 +3,16 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-const { loadEnvConfig } = require('@next/env')
+import fs from 'fs'
+import path from 'path'
+import { loadEnvConfig } from '@next/env'
+import withHashicorp from '@hashicorp/platform-nextjs-plugin'
+import { redirectsConfig } from './build-libs/redirects'
+import HashiConfigPlugin from './config/plugin'
+import { loadHashiConfigForEnvironment } from './config/index'
 
 // Load environment variables, as they are not normally available in the next.config.js file. (https://nextjs.org/docs/app/guides/environment-variables#loading-environment-variables-with-nextenv)
-const projectDir = process.cwd()
-loadEnvConfig(projectDir)
-
-const fs = require('fs')
-const path = require('path')
-const withHashicorp = require('@hashicorp/platform-nextjs-plugin')
-const { redirectsConfig } = require('./build-libs/redirects')
-
-const HashiConfigPlugin = require('./config/plugin')
-const { loadHashiConfigForEnvironment } = require('./config/index')
+loadEnvConfig(process.cwd())
 
 /**
  * @type {import('next/dist/lib/load-custom-routes').Header}
@@ -41,7 +38,7 @@ const hideWaypointTipContent = {
 
 let alreadyLoggedUDRInfo = false
 
-module.exports = async () => {
+export default async () => {
 	process.env.VERCEL_ENV = process.env.VERCEL_ENV || 'development'
 
 	const appConfig = await loadHashiConfigForEnvironment()

--- a/src/lib/__tests__/docs-content-fields.test.ts
+++ b/src/lib/__tests__/docs-content-fields.test.ts
@@ -31,9 +31,12 @@ describe('allDocsFields', () => {
 		global.fetch = vi
 			.fn()
 			.mockResolvedValueOnce({
+				status: 200,
 				json: vi.fn().mockResolvedValue({ result: mockContentAPIDocsResult }),
 			})
 			.mockResolvedValueOnce({
+				status: 200,
+				ok: true,
 				json: vi.fn().mockResolvedValue({ result: mockUDRDocsResult }),
 			})
 
@@ -84,9 +87,12 @@ describe('allDocsFields', () => {
 		global.fetch = vi
 			.fn()
 			.mockResolvedValueOnce({
+				status: 200,
 				json: vi.fn().mockResolvedValue({ result: mockContentAPIDocsResult }),
 			})
 			.mockResolvedValueOnce({
+				status: 200,
+				ok: true,
 				json: vi.fn().mockResolvedValue({ result: mockUDRDocsResult }),
 			})
 

--- a/src/lib/content-client/content-client.ts
+++ b/src/lib/content-client/content-client.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright IBM Corp. 2021, 2025
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { getContentApiBaseUrl } from '../unified-docs-migration-utils'
+
+export class ContentApiError extends Error {
+	name = 'ContentApiError' as const
+	constructor(
+		message: string,
+		public status: number,
+		public resource: 'nav-data' | 'doc' | 'version-metadata',
+		public resource_url: string,
+	) {
+		super(message)
+	}
+}
+
+export const ContentClient = async (
+	url: string,
+	hasHeaders: boolean,
+	isContentAPI: boolean,
+	product?: string,
+	resource?: 'nav-data' | 'doc' | 'version-metadata',
+): Promise<Response> => {
+	let API_BASE_URL = ''
+	// builder headers
+	const headers =
+		hasHeaders && process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
+			? new Headers({
+					'x-vercel-protection-bypass':
+						process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
+				})
+			: new Headers()
+
+	// 1. Check if content API
+	if (isContentAPI) {
+		API_BASE_URL = getContentApiBaseUrl(product)
+	} else {
+		API_BASE_URL = process.env.UNIFIED_DOCS_API
+	}
+
+	// 2. Form fetch query
+	const QUERY_URL = `${API_BASE_URL}/${url}`
+
+	// 3. Fetch the query
+	const response = await fetch(QUERY_URL, { headers })
+
+	// 4. For content API calls, throw a typed error on non-200 so callers get
+	//    structured error info. For non-content-API calls, return the response
+	//    and let the caller inspect .ok / .status as needed.
+	if (response.status !== 200 && isContentAPI) {
+		throw new ContentApiError(
+			`Failed to fetch: ${QUERY_URL}`,
+			response.status,
+			resource,
+			QUERY_URL,
+		)
+	}
+
+	return response
+}

--- a/src/lib/sitemap/docs-content-fields.ts
+++ b/src/lib/sitemap/docs-content-fields.ts
@@ -4,13 +4,8 @@
  */
 
 import { isRestrictedDocsPath } from 'lib/is-restricted-docs-path'
+import { ContentClient } from 'lib/content-client/content-client'
 import { makeSitemapField } from './helpers'
-
-const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
-	? new Headers({
-			'x-vercel-protection-bypass': process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
-		})
-	: new Headers()
 
 export async function allDocsFields(config: typeof __config) {
 	const contentAPIFilter = config.flags.unified_docs_migrated_repos.map(
@@ -28,9 +23,10 @@ export async function allDocsFields(config: typeof __config) {
 		return `products=${repo}`
 	})
 	const UDRFilterString = UDRFilter.join('&')
-	const getUDRDocsPaths = await fetch(
-		`${process.env.UNIFIED_DOCS_API}/api/all-docs-paths?${UDRFilterString}`,
-		{ headers },
+	const getUDRDocsPaths = await ContentClient(
+		`api/all-docs-paths?${UDRFilterString}`,
+		true,
+		false
 	)
 	const { result: udrDocsResult } = await getUDRDocsPaths.json()
 

--- a/src/views/docs-view/loaders/content-api/index.ts
+++ b/src/views/docs-view/loaders/content-api/index.ts
@@ -3,24 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { getContentApiBaseUrl } from 'lib/unified-docs-migration-utils'
-export class ContentApiError extends Error {
-	name = 'ContentApiError' as const
-	constructor(
-		message: string,
-		public status: number,
-		public resource: 'nav-data' | 'doc' | 'version-metadata',
-		public resource_url: string,
-	) {
-		super(message)
-	}
-}
-
-const headers = process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN
-	? new Headers({
-			'x-vercel-protection-bypass': process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN,
-		})
-	: new Headers()
+import { ContentClient } from 'lib/content-client/content-client'
 
 /**
  * Retries an async operation with exponential backoff for transient 404 errors.
@@ -66,20 +49,9 @@ export async function fetchNavData(
 	version: string, //: string // v0.5.x
 ) {
 	return retryOn404(async () => {
-		const contentApiBaseUrl = getContentApiBaseUrl(product)
 		const fullPath = `nav-data/${version}/${basePath}`
-		const url = `${contentApiBaseUrl}/api/content/${product}/${fullPath}`
-
-		const response = await fetch(url, { headers })
-
-		if (response.status !== 200) {
-			throw new ContentApiError(
-				`Failed to fetch: ${url}`,
-				response.status,
-				'nav-data',
-				url,
-			)
-		}
+		const url = `api/content/${product}/${fullPath}`
+		const response = await ContentClient(url, true, true, product, 'nav-data')
 
 		const { result } = await response.json()
 		return result
@@ -88,18 +60,8 @@ export async function fetchNavData(
 
 export async function fetchDocument(product: string, fullPath: string) {
 	return retryOn404(async () => {
-		const contentApiBaseUrl = getContentApiBaseUrl(product)
-		const url = `${contentApiBaseUrl}/api/content/${product}/${fullPath}`
-		const response = await fetch(url, { headers })
-
-		if (response.status !== 200) {
-			throw new ContentApiError(
-				`Failed to fetch: ${url}`,
-				response.status,
-				'doc',
-				url,
-			)
-		}
+		const url = `api/content/${product}/${fullPath}`
+		const response = await ContentClient(url, true, true, product, 'doc')
 
 		const { result } = await response.json()
 		const docHeaders = Object.fromEntries(response.headers)
@@ -108,18 +70,14 @@ export async function fetchDocument(product: string, fullPath: string) {
 }
 
 export async function fetchVersionMetadataList(product: string) {
-	const contentApiBaseUrl = getContentApiBaseUrl(product)
-	const url = `${contentApiBaseUrl}/api/content/${product}/version-metadata?partial=true`
-	const response = await fetch(url, { headers })
-
-	if (response.status !== 200) {
-		throw new ContentApiError(
-			`Failed to fetch: ${url}`,
-			response.status,
-			'version-metadata',
-			url,
-		)
-	}
+	const url = `api/content/${product}/version-metadata?partial=true`
+	const response = await ContentClient(
+		url,
+		true,
+		true,
+		product,
+		'version-metadata',
+	)
 
 	const { result } = await response.json()
 	return result

--- a/src/views/docs-view/loaders/index.ts
+++ b/src/views/docs-view/loaders/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { GetStaticPaths, GetStaticProps, GetStaticPathsResult } from 'next'
-import { ContentApiError } from './content-api'
+import { ContentApiError } from './../../../lib/content-client/content-client'
 import FileSystemLoader from './file-system'
 import RemoteContentLoader from './remote-content'
 import { DataLoader, RemarkPlugins } from './types'
@@ -43,7 +43,7 @@ export function getStaticGenerationFunctions(
 				 * Defaults to "content/partials". */
 				localPartialsDir?: string
 		  } & BaseOpts &
-				Partial<ConstructorParameters<typeof FileSystemLoader>[0]>)
+				Partial<ConstructorParameters<typeof FileSystemLoader>[0]>),
 ): {
 	getStaticPaths: GetStaticPaths
 	getStaticProps: GetStaticProps


### PR DESCRIPTION
## 🔗 Relevant links

<!--
Include links to the branch preview, Asana task, and Figma designs wherever possible to make reviewing your PR easier.
When including the preview link, make sure to remove any '.' characters from the branch name:
  - Example: ks.my-branch -> ksmy-branch
-->

- [Preview link](https://dev-portal-git-BRANCH_NAME-hashicorp.vercel.app/PATH_TO_VIEW) 🔎
- [Monday task](https://ibm.monday.com/boards/18402251594/pulses/10910814663) 🎟️

## 🗒️ What

<!--
Briefly list out the changes proposed in this PR.
-->

This PR creates a single `ContentClient` as our source of data fetching in order to remove repeated uses of `process.env.UNIFIED_DOCS_API` and `process.env.MKTG_CONTENT_DOCS_API`. 

## Content Client Args
- url: string - Attached URL portion to the base API string (i.e. ${process.env.UNIFIED_DOCS_API}/${url})
- hasHeaders: boolean - Dictates whether to populate headers with a `process.env.UDR_VERCEL_AUTH_BYPASS_TOKEN` or build an empty header
- isContentAPI: boolean - Used to determine whether to query from UDR or MKTG Content
- product?: string - Optional string for figuring out if the product's content lies within UDR or MKTG Content; Passed in only with isContentAPI is true
- resource?: 'nav-data' | 'doc' | 'version-metadata' - Specifically for MKTG Content to describe the resource type when errors occur

>[!NOTE]
I made changes to file extensions (js -> ts) that should be verified with their predecessors. This was needed as `ContentClient` is a TypeScript file while config, build-libs, and next.config were in JavaScript, thus causing errors when trying to import. I'd also like feedback on my design choices and for places of improvement!

## 🛠️ How

<!--
Dive into the approach you took, list resources you referenced, detail other approaches you tried but didn't end up going with, etc.
-->

## 🧪 Testing

<!--
Create a checklist for going through how to test your proposed changes. If there is anything to configure before interacting with the project in a browser, such as toggling feature flags, changing machine settings, or simulating behavior in browser dev tools, list those steps first.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
-->

1. Check the preview to ensure the deployment still works
2. Make sure the changes to the file types (e.g. next.config.js -> next.config.ts) do not break things and are completely valid

## 💭 Anything else?

<!--
If there is anything you came across that you chose not to address in this PR but plan to soon, list those items here and any Asana tasks you created to go with them.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
